### PR TITLE
Configuration to disable hot-reload

### DIFF
--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -170,11 +170,15 @@ An optional object with the following settings:
 
 ### `plugin`
 
-An optional object that defines a plugin to be loaded with [`fastify-isolate`](https://github.com/mcollina/fastify-isolate):
-
+An optional object that defines a plugin loaded by Platformatic DB.
 - **`path`** (**required**, `string`): Relative path to plugin's entry point.
+- **`hotReload`** if `true` or not specified, the plugin is loaded using [`fastify-isolate`](https://github.com/mcollina/fastify-isolate), otherwise is loaded directly using `require`/`import` and the hot reload is not enabled
+- **`options`** (`object`): Optional plugin options.
 
-All properties will be passed to `fastify-isolate`.
+:::warning:::
+While hot reloading is useful for development, it is not recommended to use it in production.
+To switch if off, set `hotReload` to `false`.
+:::
 
 ### `server`
 

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -172,7 +172,7 @@ An optional object with the following settings:
 
 An optional object that defines a plugin loaded by Platformatic DB.
 - **`path`** (**required**, `string`): Relative path to plugin's entry point.
-- **`hotReload`** if `true` or not specified, the plugin is loaded using [`fastify-isolate`](https://github.com/mcollina/fastify-isolate), otherwise is loaded directly using `require`/`import` and the hot reload is not enabled
+- **`hotReload`** if `true` or not specified, the plugin is loaded using [`fastify-sandbox`](https://github.com/mcollina/fastify-sandbox), otherwise is loaded directly using `require`/`import` and the hot reload is not enabled
 - **`options`** (`object`): Optional plugin options.
 
 :::warning:::

--- a/packages/db/.taprc
+++ b/packages/db/.taprc
@@ -1,2 +1,3 @@
 jobs: 1
 timeout: 80
+coverage: false

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -101,6 +101,8 @@ async function platformaticDB (app, opts) {
           }
         }
       })
+    // c8 fails in reporting the coverage of this else branch, so we ignore it
+    /* c8 ignore next 4 */
     } else {
       const plugin = await import(`file://${pluginOptions.path}`)
       await app.register(plugin, pluginOptions.options)

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -102,7 +102,7 @@ async function platformaticDB (app, opts) {
         }
       })
     } else {
-      const plugin = await import(pluginOptions.path)
+      const plugin = await import(`file://${pluginOptions.path}`)
       await app.register(plugin, pluginOptions.options)
     }
   }

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -397,6 +397,10 @@ const platformaticDBschema = {
         },
         stopTimeout: {
           type: 'integer'
+        },
+        hotReload: {
+          type: 'boolean',
+          default: true
         }
       },
       required: ['path']

--- a/packages/db/test/cli/start.test.mjs
+++ b/packages/db/test/cli/start.test.mjs
@@ -256,3 +256,17 @@ test('default logger', async ({ equal, same, match, teardown }) => {
   match(url, /http:\/\/127.0.0.1:[0-9]+/)
   child.kill('SIGINT')
 })
+
+test('start with hotreload disabled', async ({ equal, same, match, teardown }) => {
+  const db = await connectAndResetDB()
+  teardown(() => db.dispose())
+
+  await db.query(db.sql`CREATE TABLE pages (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(42)
+  );`)
+
+  const { child, url } = await start('-c', join(import.meta.url, '..', 'fixtures', 'no-hotreload.json'))
+  match(url, /http:\/\/127.0.0.1:[0-9]+/)
+  child.kill('SIGINT')
+})

--- a/packages/db/test/fixtures/no-hotreload.json
+++ b/packages/db/test/fixtures/no-hotreload.json
@@ -1,0 +1,21 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    }
+  },
+  "core": {
+    "connectionString": "postgres://postgres:postgres@127.0.0.1/postgres"
+  },
+  "migrations": {
+    "dir": "./migrations",
+    "table": "versions",
+    "autoApply": false
+  },
+  "plugin": {
+    "path": "./plugin.mjs",
+    "hotReload": false
+  }
+}

--- a/packages/db/test/fixtures/plugin.mjs
+++ b/packages/db/test/fixtures/plugin.mjs
@@ -1,0 +1,5 @@
+export default async function (app) {
+  app.get('/test', {}, async function (request, response) {
+    return { res: 'plugin, version 1' }
+  })
+}


### PR DESCRIPTION
[Had to disable c8 for a branch](https://github.com/platformatic/platformatic/blob/disable-hot-reload/packages/db/index.js#L105) because c8 wrongly reported their coverage (lines are executed and well covered by tests). It might be related with the fact that if tap coverage is enabled instead, it throws in getting the coverage on the very same lines.
To reproduce:
```
npx c8 node ./test/load-and-reload-files.test.js
```
...and check that lines 106-08 are not covered.

 