### PR TITLE
Add `like` support on where clause

### DIFF
--- a/docs/reference/sql-mapper/entities/api.md
+++ b/docs/reference/sql-mapper/entities/api.md
@@ -6,7 +6,7 @@ A set of operation methods are available on each entity:
 - [`insert`](#insert)
 - [`save`](#save)
 - [`delete`](#delete)
-- [`updateMany`](#updateMany)
+- [`updateMany`](#updatemany)
 
 
 ## Returned fields
@@ -29,6 +29,7 @@ The `where` object's key is the field you want to check, the value is a key/valu
 | gte | `'>='` |
 | lt | `'<'` |
 | lte | `'<='` |
+| like | `'LIKE'` |
 
 ### Examples
 

--- a/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
@@ -44,6 +44,7 @@ input PageWhereArgumentsid {
   gte: ID
   lt: ID
   lte: ID
+  like: ID
   in: [ID]
   nin: [ID]
 }
@@ -55,6 +56,7 @@ input PageWhereArgumentstitle {
   gte: String
   lt: String
   lte: String
+  like: String
   in: [String]
   nin: [String]
 }

--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -44,6 +44,7 @@ input GraphWhereArgumentsid {
   gte: ID
   lt: ID
   lte: ID
+  like: ID
   in: [ID]
   nin: [ID]
 }
@@ -55,6 +56,7 @@ input GraphWhereArgumentsname {
   gte: String
   lt: String
   lte: String
+  like: String
   in: [String]
   nin: [String]
 }
@@ -206,6 +208,14 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
           },
           {
             "schema": {
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "where.id.like",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -266,6 +276,14 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
             },
             "in": "query",
             "name": "where.name.lte",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "where.name.like",
             "required": false
           },
           {
@@ -425,6 +443,14 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
           },
           {
             "schema": {
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "where.id.like",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -485,6 +511,14 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
             },
             "in": "query",
             "name": "where.name.lte",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "where.name.like",
             "required": false
           },
           {

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -81,6 +81,7 @@ function constructGraph (app, entity, opts) {
             gte: { type: fields[field].type },
             lt: { type: fields[field].type },
             lte: { type: fields[field].type },
+            like: { type: fields[field].type },
             in: { type: new graphql.GraphQLList(fields[field].type) },
             nin: { type: new graphql.GraphQLList(fields[field].type) }
           }

--- a/packages/sql-graphql/test/where.test.js
+++ b/packages/sql-graphql/test/where.test.js
@@ -812,3 +812,291 @@ test('delete all', async ({ pass, teardown, same, equal }) => {
     }, 'posts response')
   }
 })
+
+test('like', async ({ pass, teardown, same, equal }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      }
+    }
+  })
+  app.register(sqlGraphQL)
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const posts = [{
+    title: 'Dog',
+    longText: 'The dog barks',
+    counter: 10
+  }, {
+    title: 'Cat',
+    longText: 'The cat meows',
+    counter: 20
+  }, {
+    title: 'Mouse',
+    longText: 'The mouse likes cheese',
+    counter: 30
+  }, {
+    title: 'Duck',
+    longText: 'A duck tale',
+    counter: 40
+  }]
+
+  await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: {
+      query: `
+          mutation batch($inputs : [PostInput]!) {
+            insertPosts(inputs: $inputs) {
+              id
+              title
+            }
+          }
+        `,
+      variables: {
+        inputs: posts
+      }
+    }
+  })
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [{
+          id: '1',
+          title: 'Dog',
+          longText: 'The dog barks',
+          counter: 10
+        }, {
+          id: '2',
+          title: 'Cat',
+          longText: 'The cat meows',
+          counter: 20
+        }, {
+          id: '3',
+          title: 'Mouse',
+          longText: 'The mouse likes cheese',
+          counter: 30
+        }, {
+          id: '4',
+          title: 'Duck',
+          longText: 'A duck tale',
+          counter: 40
+        }]
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { longText: { like: "The%" } }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'where: { longText: { like: "The%" } } status code')
+    same(res.json(), {
+      data: {
+        posts: [{
+          id: '1',
+          title: 'Dog',
+          longText: 'The dog barks',
+          counter: 10
+        }, {
+          id: '2',
+          title: 'Cat',
+          longText: 'The cat meows',
+          counter: 20
+        }, {
+          id: '3',
+          title: 'Mouse',
+          longText: 'The mouse likes cheese',
+          counter: 30
+        }]
+      }
+    }, 'where: { longText: { like: "The%" } } response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { longText: { like: "%s" } }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'where: { longText: { like: "%s" } } status code')
+    same(res.json(), {
+      data: {
+        posts: [{
+          id: '1',
+          title: 'Dog',
+          longText: 'The dog barks',
+          counter: 10
+        }, {
+          id: '2',
+          title: 'Cat',
+          longText: 'The cat meows',
+          counter: 20
+        }]
+      }
+    }, 'where: { longText: { like: "%s" } } response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { longText: { like: "%o%" } }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'where: { longText: { like: "%o%" } } status code')
+    same(res.json(), {
+      data: {
+        posts: [{
+          id: '1',
+          title: 'Dog',
+          longText: 'The dog barks',
+          counter: 10
+        }, {
+          id: '2',
+          title: 'Cat',
+          longText: 'The cat meows',
+          counter: 20
+        }, {
+          id: '3',
+          title: 'Mouse',
+          longText: 'The mouse likes cheese',
+          counter: 30
+        }]
+      }
+    }, 'where: { longText: { like: "%o%" } } response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { counter: { like: 10 } }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'where: { counter: { like: 10 } } status code')
+    same(res.json(), {
+      data: {
+        posts: [{
+          id: '1',
+          title: 'Dog',
+          longText: 'The dog barks',
+          counter: 10
+        }]
+      }
+    }, 'where: { counter: { like: 10 } } response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { counter: { like: 40 } }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'where: { counter: { like: 40 } } status code')
+    same(res.json(), {
+      data: {
+        posts: [{
+          id: '4',
+          title: 'Duck',
+          longText: 'A duck tale',
+          counter: 40
+        }]
+      }
+    }, 'where: { counter: { like: 40 } } response')
+  }
+})

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -165,7 +165,8 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKey, relations
     gt: '>',
     gte: '>=',
     lt: '<',
-    lte: '<='
+    lte: '<=',
+    like: 'LIKE'
   }
 
   function computeCriteria (opts) {
@@ -186,6 +187,14 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKey, relations
           criteria.push(sql`${sql.ident(field)} IS NULL`)
         } else if (operator === '<>' && value[key] === null) {
           criteria.push(sql`${sql.ident(field)} IS NOT NULL`)
+        } else if (operator === 'LIKE') {
+          let leftHand = sql.ident(field)
+          // NOTE: cast fields AS CHAR(64) and TRIM the whitespaces
+          // to prevent errors with fields different than VARCHAR & TEXT
+          if (!['text', 'varchar'].includes(fieldWrap.sqlType)) {
+            leftHand = sql`TRIM(CAST(${sql.ident(field)} AS CHAR(64)))`
+          }
+          criteria.push(sql`${leftHand} LIKE ${value[key]}`)
         } else {
           criteria.push(sql`${sql.ident(field)} ${sql.__dangerous__rawValue(operator)} ${computeCriteriaValue(fieldWrap, value[key])}`)
         }

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -94,6 +94,10 @@ export interface WhereCondition {
      * Not in values.
      */
     nin?: any[]
+    /**
+     * Like value.
+     */
+    like?: string
   }
 }
 

