### PR TITLE
feat(sql-mapper): configurable pool size

### DIFF
--- a/docs/reference/sql-mapper/introduction.md
+++ b/docs/reference/sql-mapper/introduction.md
@@ -9,6 +9,7 @@ The Platformatic DB Mapper will inspect a database schema and return an object c
 It exports a function that accepts an object with the following properties:
 
 - `connectionString` — The Database connection string
+- `poolSize` - Maximum number of connections in the connection pool. Defaults to `10`.
 - `log` — A logger object (like [Pino](https://getpino.io))
 - `onDatabaseLoad` — An async function that is called after the connection is established. It will receive `db` and `sql` as parameter.
 - `ignore` — Object used to ignore some tables from building entities. (i.e. `{ 'versions': true }` will ignore `versions` table)

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -109,6 +109,9 @@ const core = {
     connectionString: {
       type: 'string'
     },
+    poolSize: {
+      type: 'integer'
+    },
     graphql: {
       anyOf: [{
         type: 'boolean'

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -6,10 +6,11 @@ const fp = require('fastify-plugin')
 
 // Ignore the function as it is only used only for MySQL and PostgreSQL
 /* istanbul ignore next */
-async function buildConnection (log, createConnectionPool, connectionString) {
+async function buildConnection (log, createConnectionPool, connectionString, poolSize) {
   const db = await createConnectionPool({
     connectionString,
     bigIntMode: 'string',
+    poolSize,
     onQueryStart: (_query, { text, values }) => {
       log.trace({
         query: {
@@ -38,7 +39,7 @@ async function buildConnection (log, createConnectionPool, connectionString) {
   return db
 }
 
-async function connect ({ connectionString, log, onDatabaseLoad, ignore = {}, autoTimestamp = true, hooks = {} }) {
+async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, ignore = {}, autoTimestamp = true, hooks = {} }) {
   // TODO validate config using the schema
   if (!connectionString) {
     throw new Error('connectionString is required')
@@ -51,13 +52,13 @@ async function connect ({ connectionString, log, onDatabaseLoad, ignore = {}, au
   /* istanbul ignore next */
   if (connectionString.indexOf('postgres') === 0) {
     const createConnectionPoolPg = require('@databases/pg')
-    db = await buildConnection(log, createConnectionPoolPg, connectionString)
+    db = await buildConnection(log, createConnectionPoolPg, connectionString, poolSize)
     sql = createConnectionPoolPg.sql
     queries = queriesFactory.pg
     db.isPg = true
   } else if (connectionString.indexOf('mysql') === 0) {
     const createConnectionPoolMysql = require('@databases/mysql')
-    db = await buildConnection(log, createConnectionPoolMysql, connectionString)
+    db = await buildConnection(log, createConnectionPoolMysql, connectionString, poolSize)
     sql = createConnectionPoolMysql.sql
     const version = (await db.query(sql`SELECT VERSION()`))[0]['VERSION()']
     db.version = version


### PR DESCRIPTION
This feature adds an optional configurable maximum pool size to `sql-mapper`. While the default `10`, as advised by atdatabases, is good enough for most applications, a busier application will benefit from a larger (and configurable) pool size.

refs:

- https://www.atdatabases.org/docs/pg-options
- https://www.atdatabases.org/docs/mysql-options