### PR TITLE
Update reference documentation URLs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -108,7 +108,7 @@ plugins in the `outDir` directory.
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.
 
   
 #### help
@@ -187,7 +187,7 @@ Options:
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.
 
   
 #### schema
@@ -204,7 +204,7 @@ Options:
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.
 
   
 #### seed
@@ -239,7 +239,7 @@ Options:
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.
 
   
 #### start
@@ -290,7 +290,7 @@ Options:
 If not specified, the configuration specified will be loaded from `platformatic.db.json`,
 `platformatic.db.yml`, or `platformatic.db.tml` in the current directory. You can find more details about
 the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.
 
   
 #### types
@@ -330,6 +330,6 @@ module.exports = async function (app) {
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.
 
   

--- a/packages/db-authorization/README.md
+++ b/packages/db-authorization/README.md
@@ -2,7 +2,7 @@
 
 Fastify plugin that adds role-based authorization hooks to [`@platformatic/sql-mapper`](https://www.npmjs.com/package/@platformatic/sql-mapper).
 
-Check out the full documentation on [our website](https://oss.platformatic.dev/docs/reference/db-authorization/introduction).
+Check out the full documentation on [our website](https://oss.platformatic.dev/docs/reference/db/authorization/introduction).
 
 ## Install
 

--- a/packages/db/help/compile.txt
+++ b/packages/db/help/compile.txt
@@ -9,4 +9,4 @@ plugins in the `outDir` directory.
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.

--- a/packages/db/help/migrate.txt
+++ b/packages/db/help/migrate.txt
@@ -37,4 +37,4 @@ Options:
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.

--- a/packages/db/help/schema.txt
+++ b/packages/db/help/schema.txt
@@ -10,4 +10,4 @@ Options:
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.

--- a/packages/db/help/seed.txt
+++ b/packages/db/help/seed.txt
@@ -28,4 +28,4 @@ Options:
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.

--- a/packages/db/help/start.txt
+++ b/packages/db/help/start.txt
@@ -44,4 +44,4 @@ Options:
 If not specified, the configuration specified will be loaded from `platformatic.db.json`,
 `platformatic.db.yml`, or `platformatic.db.tml` in the current directory. You can find more details about
 the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.

--- a/packages/db/help/types.txt
+++ b/packages/db/help/types.txt
@@ -33,4 +33,4 @@ module.exports = async function (app) {
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
 You can find more details about the configuration format at:
-https://oss.platformatic.dev/docs/reference/configuration.
+https://oss.platformatic.dev/docs/reference/db/configuration.


### PR DESCRIPTION
This is a follow up to #175 and #195.

- Update Configuration reference docs URL in CLI help texts
- Update generated CLI reference documentation
- Update reference documentation link for @platformatic/db-authorization

Fixes #178.
