### PR TITLE
feat(deps): add markdown linter

### DIFF
--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -1,0 +1,43 @@
+name: markdown lint
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - main
+    paths:
+       - "**/*.md"
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+       - "**/*.md"
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+        
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Install Linter
+        run: npm install --ignore-scripts
+
+      - name: Add Matcher
+        uses: xt0rted/markdownlint-problem-matcher@v2
+
+      - name: Run Linter
+        run: ./node_modules/.bin/markdownlint-cli2

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ build/Release
 node_modules/
 jspm_packages/
 
+# Dependency lock file
+package-lock.json
+
 # TypeScript v1 declaration files
 typings/
 

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,22 @@
+# See https://github.com/DavidAnson/markdownlint-cli2
+config:
+  # Disable all rules by default.
+  default: false
+
+  # Enforce line length.
+  MD013:
+    line_length: 80
+    code_block_line_length: 120
+    headers: false
+    tables: false
+    strict: false
+    stern: false
+
+globs:
+  - '**/*.md'
+
+ignores:
+  - 'node_modules/**'
+  - 'test/**/*.md'
+
+noProgress: true

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "dashboard:build": "cd packages/db-dashboard && pnpm run build",
     "ra-data-rest": "pnpm -F @platformatic/db-ra-data-rest",
     "cleanall": "rm pnpm-lock.yaml && rm -rf node_modules && rm -rf packages/*/node_modules",
-    "postinstall": "node ./scripts/postinstall.js"
+    "postinstall": "node ./scripts/postinstall.js",
+    "lint:markdown": "markdownlint-cli2"
   },
   "packageManager": "pnpm@7.14.2",
   "devDependencies": {
-    "@fastify/pre-commit": "^2.0.2"
+    "@fastify/pre-commit": "^2.0.2",
+    "markdownlint-cli2": "^0.5.1"
   },
   "dependencies": {
     "desm": "^1.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,12 @@ importers:
     specifiers:
       '@fastify/pre-commit': ^2.0.2
       desm: ^1.2.0
+      markdownlint-cli2: ^0.5.1
     dependencies:
       desm: 1.3.0
     devDependencies:
       '@fastify/pre-commit': 2.0.2
+      markdownlint-cli2: 0.5.1
 
   packages/authenticate:
     specifiers:
@@ -2811,6 +2813,11 @@ packages:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
     dev: true
 
+  /entities/3.0.1:
+    resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
+    engines: {node: '>=0.12'}
+    dev: true
+
   /env-paths/2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -3952,6 +3959,17 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /globby/13.1.2:
+    resolution: {integrity: sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      dir-glob: 3.0.1
+      fast-glob: 3.2.12
+      ignore: 5.2.0
+      merge2: 1.4.1
+      slash: 4.0.0
+    dev: true
+
   /goober/2.1.11_csstype@3.1.1:
     resolution: {integrity: sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==}
     peerDependencies:
@@ -4861,6 +4879,12 @@ packages:
       uc.micro: 1.0.6
     dev: true
 
+  /linkify-it/4.0.1:
+    resolution: {integrity: sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==}
+    dependencies:
+      uc.micro: 1.0.6
+    dev: true
+
   /load-json-file/5.3.0:
     resolution: {integrity: sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==}
     engines: {node: '>=6'}
@@ -5035,6 +5059,45 @@ packages:
       linkify-it: 3.0.3
       mdurl: 1.0.1
       uc.micro: 1.0.6
+    dev: true
+
+  /markdown-it/13.0.1:
+    resolution: {integrity: sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      entities: 3.0.1
+      linkify-it: 4.0.1
+      mdurl: 1.0.1
+      uc.micro: 1.0.6
+    dev: true
+
+  /markdownlint-cli2-formatter-default/0.0.3_markdownlint-cli2@0.5.1:
+    resolution: {integrity: sha512-QEAJitT5eqX1SNboOD+SO/LNBpu4P4je8JlR02ug2cLQAqmIhh8IJnSK7AcaHBHhNADqdGydnPpQOpsNcEEqCw==}
+    peerDependencies:
+      markdownlint-cli2: '>=0.0.4'
+    dependencies:
+      markdownlint-cli2: 0.5.1
+    dev: true
+
+  /markdownlint-cli2/0.5.1:
+    resolution: {integrity: sha512-f3Nb1GF/c8YSrV/FntsCWzpa5mLFJRlO+wzEgv+lkNQjU6MZflUwc2FbyEDPTo6oVhP2VyUOkK0GkFgfuktl1w==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      globby: 13.1.2
+      markdownlint: 0.26.2
+      markdownlint-cli2-formatter-default: 0.0.3_markdownlint-cli2@0.5.1
+      micromatch: 4.0.5
+      strip-json-comments: 5.0.0
+      yaml: 2.1.1
+    dev: true
+
+  /markdownlint/0.26.2:
+    resolution: {integrity: sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==}
+    engines: {node: '>=14'}
+    dependencies:
+      markdown-it: 13.0.1
     dev: true
 
   /match-sorter/6.3.1:
@@ -6796,6 +6859,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /slash/4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
+    dev: true
+
   /slice-ansi/4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
@@ -7109,6 +7177,11 @@ packages:
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  /strip-json-comments/5.0.0:
+    resolution: {integrity: sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==}
+    engines: {node: '>=14.16'}
+    dev: true
 
   /strip-literal/0.4.2:
     resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
@@ -8009,6 +8082,11 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /yaml/2.1.1:
+    resolution: {integrity: sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==}
+    engines: {node: '>= 14'}
     dev: true
 
   /yaml/2.1.3:


### PR DESCRIPTION
Hi maintainers 👋🏻, this pr will add the markdown linter (same as fastify) as written in the issue #231 .

Btw i have a doubt, i also added the gh action CI config, was it implicit in the issue or the general idea was just to add the dependency and configuration?

Thanks for any feedback!