### PR TITLE
fix: add sql files to watch ignore

### DIFF
--- a/packages/db/lib/config.js
+++ b/packages/db/lib/config.js
@@ -16,7 +16,7 @@ class DBConfigManager extends ConfigManager {
         coerceTypes: true,
         allErrors: true
       },
-      watchIgnore: ['*.ts', ...(opts.watchIgnore || [])],
+      watchIgnore: ['*.ts', '*.sql', '**/*.sql', ...(opts.watchIgnore || [])],
       envWhitelist: ['PORT', 'DATABASE_URL', ...(opts.envWhitelist || [])]
     })
   }

--- a/packages/db/test/config.test.js
+++ b/packages/db/test/config.test.js
@@ -229,7 +229,7 @@ test('ignore watch sqlite file', async ({ teardown, equal, same, comment }) => {
     })
     const parseResult = await cm.parse()
     equal(parseResult, true)
-    same(cm.watchIgnore, ['*.ts', 'db-watchIgnore.sqlite', 'db-watchIgnore.sqlite-journal', '.esm*'])
+    same(cm.watchIgnore, ['*.ts', '*.sql', '**/*.sql', 'db-watchIgnore.sqlite', 'db-watchIgnore.sqlite-journal', '.esm*'])
   }
 
   {
@@ -249,7 +249,7 @@ test('ignore watch sqlite file', async ({ teardown, equal, same, comment }) => {
     })
     const parseResult = await cm.parse()
     equal(parseResult, true)
-    same(cm.watchIgnore, ['*.ts', join('databases', 'db-watchIgnore.sqlite'), join('databases', 'db-watchIgnore.sqlite-journal'), '.esm*'])
+    same(cm.watchIgnore, ['*.ts', '*.sql', '**/*.sql', join('databases', 'db-watchIgnore.sqlite'), join('databases', 'db-watchIgnore.sqlite-journal'), '.esm*'])
   }
 })
 


### PR DESCRIPTION
Fix #87 

@mcollina @marcopiraccini Since we don't want to watch .sql files, maybe it's better to watch only .js, .mjs, .json files instead of ignoring all others in watch ignore. There can be a lot of configs, docs, etc files that shouldn't trigger server reload. WDYT?
