### PR TITLE
feat(db): restrict additional properties usage in db config

### DIFF
--- a/packages/db/lib/gen-types.mjs
+++ b/packages/db/lib/gen-types.mjs
@@ -41,7 +41,7 @@ async function generateGlobalTypes (entities, config) {
   const globalTypesImports = []
   const globalTypesInterface = []
 
-  if (config.core.graphiql) {
+  if (config.core.graphql) {
     globalTypesImports.push('import graphqlPlugin from \'@platformatic/sql-graphql\'')
   }
 
@@ -88,7 +88,7 @@ async function checkForDependencies (logger, args, config) {
   requiredDependencies.fastify = await getDependencyVersion('fastify')
   requiredDependencies['@platformatic/sql-mapper'] = await getPlatformaticPackageVersion('sql-mapper')
 
-  if (config.core.graphiql) {
+  if (config.core.graphql) {
     requiredDependencies['@platformatic/sql-graphql'] = await getPlatformaticPackageVersion('sql-graphql')
   }
 

--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -55,7 +55,7 @@ function generateConfig (args) {
 
   const config = {
     server: { hostname, port },
-    core: { connectionString, graphiql: true },
+    core: { connectionString, graphql: true },
     migrations: { dir: migrations }
   }
 

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -90,6 +90,7 @@ const server = {
         {
           type: 'object',
           properties: {
+            enabled: { type: 'boolean' },
             interval: { type: 'integer' }
           },
           additionalProperties: false
@@ -98,7 +99,6 @@ const server = {
     },
     cors
   },
-  additionalProperties: false,
   required: ['hostname', 'port']
 }
 
@@ -147,16 +147,9 @@ const core = {
     ignore: {
       type: 'object',
       // TODO add support for column-level ignore
-      properties: {
-        key: {
-          type: 'string',
-          description: 'Non-entity table name.'
-        },
-        value: {
-          type: 'boolean'
-        }
-      },
-      additionalProperties: false
+      additionalProperties: {
+        type: 'boolean'
+      }
     }
   },
   additionalProperties: false,
@@ -225,10 +218,8 @@ const authorization = {
           defaults: {
             type: 'object',
             description: 'defaults for entity creation',
-            patternProperties: {
-              '.*': {
-                type: 'string'
-              }
+            additionalProperties: {
+              type: 'string'
             }
           },
           find: {
@@ -257,28 +248,26 @@ const authorization = {
           checks: {
             description: 'checks for the operation',
             type: 'object',
-            patternProperties: {
-              '.*': {
-                if: {
-                  type: 'object'
+            additionalProperties: {
+              if: {
+                type: 'object'
+              },
+              then: {
+                type: 'object',
+                properties: {
+                  eq: { type: 'string' },
+                  in: { type: 'string' },
+                  nin: { type: 'string' },
+                  nen: { type: 'string' },
+                  gt: { type: 'string' },
+                  gte: { type: 'string' },
+                  lt: { type: 'string' },
+                  lte: { type: 'string' }
                 },
-                then: {
-                  type: 'object',
-                  properties: {
-                    eq: { type: 'string' },
-                    in: { type: 'string' },
-                    nin: { type: 'string' },
-                    nen: { type: 'string' },
-                    gt: { type: 'string' },
-                    gte: { type: 'string' },
-                    lt: { type: 'string' },
-                    lte: { type: 'string' }
-                  },
-                  additionalProperties: false
-                },
-                else: {
-                  type: 'string'
-                }
+                additionalProperties: false
+              },
+              else: {
+                type: 'string'
               }
             }
           },
@@ -303,6 +292,9 @@ const dashboard = {
   $id: 'https://schemas.platformatic.dev/db/dashboard',
   type: 'object',
   properties: {
+    enabled: {
+      type: 'boolean'
+    },
     rootPath: {
       type: 'boolean',
       description: 'Whether the dashboard should be served on / path or not.',
@@ -319,6 +311,12 @@ const migrations = {
     dir: {
       type: 'string',
       description: 'The path to the directory containing the migrations.'
+    },
+    table: {
+      type: 'string'
+    },
+    validateChecksums: {
+      type: 'boolean'
     },
     autoApply: {
       type: 'boolean',

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -66,9 +66,10 @@ const cors = {
       type: 'boolean',
       default: true
     }
-  }
-
+  },
+  additionalProperties: false
 }
+
 const server = {
   $id: 'https://schemas.platformatic.dev/db/server',
   type: 'object',
@@ -90,12 +91,14 @@ const server = {
           type: 'object',
           properties: {
             interval: { type: 'integer' }
-          }
+          },
+          additionalProperties: false
         }
       ]
     },
     cors
   },
+  additionalProperties: false,
   required: ['hostname', 'port']
 }
 
@@ -115,7 +118,8 @@ const core = {
           graphiql: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }]
     },
     openapi: {
@@ -136,7 +140,8 @@ const core = {
             type: 'string',
             description: 'Base URL for the OpenAPI'
           }
-        }
+        },
+        additionalProperties: false
       }]
     },
     ignore: {
@@ -150,9 +155,11 @@ const core = {
         value: {
           type: 'boolean'
         }
-      }
+      },
+      additionalProperties: false
     }
   },
+  additionalProperties: false,
   required: ['connectionString']
 }
 
@@ -199,7 +206,8 @@ const authorization = {
           type: 'string',
           description: 'the webhook url'
         }
-      }
+      },
+      additionalProperties: false
     },
     rules: {
       type: 'array',
@@ -287,7 +295,6 @@ const authorization = {
         type: 'boolean',
         description: 'true if enabled (with not authorization constraints enabled)'
       }]
