### PR TITLE
docs: [documentation-style-guide] update formatting, wordsmith

### DIFF
--- a/docs/contributing/documentation-style-guide.md
+++ b/docs/contributing/documentation-style-guide.md
@@ -9,7 +9,7 @@ you with a conventional writing style for users writing developer documentation 
 our Open Source framework. Each topic is precise and well explained to help you write
 documentation users can easily understand and implement.
 
-## Who is this guide for?
+## Who is This Guide For?
 
 This guide is for anyone who loves to build with Platformatic or wants to contribute
 to our documentation. You do not need to be an expert in writing technical
@@ -18,7 +18,7 @@ documentation. This guide is here to help you.
 Visit [CONTRIBUTING.md](https://github.com/platformatic/platformatic/blob/main/CONTRIBUTING.md)
 file on GitHub to join our Open Source folks.
 
-## Before you write
+## Before you Write
 
 You should have a basic understanding of:
 
@@ -30,7 +30,7 @@ You should have a basic understanding of:
 * HTTP
 * NPM
 
-### Consider your Audience
+### Consider Your Audience
 
 Before you start writing, think about your audience. In this case, your audience
 should already know HTTP, JavaScript, NPM, and Node.js. It is necessary to keep
@@ -41,7 +41,7 @@ readers can relate to easily. Ask for feedback from the community, it can help
 you write better documentation that focuses on the user and what you want to
 achieve.
 
-### Get straight to the point
+### Get Straight to the Point
 
 Give your readers a clear and precise action to take. Start with what is most
 important. This way, you can help them find what they need faster. Mostly,
@@ -50,15 +50,17 @@ further.
 
 **Example**
 
-Less like this: Colons are very important to register a parametric path. It lets
+Less like this:
+>Colons are very important to register a parametric path. It lets
 the framework know there is a new parameter created. You can place the colon
 before the parameter name so the parametric path can be created.
 
-More Like this: To register a parametric path, put a colon before the parameter
+More Like this:
+>To register a parametric path, put a colon before the parameter
 name. Using a colon lets the framework know it is a parametric path and not a
 static path.
 
-### Images and video should enhance the written documentation
+### Images and Video Should Enhance the Written Documentation
 
 
 Images and video should only be added if they complement the written
@@ -72,7 +74,7 @@ external site, such as YouTube. You can add links by using
 
 
 
-### Avoid plagiarism
+### Avoid Plagiarism
 
 Make sure you avoid copying other people's work. Keep it as original as
 possible. You can learn from what they have done and reference where it is from
@@ -86,7 +88,7 @@ to improve readability for readers and make documentation neat, direct, and
 clean.
 
 
-### When to use the second person "you" as the pronoun
+### When to use the Second Person "you" as the Pronoun
 
 When writing articles or guides, your content should communicate directly to
 readers in the second person ("you") addressed form. It is easier to give them
@@ -95,15 +97,19 @@ the [Quick Start Guide](../getting-started/quick-start-guide.md).
 
 **Example**
 
-Less like this: we can use the following plugins.
+Less like this:
+>We can use the following plugins.
 
-More like this: You can use the following plugins.
+More like this:
+>You can use the following plugins.
 
-> According to [Wikipedia](#), ***You*** is usually a second person pronoun.
-> Also, used to refer to an indeterminate person, as a more common alternative
-> to a very formal indefinite pronoun.
+According to [Wikipedia](#), ***You*** is usually a second person pronoun.
+Also, used to refer to an indeterminate person, as a more common alternative
+to a very formal indefinite pronoun.
 
-## When to avoid the second person "you" as the pronoun
+To recap, **use "you" when writing articles or guides.**
+
+## When to Avoid the Second Person "you" as the Pronoun
 
 One of the main rules of formal writing such as reference documentation, or API
 documentation, is to avoid the second person ("you") or directly addressing the
@@ -111,22 +117,25 @@ reader.
 
 **Example**
 
-Less like this: You can use the following recommendation as an example.
+Less like this:
+>You can use the following recommendation as an example.
 
-More like this: As an example, the following recommendations should be
+More like this:
+>As an example, the following recommendations should be
 referenced.
 
 To view a live example, refer to the [Decorators](../reference/configuration.md)
 reference document.
 
+To recap, **avoid "you" in reference documentation or API documentation.**
 
-### Avoid using contractions
+### Avoid Using Contractions
 
 Contractions are the shortened version of written and spoken forms of a word,
 i.e. using "don't" instead of "do not". Avoid contractions to provide a more
 formal tone.
 
-### Avoid using condescending terms
+### Avoid Using Condescending Terms
 
 Condescending terms are words that include:
 
@@ -140,7 +149,7 @@ The reader may not find it easy to use Platformatic; avoid
 words that make it sound simple, easy, offensive, or insensitive. Not everyone
 who reads the documentation has the same level of understanding.
 
-### Starting with a verb
+### Starting With a Verb
 
 Mostly start your description with a verb, which makes it simple and precise for
 the reader to follow. Prefer using present tense because it is easier to read
@@ -148,12 +157,14 @@ and understand than the past or future tense.
 
 **Example**
 
- Less like this: There is a need for Node.js to be installed before you can be
+ Less like this:
+ >There is a need for Node.js to be installed before you can be
  able to use Platformatic.
 
- More like this: Install Node.js to make use of Platformatic.
+ More like this:
+ >Install Node.js to make use of Platformatic.
 
-### Grammatical moods
+### Grammatical Moods
 
 Grammatical moods are a great way to express your writing. Avoid sounding too
 bossy while making a direct statement. Know when to switch between indicative,
@@ -162,36 +173,40 @@ imperative, and subjunctive moods.
 
 **Indicative** - Use when making a factual statement or question.
 
-Example: Since there is no testing framework available, "Platformatic recommends ways
+**Example**
+>Since there is no testing framework available, "Platformatic recommends ways
 to write tests".
 
 **Imperative** - Use when giving instructions, actions, commands, or when you
 write your headings.
 
-Example: Install dependencies before starting development.
+**Example**
+>Install dependencies before starting development.
 
 
-**Subjunctive** -  Use when making suggestions, hypotheses, or non-factual
+**Subjunctive** - Use when making suggestions, hypotheses, or non-factual
 statements.
 
-Example: Reading the documentation on our website is recommended to get
+**Example**
+>Reading the documentation on our website is recommended to get
 comprehensive knowledge of the framework.
 
-### Use **active** voice instead of **passive**
+### Use **Active** Voice Instead of **Passive**
 
 Using active voice is a more compact and direct way of conveying your
 documentation.
 
 **Example**
 
+Passive:
+>The node dependencies and packages are installed by npm.
 
-Passive: The node dependencies and packages are installed by npm.
-
-Active:  npm installs packages and node dependencies.
+Active:
+>npm installs packages and node dependencies.
 
 ## Writing Style
 
-### Documentation titles
+### Documentation Titles
 
 When creating a new guide, API, or reference in the `/docs/` directory, use
 short titles that best describe the topic of your documentation. Name your files
@@ -201,11 +216,11 @@ Styles](https://medium.com/better-programming/string-case-styles-camel-pascal-sn
 
 **Examples**:
 
->`hook-and-plugins.md`,
+>`hook-and-plugins.md`
 
- `adding-test-plugins.md`,
+>`adding-test-plugins.md`
 
- `removing-requests.md`.
+>`removing-requests.md`
 
 ### Hyperlinks
 
@@ -235,4 +250,4 @@ hyperlink should look:
 ```
 
 Include in your documentation as many essential references as possible, but
-avoid having numerous links when writing for beginners to avoid distractions.
+avoid having numerous links when writing to avoid distractions.


### PR DESCRIPTION
This PR does the following,
- updates the `documentation-style-guide`
	- formatting consistency in titles (using the [APA](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case) guide) 
  	- formatting of examples
	- minor wordsmith