### PR TITLE
fix(db): exclude the root endpoint from the openapi documentation

### DIFF
--- a/packages/db/lib/root-endpoint/index.js
+++ b/packages/db/lib/root-endpoint/index.js
@@ -8,14 +8,19 @@ module.exports = async (app, opts) => {
     root: path.join(__dirname, 'public')
   })
   // root endpoint
-  app.get('/', (req, reply) => {
-    const uaString = req.headers['user-agent']
-    if (uaString) {
-      const parsed = userAgentParser(uaString)
-      if (parsed.browser.name !== undefined) {
-        return reply.sendFile('./index.html')
+  app.route({
+    method: 'GET',
+    path: '/',
+    schema: { hide: true },
+    handler: (req, reply) => {
+      const uaString = req.headers['user-agent']
+      if (uaString) {
+        const parsed = userAgentParser(uaString)
+        if (parsed.browser.name !== undefined) {
+          return reply.sendFile('./index.html')
+        }
       }
+      return { message: 'Welcome to Platformatic! Please visit https://oss.platformatic.dev' }
     }
-    return { message: 'Welcome to Platformatic! Please visit https://oss.platformatic.dev' }
   })
 }

--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -519,15 +519,6 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
           }
         }
       }
-    },
-    "/": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
     }
   }
 }

--- a/packages/db/test/admin.test.js
+++ b/packages/db/test/admin.test.js
@@ -325,8 +325,7 @@ test('admin routes are not included in main openapi', async ({ teardown, same, e
 
     same(Object.keys(body.paths), [
       '/pages/',
-      '/pages/{id}',
-      '/'
+      '/pages/{id}'
     ])
   }
 })

--- a/packages/db/test/routes.test.js
+++ b/packages/db/test/routes.test.js
@@ -112,3 +112,28 @@ test('should not overwrite dashboard endpoint', async ({ teardown, equal, same }
   equal(res.statusCode, 302)
   equal(res.headers.location, '/dashboard')
 })
+
+test('should exclude the root endpoint from the openapi documentation', async ({ teardown, equal, has }) => {
+  const server = await buildServer(buildConfig({
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    core: {
+      ...connInfo
+    },
+    authorization: {
+      adminSecret: 'secret'
+    },
+    dashboard: {
+      enabled: false
+    }
+  }))
+  teardown(server.stop)
+
+  await server.listen()
+  const res = await (request(`${server.url}/documentation/json`))
+  const openapi = await res.body.json()
+  equal(res.statusCode, 200)
+  has(openapi.paths, { '/': undefined })
+})


### PR DESCRIPTION
fixes #163 

This fixes a bug where the platformatic root endpoint `/` (the one that displays the platformatic welcoming page) was being included in the openapi documentation.

This PR introduces the `schema: { hide: true }`  option in the root `/` route definition to exclude it from the openapi documentation and consequently from the swagger ui page.