### PR TITLE
Nested routes in openapi

### DIFF
--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -104,7 +104,7 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
   "paths": {
     "/graphs/": {
       "get": {
-        "operationId": "getAllGraph",
+        "operationId": "getGraphs",
         "parameters": [
           {
             "schema": {

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -4,25 +4,18 @@ const { mapSQLTypeToOpenAPIType } = require('@platformatic/sql-json-schema-mappe
 const camelcase = require('camelcase')
 const { singularize } = require('inflected')
 
-async function entityPlugin (app, opts) {
-  const entity = opts.entity
-
-  const entitySchema = {
-    $ref: entity.name + '#'
-  }
-  const primaryKeyParams = getPrimaryKeyParams(entity)
+const getEntityLinksForEntity = (app, entity) => {
   const entityLinks = {}
-  const primaryKeyCamelcase = camelcase(entity.primaryKey)
-
   for (const relation of entity.relations) {
     const ownField = camelcase(relation.column_name)
     const relatedEntity = app.platformatic.entities[camelcase(singularize(relation.foreign_table_name))]
-    const relatedEntityPrimaryKeyCamelcase = capitalize(camelcase(relatedEntity.primaryKey))
-    const getEntityById = `Get${relatedEntity.name}With${relatedEntityPrimaryKeyCamelcase}`
+    const relatedEntityPrimaryKeyCamelcase = camelcase(relatedEntity.primaryKey)
+    const relatedEntityPrimaryKeyCamelcaseCapitalized = capitalize(relatedEntityPrimaryKeyCamelcase)
+    const getEntityById = `Get${relatedEntity.name}By${relatedEntityPrimaryKeyCamelcaseCapitalized}`
     entityLinks[getEntityById] = {
-      operationId: `get${relatedEntity.name}By${relatedEntityPrimaryKeyCamelcase}`,
+      operationId: `get${relatedEntity.name}By${relatedEntityPrimaryKeyCamelcaseCapitalized}`,
       parameters: {
-        [primaryKeyCamelcase]: `$response.body#/${ownField}`
+        [relatedEntityPrimaryKeyCamelcase]: `$response.body#/${ownField}`
       }
     }
   }
@@ -32,14 +25,34 @@ async function entityPlugin (app, opts) {
     const theirField = camelcase(relation.column_name)
     const ownField = camelcase(relation.foreign_column_name)
     const relatedEntity = app.platformatic.entities[camelcase(singularize(relation.table_name))]
-    const getAllEntities = `GetAll${capitalize(relatedEntity.pluralName)}`
-    entityLinks[getAllEntities] = {
-      operationId: `getAll${capitalize(relatedEntity.pluralName)}`,
+    const getEntities = `Get${capitalize(relatedEntity.pluralName)}`
+    entityLinks[getEntities] = {
+      operationId: `get${capitalize(relatedEntity.pluralName)}`,
       parameters: {
         [`where.${theirField}.eq`]: `$response.body#/${ownField}`
       }
     }
   }
+  return entityLinks
+}
+
+const getFieldsForEntity = (entity) => ({
+  type: 'array',
+  items: {
+    type: 'string',
+    enum: Object.keys(entity.fields).map((field) => entity.fields[field].camelcase).sort()
+  }
+})
+
+async function entityPlugin (app, opts) {
+  const entity = opts.entity
+
+  const entitySchema = {
+    $ref: entity.name + '#'
+  }
+  const primaryKeyParams = getPrimaryKeyParams(entity)
+  const primaryKeyCamelcase = camelcase(entity.primaryKey)
+  const entityLinks = getEntityLinksForEntity(app, entity)
 
   const whereArgs = Object.keys(entity.fields).sort().map((name) => {
     return entity.fields[name]
@@ -72,17 +85,11 @@ async function entityPlugin (app, opts) {
     }
   })
 
-  const fields = {
-    type: 'array',
-    items: {
-      type: 'string',
-      enum: Object.keys(entity.fields).map((field) => entity.fields[field].camelcase).sort()
-    }
-  }
+  const fields = getFieldsForEntity(entity)
 
   app.get('/', {
     schema: {
-      operationId: 'getAll' + entity.name,
+      operationId: 'get' + capitalize(entity.pluralName),
       querystring: {
         type: 'object',
         properties: {
@@ -191,6 +198,137 @@ async function entityPlugin (app, opts) {
     }
     return res[0]
   })
+
+  // For every reverse relationship we create: entity/:entity_Id/target_entity
+  for (const reverseRelationship of entity.reverseRelationships) {
+    const targetEntityName = singularize(camelcase(reverseRelationship.relation.table_name))
+    const targetEntity = app.platformatic.entities[targetEntityName]
+    const targetForeignKeyCamelcase = camelcase(reverseRelationship.relation.column_name)
+    const targetEntitySchema = {
+      $ref: targetEntity.name + '#'
+    }
+    const entityLinks = getEntityLinksForEntity(app, targetEntity)
+    // e.g. getQuotesForMovie
+    const operationId = `get${capitalize(targetEntity.pluralName)}For${capitalize(entity.singularName)}`
+    app.get(`/:${camelcase(entity.primaryKey)}/${targetEntity.pluralName}`, {
+      schema: {
+        operationId,
+        params: getPrimaryKeyParams(entity),
+        querystring: {
+          type: 'object',
+          properties: {
+            fields: getFieldsForEntity(targetEntity)
+          }
+        },
+        response: {
+          200: {
+            type: 'array',
+            items: targetEntitySchema
+          }
+        }
+      },
+      links: {
+        200: entityLinks
+      }
+    }, async function (request, reply) {
+      const ctx = { app: this, reply }
+      // IF we want to have HTTP/404 in case the entity does not exist
+      // we need to do 2 queries. One to check if the entity exists. the other to get the related entities
+      // Improvement: this could be also done with a single query with a join,
+
+      // check that the entity exists
+      const resEntity = await entity.count({
+        ctx,
+        where: {
+          [primaryKeyCamelcase]: {
+            eq: request.params[primaryKeyCamelcase]
+          }
+        }
+      })
+      if (resEntity === 0) {
+        return reply.callNotFound()
+      }
+
+      // get the related entities
+      const res = await targetEntity.find({
+        ctx,
+        where: {
+          [targetForeignKeyCamelcase]: {
+            eq: request.params[primaryKeyCamelcase]
+          }
+        },
+        fields: request.query.fields
+
+      })
+      if (res.length === 0) {
+        // This is a query on a FK, so
+        return []
+      }
+      return res
+    })
+  }
+
+  // For every relationship we create: entity/:entity_Id/target_entity
+  for (const relation of entity.relations) {
+    const targetEntityName = singularize(camelcase(relation.foreign_table_name))
+    const targetEntity = app.platformatic.entities[targetEntityName]
+    const targetForeignKeyCamelcase = camelcase(relation.foreign_column_name)
+    const targetEntitySchema = {
+      $ref: targetEntity.name + '#'
+    }
+    const entityLinks = getEntityLinksForEntity(app, targetEntity)
+    // e.g. getMovieForQuote
+    const operationId = `get${capitalize(targetEntity.singularName)}For${capitalize(entity.singularName)}`
+    app.get(`/:${camelcase(entity.primaryKey)}/${targetEntity.singularName}`, {
+      schema: {
+        operationId,
+        params: getPrimaryKeyParams(entity),
+        querystring: {
+          type: 'object',
+          properties: {
+            fields: getFieldsForEntity(targetEntity)
+          }
+        },
+        response: {
+          200: targetEntitySchema
+        }
+      },
+      links: {
+        200: entityLinks
+      }
+    }, async function (request, reply) {
+      const ctx = { app: this, reply }
+      // check that the entity exists
+      const resEntity = await entity.count({
+        ctx,
+        where: {
+          [primaryKeyCamelcase]: {
+            eq: request.params[primaryKeyCamelcase]
+          }
+        }
+      })
+
+      if (resEntity === 0) {
+        return reply.callNotFound()
+      }
+
+      // get the related entity
+      const res = await targetEntity.find({
+        ctx,
+        where: {
+          [targetForeignKeyCamelcase]: {
+            eq: request.params[primaryKeyCamelcase]
+          }
+        },
+        fields: request.query.fields
+      })
+
+      if (res.length === 0) {
+        return reply.callNotFound()
+      }
+      return res[0]
+    })
+  }
 
   for (const method of ['POST', 'PUT']) {
     app.route({

--- a/packages/sql-openapi/test/nested.test.js
+++ b/packages/sql-openapi/test/nested.test.js
@@ -1,0 +1,216 @@
+
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')
+const sqlOpenAPI = require('..')
+const sqlMapper = require('@platformatic/sql-mapper')
+const { clear, connInfo, isSQLite, isMysql } = require('./helper')
+const { resolve } = require('path')
+const { test } = t
+
+Object.defineProperty(t, 'fullname', {
+  value: 'platformatic/db/openapi/where'
+})
+
+test('nested routes', async (t) => {
+  const { pass, teardown, same, equal, matchSnapshot } = t
+  t.snapshotFile = resolve(__dirname, 'tap-snapshots', 'nested-routes-openapi.cjs')
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isMysql) {
+        await db.query(sql`
+          CREATE TABLE owners (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(255)
+          );
+          CREATE TABLE posts (
+            id SERIAL PRIMARY KEY,
+            title VARCHAR(42),
+            long_text TEXT,
+            counter INTEGER,
+            owner_id BIGINT UNSIGNED,
+            FOREIGN KEY (owner_id) REFERENCES owners(id) ON DELETE CASCADE
+          );
+        `)
+      } else if (isSQLite) {
+        await db.query(sql`
+          CREATE TABLE owners (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR(255)
+          );
+        `)
+
+        await db.query(sql`
+          CREATE TABLE posts (
+            id INTEGER PRIMARY KEY,
+            title VARCHAR(42),
+            long_text TEXT,
+            counter INTEGER,
+            owner_id BIGINT UNSIGNED,
+            FOREIGN KEY (owner_id) REFERENCES owners(id) ON DELETE CASCADE
+          );
+        `)
+      } else {
+        await db.query(sql`
+        CREATE TABLE owners (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(255)
+        );
+        CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER,
+          owner_id INTEGER REFERENCES owners(id)
+        );`)
+      }
+    }
+  })
+  app.register(sqlOpenAPI)
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json'
+    })
+    const openapi = res.json()
+    matchSnapshot(openapi, 'matches expected OpenAPI defs')
+  }
+
+  const owners = [{
+    name: 'Matteo'
+  }, {
+    name: 'Luca'
+  }, {
+    name: 'Marco'
+  }]
+
+  const posts = [{
+    title: 'Dog',
+    longText: 'Foo',
+    counter: 10
+  }, {
+    title: 'Cat',
+    longText: 'Bar',
+    counter: 20
+  }, {
+    title: 'Mouse',
+    longText: 'Baz',
+    counter: 30
+  }, {
+    title: 'Duck',
+    longText: 'A duck tale',
+    counter: 40
+  }, {
+    title: 'Horse',
+    longText: 'A horse tale',
+    counter: 50
+  }]
+
+  const ownerIds = []
+  for (const body of owners) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/owners',
+      body
+    })
+    equal(res.statusCode, 200, 'POST /owners status code')
+    ownerIds.push(res.json().id)
+  }
+
+  // Marco has no posts on purpose
+  posts[0].ownerId = ownerIds[0]
+  posts[1].ownerId = ownerIds[0]
+  posts[2].ownerId = ownerIds[1]
+  posts[3].ownerId = ownerIds[1]
+  posts[4].ownerId = null
+
+  for (const body of posts) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/posts',
+      body
+    })
+    equal(res.statusCode, 200, 'POST /posts status code')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/owners/${ownerIds[0]}/posts?fields=title,longText,counter,ownerId`
+    })
+    equal(res.statusCode, 200, 'GET /owners/:id/posts status code')
+    same(res.json(), [posts[0], posts[1]], 'GET /owners/:id/posts response')
+  }
+
+  {
+    // Owner exists, but has no posts
+    const res = await app.inject({
+      method: 'GET',
+      url: '/owners/3/posts'
+    })
+    equal(res.statusCode, 200, 'GET /owners/:id/posts status code')
+    same(res.json(), [], 'GET /owners/:id/posts response')
+  }
+
+  {
+    // Owner does not exist
+    const res = await app.inject({
+      method: 'GET',
+      url: '/owners/42/posts'
+    })
+    equal(res.statusCode, 404, 'GET /posts status code')
+    same(res.json(), {
+      message: 'Route GET:/owners/42/posts not found',
+      error: 'Not Found',
+      statusCode: 404
+    }, 'GET /owners/:id/posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts/1/owner'
+    })
+    equal(res.statusCode, 200, 'GET /posts/:id/owner status code')
+    same(res.json().name, owners[0].name, 'GET /posts/:id/owner response')
+  }
+
+  {
+    // Post does not exist
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts/42/owner'
+    })
+    equal(res.statusCode, 404, 'GET /posts/:id/owner status code')
+    same(res.json(), {
+      message: 'Route GET:/posts/42/owner not found',
+      error: 'Not Found',
+      statusCode: 404
+    }, 'GET /posts/:id/owner response')
+  }
+
+  {
+    // Post exists, owner does not
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts/5/owner'
+    })
+    equal(res.statusCode, 404, 'GET /posts/:id/owner status code')
+    same(res.json(), {
+      message: 'Route GET:/posts/5/owner not found',
+      error: 'Not Found',
+      statusCode: 404
+    }, 'GET /posts/:id/owner response')
+  }
+})

--- a/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports['platformatic/db/openapi/where nested where > matches expected OpenAPI defs 1'] = `
+exports['platformatic/db/openapi/where nested routes > matches expected OpenAPI defs 1'] = `
 Object {
   "components": Object {
     "schemas": Object {

--- a/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
@@ -38,7 +38,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
-        "operationId": "getAllPage",
+        "operationId": "getPages",
         "parameters": Array [
           Object {
             "in": "query",

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
@@ -35,7 +35,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
-        "operationId": "getAllPage",
+        "operationId": "getPages",
         "parameters": Array [
           Object {
             "in": "query",

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
@@ -34,7 +34,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
-        "operationId": "getAllPage",
+        "operationId": "getPages",
         "parameters": Array [
           Object {
             "in": "query",

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
@@ -36,7 +36,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
-        "operationId": "getAllPage",
+        "operationId": "getPages",
         "parameters": Array [
           Object {
             "in": "query",

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
@@ -42,7 +42,7 @@ Object {
   "paths": Object {
     "/posts/": Object {
       "get": Object {
-        "operationId": "getAllPost",
+        "operationId": "getPosts",
         "parameters": Array [
           Object {
             "in": "query",


### PR DESCRIPTION
Fixes: #8 

Some notes: 
- Renamed `getAllXXX` to `getXXX`. The reason is that we can filter, so we don're really get `all`, IMO is a wrong naming. 
- `/movies/42/posts`: if the movie with PK `42` does not exists, returns HTTP/404, then if there are no posts, `[]`
- `/post/42/movie`: Returns HTTP/404, then if there are no post `42` OR if there is no movie associated.

For the check above this implementation uses 2 `entity.find`. This can be improved with one query (with outer join)

TODO: documentation, will do in a different PR, this one is already too big. 
