### PR TITLE
docs: fix sample config enabling dashboard

### DIFF
--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -470,8 +470,6 @@ Server will listen to `http://127.0.0.1:3042`
       "enabled": true
     }
   },
-  "dashboard": {
-    "enabled": true
-  }
+  "dashboard": true
 }
 ```


### PR DESCRIPTION
The `dashboard` setting in the sample configuration here is invalid: https://oss.platformatic.dev/docs/reference/db/configuration#sample-configuration