### PR TITLE
refactor(config): separate FileWatcher from ConfigManager

### DIFF
--- a/packages/config/index.d.ts
+++ b/packages/config/index.d.ts
@@ -10,8 +10,7 @@ interface IConfigManagerOptions {
   env?: IEnv
   envWhitelist?: string[]
   watch?: boolean
-  watchIgnore?: string[]
-  allowedToWatch?: string[]
+  allowToWatch?: string[]
 }
 
 type JsonArray = boolean[] | number[] | string[] | JsonMap[] | Date[]
@@ -28,8 +27,8 @@ interface ISerializer {
 export declare class ConfigManager {
   constructor(opts: IConfigManagerOptions)
   current: object
-  stopWatch(): void
-  startWatch(): Promise<void>
+  startWatching(): void
+  stopWatching(): Promise<void>
   getSerializer(): ISerializer
   purgeEnv(): IEnv
   replaceEnv(configString: string): string

--- a/packages/config/test/watch.test.js
+++ b/packages/config/test/watch.test.js
@@ -10,7 +10,7 @@ const ConfigManager = require('..')
 const pid = process.pid
 const { setTimeout: sleep } = require('timers/promises')
 
-test('should emit event if file is updated', async ({ same, fail, plan, teardown }) => {
+test('should emit event if config is updated', async ({ same, plan }) => {
   plan(1)
   const config = {
     name: 'Platformatic',
@@ -46,12 +46,11 @@ test('should emit event if file is updated', async ({ same, fail, plan, teardown
     writeFile(file, JSON.stringify(updatedConfig))
   ])
   same(cm.current, updatedConfig)
-  await cm.stopWatch()
+  await cm.stopWatching()
   await unlink(file)
 })
 
 test('start & stop cannot be called multiple times', async ({ same, fail, plan, teardown, rejects }) => {
-  plan(2)
   const config = {
     name: 'Platformatic',
     props: {
@@ -75,14 +74,13 @@ test('start & stop cannot be called multiple times', async ({ same, fail, plan, 
   const file = await saveConfigToFile(config, 'emit-event.json')
   const cm = new ConfigManager({ source: file, schema })
   await cm.parse()
-  const p1 = cm.startWatch()
-  const p2 = cm.startWatch()
-  same(p1, p2)
+  cm.startWatching()
+  cm.startWatching()
+
   await Promise.all([
-    cm.stopWatch(),
-    rejects(p1)
+    cm.stopWatching(),
+    cm.stopWatching()
   ])
-  await cm.stopWatch()
 })
 
 test('should emit error for invalid config and not update current', async ({ teardown, fail }) => {
@@ -109,7 +107,7 @@ test('should emit error for invalid config and not update current', async ({ tea
 
   const file = await saveConfigToFile(config)
   teardown(async () => {
-    await cm.stopWatch()
+    await cm.stopWatching()
     await unlink(file)
   })
   const cm = new ConfigManager({ source: file, schema, watch: true })
@@ -159,7 +157,7 @@ test('should emit event if .env file is updated', async ({ same, fail, plan, tea
   await writeFile(envFile, 'PLT_PROP=foo\n')
   await writeFile(file, JSON.stringify(config))
 
-  const cm = new ConfigManager({ source: file, schema, watch: true, allowedToWatch: ['.env'] })
+  const cm = new ConfigManager({ source: file, schema, watch: true, allowToWatch: ['.env'] })
   await cm.parse()
   const updatedConfig = {
     name: 'Platformatic',
@@ -173,102 +171,9 @@ test('should emit event if .env file is updated', async ({ same, fail, plan, tea
     writeFile(envFile, 'PLT_PROP=foobar')
   ])
   same(cm.current, updatedConfig)
-  await cm.stopWatch()
+  await cm.stopWatching()
   await unlink(file)
   await unlink(envFile)
-})
-
-test('initialize watchIgnore array', async ({ same, plan }) => {
-  plan(2)
-  {
-    const config = {
-      core: {
-        connectionString: 'sqlite://db.sqlite'
-      }
-    }
-    const file = await saveConfigToFile(config, 'test-watchIgnore.json')
-    const cm = new ConfigManager({ source: file, watch: true })
-    await cm.parse()
-    same(cm.watchIgnore, [])
-    await cm.stopWatch()
-    await unlink(file)
-  }
-  {
-    const config = {
-      core: {
-        connectionString: 'sqlite://db.sqlite'
-      }
-    }
-    const file = await saveConfigToFile(config, 'test-watchIgnore.json')
-    const cm = new ConfigManager({ source: file, watch: true, watchIgnore: ['foo.bar'] })
-    await cm.parse()
-    same(cm.watchIgnore, ['foo.bar'])
-    await cm.stopWatch()
-    await unlink(file)
-  }
-})
-
-test('return correct files to ignore watch', async ({ equal, same, plan }) => {
-  {
-    const config = {
-      core: {
-        connectionString: 'sqlite://db.sqlite'
-      }
-    }
-    const file = await saveConfigToFile(config, 'test-watchIgnore.json')
-    const cm = new ConfigManager({
-      source: file,
-      allowedToWatch: ['*'],
-      watchIgnore: ['test.file', 'test2.file']
-    })
-    equal(false, cm.shouldFileBeWatched('test.file'))
-    equal(false, cm.shouldFileBeWatched('test2.file'))
-    await unlink(file)
-  }
-
-  {
-    const config = {
-      core: {
-        connectionString: 'sqlite://db.sqlite'
-      }
-    }
-    const file = await saveConfigToFile(config, 'test-watchIgnore.json')
-    const cm = new ConfigManager({
-      source: file,
-      allowedToWatch: ['*'],
-      watchIgnore: ['test.file', 'test2.file']
-    })
-    equal(true, cm.shouldFileBeWatched('another.file'))
-    await unlink(file)
-  }
-})
-
-test('do not emit event for ignored files', async ({ teardown, equal, same, fail }) => {
-  const configFile = path.join(__dirname, 'fixtures', 'simple.json')
-  const cm = new ConfigManager({
-    source: configFile,
-    schema: {},
-    watch: true,
-    watchIgnore: ['test.file']
-  })
-  const parseResult = await cm.parse()
-  equal(parseResult, true)
-  const testFileFullPath = `${path.join(path.dirname(cm.fullPath))}/test.file`
-  cm.on('update', () => {
-    fail()
-  })
-  await writeFile(testFileFullPath, 'foobar')
-
-  teardown(async () => {
-    await cm.stopWatch()
-    await unlink(testFileFullPath)
-  })
-
-  same(cm.watchIgnore, ['test.file'])
-
-  // await a full event loop cycle to make sure all possible updates
-  // have been processed.
-  await sleep(150)
 })
 
 test('do not emit event for not allowed files', async ({ teardown, equal, fail }) => {
@@ -287,43 +192,11 @@ test('do not emit event for not allowed files', async ({ teardown, equal, fail }
   await writeFile(testFileFullPath, 'foobar')
 
   teardown(async () => {
-    await cm.stopWatch()
+    await cm.stopWatching()
     await unlink(testFileFullPath)
   })
 
   // await a full event loop cycle to make sure all possible updates
   // have been processed.
   await sleep(150)
-})
-
-test('emit event for not-ignored files', async ({ teardown, equal, same, pass, fail }) => {
-  const configFile = path.join(__dirname, 'fixtures', 'simple.json')
-  const cm = new ConfigManager({
-    source: configFile,
-    schema: {},
-    watch: true,
-    allowedToWatch: ['*'],
-    watchIgnore: ['test.file']
-  })
-  let eventEmitted = false
-  const parseResult = await cm.parse()
-  equal(parseResult, true)
-  const testFileFullPath = `${path.join(path.dirname(cm.fullPath))}/test2.file`
-  cm.on('update', () => {
-    pass()
-    eventEmitted = true
-  })
-  await writeFile(testFileFullPath, 'foobar')
-
-  teardown(async () => {
-    await cm.stopWatch()
-    await unlink(testFileFullPath)
-  })
-
-  same(cm.watchIgnore, ['test.file'])
-
-  // await a full event loop cycle to make sure all possible updates
-  // have been processed.
-  await sleep(150)
-  equal(eventEmitted, true)
 })

--- a/packages/db/lib/config.js
+++ b/packages/db/lib/config.js
@@ -15,8 +15,7 @@ class DBConfigManager extends ConfigManager {
         coerceTypes: true,
         allErrors: true
       },
-      allowedToWatch: opts.allowedToWatch || ['*.js', '**/*.js'],
-      watchIgnore: opts.watchIgnore || [],
+      allowToWatch: ['.env'],
       envWhitelist: ['PORT', 'DATABASE_URL', ...(opts.envWhitelist || [])]
     })
   }

--- a/packages/db/lib/load-config.mjs
+++ b/packages/db/lib/load-config.mjs
@@ -25,22 +25,10 @@ async function loadConfig (minimistConfig, _args, configOpts = {}) {
     console.error('Missing config file')
     process.exit(1)
   }
-  let watchIgnore = null
-  // Apparently C8 cannot detect these three lines on Windows
-  /* c8 ignore next 3 */
-  if (args['watch-ignore']) {
-    watchIgnore = args['watch-ignore'].split(',')
-  }
-  let allowedToWatch = null
-  /* c8 ignore next 3 */
-  if (args['allow-to-watch']) {
-    allowedToWatch = args['allow-to-watch'].split(',')
-  }
+
   const configManager = new ConfigManager({
     source: args.config,
     envWhitelist: [...args.allowEnv.split(',')],
-    watchIgnore,
-    allowedToWatch,
     ...configOpts
   })
 

--- a/packages/db/lib/start.mjs
+++ b/packages/db/lib/start.mjs
@@ -1,3 +1,5 @@
+import { dirname } from 'path'
+import { FileWatcher } from '@platformatic/utils'
 import { buildServer } from '../index.js'
 import close from 'close-with-grace'
 import loadConfig from './load-config.mjs'
@@ -8,9 +10,21 @@ import { addLoggerToTheConfig } from './utils.js'
 // Currently C8 is not reporting it
 /* c8 ignore start */
 async function start (_args) {
-  const { configManager } = await loadConfig({
+  const { configManager, args } = await loadConfig({
     string: ['to']
   }, _args, { watch: true })
+
+  let watchIgnore = null
+  // Apparently C8 cannot detect these three lines on Windows
+  /* c8 ignore next 3 */
+  if (args['watch-ignore']) {
+    watchIgnore = args['watch-ignore'].split(',')
+  }
+  let allowToWatch = ['*.js', '**/*.js']
+  /* c8 ignore next 3 */
+  if (args['allow-to-watch']) {
+    allowToWatch = args['allow-to-watch'].split(',')
+  }
 
   const config = configManager.current
 
@@ -30,6 +44,16 @@ async function start (_args) {
     ...config,
     configManager
   })
+
+  const fileWatcher = new FileWatcher({
+    path: dirname(configManager.fullPath),
+    allowToWatch,
+    watchIgnore
+  })
+  fileWatcher.on('update', () => {
+    onFilesUpdated(server)
+  })
+  fileWatcher.startWatching()
 
   configManager.on('update', (newConfig) => onConfigUpdated(newConfig, server))
   server.app.platformatic.configManager = configManager
@@ -93,6 +117,22 @@ async function onConfigUpdated (newConfig, server) {
         stack: err.stack
       }
     }, 'failed to reload config')
+  }
+}
+
+async function onFilesUpdated (server) {
+  try {
+    const config = server.app.platformatic.config
+    server.app.log.info('files changed')
+    await server.restart(config)
+  } catch (err) {
+    // TODO: test this
+    server.app.log.error({
+      err: {
+        message: err.message,
+        stack: err.stack
+      }
+    }, 'failed to reload server')
   }
 }
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -46,6 +46,7 @@
     "@platformatic/db-authorization": "workspace:*",
     "@platformatic/db-core": "workspace:*",
     "@platformatic/db-dashboard": "workspace:*",
+    "@platformatic/utils": "workspace:*",
     "close-with-grace": "^1.1.0",
     "commist": "^3.1.2",
     "desm": "^1.2.0",

--- a/packages/db/test/config.test.js
+++ b/packages/db/test/config.test.js
@@ -229,10 +229,9 @@ test('ignore watch sqlite file', async ({ teardown, equal, same, comment }) => {
     })
     const parseResult = await cm.parse()
     equal(parseResult, true)
-    same(cm.watchIgnore, [])
 
     const configFileName = basename(cm.fullPath)
-    same(cm.allowedToWatch, ['*.js', '**/*.js', configFileName])
+    same(cm.fileWatcher.allowToWatch, ['.env', configFileName])
   }
 
   {
@@ -252,10 +251,9 @@ test('ignore watch sqlite file', async ({ teardown, equal, same, comment }) => {
     })
     const parseResult = await cm.parse()
     equal(parseResult, true)
-    same(cm.watchIgnore, [])
 
     const configFileName = basename(cm.fullPath)
-    same(cm.allowedToWatch, ['*.js', '**/*.js', configFileName])
+    same(cm.fileWatcher.allowToWatch, ['.env', configFileName])
   }
 })
 

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const FileWatcher = require('./lib/file-watcher')
+
+module.exports = { FileWatcher }

--- a/packages/utils/lib/file-watcher.js
+++ b/packages/utils/lib/file-watcher.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const { EventEmitter } = require('events')
+const { watch } = require('fs/promises')
+
+const minimatch = require('minimatch')
+
+const ALLOWED_FS_EVENTS = ['change', 'rename']
+
+class FileWatcher extends EventEmitter {
+  constructor (opts) {
+    super()
+
+    if (typeof opts.path !== 'string') {
+      throw new Error('path option is required')
+    }
+    this.path = opts.path
+    this.allowToWatch = opts.allowToWatch || null
+    this.watchIgnore = opts.watchIgnore || null
+
+    this.fsWatcher = null
+    this.handlePromise = null
+    this.abortController = null
+
+    this.isWatching = false
+  }
+
+  startWatching () {
+    if (this.isWatching) return
+    this.isWatching = true
+
+    this.abortController = new AbortController()
+    const signal = this.abortController.signal
+
+    const fsWatcher = watch(this.path, { signal, recursive: true })
+
+    let updateTimeout = null
+
+    this.on('update', () => {
+      clearTimeout(updateTimeout)
+      updateTimeout = null
+    })
+
+    const eventHandler = async () => {
+      for await (const { eventType, filename } of fsWatcher) {
+        const isTimeoutSet = updateTimeout === null
+        const isTrackedEvent = ALLOWED_FS_EVENTS.includes(eventType)
+        const isTrackedFile = this.shouldFileBeWatched(filename)
+
+        if (isTimeoutSet && isTrackedEvent && isTrackedFile) {
+          updateTimeout = setTimeout(() => this.emit('update'), 100)
+        }
+      }
+    } /* c8 ignore next */
+    this.handlePromise = eventHandler()
+  }
+
+  async stopWatching () {
+    if (!this.isWatching) return
+    this.isWatching = false
+
+    this.abortController.abort()
+    await this.handlePromise.catch(() => {})
+  }
+
+  shouldFileBeWatched (fileName) {
+    return this.isFileAllowed(fileName) && !this.isFileIgnored(fileName)
+  }
+
+  isFileAllowed (fileName) {
+    if (this.allowToWatch === null) return true
+    return this.allowToWatch.some((allowedFile) => minimatch(fileName, allowedFile))
+  }
+
+  isFileIgnored (fileName) {
+    if (this.watchIgnore === null) return false
+    return this.watchIgnore.some((ignoredFile) => minimatch(fileName, ignoredFile))
+  }
+}
+
+module.exports = FileWatcher

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@platformatic/config",
+  "name": "@platformatic/utils",
   "version": "0.3.0",
-  "description": "Platformatic DB Config Manager",
+  "description": "Platformatic DB Utils",
   "main": "index.js",
   "scripts": {
     "test": "standard | snazzy && c8 --100 tap --no-coverage test/*test.js"
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/platformatic/platformatic.git"
   },
-  "author": "Leonardo Rossi <leonardo.rossi@gmail.com>",
+  "author": "Ivan Tymoshenko <ivan@tymoshenko.me>",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/platformatic/platformatic/issues"
@@ -20,17 +20,9 @@
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.0.0",
-    "fastify": "^4.6.0"
+    "c8": "^7.11.0"
   },
   "dependencies": {
-    "@platformatic/utils": "workspace:*",
-    "@iarna/toml": "^2.2.5",
-    "ajv": "^8.11.0",
-    "c8": "^7.11.0",
-    "dotenv": "^16.0.1",
-    "json5": "^2.2.1",
-    "pupa": "^3.1.0",
-    "undici": "^5.8.0",
-    "yaml": "^2.1.1"
+    "minimatch": "^5.1.0"
   }
 }

--- a/packages/utils/test/file-watcher.test.js
+++ b/packages/utils/test/file-watcher.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const os = require('os')
+const { writeFile } = require('fs/promises')
+const { join } = require('path')
+const { test } = require('tap')
+const FileWatcher = require('../lib/file-watcher')
+
+test('should throw an error if there is no path argument', async ({ throws, plan }) => {
+  plan(1)
+  throws(() => new FileWatcher({}), 'path option is required')
+})
+
+test('initialize watchIgnore and allowToWatch arrays', async ({ same, plan }) => {
+  plan(4)
+  {
+    const fileWatcher = new FileWatcher({ path: os.tmpdir() })
+    same(fileWatcher.watchIgnore, null)
+    same(fileWatcher.allowToWatch, null)
+  }
+  {
+    const fileWatcher = new FileWatcher({
+      path: os.tmpdir(),
+      watchIgnore: ['foo'],
+      allowToWatch: ['bar']
+    })
+    same(fileWatcher.watchIgnore, ['foo'])
+    same(fileWatcher.allowToWatch, ['bar'])
+  }
+})
+
+test('should not watch ignored files', async ({ equal, plan }) => {
+  plan(3)
+
+  const fileWatcher = new FileWatcher({
+    path: os.tmpdir(),
+    watchIgnore: ['test.file', 'test2.file']
+  })
+  equal(false, fileWatcher.shouldFileBeWatched('test.file'))
+  equal(false, fileWatcher.shouldFileBeWatched('test2.file'))
+  equal(true, fileWatcher.shouldFileBeWatched('another.file'))
+})
+
+test('should not watch not allowed files', async ({ equal, plan }) => {
+  plan(3)
+
+  const fileWatcher = new FileWatcher({
+    path: os.tmpdir(),
+    allowToWatch: ['test.file', 'test2.file']
+  })
+  equal(true, fileWatcher.shouldFileBeWatched('test.file'))
+  equal(true, fileWatcher.shouldFileBeWatched('test2.file'))
+  equal(false, fileWatcher.shouldFileBeWatched('another.file'))
+})
+
+test('should emit event if file is updated', ({ end }) => {
+  const tmpDir = os.tmpdir()
+  const filename = join(tmpDir, 'test.file')
+  const fileWatcher = new FileWatcher({ path: tmpDir })
+
+  fileWatcher.once('update', async () => {
+    await fileWatcher.stopWatching()
+    end()
+  })
+  fileWatcher.startWatching()
+
+  writeFile(filename, 'foobar')
+})
+
+test('should not call fs watch twice', ({ pass, plan, end }) => {
+  const tmpDir = os.tmpdir()
+  const filename = join(tmpDir, 'test.file')
+  const fileWatcher = new FileWatcher({ path: tmpDir })
+
+  fileWatcher.once('update', async () => {
+    await fileWatcher.stopWatching()
+    await fileWatcher.stopWatching()
+    end()
+  })
+  fileWatcher.startWatching()
+  fileWatcher.startWatching()
+
+  writeFile(filename, 'foobar')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,11 +72,12 @@ importers:
   packages/config:
     specifiers:
       '@iarna/toml': ^2.2.5
+      '@platformatic/utils': workspace:*
       ajv: ^8.11.0
       c8: ^7.11.0
       dotenv: ^16.0.1
+      fastify: ^4.6.0
       json5: ^2.2.1
-      minimatch: ^5.1.0
       pupa: ^3.1.0
       snazzy: ^9.0.0
       standard: ^17.0.0
@@ -85,15 +86,16 @@ importers:
       yaml: ^2.1.1
     dependencies:
       '@iarna/toml': 2.2.5
+      '@platformatic/utils': link:../utils
       ajv: 8.11.0
       c8: 7.12.0
       dotenv: 16.0.2
       json5: 2.2.1
-      minimatch: 5.1.0
       pupa: 3.1.0
       undici: 5.10.0
       yaml: 2.1.1
     devDependencies:
+      fastify: 4.6.0
       snazzy: 9.0.0
       standard: 17.0.0
       tap: 16.3.0
@@ -117,6 +119,7 @@ importers:
       '@platformatic/sql-graphql': workspace:*
       '@platformatic/sql-json-schema-mapper': workspace:*
       '@platformatic/sql-mapper': workspace:*
+      '@platformatic/utils': workspace:*
       c8: ^7.11.0
       close-with-grace: ^1.1.0
       commist: ^3.1.2
@@ -161,6 +164,7 @@ importers:
       '@platformatic/db-authorization': link:../db-authorization
       '@platformatic/db-core': link:../db-core
       '@platformatic/db-dashboard': link:../db-dashboard
+      '@platformatic/utils': link:../utils
       close-with-grace: 1.1.0
       commist: 3.1.2
       desm: 1.3.0
@@ -414,6 +418,21 @@ importers:
       standard: 17.0.0
       tap: 16.3.0
       tsd: 0.24.1
+
+  packages/utils:
+    specifiers:
+      c8: ^7.11.0
+      minimatch: ^5.1.0
+      snazzy: ^9.0.0
+      standard: ^17.0.0
+      tap: ^16.0.0
+    dependencies:
+      minimatch: 5.1.0
+    devDependencies:
+      c8: 7.12.0
+      snazzy: 9.0.0
+      standard: 17.0.0
+      tap: 16.3.0
 
 packages:
 


### PR DESCRIPTION
Quick explanations
1. FileWatcher is now an external entity in the `@platformatic/utils` package.
2. There are two instances of FileWatcher used in the Platformatic DB.
- The ConfigManager uses FileWatcher to reload the config and emit an `update` event if there are some changes in the config file or in the files on which the config might depend (it's only `.env` for now).
- The `db` package uses the FileWatcher to watch and reload files used by the server.

That means that we can handle these two events differently. And we can move `--allow-to-watch` and `--watch-ignore` cli options to the config.