### PR TITLE
Optional `X-Total-Count` header in GET

### DIFF
--- a/docs/reference/sql-graphql/queries.md
+++ b/docs/reference/sql-graphql/queries.md
@@ -87,13 +87,13 @@ const res = await app.inject({
     query: `
       query {
         countPages {
-          totalCount
+          total
         }
       }
     `
   }
 })
 const result = await res.json()
-console.log(result.data) // { countMovies : { totalCount: { 17 } } }
+console.log(result.data) // { countMovies : { total: { 17 } }
 ```
 

--- a/docs/reference/sql-graphql/queries.md
+++ b/docs/reference/sql-graphql/queries.md
@@ -75,3 +75,25 @@ const res = await app.inject({
 const result = await res.json()
 console.log(result.data) // { getPageById: { id: '3', title: 'A fiction' } }
 ```
+
+### `count[ENTITIES]`
+
+```js
+...
+const res = await app.inject({
+  method: 'POST',
+  url: '/graphql',
+  body: {
+    query: `
+      query {
+        countPages {
+          totalCount
+        }
+      }
+    `
+  }
+})
+const result = await res.json()
+console.log(result.data) // { countMovies : { totalCount: { 17 } } }
+```
+

--- a/docs/reference/sql-rest/api.md
+++ b/docs/reference/sql-rest/api.md
@@ -69,6 +69,23 @@ $ curl -X 'GET' \
   -H 'accept: application/json'
 ```
 
+### Total Count
+
+If `totalCount` boolean is in query, the GET returns the total number of elements in the `X-Total-Count` header ignoring `limit` and `offset` (if specified).
+
+```bash
+$ curl -v -X 'GET' \
+  'http://localhost:3042/movies/?limit=2&offset=0&totalCount=true' \
+  -H 'accept: application/json'
+
+ (...)
+> HTTP/1.1 200 OK
+> x-total-count: 18
+ (...)
+
+[{"id":1,"title":"Movie1"},{"id":2,"title":"Movie2"}]%
+```
+
 
 ## `POST [PLURAL_ENTITY_NAME]`
 
@@ -147,3 +164,4 @@ $ curl -X 'DELETE' 'http://localhost:3042/pages/1?fields=title'
   "title": "Hello Platformatic!"
 }
 ```
+

