### PR TITLE
Remove logger from config created with `db init`

### DIFF
--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -23,11 +23,10 @@ CREATE TABLE IF NOT EXISTS movies (
 `
 
 function generateConfig (hostname, port, database, migrations, types) {
-  const logger = { level: 'info' }
   const connectionString = connectionStrings[database]
 
   const config = {
-    server: { logger, hostname, port },
+    server: { hostname, port },
     core: { connectionString, graphiql: true },
     migrations: { dir: migrations }
   }

--- a/packages/db/test/cli/init.test.mjs
+++ b/packages/db/test/cli/init.test.mjs
@@ -30,7 +30,6 @@ test('run db init with default options', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 
@@ -74,7 +73,6 @@ test('run init with default options twice', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 
@@ -104,7 +102,6 @@ test('run db init --database postgres', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 
@@ -134,7 +131,6 @@ test('run db init --database mysql', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 
@@ -164,7 +160,6 @@ test('run db init --database mariadb', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 
@@ -194,7 +189,6 @@ test('run db init --database mysql8', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 
@@ -224,7 +218,6 @@ test('run db init --hostname 127.0.0.5', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.5')
   t.equal(server.port, 3042)
 
@@ -254,7 +247,6 @@ test('run db init --port 3055', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3055)
 
@@ -284,7 +276,6 @@ test('run db init --migrations custom-migrations-folder', async (t) => {
 
   const { server, core, migrations } = dbConfig
 
-  t.same(server.logger, { level: 'info' })
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 


### PR DESCRIPTION
Currently `npb platformatic db init` creates a config with `logger` level set to `info`: 
```json
{
  "server": {
    "logger": {
      "level": "info"
    },
    
  },

```
...which is the default, so this is not necessary anymore. 