### PR TITLE
Fix docs: url points to wrong page

### DIFF
--- a/docs/guides/jwt-auth0.md
+++ b/docs/guides/jwt-auth0.md
@@ -1,7 +1,7 @@
 # Configure JWT with Auth0
 
 [Auth0](https://auth0.com/) is a powerful authentication and authorization service provider that can be integrated with Platformatic DB through [JSON Web Tokens](https://jwt.io/) (JWT) tokens. 
-When a user is authenticated, Auth0 creates a JWT token with all necessary security informations and custom claims (like the `X-PLATFORMATIC-ROLE`, see [User Metadata](../reference/db-authorization/intro#user-metadata)) and signs the token. 
+When a user is authenticated, Auth0 creates a JWT token with all necessary security informations and custom claims (like the `X-PLATFORMATIC-ROLE`, see [User Metadata](../reference/db-authorization/introduction#user-metadata)) and signs the token. 
 
 Platformatic DB needs the correct public key to verify the JWT signature. 
 The fastest way is to leverage [JWKS](https://www.rfc-editor.org/rfc/rfc7517), since Auth0 exposes a [JWKS](https://www.rfc-editor.org/rfc/rfc7517) endpoint for each tenant.


### PR DESCRIPTION
URL points to 'reference/db-authorization/intro#user-metadata' instead of 'reference/db-authorization/introduction#user-metadata'