### PR TITLE
docs(extend-rest): Fix request handler name

### DIFF
--- a/docs/guides/add-custom-functionality/extend-rest.md
+++ b/docs/guides/add-custom-functionality/extend-rest.md
@@ -9,7 +9,7 @@ Copy and paste this code into `./sample-plugin.js` file
 ```js
 'use strict'
 module.exports = async(app, opts) => {
-  app.get('/sum', async(req, reply) => {
+  app.post('/sum', async(req, reply) => {
     const { x, y } = req.body
     return { sum: (x + y)}
   })


### PR DESCRIPTION
In guide POST request is described but in example GET handler is using.