### PR TITLE
Correctly handle entity PK when snake_case

### DIFF
--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -16,7 +16,7 @@ const ascDesc = new graphql.GraphQLEnumType({
 })
 
 function constructGraph (app, entity, opts) {
-  const primaryKey = entity.primaryKey
+  const primaryKey = camelcase(entity.primaryKey)
   const relationalFields = entity.relations
     .map((relation) => relation.column_name)
   const entityName = entity.name


### PR DESCRIPTION
Fixes #28 

Basically, we were using the field DB value to get the PK data from `fields` where the keys are all camelCase. So with a non camel-case field, this was failing. 
Fixed and added specific tests