--- a/docs/reference/sql-rest/api.md
+++ b/docs/reference/sql-rest/api.md
@@ -75,7 +75,7 @@ If `totalCount` boolean is in query, the GET returns the total number of element
 
 ```bash
 $ curl -v -X 'GET' \
-  'http://localhost:3042/movies/?limit=2&offset=0&totalCount=true' \
+  'http://localhost:3042/pages/?limit=2&offset=0&totalCount=true' \
   -H 'accept: application/json'
 
  (...)

--- a/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
@@ -9,6 +9,7 @@ exports['test/cli/env.test.mjs TAP env white list schema > must match snapshot 1
 type Query {
   getPageById(id: ID!): Page
   pages(limit: Int, offset: Int, orderBy: [PageOrderByArguments], where: PageWhereArguments): [Page]
+  countPages(where: PageWhereArguments): pagesCount
 }
 
 type Page {
@@ -56,6 +57,10 @@ input PageWhereArgumentstitle {
   lte: String
   in: [String]
   nin: [String]
+}
+
+type pagesCount {
+  totalCount: Int
 }
 
 type Mutation {

--- a/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
@@ -60,7 +60,7 @@ input PageWhereArgumentstitle {
 }
 
 type pagesCount {
-  totalCount: Int
+  total: Int
 }
 
 type Mutation {

--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -119,6 +119,15 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
           },
           {
             "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "in": "query",
+            "name": "totalCount",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "array",
               "items": {
                 "type": "string",

--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -9,6 +9,7 @@ exports['test/cli/schema.test.mjs TAP print the graphql schema to stdout > must 
 type Query {
   getGraphById(id: ID!): Graph
   graphs(limit: Int, offset: Int, orderBy: [GraphOrderByArguments], where: GraphWhereArguments): [Graph]
+  countGraphs(where: GraphWhereArguments): graphsCount
 }
 
 type Graph {
@@ -56,6 +57,10 @@ input GraphWhereArgumentsname {
   lte: String
   in: [String]
   nin: [String]
+}
+
+type graphsCount {
+  totalCount: Int
 }
 
 type Mutation {

--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -60,7 +60,7 @@ input GraphWhereArgumentsname {
 }
 
 type graphsCount {
-  totalCount: Int
+  total: Int
 }
 
 type Mutation {

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -148,7 +148,7 @@ function constructGraph (app, entity, opts) {
   const countType = new graphql.GraphQLObjectType({
     name: `${plural}Count`,
     fields: {
-      totalCount: { type: graphql.GraphQLInt }
+      total: { type: graphql.GraphQLInt }
     }
   })
 
@@ -162,8 +162,8 @@ function constructGraph (app, entity, opts) {
   resolvers.Query[count] = async (_, query, ctx, info) => {
     const requestedFields = info.fieldNodes[0].selectionSet.selections.map((s) => s.name.value)
     requestedFields.push(primaryKey)
-    const totalCount = await entity.count({ ...query, fields: [...requestedFields, ...relationalFields], ctx })
-    return { totalCount }
+    const total = await entity.count({ ...query, fields: [...requestedFields, ...relationalFields], ctx })
+    return { total }
   }
 
   const save = camelcase(['save', singular])

--- a/packages/sql-graphql/test/count.test.js
+++ b/packages/sql-graphql/test/count.test.js
@@ -84,7 +84,7 @@ test('count', async ({ pass, teardown, same, equal }) => {
         query: `
           query {
             countPosts {
-              totalCount
+              total
             }
           }
         `
@@ -94,7 +94,7 @@ test('count', async ({ pass, teardown, same, equal }) => {
     same(res.json(), {
       data: {
         countPosts: {
-          totalCount: 4
+          total: 4
         }
       }
     }, 'posts response')
@@ -108,7 +108,7 @@ test('count', async ({ pass, teardown, same, equal }) => {
         query: `
           query {
             countPosts(where: { counter: { gt: 20 } }) {
-              totalCount
+              total
             }
           }
         `
@@ -118,7 +118,7 @@ test('count', async ({ pass, teardown, same, equal }) => {
     same(res.json(), {
       data: {
         countPosts: {
-          totalCount: 2
+          total: 2
         }
       }
     }, 'posts response')

--- a/packages/sql-graphql/test/count.test.js
+++ b/packages/sql-graphql/test/count.test.js
@@ -1,0 +1,126 @@
+'use strict'
+
+const { test } = require('tap')
+const sqlGraphQL = require('..')
+const sqlMapper = require('@platformatic/sql-mapper')
+const fastify = require('fastify')
+const { clear, connInfo, isSQLite } = require('./helper')
+
+test('count', async ({ pass, teardown, same, equal }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      }
+    }
+  })
+  app.register(sqlGraphQL)
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const posts = [{
+    title: 'Dog',
+    longText: 'Foo',
+    counter: 10
+  }, {
+    title: 'Cat',
+    longText: 'Bar',
+    counter: 20
+  }, {
+    title: 'Mouse',
+    longText: 'Baz',
+    counter: 30
+  }, {
+    title: 'Duck',
+    longText: 'A duck tale',
+    counter: 40
+  }]
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+            mutation batch($inputs : [PostInput]!) {
+              insertPosts(inputs: $inputs) {
+                id
+                title
+              }
+            }
+          `,
+        variables: {
+          inputs: posts
+        }
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            countPosts {
+              totalCount
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        countPosts: {
+          totalCount: 4
+        }
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            countPosts(where: { counter: { gt: 20 } }) {
+              totalCount
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        countPosts: {
+          totalCount: 2
+        }
+      }
+    }, 'posts response')
+  }
+})

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -213,7 +213,7 @@ function createMapper (db, sql, log, table, fields, primaryKey, relations, queri
     return res.map(fixOutput)
   }
 
