### PR TITLE
feat: add endpoint for dashboard metrics

### DIFF
--- a/packages/db-dashboard/index.js
+++ b/packages/db-dashboard/index.js
@@ -2,6 +2,64 @@
 
 const fastifyStatic = require('@fastify/static')
 const path = require('path')
+
+function roundNumber (value, precision = 0) {
+  const multiplier = Math.pow(10, precision || 0)
+  return Math.round((value + Number.EPSILON) * multiplier) / multiplier
+}
+
+function transformHttpPromMetrics (httpMetrics = []) {
+  const requestMetrics = {
+    reqMetrics: {},
+    totalReqCount: 0
+  }
+
+  for (const metric of httpMetrics) {
+    const { method, route, status_code: statusCode } = metric.labels
+    if (!requestMetrics.reqMetrics[method]) {
+      requestMetrics.reqMetrics[method] = {}
+    }
+    const methodMetrics = requestMetrics.reqMetrics[method]
+
+    if (!methodMetrics[route]) {
+      methodMetrics[route] = {
+        reqCountPerStatusCode: {},
+        totalReqCount: 0
+      }
+    }
+    const routeMetrics = methodMetrics[route]
+
+    if (metric.metricName === 'http_request_summary_seconds_count') {
+      routeMetrics.reqCountPerStatusCode[statusCode] = metric.value
+      routeMetrics.totalReqCount += metric.value
+      requestMetrics.totalReqCount += metric.value
+      continue
+    }
+    if (metric.labels && metric.labels.quantile === 0.5) {
+      const medianResponseTimeSec = metric.value
+      routeMetrics.medianResponseTime = roundNumber(medianResponseTimeSec * 1000)
+      continue
+    }
+  }
+
+  let failedCount = 0
+  for (const methodMetrics of Object.values(requestMetrics.reqMetrics)) {
+    for (const routeMetrics of Object.values(methodMetrics)) {
+      let reqFailedCount = 0
+      for (const statusCode in routeMetrics.reqCountPerStatusCode) {
+        if (statusCode.charAt(0) !== '2') {
+          reqFailedCount += routeMetrics.reqCountPerStatusCode[statusCode]
+        }
+      }
+      failedCount += reqFailedCount
+      routeMetrics.failureRate = roundNumber(reqFailedCount / routeMetrics.totalReqCount, 2)
+    }
+  }
+  requestMetrics.failureRate = roundNumber(failedCount / requestMetrics.totalReqCount || 0, 2)
+
+  return requestMetrics
+}
+
 module.exports = async function app (app, opts) {
   app.log.info('dashboard plugin loaded.')
   if (opts.dashboardAtRoot !== false) {
@@ -16,5 +74,17 @@ module.exports = async function app (app, opts) {
 
   app.get('/dashboard', { hide: true }, function (req, reply) {
     return reply.sendFile('index.html')
+  })
+
+  app.get('/dashboard/metrics', { hide: true }, async function (req, reply) {
+    if (app.metrics === undefined) {
+      reply.status = 404
+      reply.send({ error: 'Metrics plugin is not enabled' })
+      return
+    }
+
+    const metrics = await app.metrics.client.register.getMetricsAsJSON()
+    const httpMetrics = metrics.find((metric) => metric.name === 'http_request_summary_seconds').values
+    return transformHttpPromMetrics(httpMetrics)
   })
 }

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -55,16 +55,16 @@ async function platformaticDB (app, opts) {
     await execute(app.log, { config: opts.configFileLocation }, opts)
   }
 
-  // Metrics plugin
-  if (isKeyEnabledInConfig('metrics', opts)) {
-    app.register(require('./lib/metrics-plugin'), opts.metrics)
-  }
-
   app.register(require('./_admin'), { ...opts, prefix: '_admin' })
   if (isKeyEnabledInConfig('dashboard', opts) && opts.dashboard.enabled) {
     await app.register(dashboard, {
       dashboardAtRoot: opts.dashboard.rootPath || true
     })
+  }
+
+  // Metrics plugin
+  if (isKeyEnabledInConfig('metrics', opts)) {
+    app.register(require('./lib/metrics-plugin'), opts.metrics)
   }
 
   app.register(core, opts.core)

--- a/packages/db/lib/metrics-plugin.js
+++ b/packages/db/lib/metrics-plugin.js
@@ -29,7 +29,10 @@ module.exports = fp(async function (app, opts) {
     defaultMetrics: { enabled: true },
     endpoint: null,
     name: 'metrics',
-    routeMetrics: { enabled: true },
+    routeMetrics: {
+      enabled: true,
+      groupStatusCodes: true
+    },
     clearRegisterOnInit: true
   })
 

--- a/packages/db/lib/metrics-plugin.js
+++ b/packages/db/lib/metrics-plugin.js
@@ -29,10 +29,7 @@ module.exports = fp(async function (app, opts) {
     defaultMetrics: { enabled: true },
     endpoint: null,
     name: 'metrics',
-    routeMetrics: {
-      enabled: true,
-      groupStatusCodes: true
-    },
+    routeMetrics: { enabled: true },
     clearRegisterOnInit: true
   })
 

--- a/packages/db/lib/metrics-plugin.js
+++ b/packages/db/lib/metrics-plugin.js
@@ -6,65 +6,12 @@ const basicAuth = require('@fastify/basic-auth')
 const fastifyAccepts = require('@fastify/accepts')
 const Fastify = require('fastify')
 const http = require('http')
-const { roundNumber } = require('./utils')
 
 // This is a global server to match global
 // prometheus. It's an antipattern, so do
 // not use it elsewhere.
 let server = null
 let handler = null
-
-function transformHttpPromMetrics (httpMetrics = []) {
-  const requestMetrics = {
-    reqMetrics: {},
-    totalReqCount: 0
-  }
-
-  for (const metric of httpMetrics) {
-    const { method, route, status_code: statusCode } = metric.labels
-    if (!requestMetrics.reqMetrics[method]) {
-      requestMetrics.reqMetrics[method] = {}
-    }
-    const methodMetrics = requestMetrics.reqMetrics[method]
-
-    if (!methodMetrics[route]) {
-      methodMetrics[route] = {
-        reqCountPerStatusCode: {},
-        totalReqCount: 0
-      }
-    }
-    const routeMetrics = methodMetrics[route]
-
-    if (metric.metricName === 'http_request_summary_seconds_count') {
-      routeMetrics.reqCountPerStatusCode[statusCode] = metric.value
-      routeMetrics.totalReqCount += metric.value
-      requestMetrics.totalReqCount += metric.value
-      continue
-    }
-    if (metric.labels && metric.labels.quantile === 0.5) {
-      const medianResponseTimeSec = metric.value
-      routeMetrics.medianResponseTime = roundNumber(medianResponseTimeSec * 1000)
-      continue
-    }
-  }
-
-  let failedCount = 0
-  for (const methodMetrics of Object.values(requestMetrics.reqMetrics)) {
-    for (const routeMetrics of Object.values(methodMetrics)) {
-      let reqFailedCount = 0
-      for (const statusCode in routeMetrics.reqCountPerStatusCode) {
-        if (statusCode.charAt(0) !== '2') {
-          reqFailedCount += routeMetrics.reqCountPerStatusCode[statusCode]
-        }
-      }
-      failedCount += reqFailedCount
-      routeMetrics.failureRate = roundNumber(reqFailedCount / routeMetrics.totalReqCount, 2)
-    }
-  }
-  requestMetrics.failureRate = roundNumber(failedCount / requestMetrics.totalReqCount || 0, 2)
-
-  return requestMetrics
-}
 
 module.exports = fp(async function (app, opts) {
   let port = 9090
@@ -128,17 +75,6 @@ module.exports = fp(async function (app, opts) {
     }
   }
 
-  const dashboardMetricsEndpointOptions = {
-    url: '/metrics/dashboard',
-    method: 'GET',
-    logLevel: 'info',
-    handler: async () => {
-      const metrics = await app.metrics.client.register.getMetricsAsJSON()
-      const httpMetrics = metrics.find((metric) => metric.name === 'http_request_summary_seconds').values
-      return transformHttpPromMetrics(httpMetrics)
-    }
-  }
-
   if (opts.auth) {
     const { username, password } = opts.auth
     await promServer.register(basicAuth, {
@@ -152,7 +88,6 @@ module.exports = fp(async function (app, opts) {
     metricsEndpointOptions.onRequest = promServer.basicAuth
   }
   promServer.route(metricsEndpointOptions)
-  promServer.route(dashboardMetricsEndpointOptions)
 
   app.addHook('onClose', async (instance) => {
     await promServer.close()

--- a/packages/db/lib/utils.js
+++ b/packages/db/lib/utils.js
@@ -104,6 +104,11 @@ function getJSPluginPath (tsPluginPath, compileDir) {
   return join(cwd, compileDir, jsPluginRelativePath)
 }
 
+function roundNumber (value, precision = 0) {
+  const multiplier = Math.pow(10, precision || 0)
+  return Math.round((value + Number.EPSILON) * multiplier) / multiplier
+}
+
 module.exports = {
   setupDB,
   getJSPluginPath,
@@ -111,5 +116,6 @@ module.exports = {
   computeSQLiteIgnores,
   addLoggerToTheConfig,
   findConfigFile,
-  urlDirname
+  urlDirname,
+  roundNumber
 }

--- a/packages/db/lib/utils.js
+++ b/packages/db/lib/utils.js
@@ -104,11 +104,6 @@ function getJSPluginPath (tsPluginPath, compileDir) {
   return join(cwd, compileDir, jsPluginRelativePath)
 }
 
-function roundNumber (value, precision = 0) {
-  const multiplier = Math.pow(10, precision || 0)
-  return Math.round((value + Number.EPSILON) * multiplier) / multiplier
-}
-
 module.exports = {
   setupDB,
   getJSPluginPath,
@@ -116,6 +111,5 @@ module.exports = {
   computeSQLiteIgnores,
   addLoggerToTheConfig,
   findConfigFile,
-  urlDirname,
-  roundNumber
+  urlDirname
 }

--- a/packages/db/test/metrics.test.js
+++ b/packages/db/test/metrics.test.js
@@ -2,7 +2,7 @@
 
 const { test, equal } = require('tap')
 const { buildServer } = require('..')
-const { buildConfig, connInfo } = require('./helper')
+const { buildConfig, connInfo, createBasicPages, clear } = require('./helper')
 const { request } = require('undici')
 
 test('has /metrics endpoint on default prometheus port', async ({ teardown, equal, fail, match }) => {
@@ -215,6 +215,122 @@ test('do not error on restart', async ({ teardown, equal, fail, match }) => {
   const body = await res.body.text()
   try {
     testPrometheusOutput(body)
+  } catch (err) {
+    fail()
+  }
+})
+
+test('call /metrics/dashboard before any requests', async ({ teardown, equal, same, fail, match }) => {
+  const server = await buildServer(buildConfig({
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    metrics: true,
+    core: {
+      ...connInfo,
+      async onDatabaseLoad (db, sql) {
+        await clear(db, sql)
+        await createBasicPages(db, sql)
+      }
+    },
+    authorization: {
+      adminSecret: 'secret'
+    }
+  }))
+  teardown(server.stop)
+  await server.listen()
+
+  const res = await (request('http://127.0.0.1:9090/metrics/dashboard'))
+  equal(res.statusCode, 200)
+  match(res.headers['content-type'], /^application\/json/)
+  try {
+    const body = await res.body.json()
+
+    same(body.reqMetrics, {})
+    equal(body.failureRate, 0)
+    equal(body.totalReqCount, 0)
+  } catch (err) {
+    fail()
+  }
+})
+
+test('call /metrics/dashboard after user requests', async ({ teardown, equal, has, fail, match }) => {
+  const server = await buildServer(buildConfig({
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    metrics: true,
+    core: {
+      ...connInfo,
+      async onDatabaseLoad (db, sql) {
+        await clear(db, sql)
+        await createBasicPages(db, sql)
+      }
+    },
+    authorization: {
+      adminSecret: 'secret'
+    }
+  }))
+  teardown(server.stop)
+  await server.listen()
+
+  const authHeaders = {
+    'X-PLATFORMATIC-ADMIN-SECRET': 'secret'
+  }
+
+  await Promise.all([
+    server.inject({ method: 'GET', url: '/pages' }),
+    server.inject({ method: 'GET', url: '/pages', headers: authHeaders }),
+    server.inject({ method: 'GET', url: '/pages', headers: authHeaders }),
+    server.inject({ method: 'GET', url: '/pages/0' }),
+    server.inject({ method: 'GET', url: '/pages/0', headers: authHeaders }),
+    server.inject({ method: 'POST', url: '/pages/0', body: {} }),
+    server.inject({ method: 'POST', url: '/graphql', headers: authHeaders, body: {} })
+  ])
+
+  const res = await (request('http://127.0.0.1:9090/metrics/dashboard'))
+  equal(res.statusCode, 200)
+  match(res.headers['content-type'], /^application\/json/)
+  try {
+    const body = await res.body.json()
+
+    const expectedReqMetrics = {
+      GET: {
+        '/pages': {
+          reqCountPerStatusCode: { 200: 2, 401: 1 },
+          totalReqCount: 3,
+          failureRate: 0.33
+        },
+        '/pages/:id': {
+          reqCountPerStatusCode: { 401: 1 },
+          totalReqCount: 1,
+          failureRate: 1
+        },
+        __unknown__: {
+          reqCountPerStatusCode: { 404: 1 },
+          totalReqCount: 1,
+          failureRate: 1
+        }
+      },
+      POST: {
+        '/pages/:id': {
+          reqCountPerStatusCode: { 401: 1 },
+          totalReqCount: 1,
+          failureRate: 1
+        },
+        '/graphql': {
+          reqCountPerStatusCode: { 400: 1 },
+          totalReqCount: 1,
+          failureRate: 1
+        }
+      }
+    }
+
+    has(body.reqMetrics, expectedReqMetrics)
+    equal(body.failureRate, 0.71)
+    equal(body.totalReqCount, 7)
   } catch (err) {
     fail()
   }

--- a/packages/db/test/metrics.test.js
+++ b/packages/db/test/metrics.test.js
@@ -227,6 +227,9 @@ test('call /metrics/dashboard before any requests', async ({ teardown, equal, sa
       port: 0
     },
     metrics: true,
+    dashboard: {
+      enabled: true
+    },
     core: {
       ...connInfo,
       async onDatabaseLoad (db, sql) {
@@ -239,9 +242,9 @@ test('call /metrics/dashboard before any requests', async ({ teardown, equal, sa
     }
   }))
   teardown(server.stop)
-  await server.listen()
+  const { port } = await server.listen()
 
-  const res = await (request('http://127.0.0.1:9090/metrics/dashboard'))
+  const res = await (request(`http://127.0.0.1:${port}/dashboard/metrics`))
   equal(res.statusCode, 200)
   match(res.headers['content-type'], /^application\/json/)
   try {
@@ -262,6 +265,9 @@ test('call /metrics/dashboard after user requests', async ({ teardown, equal, ha
       port: 0
     },
     metrics: true,
+    dashboard: {
+      enabled: true
+    },
     core: {
       ...connInfo,
       async onDatabaseLoad (db, sql) {
@@ -274,7 +280,7 @@ test('call /metrics/dashboard after user requests', async ({ teardown, equal, ha
     }
   }))
   teardown(server.stop)
-  await server.listen()
+  const { port } = await server.listen()
 
   const authHeaders = {
     'X-PLATFORMATIC-ADMIN-SECRET': 'secret'
@@ -290,11 +296,12 @@ test('call /metrics/dashboard after user requests', async ({ teardown, equal, ha
     server.inject({ method: 'POST', url: '/graphql', headers: authHeaders, body: {} })
   ])
 
-  const res = await (request('http://127.0.0.1:9090/metrics/dashboard'))
+  const res = await (request(`http://127.0.0.1:${port}/dashboard/metrics`))
   equal(res.statusCode, 200)
   match(res.headers['content-type'], /^application\/json/)
   try {
     const body = await res.body.json()
+    console.log(body)
 
     const expectedReqMetrics = {
       GET: {


### PR DESCRIPTION
Example of output:

```json
{
  "reqMetrics": {
    "POST": {
      "/movies": {
        "reqCountPerStatusCode": {
          "200": 4,
          "400": 3
        },
        "totalReqCount": 7,
        "medianResponseTime": 1,
        "failureRate": 0.43
      }
    },
    "GET": {
      "/movies": {
        "reqCountPerStatusCode": {
          "200": 5
        },
        "totalReqCount": 5,
        "medianResponseTime": 2,
        "failureRate": 0
      },
      "__unknown__": {
        "reqCountPerStatusCode": {
          "404": 3
        },
        "totalReqCount": 3,
        "medianResponseTime": 1,
        "failureRate": 1
      }
    }
  },
  "totalReqCount": 15,
  "failureRate": 0.4
}
```