### PR TITLE
refactor: optimize totalCount compute for X-Total-Count header

### DIFF
--- a/docs/reference/sql-rest/api.md
+++ b/docs/reference/sql-rest/api.md
@@ -71,7 +71,7 @@ $ curl -X 'GET' \
 
 ### Total Count
 
-If `totalCount` boolean is in query, the GET returns the total number of elements in the `X-Total-Count` header ignoring `limit` and `offset` (if specified).
+If `totalCount` boolean is `true` in query, the GET returns the total number of elements in the `X-Total-Count` header ignoring `limit` and `offset` (if specified).
 
 ```bash
 $ curl -v -X 'GET' \

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -140,10 +140,18 @@ async function entityPlugin (app, opts) {
 
     const ctx = { app: this, reply }
     const res = await entity.find({ limit, offset, fields, orderBy, where, ctx })
+
+    // X-Total-Count header
     if (query.totalCount) {
-      const totalCount = await entity.count({ where, ctx })
+      let totalCount
+      if ((((offset ?? 0) === 0) || (res.length > 0)) && ((limit === undefined) || (res.length < limit))) {
+        totalCount = (offset ?? 0) + res.length
+      } else {
+        totalCount = await entity.count({ where, ctx })
+      }
       reply.header('X-Total-Count', totalCount)
     }
+
     return res
   })
 

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -324,10 +324,17 @@ test('list', async ({ pass, teardown, same, equal }) => {
   }
 
   {
+    const url = '/posts?totalCount=true'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
+  }
+
+  {
     const url = '/posts?totalCount=true&limit=2&offset=1'
     const res = await app.inject({ method: 'GET', url })
-    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
     equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
     }).slice(1, 3), `${url} response`)

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -284,70 +284,58 @@ test('list', async ({ pass, teardown, same, equal }) => {
   }
 
   {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/posts'
-    })
-    equal(res.statusCode, 200, '/posts status code')
-    equal(res.headers['x-total-count'], undefined, '/posts without x-total-count')
+    const url = '/posts'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], undefined, `${url} without x-total-count`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
     }), '/posts response')
   }
 
   {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/posts?limit=3'
-    })
-    equal(res.statusCode, 200, '/posts?limit=3 status code')
+    const url = '/posts?limit=3'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
-    }).slice(0, 3), '/posts?limit=3 response')
+    }).slice(0, 3), `${url} response`)
   }
 
   {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/posts?offset=2'
-    })
-    equal(res.statusCode, 200, '/posts?offset=2 status code')
+    const url = '/posts?offset=2'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
-    }).slice(2), '/posts?offset=2 response')
+    }).slice(2), `${url} response`)
   }
 
   {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/posts?totalCount=true'
-    })
-    equal(res.headers['x-total-count'], posts.length, '/posts?totalCount=true with x-total-count')
-    equal(res.statusCode, 200, '/posts?totalCount=true status code')
+    const url = '/posts?totalCount=true'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
+    equal(res.statusCode, 200, `${url} status code`)
   }
 
   {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/posts?limit=2&offset=1'
-    })
-    equal(res.statusCode, 200, '/posts?limit=2&offset=1 status code')
-    same(res.headers['x-total-count'], undefined, '/posts?limit=2&offset=1 without x-total-count')
+    const url = '/posts?limit=2&offset=1'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], undefined, `${url} without x-total-count`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
-    }).slice(1, 3), '/posts?limit=2&offset=1 response')
+    }).slice(1, 3), `${url} response`)
   }
 
   {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/posts?limit=2&offset=1&totalCount=true'
-    })
-    equal(res.headers['x-total-count'], posts.length, '/posts?limit=2&offset=1&totalCount=true without x-total-count')
-    equal(res.statusCode, 200, 'posts status code')
+    const url = '/posts?limit=2&offset=1&totalCount=true'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.headers['x-total-count'], posts.length, `${url} without x-total-count`)
+    equal(res.statusCode, 200, `${url} status code`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
-    }).slice(1, 3), '/posts?limit=2&offset=1&totalCount=true response')
+    }).slice(1, 3), `${url} response`)
   }
 })
 

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -329,9 +329,9 @@ test('list', async ({ pass, teardown, same, equal }) => {
   }
 
   {
-    const url = '/posts?limit=2&offset=1&totalCount=true'
+    const url = '/posts?totalCount=true&limit=2&offset=1'
     const res = await app.inject({ method: 'GET', url })
-    equal(res.headers['x-total-count'], posts.length, `${url} without x-total-count`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
     equal(res.statusCode, 200, `${url} status code`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -331,6 +331,26 @@ test('list', async ({ pass, teardown, same, equal }) => {
   }
 
   {
+    const url = '/posts?totalCount=true&limit=3'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
+    same(res.json(), posts.map((p, i) => {
+      return { ...p, id: i + 1 + '' }
+    }).slice(0, 3), `${url} response`)
+  }
+
+  {
+    const url = '/posts?totalCount=true&offset=2'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
+    same(res.json(), posts.map((p, i) => {
+      return { ...p, id: i + 1 + '' }
+    }).slice(2), `${url} response`)
+  }
+
+  {
     const url = '/posts?totalCount=true&limit=2&offset=1'
     const res = await app.inject({ method: 'GET', url })
     equal(res.statusCode, 200, `${url} status code`)
@@ -338,6 +358,34 @@ test('list', async ({ pass, teardown, same, equal }) => {
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
     }).slice(1, 3), `${url} response`)
+  }
+
+  {
+    const url = '/posts?totalCount=true&limit=2&offset=99'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
+    same(res.json(), [], `${url} response`)
+  }
+
+  {
+    const url = '/posts?totalCount=true&limit=99&offset=0'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
+    same(res.json(), posts.map((p, i) => {
+      return { ...p, id: i + 1 + '' }
+    }).slice(0, 4), `${url} response`)
+  }
+
+  {
+    const url = '/posts?totalCount=true&limit=99&offset=2'
+    const res = await app.inject({ method: 'GET', url })
+    equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
+    same(res.json(), posts.map((p, i) => {
+      return { ...p, id: i + 1 + '' }
+    }).slice(2, 4), `${url} response`)
   }
 })
 

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -312,13 +312,6 @@ test('list', async ({ pass, teardown, same, equal }) => {
   }
 
   {
-    const url = '/posts?totalCount=true'
-    const res = await app.inject({ method: 'GET', url })
-    equal(res.headers['x-total-count'], posts.length, `${url} with x-total-count`)
-    equal(res.statusCode, 200, `${url} status code`)
-  }
-
-  {
     const url = '/posts?limit=2&offset=1'
     const res = await app.inject({ method: 'GET', url })
     equal(res.statusCode, 200, `${url} status code`)

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -297,6 +297,7 @@ test('list', async ({ pass, teardown, same, equal }) => {
     const url = '/posts?limit=3'
     const res = await app.inject({ method: 'GET', url })
     equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], undefined, `${url} without x-total-count`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
     }).slice(0, 3), `${url} response`)
@@ -306,6 +307,7 @@ test('list', async ({ pass, teardown, same, equal }) => {
     const url = '/posts?offset=2'
     const res = await app.inject({ method: 'GET', url })
     equal(res.statusCode, 200, `${url} status code`)
+    equal(res.headers['x-total-count'], undefined, `${url} without x-total-count`)
     same(res.json(), posts.map((p, i) => {
       return { ...p, id: i + 1 + '' }
     }).slice(2), `${url} response`)


### PR DESCRIPTION
computes `totalCount` without extra query execution when possible