### PR TITLE
Docker release fix

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   buildx:
     runs-on: ubuntu-latest
-    environment: main
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
In the docker release action, we specified the `main` environment, which can be "deployed" only from `main` branch. 
But the docker release is done from the release tag, so the workflow action failed (didn't even start, actually). 

*NOTE*: it's a draft because I still need to test it.