### PR TITLE
fix checking for authorized fields if no field is specified

### DIFF
--- a/packages/db-authorization/index.js
+++ b/packages/db-authorization/index.js
@@ -170,7 +170,7 @@ async function auth (app, opts) {
           }
           const request = getRequestFromContext(ctx)
           const rule = findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
-          checkFieldsFromRule(rule.find, fields)
+          checkFieldsFromRule(rule.find, fields || Object.keys(app.platformatic.entities[entityKey].fields))
           where = await fromRuleToWhere(ctx, rule.find, where, request.user)
 
           return originalFind({ ...restOpts, where, ctx, fields })

--- a/packages/db-authorization/test/fields-permissions.test.js
+++ b/packages/db-authorization/test/fields-permissions.test.js
@@ -186,6 +186,22 @@ test('users can find only the authorized fields', async ({ pass, teardown, same,
       ]
     }, 'pages response')
   }
+
+  {
+    const res = await app.inject({
+      url: '/pages',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+    equal(res.statusCode, 401, 'GET /pages status code (Unauthorized)')
+    same(res.json(), {
+      statusCode: 401,
+      error: 'Unauthorized',
+      code: 'PLT_DB_AUTH_UNAUTHORIZED',
+      message: 'field not allowed: author'
+    }, 'GET /pages status response (Unauthorized)')
+  }
 })
 
 test('users can save only the authorized fields', async ({ pass, teardown, same, equal }) => {


### PR DESCRIPTION
fix #323 