### PR TITLE
Fixed link of platformatic through pnpm issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ pnpm i
 The CLI package is now available at **./node_modules/.bin/platformatic**. Use
 `pnpm link` to use `platformatic` everywhere.
 ```sh
-(cd packages/cli && pnpm link)
+(cd packages/cli && pnpm link --global)
 ```
 
 ### Run dashboard development server


### PR DESCRIPTION
fixes #167 
According to pnpm link documentation, we have to use ```(cd packages/cli && pnpm link <dir>)``` for the link to work, but in that case we need to use platformatic through the pnpm always like this
```
pnpm platformatic db
```

If we want to use it globally, we need to specify the --global param as I did on the PR. 