### PR TITLE
JWT namespace configuration

### DIFF
--- a/docs/guides/jwt-auth0.md
+++ b/docs/guides/jwt-auth0.md
@@ -1,7 +1,7 @@
 # Configure JWT with Auth0
 
 [Auth0](https://auth0.com/) is a powerful authentication and authorization service provider that can be integrated with Platformatic DB through [JSON Web Tokens](https://jwt.io/) (JWT) tokens. 
-When a user is authenticated, Auth0 creates a JWT token with all necessary security informations and custom claims (like the `X-PLATFORMATIC-ROLE`, see [User Metadata](../reference/db-authorization/introduction#user-metadata)) and signs the token. 
+When a user is authenticated, Auth0 creates a JWT token with all necessary security informations and custom claims (like the `X-PLATFORMATIC-ROLE`, see [User Metadata](../reference/db/authorization/introduction#user-metadata)) and signs the token. 
 
 Platformatic DB needs the correct public key to verify the JWT signature. 
 The fastest way is to leverage [JWKS](https://www.rfc-editor.org/rfc/rfc7517), since Auth0 exposes a [JWKS](https://www.rfc-editor.org/rfc/rfc7517) endpoint for each tenant.
@@ -25,7 +25,30 @@ To configure Platformatic DB authorization to use [JWKS](https://www.rfc-editor.
 ...
 
 ```
-
+:::danger
 Note that specify `allowedDomains` is critical to correctly restrict the JWT that MUST be issued from one of the allowed domains.
+:::
 
+## Custom Claim Namespace
+
+In Auth0 there are [restrictions](https://auth0.com/docs/secure/tokens/json-web-tokens/create-custom-claims#general-restrictions) about the custom claim that can be set on access tokens. One of these is that the custom claims MUST be namespaced, i.e. we cannot have `X-PLATFORMATIC-ROLE` but we must specify a namespace, e.g.: `https://platformatic.dev/X-PLATFORMATIC-ROLE`
+
+To map these claims to user metadata removing the namespace, we can specify the namespace in the JWT options:
+
+```json
+...
+"authorization": {
+    "jwt": {
+      "namespace": "https://platformatic.dev/",
+      "jwks": {
+        "allowedDomains": [
+          "https://dev-xxx.us.auth0.com/"
+        ]
+      }
+    },
+  }
+...
+
+```
+With this configuration, the `https://platformatic.dev/X-PLATFORMATIC-ROLE` claim is mapped to `X-PLATFORMATIC-ROLE` user metadata.
 

--- a/docs/reference/db/authorization/introduction.md
+++ b/docs/reference/db/authorization/introduction.md
@@ -68,6 +68,25 @@ It's also possible to enable [JWKS](https://www.rfc-editor.org/rfc/rfc7517) with
 ```
 In this case, the JWKS URL is calculated from the `iss` (issuer) field of JWT, so every JWT token from an issuer that exposes a valid JWKS token will pass the validation. For that reason, **this configuration should be used only for development**, while in every other case the `allowedDomains` should be specified.
 
+### JWT Custom Claim Namespace
+JWT claims can be namespaced to avoid name collisions. If so, we will receive tokens with custom claims such as: `https://platformatic.dev/X-PLATFORMATIC-ROLE` (where `https://platformatic.cloud/ is the namespace).
+If we want to map these claims to user metadata removing our namespace, we can specify the namespace in the JWT options:
+
+```json
+  ...
+
+  "authorization": {
+    "jwt": {
+      "namespace": "https://platformatic.dev/"
+      }
+    },
+  }
+
+  ...
+```
+
+With this configuration, the `https://platformatic.dev/X-PLATFORMATIC-ROLE` claim is mapped to `X-PLATFORMATIC-ROLE` user metadata.
+
 
 ## Webhook
 Platformatic can use a webhook to authenticate the requests.

--- a/packages/db-authorization/lib/jwt.js
+++ b/packages/db-authorization/lib/jwt.js
@@ -7,9 +7,28 @@ const buildGetJwks = require('get-jwks')
 module.exports = fp(async function (app, opts) {
   // opts.jwks can be `true` (to enable with no options)
   // or options from https://github.com/nearform/get-jwks#options
+
+  const namespace = opts?.namespace
+  // @fastify/jwt does not init correctly if `namespace` is set in options, so we remove it
+  delete opts.namespace
+  const formatUser = namespace
+    ? user => {
+      const userDataNoNamespace = {}
+      for (const key of Object.keys(user)) {
+        if (key.startsWith(namespace)) {
+          userDataNoNamespace[key.slice(namespace.length)] = user[key]
+        } else {
+          userDataNoNamespace[key] = user[key]
+        }
+      }
+      return userDataNoNamespace
+    }
+    : user => user
+
   if (opts.jwks) {
     const getJwks = buildGetJwks(typeof opts.jwks === 'object' ? opts.jwks : {})
     app.register(jwt, {
+      formatUser,
       ...opts,
       decode: { complete: true },
       secret: function (request, token) {
@@ -21,7 +40,7 @@ module.exports = fp(async function (app, opts) {
       }
     })
   } else {
-    app.register(jwt, opts)
+    app.register(jwt, { formatUser, ...opts })
   }
 
   app.decorateRequest('createJWTSession', function () {

--- a/packages/db-authorization/test/jwt.test.js
+++ b/packages/db-authorization/test/jwt.test.js
@@ -513,3 +513,140 @@ test('jwt verify fail if the domain is not allowed', async ({ pass, teardown, sa
     }, 'savePage response')
   }
 })
+
+test('jwt skips configure namespace in custom claims', async ({ pass, teardown, same, equal }) => {
+  const { n, e, kty } = jwtPublicKey
+  const kid = 'TEST-KID'
+  const alg = 'RS256'
+  const jwksEndpoint = await buildJwksEndpoint(
+    {
+      keys: [
+        {
+          alg,
+          kty,
+          n,
+          e,
+          use: 'sig',
+          kid
+        }
+      ]
+    }
+  )
+  const issuer = `http://localhost:${jwksEndpoint.server.address().port}`
+  const header = {
+    kid,
+    alg,
+    typ: 'JWT'
+  }
+  const namespace = 'https://test.com/'
+  const payload = {
+    [`${namespace}X-PLATFORMATIC-USER-ID`]: 42,
+    [`${namespace}X-PLATFORMATIC-ROLE`]: ['user']
+  }
+
+  const app = fastify()
+  app.register(core, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(auth, {
+    jwt: {
+      jwks: true,
+      namespace
+    },
+    rules: [{
+      role: 'user',
+      entity: 'page',
+      find: true,
+      delete: false,
+      defaults: {
+        userId: 'X-PLATFORMATIC-USER-ID'
+      },
+      save: {
+        checks: {
+          userId: 'X-PLATFORMATIC-USER-ID'
+        }
+      }
+    }]
+  })
+  teardown(app.close.bind(app))
+  teardown(() => jwksEndpoint.close())
+
+  await app.ready()
+
+  const signSync = createSigner({
+    algorithm: 'RS256',
+    key: privateKey,
+    header,
+    iss: issuer,
+    kid
+  })
+  const token = signSync(payload)
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          mutation {
+            savePage(input: { title: "Hello" }) {
+              id
+              title
+              userId
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'savePage status code')
+    same(res.json(), {
+      data: {
+        savePage: {
+          id: 1,
+          title: 'Hello',
+          userId: 42
+        }
+      }
+    }, 'savePage response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          query {
+            getPageById(id: 1) {
+              id
+              title
+              userId
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'pages status code')
+    same(res.json(), {
+      data: {
+        getPageById: {
+          id: 1,
+          title: 'Hello',
+          userId: 42
+        }
+      }
+    }, 'pages response')
+  }
+})

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -102,6 +102,10 @@ const authorization = {
           type: 'string',
           description: 'the shared secret for JWT'
         },
+        namespace: {
+          type: 'string',
+          description: 'the namespace for JWT custom claims'
+        },
         jwks: {
           oneOf: [{
             type: 'boolean'


### PR DESCRIPTION
In Auth0 we have [restrictions](https://auth0.com/docs/secure/tokens/json-web-tokens/create-custom-claims#general-restrictions) about ther custom claim. 
One is that they MUST have a namespace for access tokens. 
So, instead of  `X-PLATFORMATIC-ROLE` we receive `https://platformatic.dev/X-PLATFORMATIC-ROLE`. 
This is a problem when we have BOTH JWT and webhook configured.
With this change it's possible to specify in JWT configuration a  `namespace` that is automatically removed when extracting user metadata from JWT claims, so that we can user a `roleKey` without a namespace (or the default X-PLATFORMATIC-ROLE) 