### PR TITLE
feat(db): add watch plugin config option

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -282,10 +282,6 @@ By sending the SIGUSR2 signal, the server can be reloaded.
 Options:
 
   -c, --config FILE      Specify a configuration file to use
-  --watch-ignore LIST    Specify a comma separated list of glob patterns to
-                         ignore when watching for changes
-  --allow-to-watch LIST  Specify a comma separated list of glob patterns to
-                         allow when watching for changes. Default is *.js and **/*.js
 
 If not specified, the configuration specified will be loaded from `platformatic.db.json`,
 `platformatic.db.yml`, or `platformatic.db.tml` in the current directory. You can find more details about

--- a/packages/db/help/start.txt
+++ b/packages/db/help/start.txt
@@ -36,10 +36,6 @@ By sending the SIGUSR2 signal, the server can be reloaded.
 Options:
 
   -c, --config FILE      Specify a configuration file to use
-  --watch-ignore LIST    Specify a comma separated list of glob patterns to
-                         ignore when watching for changes
-  --allow-to-watch LIST  Specify a comma separated list of glob patterns to
-                         allow when watching for changes. Default is *.js and **/*.js
 
 If not specified, the configuration specified will be loaded from `platformatic.db.json`,
 `platformatic.db.yml`, or `platformatic.db.tml` in the current directory. You can find more details about

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -87,8 +87,10 @@ async function platformaticDB (app, opts) {
     // if not defined, we defaults to true (which can happen only if config is set programmatically,
     // that's why we ignore the coverage of the `undefined` case, which cannot be covered in cli tests)
     /* c8 ignore next */
-    const hotReload = opts.plugin.hotReload === undefined ? true : opts.plugin.hotReload
-    if (hotReload) {
+    const hotReload = opts.plugin.watchOptions?.hotReload !== false
+    const isWatchEnabled = opts.plugin.watch !== false
+
+    if (isWatchEnabled && hotReload) {
       await app.register(sandbox, {
         ...pluginOptions,
         customizeGlobalThis (_globalThis) {

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -377,6 +377,49 @@ const typescript = {
   required: ['outDir']
 }
 
+const plugin = {
+  type: 'object',
+  properties: {
+    path: {
+      type: 'string'
+    },
+    stopTimeout: {
+      type: 'integer'
+    },
+    watch: {
+      type: 'boolean'
+    },
+    watchOptions: {
+      type: 'object',
+      properties: {
+        hotReload: {
+          type: 'boolean',
+          default: true
+        },
+        allow: {
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          minItems: 1,
+          nullable: true,
+          default: null
+        },
+        ignore: {
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          nullable: true,
+          default: null
+        }
+      },
+      additionalProperties: false
+    }
+  },
+  required: ['path']
+}
+
 const platformaticDBschema = {
   $id: 'https://schemas.platformatic.dev/db',
   type: 'object',
@@ -389,22 +432,7 @@ const platformaticDBschema = {
     metrics,
     types,
     typescript,
-    plugin: {
-      type: 'object',
-      properties: {
-        path: {
-          type: 'string'
-        },
-        stopTimeout: {
-          type: 'integer'
-        },
-        hotReload: {
-          type: 'boolean',
-          default: true
-        }
-      },
-      required: ['path']
-    }
+    plugin
   },
   additionalProperties: false,
   required: ['core', 'server']

--- a/packages/db/test/cli/load-and-reload-files.test.mjs
+++ b/packages/db/test/cli/load-and-reload-files.test.mjs
@@ -160,7 +160,10 @@ test('hotreload disabled', { skip: isWindows }, async ({ teardown, equal, same, 
   "plugin": {
     "path": "./${basename(file)}",
     "stopTimeout": 1000,
-    "hotReload": false
+    "watch": true,
+    "watchOptions": {
+      "hotReload": false
+    }
   },
   "core": {
     "connectionString": "postgres://postgres:postgres@127.0.0.1/postgres"

--- a/packages/db/test/load-and-reload-files.test.js
+++ b/packages/db/test/load-and-reload-files.test.js
@@ -567,8 +567,11 @@ test('hot reload disabled, CommonJS', async ({ teardown, equal, pass, same }) =>
       port: 0
     },
     plugin: {
-      hotReload: false,
-      path: file
+      path: file,
+      watch: true,
+      watchOptions: {
+        hotReload: false
+      }
     },
     core: {
       ...connInfo,
@@ -627,9 +630,12 @@ test('hot reload disabled, ESM', async ({ teardown, equal, pass, same }) => {
       port: 0
     },
     plugin: {
-      hotReload: false,
       path: file,
-      stopTimeout: 1000
+      stopTimeout: 1000,
+      watch: true,
+      watchOptions: {
+        hotReload: false
+      }
     },
     core: {
       ...connInfo,


### PR DESCRIPTION
The new plugin config option will look like that:
```json
...
"plugin": {
  "path": "./plugin.js",
  "watch": true,
  "watchOptions": {
    "hotReload": false,
    "allow": ["**/*.js", "**/*.mjs"],
    "ignore": ["**/*.test.js"]
  }
}
```
All options are optional.

\+ I removed `--allow-to-watch` and `--watch-ignore` start command options.
\+ Refactored and sped up the clock test.