### PR TITLE
Docker automatic publish on GH release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,9 +1,8 @@
-name: docker build
+name: docker release build
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   buildx:
@@ -25,5 +24,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: platformatic/platformatic:development
+          tags: |
+            platformatic/platformatic:latest
+            platformatic/platformatic:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,8 @@
 name: docker build
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   buildx:
@@ -25,5 +24,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: platformatic/platformatic:latest
+          tags: |
+            platformatic/platformatic:latest
+            platformatic/platformatic:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This leverage [the `release` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) to trigger the publish on dockerhub.
Then  `${{ github.ref_name }}` contains the name of the version (the tag name). 
Every time we create a new label with a version and we move `latest`
