### PR TITLE
Param to skip auth when using entities programmatically

### DIFF
--- a/docs/reference/db/authorization/introduction.md
+++ b/docs/reference/db/authorization/introduction.md
@@ -149,3 +149,21 @@ The check is performed based on the `find` permissions, the only permissions tha
 3. `find: { checks: { [prop]: { eq: 'X-PLATFORMATIC-PROP' } } }` validates that the given prop is equal
 
 Conflicting rules across roles for different equality checks will not be supported.
+
+## Programmatically skip authorization rules 
+
+In custom plugins, it's possible to skip the authorization rules on entities programmatically by setting the `skipAuth` flag to `true`, e.g.:
+
+
+```js
+    // this works even if the user's role doesn't have the `find` permission
+    const res = await app.platformatic.entities.page.find({skipAuth: true})
+```
+
+This is useful for custom plugins for which the authentication is not necessary, so there is no user role set when invoked.
+
+:::info
+Skip authorization rules is not possible on the automatically generated REST and GraphQL APIs. 
+:::
+
+

--- a/packages/db-authorization/index.js
+++ b/packages/db-authorization/index.js
@@ -163,7 +163,10 @@ async function auth (app, opts) {
       checkSaveMandatoryFieldsInRules(type, rules)
 
       app.platformatic.addEntityHooks(entityKey, {
-        async find (originalFind, { where, ctx, fields, ...restOpts }) {
+        async find (originalFind, { where, ctx, fields, skipAuth, ...restOpts }) {
+          if (skipAuth) {
+            return originalFind({ ...restOpts, where, ctx, fields })
+          }
           const request = getRequestFromContext(ctx)
           const rule = findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
           checkFieldsFromRule(rule.find, fields)
@@ -172,7 +175,10 @@ async function auth (app, opts) {
           return originalFind({ ...restOpts, where, ctx, fields })
         },
 
-        async save (originalSave, { input, ctx, fields }) {
+        async save (originalSave, { input, ctx, fields, skipAuth }) {
+          if (skipAuth) {
+            return originalSave({ input, ctx, fields })
+          }
           const request = getRequestFromContext(ctx)
           const rule = findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
 
@@ -216,7 +222,10 @@ async function auth (app, opts) {
           return originalSave({ input, ctx, fields })
         },
 
-        async insert (originalInsert, { inputs, ctx, fields }) {
+        async insert (originalInsert, { inputs, ctx, fields, skipAuth }) {
+          if (skipAuth) {
+            return originalInsert({ inputs, ctx, fields })
+          }
           const request = getRequestFromContext(ctx)
           const rule = findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
 
@@ -244,7 +253,10 @@ async function auth (app, opts) {
           return originalInsert({ inputs, ctx, fields })
         },
 
-        async delete (originalDelete, { where, ctx, fields }) {
+        async delete (originalDelete, { where, ctx, fields, skipAuth }) {
+          if (skipAuth) {
+            return originalDelete({ where, ctx, fields })
+          }
           const request = getRequestFromContext(ctx)
           const rule = findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
 

--- a/packages/db-authorization/test/skip-authorization.test.js
+++ b/packages/db-authorization/test/skip-authorization.test.js
@@ -1,0 +1,240 @@
+'use strict'
+
+const { test } = require('tap')
+const fastify = require('fastify')
+const core = require('@platformatic/db-core')
+const { connInfo, clear, isSQLite } = require('./helper')
+const auth = require('..')
+
+async function createBasicPages (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE pages (
+      id INTEGER PRIMARY KEY,
+      title VARCHAR(42),
+      user_id INTEGER
+    );`)
+  } else {
+    await db.query(sql`CREATE TABLE pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(42),
+      user_id INTEGER
+    );`)
+  }
+}
+
+test('use the skipAuth option tp avoid permissions programatically', async ({ pass, teardown, same, equal }) => {
+  const app = fastify()
+  app.register(core, {
+    ...connInfo,
+    events: false,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(auth, {
+    jwt: {
+      secret: 'supersecret'
+    },
+    roleKey: 'X-PLATFORMATIC-ROLE',
+    anonymousRole: 'anonymous',
+    rules: [{
+      role: 'user',
+      entity: 'page',
+      find: false,
+      delete: false,
+      save: false
+    }, {
+      role: 'anonymous',
+      entity: 'page',
+      find: false,
+      delete: false,
+      save: false
+    }]
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const token = await app.jwt.sign({
+    'X-PLATFORMATIC-USER-ID': 42,
+    'X-PLATFORMATIC-ROLE': 'user'
+  })
+
+  // create a page through the API fails...
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          mutation {
+            savePage(input: { title: "Hello" }) {
+              id
+              title
+              userId
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'savePage status code')
+
+    same(res.json(), {
+      data: {
+        savePage: null
+      },
+      errors: [
+        {
+          message: 'operation not allowed',
+          locations: [
+            {
+              line: 3,
+              column: 13
+            }
+          ],
+          path: [
+            'savePage'
+          ]
+        }
+      ]
+    }, 'savePage response')
+  }
+
+  // ...but it works if we skip the authorization programmatically
+  {
+    const res = await app.platformatic.entities.page.save({
+      input: { title: 'page title' },
+      skipAuth: true
+    })
+    same(res, { id: '1', title: 'page title', userId: null }, 'save')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          query {
+            getPageById(id: 1) {
+              id
+              title
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'pages status code')
+
+    same(res.json(), {
+      data: {
+        getPageById: null
+      },
+      errors: [
+        {
+          message: 'operation not allowed',
+          locations: [
+            {
+              line: 3,
+              column: 13
+            }
+          ],
+          path: [
+            'getPageById'
+          ]
+        }
+      ]
+    }, 'getPageById')
+  }
+
+  // ...but it works if we skip the authorization programmatically
+  {
+    const res = await app.platformatic.entities.page.find({
+      skipAuth: true
+    })
+    same(res, [{ id: '1', title: 'page title', userId: null }], 'find')
+  }
+
+  {
+    const resInsert = await app.platformatic.entities.page.insert({
+      inputs: [{ title: 'page title2' }],
+      skipAuth: true
+    })
+
+    same(resInsert, [{ id: '2', title: 'page title2', userId: null }], 'insert')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          mutation {
+            deletePages(where: { id: { eq: 1 } }) {
+              id
+              title
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'deletePages status code')
+    same(res.json(), {
+      data: {
+        deletePages: null
+      },
+      errors: [
+        {
+          message: 'operation not allowed',
+          locations: [
+            {
+              line: 3,
+              column: 13
+            }
+          ],
+          path: [
+            'deletePages'
+          ]
+        }
+      ]
+    }, 'deletePages response')
+  }
+
+  {
+    await app.platformatic.entities.page.delete({
+      where: {
+        id: {
+          eq: 1
+        }
+      },
+      skipAuth: true
+    })
+
+    await app.platformatic.entities.page.delete({
+      where: {
+        id: {
+          eq: 2
+        }
+      },
+      skipAuth: true
+    })
+
+    const res = await app.platformatic.entities.page.find({
+      skipAuth: true
+    })
+    same(res, [], 'find')
+  }
+})


### PR DESCRIPTION
When we use `sql-mapper` in custom plugins, we might want to skip authorization rules, for instance if we need to write an unprotected route. 
Here we add a `skipAuth` parameters for this purpose. 
This does not affect the automatically generated endpoints. 

