### PR TITLE
Exit with 1 when command not found

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -51,6 +51,7 @@ if (args.help) {
 
   if (result) {
     console.log('Command not found:', result.join(' '))
+    process.exit(1)
   }
 } else {
   help.toStdout(['help'])

--- a/packages/cli/test/platformatic.test.js
+++ b/packages/cli/test/platformatic.test.js
@@ -35,8 +35,12 @@ test('login', async (t) => {
 })
 
 test('command not found', async (t) => {
-  const { stdout } = await execa('node', [cliPath, 'foo'])
-  t.ok(stdout.includes('Command not found: foo'))
+  try {
+    await execa('node', [cliPath, 'foo'])
+    t.fail('bug')
+  } catch (err) {
+    t.ok(err.stdout.includes('Command not found: foo'))
+  }
 })
 
 test('prints the help with help command', async (t) => {


### PR DESCRIPTION
I think we should exit with code 1 when a command is not found.

Not that I had an issue because of this. Was using the code as an inspiration for the `rescript-platformatic-cli`, and this part was looking wrong to me.