### PR TITLE
Fixed the order of docker compose params according to the official do…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ We use Docker to start all the databases we develop against.
 
 On Linux, execute: `docker compose up`
 
-On Intel Macs: `docker compose up -f docker-compose-mac.yml` 
+On Intel Macs: `docker compose -f docker-compose-mac.yml up` 
 
-On Apple Silicon Macs: `docker compose up -f docker-compose-apple-silicon.yml` 
+On Apple Silicon Macs: `docker compose -f docker-compose-apple-silicon.yml up` 
 
 ### Start platformatic db
 


### PR DESCRIPTION
The section for the docker compose commands inside contributing file is not correct, the 'up' command should go after the -f value 

This doesn't work:
```
docker compose up -f docker-compose-mac.yml
```

This works:
```
docker compose -f docker-compose-mac.yml up
```

https://docs.docker.com/compose/reference/ 

The order is like this
```
 docker compose [-f <arg>...] [--profile <name>...] [options] [COMMAND] [ARGS...]
```
