### PR TITLE
Use to the correct dockerhub repository

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,5 +25,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: platformatic/platformatic-private:latest
+          tags: platformatic/platformatic:latest
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
@mcollina currently we just tag as `latest`, shall we also tag with version?