### PR TITLE
fix: adds basic query logging for sqlite

### DIFF
--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -72,6 +72,13 @@ async function connect ({ connectionString, log, onDatabaseLoad, ignore = {}, au
     const sqlite = require('@databases/sqlite')
     const path = connectionString.replace('sqlite://', '')
     db = sqlite(connectionString === 'sqlite://:memory:' ? undefined : path)
+    db._database.on('trace', sql => {
+      log.trace({
+        query: {
+          text: sql
+        }
+      }, 'query')
+    })
     sql = sqlite.sql
     queries = queriesFactory.sqlite
     db.isSQLite = true


### PR DESCRIPTION
Partially fixes: #92.

Simple "workaround" to emit queries text on trace using sqlite3 debugging hook: https://github.com/TryGhost/node-sqlite3/wiki/Debugging. 

It doesn't have all the hooks that `createConnectionPool`  but at least it provides the basic query output.
