### PR TITLE
Automatic refresh of dashboard metrics

### DIFF
--- a/packages/db-dashboard/src/components/metrics/Metrics.jsx
+++ b/packages/db-dashboard/src/components/metrics/Metrics.jsx
@@ -18,6 +18,7 @@ export default function Metrics () {
       }
     }
     getMetrics()
+    setInterval(getMetrics, 5000)
   }, [])
 
   if (!metrics || metrics.error) return

--- a/packages/db-dashboard/src/components/metrics/Metrics.jsx
+++ b/packages/db-dashboard/src/components/metrics/Metrics.jsx
@@ -18,7 +18,10 @@ export default function Metrics () {
       }
     }
     getMetrics()
-    setInterval(getMetrics, 5000)
+    const intervalId = setInterval(getMetrics, 5000)
+    return () => {
+      clearInterval(intervalId)
+    }
   }, [])
 
   if (!metrics || metrics.error) return


### PR DESCRIPTION
Simple `setTimeout` to refresh the metrics ervery 5 seconds without reloading the page. 