--- a/packages/sql-mapper/test/where.test.js
+++ b/packages/sql-mapper/test/where.test.js
@@ -434,3 +434,143 @@ test('is NULL', async ({ pass, teardown, same, equal }) => {
     title: 'Dog'
   }])
 })
+
+test('LIKE', async ({ pass, teardown, same, equal }) => {
+  const mapper = await connect({
+    ...connInfo,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      teardown(() => db.dispose())
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      }
+    }
+  })
+
+  const entity = mapper.entities.post
+
+  const posts = [
+    {
+      title: 'Dog',
+      longText: 'The Dog barks',
+      counter: 1
+    },
+    {
+      title: 'Cat',
+      longText: 'The Cat meows',
+      counter: 2
+    },
+    {
+      title: 'Potato',
+      longText: 'The Potato is vegetable',
+      counter: 3
+    },
+    {
+      title: 'atmosphere',
+      longText: 'The atmosphere is not a sphere',
+      counter: 4
+    },
+    {
+      title: 'planet',
+      longText: 'The planet have atmosphere',
+      counter: 14
+    }
+  ]
+
+  await entity.insert({
+    inputs: posts
+  })
+
+  same(await entity.find({ where: { title: { like: '%at' } } }), [{
+    id: '2',
+    title: 'Cat',
+    longText: 'The Cat meows',
+    counter: 2
+  }], 'where: { title: { like: \'%at\' } }')
+
+  same(await entity.find({ where: { title: { like: '%at%' } } }), [{
+    id: '2',
+    title: 'Cat',
+    longText: 'The Cat meows',
+    counter: 2
+  },
+  {
+    id: '3',
+    title: 'Potato',
+    longText: 'The Potato is vegetable',
+    counter: 3
+  },
+  {
+    id: '4',
+    title: 'atmosphere',
+    longText: 'The atmosphere is not a sphere',
+    counter: 4
+  }], 'where: { title: { like: \'%at%\' } }')
+
+  same(await entity.find({ where: { title: { like: 'at%' } } }), [{
+    id: '4',
+    title: 'atmosphere',
+    longText: 'The atmosphere is not a sphere',
+    counter: 4
+  }], 'where: { title: { like: \'at%\' } }')
+
+  same(await entity.find({ where: { longText: { like: '%is%' } } }), [{
+    id: '3',
+    title: 'Potato',
+    longText: 'The Potato is vegetable',
+    counter: 3
+  },
+  {
+    id: '4',
+    title: 'atmosphere',
+    longText: 'The atmosphere is not a sphere',
+    counter: 4
+  }], 'where: { longText: { like: \'%is%\' } }')
+
+  same(await entity.find({ where: { longText: { like: null } } }), [], 'where: { longText: { like: null } }')
+
+  same(await entity.find({ where: { counter: { like: 4 } } }), [{
+    id: '4',
+    title: 'atmosphere',
+    longText: 'The atmosphere is not a sphere',
+    counter: 4
+  }], 'where: { counter: { like: 4 } }')
+
+  same(await entity.find({ where: { counter: { like: '%4' } } }), [{
+    id: '4',
+    title: 'atmosphere',
+    longText: 'The atmosphere is not a sphere',
+    counter: 4
+  },
+  {
+    id: '5',
+    title: 'planet',
+    longText: 'The planet have atmosphere',
+    counter: 14
+  }], 'where: { counter: { like: \'%4\' } }')
+
+  same(await entity.find({ where: { counter: { like: '4%' } } }), [{
+    id: '4',
+    title: 'atmosphere',
+    longText: 'The atmosphere is not a sphere',
+    counter: 4
+  }], 'where: { counter: { like: \'4%\' } }')
+
+  same(await entity.find({ where: { counter: { like: null } } }), [], 'where: { counter: { like: null } }')
+})

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -59,7 +59,7 @@ async function entityPlugin (app, opts) {
   const whereArgs = sortedEntityFields.reduce((acc, name) => {
     const field = entity.fields[name]
     const baseKey = `where.${field.camelcase}.`
-    for (const modifier of ['eq', 'neq', 'gt', 'gte', 'lt', 'lte']) {
+    for (const modifier of ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like']) {
       const key = baseKey + modifier
       acc[key] = { type: mapSQLTypeToOpenAPIType(field.sqlType), enum: field.enum }
     }

--- a/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi-recursive.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi-recursive.cjs
@@ -133,6 +133,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -197,6 +205,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.name.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.name.in",
             "required": false,
             "schema": Object {
@@ -254,6 +270,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.parentId.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.parentId.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -433,6 +457,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -497,6 +529,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.name.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.name.in",
             "required": false,
             "schema": Object {
@@ -554,6 +594,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.parentId.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.parentId.like",
             "required": false,
             "schema": Object {
               "type": "integer",

--- a/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
@@ -154,6 +154,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -211,6 +219,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.name.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.name.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -371,6 +387,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -428,6 +452,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.name.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.name.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -838,6 +870,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -895,6 +935,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -966,6 +1014,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -1030,6 +1086,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.ownerId.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.ownerId.in",
             "required": false,
             "schema": Object {
@@ -1087,6 +1151,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -1286,6 +1358,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -1343,6 +1423,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -1414,6 +1502,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -1478,6 +1574,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.ownerId.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.ownerId.in",
             "required": false,
             "schema": Object {
@@ -1535,6 +1639,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
@@ -132,6 +132,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -196,6 +204,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -253,6 +269,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -419,6 +443,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -483,6 +515,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -540,6 +580,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
@@ -128,6 +128,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -185,6 +193,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -338,6 +354,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -395,6 +419,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
@@ -127,6 +127,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -184,6 +192,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -337,6 +353,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -394,6 +418,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
@@ -128,6 +128,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -185,6 +193,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -338,6 +354,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -395,6 +419,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-4.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-4.cjs
@@ -128,6 +128,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -185,6 +193,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -338,6 +354,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -395,6 +419,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/updateMany-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/updateMany-openapi-1.cjs
@@ -137,6 +137,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -194,6 +202,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -265,6 +281,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -322,6 +346,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -501,6 +533,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -558,6 +598,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -629,6 +677,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -686,6 +742,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
@@ -137,6 +137,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -194,6 +202,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -265,6 +281,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -322,6 +346,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -501,6 +533,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -558,6 +598,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -629,6 +677,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -686,6 +742,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
@@ -154,6 +154,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -211,6 +219,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.name.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.name.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -371,6 +387,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.id.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.id.in",
             "required": false,
             "schema": Object {
@@ -428,6 +452,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.name.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.name.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -838,6 +870,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -895,6 +935,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -966,6 +1014,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -1030,6 +1086,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.ownerId.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.ownerId.in",
             "required": false,
             "schema": Object {
@@ -1087,6 +1151,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",
@@ -1286,6 +1358,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.counter.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.counter.in",
             "required": false,
             "schema": Object {
@@ -1343,6 +1423,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.id.lte",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.id.like",
             "required": false,
             "schema": Object {
               "type": "integer",
@@ -1414,6 +1502,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.longText.like",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.longText.in",
             "required": false,
             "schema": Object {
@@ -1478,6 +1574,14 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.ownerId.like",
+            "required": false,
+            "schema": Object {
+              "type": "integer",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "where.ownerId.in",
             "required": false,
             "schema": Object {
@@ -1535,6 +1639,14 @@ Object {
           Object {
             "in": "query",
             "name": "where.title.lte",
+            "required": false,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.title.like",
             "required": false,
             "schema": Object {
               "type": "string",


### PR DESCRIPTION
fixes #348

 - [x] like support on sql-mapper
 - [x] like support on sql-openapi
 - [x] like support on sql-graphql
 - [ ] like support docs