### PR TITLE
chore: avoid running "test" script in pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
   },
   "dependencies": {
     "desm": "^1.2.0"
-  }
+  },
+  "pre-commit": []
 }


### PR DESCRIPTION
closes #242 

We're using fastify/pre-commit from the root of the monorepo and it automatically executes `npm test`
I thought it be ok to still keep the devDependency and disable the test script because in the future we might want to add some other script

