### PR TITLE
Specify plugin options

### DIFF
--- a/packages/service/fixtures/options/platformatic.service.yml
+++ b/packages/service/fixtures/options/platformatic.service.yml
@@ -1,0 +1,8 @@
+server:
+  hostname: "127.0.0.1"
+  port: 0
+plugin:
+  path: "./plugin.js"
+  options:
+    something: 'else'
+metrics: false

--- a/packages/service/fixtures/options/plugin.js
+++ b/packages/service/fixtures/options/plugin.js
@@ -1,0 +1,7 @@
+'use default'
+
+module.exports = async function (app, opts) {
+  app.get('/', async () => {
+    return opts
+  })
+}

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -151,6 +151,9 @@ const plugin = {
         }
       },
       additionalProperties: false
+    },
+    options: {
+      type: 'object'
     }
   },
   required: ['path']

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -48,7 +48,7 @@
     "fastify": "^4.6.0",
     "fastify-metrics": "^10.0.0",
     "fastify-plugin": "^4.1.0",
-    "fastify-sandbox": "^0.9.0",
+    "fastify-sandbox": "^0.10.0",
     "graphql": "^16.6.0",
     "help-me": "^4.1.0",
     "mercurius": "^11.3.0",

--- a/packages/service/test/cli/start.test.mjs
+++ b/packages/service/test/cli/start.test.mjs
@@ -17,7 +17,14 @@ test('autostart', async ({ equal, same, match, teardown }) => {
 })
 
 test('start command', async ({ equal, same, match, teardown }) => {
-  const { child } = await start('start', '-c', join(import.meta.url, '..', '..', 'fixtures', 'hello', 'platformatic.service.json'))
+  const { child, url } = await start('start', '-c', join(import.meta.url, '..', '..', 'fixtures', 'hello', 'platformatic.service.json'))
+
+  const res = await request(`${url}`)
+  equal(res.statusCode, 200)
+  const body = await res.body.json()
+  match(body, {
+    hello: 'world'
+  }, 'response')
 
   child.kill('SIGINT')
 })
@@ -25,5 +32,18 @@ test('start command', async ({ equal, same, match, teardown }) => {
 test('default logger', async ({ equal, same, match, teardown }) => {
   const { child, url } = await start('-c', join(import.meta.url, '..', '..', 'fixtures', 'hello', 'no-server-logger.json'))
   match(url, /http:\/\/127.0.0.1:[0-9]+/)
+  child.kill('SIGINT')
+})
+
+test('plugin options', async ({ equal, same, match, teardown }) => {
+  const { child, url } = await start('-c', join(import.meta.url, '..', '..', 'fixtures', 'options', 'platformatic.service.yml'))
+
+  const res = await request(`${url}`)
+  equal(res.statusCode, 200)
+  const body = await res.body.json()
+  match(body, {
+    something: 'else'
+  }, 'response')
+
   child.kill('SIGINT')
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,7 +363,7 @@ importers:
       fastify: ^4.6.0
       fastify-metrics: ^10.0.0
       fastify-plugin: ^4.1.0
-      fastify-sandbox: ^0.9.0
+      fastify-sandbox: ^0.10.0
       graphql: ^16.6.0
       help-me: ^4.1.0
       mercurius: ^11.3.0
@@ -401,7 +401,7 @@ importers:
       fastify: 4.9.2
       fastify-metrics: 10.0.0_fastify@4.9.2
       fastify-plugin: 4.3.0
-      fastify-sandbox: 0.9.2
+      fastify-sandbox: 0.10.0
       graphql: 16.6.0
       help-me: 4.1.0
       mercurius: 11.3.0_graphql@16.6.0
@@ -3579,8 +3579,8 @@ packages:
       table: 6.8.1
     dev: false
 
-  /fastify-sandbox/0.9.2:
-    resolution: {integrity: sha512-VkJR05n3ZJxMc65K9lM2JmUqKuW1W4Xv6XcB8p0FIB0THLVKNb+gsMZzTdeQl+TihluhjS42wZBbews20Har9w==}
+  /fastify-sandbox/0.10.0:
+    resolution: {integrity: sha512-Qeua7svdr3x8gztMPi8WB7yNJ05batohtYsMRhL6pwmqFxbJ36nNPjeAsGKt2Iexizaz0y+fJ/BDdcczvVdjLQ==}
     dependencies:
       import-fresh: 3.3.0
     optionalDependencies:


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

This change allows developers to specify the options for the loaded plugin from the main config file.

This partially solves https://github.com/platformatic/platformatic/issues/274.

Note that this feature was half-backed before (it worked with watch disabled) and I'm just completing it.