-  async function findTotalCount (opts = {}) {
+  async function count (opts = {}) {
     let totalCountQuery = null
     totalCountQuery = sql`
         SELECT COUNT(*) AS total 
@@ -245,7 +245,7 @@ function createMapper (db, sql, log, table, fields, primaryKey, relations, queri
     fixInput,
     fixOutput,
     find,
-    findTotalCount,
+    count,
     insert,
     save,
     delete: _delete

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -213,6 +213,20 @@ function createMapper (db, sql, log, table, fields, primaryKey, relations, queri
     return res.map(fixOutput)
   }
 
+  async function findTotalCount (opts = {}) {
+    let totalCountQuery = null
+    totalCountQuery = sql`
+        SELECT COUNT(*) AS total 
+        FROM ${sql.ident(table)}
+      `
+    const criteria = computeCriteria(opts)
+    if (criteria.length > 0) {
+      totalCountQuery = sql`${totalCountQuery} WHERE ${sql.join(criteria, sql` AND `)}`
+    }
+    const [{ total }] = await db.query(totalCountQuery)
+    return +total
+  }
+
   async function _delete (opts) {
     const fieldsToRetrieve = computeFields(opts.fields).map((f) => sql.ident(f))
     const criteria = computeCriteria(opts)
@@ -231,6 +245,7 @@ function createMapper (db, sql, log, table, fields, primaryKey, relations, queri
     fixInput,
     fixOutput,
     find,
+    findTotalCount,
     insert,
     save,
     delete: _delete

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -122,6 +122,15 @@ interface Find<EntityFields> {
   }): Promise<Partial<EntityFields>[]>
 }
 
+interface Count {
+  (options?: {
+    /**
+     * SQL where condition.
+     */
+    where?: WhereCondition,
+  }): Promise<number>
+}
+
 interface Insert<EntityFields> {
   (options: {
     /**
@@ -218,6 +227,10 @@ export interface Entity<EntityFields = any> {
    * Deletes entities from the database.
    */
   delete: Delete<EntityFields>,
+  /**
+   * Count the entities considering the where condition.
+   */
+  count: Count,
 }
 
 
@@ -227,6 +240,7 @@ export interface EntityHooks<EntityFields = any> {
     insert?: Insert<EntityFields>,
     save?: Save<EntityFields>,
     delete?: Delete<EntityFields>,
+    count?: Count,
   }
 }
 
@@ -304,5 +318,5 @@ export default plugin
  * An object that contains utility functions.
  */
 export module utils {
-  export function toSingular (str: string): string
+  export function toSingular(str: string): string
 }

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test, only } = require('tap')
 
 const { clear, connInfo, isSQLite, isMysql } = require('./helper')
 const { connect } = require('..')
@@ -43,7 +43,7 @@ test('entity fields', async ({ equal, not, same, teardown }) => {
   equal(pageEntity.camelCasedFields.id.primaryKey, true)
 })
 
-test('entity API', async ({ equal, same, teardown, rejects }) => {
+only('entity API', async ({ equal, same, teardown, rejects }) => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)
     teardown(() => db.dispose())
@@ -87,6 +87,10 @@ test('entity API', async ({ equal, same, teardown, rejects }) => {
   // find
   const findResult = await pageEntity.find({ fields: ['theTitle'] })
   same(findResult, [{ theTitle: 'foo' }, { theTitle: 'bar' }])
+
+  // findTotalCount
+  const findTotalCountResult = await pageEntity.findTotalCount({ fields: ['theTitle'] })
+  same(findTotalCountResult, 2)
 
   // insert - single
   const insertResult = await pageEntity.insert({

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, only } = require('tap')
+const { test } = require('tap')
 
 const { clear, connInfo, isSQLite, isMysql } = require('./helper')
 const { connect } = require('..')
@@ -43,7 +43,7 @@ test('entity fields', async ({ equal, not, same, teardown }) => {
   equal(pageEntity.camelCasedFields.id.primaryKey, true)
 })
 
-only('entity API', async ({ equal, same, teardown, rejects }) => {
+test('entity API', async ({ equal, same, teardown, rejects }) => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)
     teardown(() => db.dispose())

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -88,9 +88,9 @@ test('entity API', async ({ equal, same, teardown, rejects }) => {
   const findResult = await pageEntity.find({ fields: ['theTitle'] })
   same(findResult, [{ theTitle: 'foo' }, { theTitle: 'bar' }])
 
-  // findTotalCount
-  const findTotalCountResult = await pageEntity.findTotalCount({ fields: ['theTitle'] })
-  same(findTotalCountResult, 2)
+  // count
+  const countResult = await pageEntity.count({ fields: ['theTitle'] })
+  same(countResult, 2)
 
   // insert - single
   const insertResult = await pageEntity.insert({

--- a/packages/sql-mapper/test/types/mapper.test-d.ts
+++ b/packages/sql-mapper/test/types/mapper.test-d.ts
@@ -39,28 +39,34 @@ expectType<Partial<EntityFields>[]>(await entity.find())
 expectType<Partial<EntityFields>[]>(await entity.insert({ inputs: [{ id: 1, name: 'test' }] }))
 expectType<Partial<EntityFields>>(await entity.save({ input: { id: 1, name: 'test' } }))
 expectType<Partial<EntityFields>[]>(await entity.delete())
+expectType<number>(await entity.count())
 
 expectType<SQLMapperPluginInterface>(await connect({ connectionString: '' }))
 expectType<SQLMapperPluginInterface>(await connect({ connectionString: '', autoTimestamp: true }))
 expectType<SQLMapperPluginInterface>(await connect({ connectionString: '', hooks: {} }))
-expectType<SQLMapperPluginInterface>(await connect({ connectionString: '', hooks: {
-  Page: {
-    async find(options: any): Promise<any[]> { return [] },
-    async insert(options: { inputs: any[], fields?: string[] }): Promise<any[]> { return [] },
-    async save(options: { input: any, fields?: string[] }): Promise<any> { return {} },
-    async delete(options?: { where: WhereCondition, fields: string[] }): Promise<any[]> { return [] },
+expectType<SQLMapperPluginInterface>(await connect({
+  connectionString: '', hooks: {
+    Page: {
+      async find(options: any): Promise<any[]> { return [] },
+      async insert(options: { inputs: any[], fields?: string[] }): Promise<any[]> { return [] },
+      async save(options: { input: any, fields?: string[] }): Promise<any> { return {} },
+      async delete(options?: { where: WhereCondition, fields: string[] }): Promise<any[]> { return [] },
+      async count(options?: { where?: WhereCondition }): Promise<number> { return 0 },
+    }
   }
-}}))
+}))
 expectType<SQLMapperPluginInterface>(await connect({ connectionString: '', ignore: {} }))
-expectType<SQLMapperPluginInterface>(await connect({ connectionString: '', onDatabaseLoad(db: Database, sql: SQL) {
-  expectType<(query: SQLQuery) => Promise<any[]>>(db.query)
-  expectType<() => Promise<void>>(db.dispose)
-  expectType<boolean | undefined>(pluginOptions.db.isMySql)
-  expectType<boolean | undefined>(pluginOptions.db.isMariaDB)
-  expectType<boolean | undefined>(pluginOptions.db.isSQLite)
-  expectType<boolean | undefined>(pluginOptions.db.isPg)
+expectType<SQLMapperPluginInterface>(await connect({
+  connectionString: '', onDatabaseLoad(db: Database, sql: SQL) {
+    expectType<(query: SQLQuery) => Promise<any[]>>(db.query)
+    expectType<() => Promise<void>>(db.dispose)
+    expectType<boolean | undefined>(pluginOptions.db.isMySql)
+    expectType<boolean | undefined>(pluginOptions.db.isMariaDB)
+    expectType<boolean | undefined>(pluginOptions.db.isSQLite)
+    expectType<boolean | undefined>(pluginOptions.db.isPg)
 
-}}))
+  }
+}))
 
 const instance: FastifyInstance = fastify()
 instance.register(plugin, { connectionString: '', autoTimestamp: true })

--- a/packages/sql-mapper/test/where.test.js
+++ b/packages/sql-mapper/test/where.test.js
@@ -230,13 +230,13 @@ test('totalCount', async ({ pass, teardown, same, equal }) => {
     inputs: posts
   })
 
-  same(await entity.findTotalCount(), 4)
+  same(await entity.count(), 4)
 
-  same(await entity.findTotalCount({ where: { title: { eq: 'Dog' } } }), 1)
+  same(await entity.count({ where: { title: { eq: 'Dog' } } }), 1)
 
-  same(await entity.findTotalCount({ where: { title: { neq: 'Dog' } } }), 3)
+  same(await entity.count({ where: { title: { neq: 'Dog' } } }), 3)
 
-  same(await entity.findTotalCount({ limit: 2, offset: 0, fields: ['id', 'title', 'longText'] }), 4)
+  same(await entity.count({ limit: 2, offset: 0, fields: ['id', 'title', 'longText'] }), 4)
 })
 
 test('foreign keys', async ({ pass, teardown, same, equal }) => {

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -88,6 +88,7 @@ async function entityPlugin (app, opts) {
         properties: {
           limit: { type: 'integer' },
           offset: { type: 'integer' },
+          totalCount: { type: 'boolean', default: false },
           fields,
           ...whereArgs,
           ...orderByArgs
@@ -133,6 +134,10 @@ async function entityPlugin (app, opts) {
     }, [])
     const ctx = { app: this, reply }
     const res = await entity.find({ limit, offset, fields, orderBy, where, ctx })
+    if (query.totalCount) {
+      const totalCount = await entity.findTotalCount({ where, ctx })
+      reply.header('X-Total-Count', totalCount)
+    }
     return res
   })
 

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -135,7 +135,7 @@ async function entityPlugin (app, opts) {
     const ctx = { app: this, reply }
     const res = await entity.find({ limit, offset, fields, orderBy, where, ctx })
     if (query.totalCount) {
-      const totalCount = await entity.findTotalCount({ where, ctx })
+      const totalCount = await entity.count({ where, ctx })
       reply.header('X-Total-Count', totalCount)
     }
     return res

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -302,6 +302,19 @@ test('list', async ({ pass, teardown, same, equal }) => {
       url: '/posts?limit=2&offset=1'
     })
     equal(res.statusCode, 200, 'posts status code')
+    same(res.headers['x-total-count'], undefined, 'GET /api/pages without totalCount')
+    same(res.json(), posts.map((p, i) => {
+      return { ...p, id: i + 1 + '' }
+    }).slice(1, 3), 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?limit=2&offset=1&totalCount=true'
+    })
+    equal(res.headers['x-total-count'], 4, 'GET /api/pages with totalCount')
+    equal(res.statusCode, 200, 'posts status code')
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
     }).slice(1, 3), 'posts response')

--- a/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
@@ -58,6 +58,15 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "totalCount",
+            "required": false,
+            "schema": Object {
+              "default": false,
+              "type": "boolean",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": Object {

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
@@ -55,6 +55,15 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "totalCount",
+            "required": false,
+            "schema": Object {
+              "default": false,
+              "type": "boolean",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": Object {

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
@@ -54,6 +54,15 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "totalCount",
+            "required": false,
+            "schema": Object {
+              "default": false,
+              "type": "boolean",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": Object {

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
@@ -56,6 +56,15 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "totalCount",
+            "required": false,
+            "schema": Object {
+              "default": false,
+              "type": "boolean",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": Object {

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
@@ -62,6 +62,15 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "totalCount",
+            "required": false,
+            "schema": Object {
+              "default": false,
+              "type": "boolean",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": Object {

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
@@ -81,6 +81,15 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "totalCount",
+            "required": false,
+            "schema": Object {
+              "default": false,
+              "type": "boolean",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": Object {
@@ -514,6 +523,15 @@ Object {
             "required": false,
             "schema": Object {
               "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "totalCount",
+            "required": false,
+            "schema": Object {
+              "default": false,
+              "type": "boolean",
             },
           },
           Object {


### PR DESCRIPTION
Fixes #32 

There is no portable way to obtain the full count in the same query used with `limit` and `offset`, so two queries are necessary, one for the list and the other for `SELECT COUNT(*)` with the same criteria.
Added a new `findTotalCount` to `entity` so that we don't have to change what `find` returns (currently just the query result with no metadata).
Updated also reference.
```shell
➜ curl -v 'http://localhost:3042/movies?limit=2&offset=0&totalCount=true'
*   Trying 127.0.0.1:3042...
* Connected to localhost (127.0.0.1) port 3042 (#0)
> GET /movies?limit=2&offset=0&totalCount=true HTTP/1.1
> Host: localhost:3042
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-total-count: 18
< content-type: application/json; charset=utf-8
< content-length: 53
< Date: Wed, 28 Sep 2022 16:16:57 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< 
* Connection #0 to host localhost left intact
[{"id":1,"title":"Movie1"},{"id":2,"title":"Movie2"}]%  
``` 