-
     }
   }
 }
@@ -301,7 +308,8 @@ const dashboard = {
       description: 'Whether the dashboard should be served on / path or not.',
       default: false
     }
-  }
+  },
+  additionalProperties: false
 }
 
 const migrations = {
@@ -317,6 +325,7 @@ const migrations = {
       description: 'Whether to automatically apply migrations when running the migrate command.'
     }
   },
+  additionalProperties: false,
   required: ['dir']
 }
 
@@ -335,9 +344,11 @@ const metrics = {
             username: { type: 'string' },
             password: { type: 'string' }
           },
+          additionalProperties: false,
           required: ['username', 'password']
         }
-      }
+      },
+      additionalProperties: false
     }
   ]
 }
@@ -349,7 +360,8 @@ const types = {
     autogenerate: {
       type: 'boolean'
     }
-  }
+  },
+  additionalProperties: false
 }
 
 const typescript = {
@@ -363,13 +375,13 @@ const typescript = {
       type: 'boolean'
     }
   },
+  additionalProperties: false,
   required: ['outDir']
 }
 
 const platformaticDBschema = {
   $id: 'https://schemas.platformatic.dev/db',
   type: 'object',
-  additionalProperties: false,
   properties: {
     server,
     core,
@@ -392,6 +404,7 @@ const platformaticDBschema = {
       required: ['path']
     }
   },
+  additionalProperties: false,
   required: ['core', 'server']
 }
 

--- a/packages/db/test/cli/init.test.mjs
+++ b/packages/db/test/cli/init.test.mjs
@@ -38,7 +38,7 @@ t.test('run db init with default options', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'sqlite://db.sqlite')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -81,7 +81,7 @@ t.test('run init with default options twice', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'sqlite://db.sqlite')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -109,7 +109,7 @@ t.test('run db init --typescript', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'sqlite://db.sqlite')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
   t.equal(typescript.outDir, 'dist')
@@ -140,7 +140,7 @@ t.test('run db init --typescript twice', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'sqlite://db.sqlite')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
   t.equal(typescript.outDir, 'dist')
@@ -170,7 +170,7 @@ t.test('run db init --database postgres', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'postgres://postgres:postgres@localhost:5432/postgres')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -198,7 +198,7 @@ t.test('run db init --database mysql', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'mysql://root@localhost:3306/graph')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -226,7 +226,7 @@ t.test('run db init --database mariadb', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'mysql://root@localhost:3307/graph')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -254,7 +254,7 @@ t.test('run db init --database mysql8', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'mysql://root@localhost:3308/graph')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -282,7 +282,7 @@ t.test('run db init --hostname 127.0.0.5', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'sqlite://db.sqlite')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -310,7 +310,7 @@ t.test('run db init --port 3055', async (t) => {
   t.equal(server.port, 3055)
 
   t.equal(core.connectionString, 'sqlite://db.sqlite')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'migrations')
 
@@ -338,7 +338,7 @@ t.test('run db init --migrations custom-migrations-folder', async (t) => {
   t.equal(server.port, 3042)
 
   t.equal(core.connectionString, 'sqlite://db.sqlite')
-  t.equal(core.graphiql, true)
+  t.equal(core.graphql, true)
 
   t.equal(migrations.dir, 'custom-migrations-folder')
 

--- a/packages/db/test/fixtures/bad-typescript-plugin/platformatic.db.json
+++ b/packages/db/test/fixtures/bad-typescript-plugin/platformatic.db.json
@@ -8,7 +8,7 @@
   },
   "core": {
     "connectionString": "sqlite://db.sqlite",
-    "graphiql": true,
+    "graphql": true,
     "ignore": {
       "versions": true
     }

--- a/packages/db/test/fixtures/config-to-replace.json
+++ b/packages/db/test/fixtures/config-to-replace.json
@@ -8,7 +8,7 @@
   },
   "core": {
     "connectionString": "sqlite://db.sqlite",
-    "graphiql": true
+    "graphql": true
   },
   "migrations": {
     "dir": "migrations"

--- a/packages/db/test/fixtures/gen-types/platformatic.db.json
+++ b/packages/db/test/fixtures/gen-types/platformatic.db.json
@@ -1,7 +1,7 @@
 {
   "core": {
     "connectionString": "sqlite://./db",
-    "graphiql": true
+    "graphql": true
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/db/test/fixtures/typescript-plugin/platformatic.db.json
+++ b/packages/db/test/fixtures/typescript-plugin/platformatic.db.json
@@ -8,7 +8,7 @@
   },
   "core": {
     "connectionString": "sqlite://db.sqlite",
-    "graphiql": true,
+    "graphql": true,
     "ignore": {
       "versions": true
     }


### PR DESCRIPTION
It's painful when you made a typo in an optional property and doesn't see any warning.