### PR TITLE
Schema support for all DBs

### DIFF
--- a/docs/reference/db/schema-support.md
+++ b/docs/reference/db/schema-support.md
@@ -1,9 +1,5 @@
 # Schema support
 
-:::info
-*** Schemas are currently supported only in postgres***
-:::
-
 It's possible to specify the schemas where the tables are located. 
 
 _Example_

--- a/docs/reference/db/schema-support.md
+++ b/docs/reference/db/schema-support.md
@@ -1,6 +1,8 @@
 # Schema support
 
-It's possible to specify the schemas where the tables are located. 
+It's possible to specify the schemas where the tables are located (if the database supports schemas).
+
+```typescript
 
 _Example_
 

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -60,7 +60,7 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKey, relations
     if (args.input === undefined) {
       throw new Error('Input not provided.')
     }
-    // args.input is not array/
+    // args.input is not array
     const fieldsToRetrieve = computeFields(args.fields).map((f) => sql.ident(f))
     const input = fixInput(args.input)
     let now
@@ -323,7 +323,6 @@ async function buildEntity (db, sql, log, table, queries, autoTimestamp, schema,
   // To get enum values in pg
   /* istanbul ignore next */
   if (db.isPg) {
-    // TODO: schema?
     const enums = await queries.listEnumValues(db, sql, table, schema)
     for (const enumValue of enums) {
       if (!fields[enumValue.column_name].enum) {

--- a/packages/sql-mapper/lib/queries/mysql-shared.js
+++ b/packages/sql-mapper/lib/queries/mysql-shared.js
@@ -22,39 +22,23 @@ async function listTables (db, sql, schemas) {
 }
 
 async function listColumns (db, sql, table, schema) {
-  const query = schema
-    ? sql`
+  const query = sql`
     SELECT column_name as column_name, data_type as udt_name, is_nullable as is_nullable, column_type as column_type
     FROM information_schema.columns
     WHERE table_name = ${table}
     AND table_schema = ${schema}
   `
-    : sql`
-    SELECT column_name as column_name, data_type as udt_name, is_nullable as is_nullable, column_type as column_type
-    FROM information_schema.columns
-    WHERE table_name = ${table}
-    AND table_schema = (SELECT DATABASE())
-  `
   return db.query(query)
 }
 
 async function listConstraints (db, sql, table, schema) {
-  const query = schema
-    ? sql`
+  const query = sql`
     SELECT TABLE_NAME as table_name, COLUMN_NAME as column_name, CONSTRAINT_TYPE as constraint_type, referenced_table_name AS foreign_table_name, referenced_column_name AS foreign_column_name
     FROM information_schema.table_constraints t
     JOIN information_schema.key_column_usage k
     USING (constraint_name, table_schema, table_name)
     WHERE t.table_name = ${table}
     AND t.table_schema = ${schema}
-    `
-    : sql`
-      SELECT TABLE_NAME as table_name, COLUMN_NAME as column_name, CONSTRAINT_TYPE as constraint_type, referenced_table_name AS foreign_table_name, referenced_column_name AS foreign_column_name
-    FROM information_schema.table_constraints t
-    JOIN information_schema.key_column_usage k
-    USING (constraint_name, table_schema, table_name)
-    WHERE t.table_name = ${table}
-    AND t.table_schema = (SELECT DATABASE())
     `
   return db.query(query)
 }

--- a/packages/sql-mapper/lib/queries/mysql.js
+++ b/packages/sql-mapper/lib/queries/mysql.js
@@ -2,8 +2,9 @@
 
 const { insertPrep } = require('./shared')
 const shared = require('./mysql-shared')
+const { tableName } = require('../utils')
 
-function insertOne (db, sql, table, input, primaryKey, useUUID, fieldsToRetrieve) {
+function insertOne (db, sql, table, schema, input, primaryKey, useUUID, fieldsToRetrieve) {
   const keysToSql = Object.keys(input).map((key) => sql.ident(key))
   const keys = sql.join(
     keysToSql,
@@ -25,14 +26,14 @@ function insertOne (db, sql, table, input, primaryKey, useUUID, fieldsToRetrieve
 
   return db.tx(async function (db) {
     const insert = sql`
-      INSERT INTO ${sql.ident(table)} (${keys})
+      INSERT INTO ${tableName(sql, table, schema)} (${keys})
       VALUES(${values})
     `
     await db.query(insert)
 
     const res2 = await db.query(sql`
       SELECT ${sql.join(fieldsToRetrieve, sql`, `)}
-      FROM ${sql.ident(table)}
+      FROM ${tableName(sql, table, schema)}
       WHERE ${sql.ident(primaryKey)} = (
         SELECT last_insert_id()
       )
@@ -42,11 +43,11 @@ function insertOne (db, sql, table, input, primaryKey, useUUID, fieldsToRetrieve
   })
 }
 
-function insertMany (db, sql, table, inputs, inputToFieldMap, primaryKey, fieldsToRetrieve, fields) {
+function insertMany (db, sql, table, schema, inputs, inputToFieldMap, primaryKey, fieldsToRetrieve, fields) {
   return db.tx(async function (db) {
     const { keys, values } = insertPrep(inputs, inputToFieldMap, fields, sql)
     const insert = sql`
-      insert into ${sql.ident(table)} (${keys})
+      insert into ${tableName(sql, table, schema)} (${keys})
       values ${sql.join(values, sql`, `)}
     `
 
@@ -54,7 +55,7 @@ function insertMany (db, sql, table, inputs, inputToFieldMap, primaryKey, fields
 
     const res = await db.query(sql`
       SELECT ${sql.join(fieldsToRetrieve, sql`, `)}
-      FROM ${sql.ident(table)}
+      FROM ${tableName(sql, table, schema)}
       ORDER BY ${sql.ident(primaryKey)} DESC
       LIMIT ${inputs.length}
     `)
@@ -67,11 +68,11 @@ function insertMany (db, sql, table, inputs, inputToFieldMap, primaryKey, fields
   })
 }
 
-function deleteAll (db, sql, table, criteria, fieldsToRetrieve) {
+function deleteAll (db, sql, table, schema, criteria, fieldsToRetrieve) {
   return db.tx(async function (db) {
     let selectQuery = sql`
       SELECT ${sql.join(fieldsToRetrieve, sql`, `)}
-      FROM ${sql.ident(table)}
+      FROM ${tableName(sql, table, schema)}
     `
     /* istanbul ignore else */
     if (criteria.length > 0) {
@@ -84,7 +85,7 @@ function deleteAll (db, sql, table, criteria, fieldsToRetrieve) {
     const res = await db.query(selectQuery)
 
     let deleteQuery = sql`
-      DELETE FROM ${sql.ident(table)}
+      DELETE FROM ${tableName(sql, table, schema)}
     `
 
     /* istanbul ignore else */

--- a/packages/sql-mapper/lib/queries/pg.js
+++ b/packages/sql-mapper/lib/queries/pg.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const shared = require('./shared')
+const { tableName } = require('../utils')
 
-async function insertOne (db, sql, table, input, primaryKey, isUuid, fieldsToRetrieve) {
+async function insertOne (db, sql, table, schema, input, primaryKey, isUuid, fieldsToRetrieve) {
   const inputKeys = Object.keys(input)
   if (inputKeys.length === 0) {
     const insert = sql`
-      INSERT INTO ${sql.ident(table)}
+      INSERT INTO ${tableName(sql, table, schema)}
       DEFAULT VALUES
       RETURNING ${sql.join(fieldsToRetrieve, sql`, `)}
     `
@@ -14,46 +15,46 @@ async function insertOne (db, sql, table, input, primaryKey, isUuid, fieldsToRet
     return res[0]
   }
 
-  return shared.insertOne(db, sql, table, input, primaryKey, isUuid, fieldsToRetrieve)
+  return shared.insertOne(db, sql, table, schema, input, primaryKey, isUuid, fieldsToRetrieve)
 }
 
 module.exports.insertOne = insertOne
 module.exports.deleteAll = shared.deleteAll
 module.exports.insertMany = shared.insertMany
 
-// The search path are the schemas that are allowed to NOT use the schema prefix
-async function getSearchPath (db, sql) {
-  const schemas = (await db.query(sql`SHOW search_path;`))[0]
-    .search_path.split(',')
-    .map(s => s.trim())
-    .map(s => `'${s}'`)
-  return sql.__dangerous__rawValue(schemas)
-}
-
-async function listTables (db, sql) {
-  const searchPath = await getSearchPath(db, sql)
-  return (await db.query(sql`
-    SELECT tablename
+async function listTables (db, sql, schemas) {
+  if (schemas) {
+    const schemaList = sql.__dangerous__rawValue(schemas.map(s => `'${s}'`))
+    const res = await db.query(sql`
+    SELECT tablename, schemaname
     FROM pg_catalog.pg_tables
     WHERE
-      schemaname in (${searchPath})`)).map(t => t.tablename)
+      schemaname in (${schemaList})`)
+    return res.map(r => ({ schema: r.schemaname, table: r.tablename }))
+  }
+  const res = await db.query(sql`
+    SELECT tablename, schemaname
+    FROM pg_catalog.pg_tables
+    WHERE
+      schemaname = current_schema()
+  `)
+  return res.map(r => ({ schema: r.schemaname, table: r.tablename }))
 }
 
 module.exports.listTables = listTables
 
-async function listColumns (db, sql, table) {
-  const searchPath = await getSearchPath(db, sql)
+async function listColumns (db, sql, table, schema) {
   return db.query(sql`
     SELECT column_name, udt_name, is_nullable
     FROM information_schema.columns
     WHERE table_name = ${table}
-    AND table_schema in (${searchPath})
+    AND table_schema = ${schema}
   `)
 }
 
 module.exports.listColumns = listColumns
 
-async function listConstraints (db, sql, table) {
+async function listConstraints (db, sql, table, schema) {
   const query = sql`
     SELECT constraints.*, usage.*, usage2.table_name AS foreign_table_name, usage2.column_name AS foreign_column_name
     FROM information_schema.table_constraints constraints
@@ -62,22 +63,22 @@ async function listConstraints (db, sql, table) {
         AND constraints.table_name = ${table}
       JOIN information_schema.constraint_column_usage usage2
         ON usage.constraint_name = usage2.constraint_name
-        AND usage.table_name = ${table}
+        AND ( usage.table_name = ${table}
+        AND usage.table_schema = ${schema} )
   `
-
   const constraintsList = await db.query(query)
   return constraintsList
 }
 
 module.exports.listConstraints = listConstraints
 
-async function updateOne (db, sql, table, input, primaryKey, fieldsToRetrieve) {
+async function updateOne (db, sql, table, schema, input, primaryKey, fieldsToRetrieve) {
   const pairs = Object.keys(input).map((key) => {
     const value = input[key]
     return sql`${sql.ident(key)} = ${value}`
   })
   const update = sql`
-    UPDATE ${sql.ident(table)}
+    UPDATE ${tableName(sql, table, schema)}
     SET ${sql.join(pairs, sql`, `)}
     WHERE ${sql.ident(primaryKey)} = ${sql.value(input[primaryKey])}
     RETURNING ${sql.join(fieldsToRetrieve, sql`, `)}
@@ -90,14 +91,24 @@ module.exports.updateOne = updateOne
 
 module.exports.updateMany = shared.updateMany
 
-async function listEnumValues (db, sql, table) {
-  return (await db.query(sql`
-  SELECT udt_name, enumlabel, column_name
-  FROM pg_enum e 
-  JOIN pg_type t ON e.enumtypid = t.oid 
-  JOIN information_schema.columns c on c.udt_name = t.typname
-  WHERE table_name = ${table};
-  `))
+async function listEnumValues (db, sql, table, schema) {
+  const query = schema
+    ? sql`
+    SELECT udt_name, enumlabel, column_name
+    FROM pg_enum e 
+    JOIN pg_type t ON e.enumtypid = t.oid 
+    JOIN information_schema.columns c on c.udt_name = t.typname
+    WHERE table_name = ${table}
+    AND table_schema = ${schema};
+    `
+    : sql`
+    SELECT udt_name, enumlabel, column_name
+    FROM pg_enum e 
+    JOIN pg_type t ON e.enumtypid = t.oid 
+    JOIN information_schema.columns c on c.udt_name = t.typname
+    WHERE table_name = ${table};
+  `
+  return db.query(query)
 }
 
 module.exports.listEnumValues = listEnumValues

--- a/packages/sql-mapper/lib/queries/pg.js
+++ b/packages/sql-mapper/lib/queries/pg.js
@@ -92,8 +92,7 @@ module.exports.updateOne = updateOne
 module.exports.updateMany = shared.updateMany
 
 async function listEnumValues (db, sql, table, schema) {
-  const query = schema
-    ? sql`
+  const query = sql`
     SELECT udt_name, enumlabel, column_name
     FROM pg_enum e 
     JOIN pg_type t ON e.enumtypid = t.oid 
@@ -101,13 +100,6 @@ async function listEnumValues (db, sql, table, schema) {
     WHERE table_name = ${table}
     AND table_schema = ${schema};
     `
-    : sql`
-    SELECT udt_name, enumlabel, column_name
-    FROM pg_enum e 
-    JOIN pg_type t ON e.enumtypid = t.oid 
-    JOIN information_schema.columns c on c.udt_name = t.typname
-    WHERE table_name = ${table};
-  `
   return db.query(query)
 }
 

--- a/packages/sql-mapper/lib/queries/shared.js
+++ b/packages/sql-mapper/lib/queries/shared.js
@@ -1,12 +1,14 @@
 'use strict'
 
+const { tableName } = require('../utils')
+
 /* istanbul ignore file */
 
-async function insertOne (db, sql, table, input, primaryKey, isUuid, fieldsToRetrieve) {
+async function insertOne (db, sql, table, schema, input, primaryKey, isUuid, fieldsToRetrieve) {
   const inputKeys = Object.keys(input)
   if (inputKeys.length === 0) {
     const insert = sql`
-      INSERT INTO ${sql.ident(table)}
+      INSERT INTO ${tableName(sql, table, schema)}
       ()
       VALUES ()
       RETURNING ${sql.join(fieldsToRetrieve, sql`, `)}
@@ -24,7 +26,7 @@ async function insertOne (db, sql, table, input, primaryKey, isUuid, fieldsToRet
     sql`, `
   )
   const insert = sql`
-    INSERT INTO ${sql.ident(table)} (${keys})
+    INSERT INTO ${tableName(sql, table, schema)} (${keys})
     VALUES (${values})
     RETURNING ${sql.join(fieldsToRetrieve, sql`, `)}
   `
@@ -32,9 +34,9 @@ async function insertOne (db, sql, table, input, primaryKey, isUuid, fieldsToRet
   return res[0]
 }
 
-async function deleteAll (db, sql, table, criteria, fieldsToRetrieve) {
+async function deleteAll (db, sql, table, schema, criteria, fieldsToRetrieve) {
   let query = sql`
-      DELETE FROM ${sql.ident(table)}
+      DELETE FROM ${tableName(sql, table, schema)}
     `
 
   if (criteria.length > 0) {
@@ -46,10 +48,10 @@ async function deleteAll (db, sql, table, criteria, fieldsToRetrieve) {
   return res
 }
 
-async function insertMany (db, sql, table, inputs, inputToFieldMap, primaryKey, fieldsToRetrieve, fields) {
+async function insertMany (db, sql, table, schema, inputs, inputToFieldMap, primaryKey, fieldsToRetrieve, fields) {
   const { keys, values } = insertPrep(inputs, inputToFieldMap, fields, sql)
   const insert = sql`
-    insert into ${sql.ident(table)} (${keys})
+    insert into ${tableName(sql, table, schema)} (${keys})
     values ${sql.join(values, sql`, `)}
     returning ${sql.join(fieldsToRetrieve, sql`, `)}
   `
@@ -98,7 +100,7 @@ function insertPrep (inputs, inputToFieldMap, fields, sql) {
   return { keys, values }
 }
 
-async function updateMany (db, sql, table, criteria, input, fieldsToRetrieve) {
+async function updateMany (db, sql, table, schema, criteria, input, fieldsToRetrieve) {
   const pairs = Object.keys(input).map((key) => {
     const value = input[key]
     return sql`${sql.ident(key)} = ${value}`

--- a/packages/sql-mapper/lib/queries/sqlite.js
+++ b/packages/sql-mapper/lib/queries/sqlite.js
@@ -4,11 +4,12 @@ const { randomUUID } = require('crypto')
 const shared = require('./shared')
 
 async function listTables (db, sql) {
-  const tables = await db.query(sql`
+  const res = await db.query(sql`
     SELECT name FROM sqlite_master
     WHERE type='table'
   `)
-  return tables.map(t => t.name)
+  // sqlite has no schemas
+  return res.map(r => ({ schema: null, table: r.name }))
 }
 
 module.exports.listTables = listTables
@@ -67,7 +68,7 @@ async function listConstraints (db, sql, table) {
 
 module.exports.listConstraints = listConstraints
 
-async function insertOne (db, sql, table, input, primaryKey, useUUID, fieldsToRetrieve) {
+async function insertOne (db, sql, table, schema, input, primaryKey, useUUID, fieldsToRetrieve) {
   const fieldNames = Object.keys(input)
   const keysToSql = fieldNames.map((key) => sql.ident(key))
   const valuesToSql = fieldNames.map((key) => sql.value(input[key]))
@@ -118,7 +119,7 @@ async function insertOne (db, sql, table, input, primaryKey, useUUID, fieldsToRe
 
 module.exports.insertOne = insertOne
 
-async function updateOne (db, sql, table, input, primaryKey, fieldsToRetrieve) {
+async function updateOne (db, sql, table, schema, input, primaryKey, fieldsToRetrieve) {
   const pairs = Object.keys(input).map((key) => {
     const value = input[key]
     return sql`${sql.ident(key)} = ${value}`
@@ -142,7 +143,7 @@ async function updateOne (db, sql, table, input, primaryKey, fieldsToRetrieve) {
 
 module.exports.updateOne = updateOne
 
-async function deleteAll (db, sql, table, criteria, fieldsToRetrieve) {
+async function deleteAll (db, sql, table, schema, criteria, fieldsToRetrieve) {
   let query = sql`
     SELECT ${sql.join(fieldsToRetrieve, sql`, `)}
     FROM ${sql.ident(table)}

--- a/packages/sql-mapper/lib/utils.js
+++ b/packages/sql-mapper/lib/utils.js
@@ -9,6 +9,11 @@ function toSingular (str) {
   return str
 }
 
+function tableName (sql, table, schema) {
+  return schema ? sql.ident(schema, table) : sql.ident(table)
+}
+
 module.exports = {
-  toSingular
+  toSingular,
+  tableName
 }

--- a/packages/sql-mapper/lib/utils.js
+++ b/packages/sql-mapper/lib/utils.js
@@ -10,6 +10,7 @@ function toSingular (str) {
 }
 
 function tableName (sql, table, schema) {
+  /* istanbul ignore next */
   return schema ? sql.ident(schema, table) : sql.ident(table)
 }
 

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -104,6 +104,7 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, 
     const tablesWithSchema = await queries.listTables(db, sql, schemaList)
     const tables = tablesWithSchema.map(({ table }) => table)
     const duplicates = tables.filter((table, index) => tables.indexOf(table) !== index)
+
     if (duplicates.length > 0) {
       throw new Error(`Conflicting table names: ${duplicates.join(', ')}`)
     }

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -50,7 +50,7 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, 
   let sql
   let db
 
-  // Specify an empty array must be the same of specifyong no schema
+  // Specify an empty array must be the same of specifying no schema
   const schemaList = schema?.length > 0 ? schema : null
 
   /* istanbul ignore next */
@@ -105,6 +105,8 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, 
     const tables = tablesWithSchema.map(({ table }) => table)
     const duplicates = tables.filter((table, index) => tables.indexOf(table) !== index)
 
+    // Ignored because this never happens in sqlite
+    /* istanbul ignore next */
     if (duplicates.length > 0) {
       throw new Error(`Conflicting table names: ${duplicates.join(', ')}`)
     }

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -50,10 +50,15 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, 
   let sql
   let db
 
+  // Specify an empty array must be the same of specifyong no schema
+  const schemaList = schema?.length > 0 ? schema : null
+
   /* istanbul ignore next */
   if (connectionString.indexOf('postgres') === 0) {
     const createConnectionPoolPg = require('@databases/pg')
-    db = await buildConnection(log, createConnectionPoolPg, connectionString, poolSize, schema)
+    // We pass schema here so @databases/pg set the schema in the search path. This is not stritly necessary, though,
+    // because now we use fully qualified names in all queries.
+    db = await buildConnection(log, createConnectionPoolPg, connectionString, poolSize, schemaList)
     sql = createConnectionPoolPg.sql
     queries = queriesFactory.pg
     db.isPg = true
@@ -96,16 +101,14 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, 
       await onDatabaseLoad(db, sql)
     }
 
-    const tables = await queries.listTables(db, sql)
-
+    const tablesWithSchema = await queries.listTables(db, sql, schemaList)
+    const tables = tablesWithSchema.map(({ table }) => table)
     const duplicates = tables.filter((table, index) => tables.indexOf(table) !== index)
-    // Ignored because this can happen only in postgres
-    /* istanbul ignore next */
     if (duplicates.length > 0) {
       throw new Error(`Conflicting table names: ${duplicates.join(', ')}`)
     }
 
-    for (const table of tables) {
+    for (const { table, schema } of tablesWithSchema) {
       // The following line is a safety net when developing this module,
       // it should never happen.
       /* istanbul ignore next */
@@ -115,8 +118,7 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, 
       if (ignore[table] === true) {
         continue
       }
-
-      const entity = await buildEntity(db, sql, log, table, queries, autoTimestamp, ignore[table] || {})
+      const entity = await buildEntity(db, sql, log, table, queries, autoTimestamp, schema, ignore[table] || {})
       // Check for primary key of all entities
       if (!entity.primaryKey) {
         throw new Error(`Cannot find primary key for ${entity.name} entity`)

--- a/packages/sql-mapper/test/helper.js
+++ b/packages/sql-mapper/test/helper.js
@@ -69,4 +69,19 @@ module.exports.clear = async function (db, sql) {
     await db.query(sql`DROP TYPE pagetype`)
   } catch {
   }
+
+  try {
+    await db.query(sql`DROP TABLE test1.pages`)
+  } catch (err) {
+  }
+
+  try {
+    await db.query(sql`DROP TABLE test2.users`)
+  } catch (err) {
+  }
+
+  try {
+    await db.query(sql`DROP TABLE test2.pages`)
+  } catch (err) {
+  }
 }

--- a/packages/sql-mapper/test/schema.test.js
+++ b/packages/sql-mapper/test/schema.test.js
@@ -1,15 +1,13 @@
 const { test } = require('tap')
 const { connect } = require('..')
 
+const { connInfo, isSQLite, isMysql, isMysql8, isPg } = require('./helper')
+
 const fakeLogger = {
   trace: () => {},
   error: () => {}
 }
 
-// Schemas are supported only by postgres for the time being
-// We need to encode the schemas
-const connectionString = 'postgres://postgres:postgres@127.0.0.1/postgres'
-const isPg = !process.env.DB || process.env.DB === 'postgresql'
 const clear = async function (db, sql) {
   try {
     await db.query(sql`DROP TABLE test1.pages`)
@@ -23,27 +21,46 @@ const clear = async function (db, sql) {
     await db.query(sql`DROP TABLE test2.pages`)
   } catch (err) {
   }
+  try {
+    await db.query(sql`DROP TYPE pagetype`)
+  } catch {
+  }
 }
 
-test('[pg] uses tables from different schemas', { skip: !isPg }, async ({ pass, teardown, equal }) => {
+test('uses tables from different schemas', { skip: isSQLite }, async ({ pass, teardown, equal }) => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)
     teardown(() => db.dispose())
 
     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test1;`)
-    await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
+    if (isMysql || isMysql8) {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test1\`.\`pages\` (
       id SERIAL PRIMARY KEY,
       title VARCHAR(255) NOT NULL
     );`)
+    } else {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL
+    );`)
+    }
 
     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test2;`)
-    await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
+
+    if (isMysql || isMysql8) {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test2\`.\`users\` (
       id SERIAL PRIMARY KEY,
       username VARCHAR(255) NOT NULL
     );`)
+    } else {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
+      id SERIAL PRIMARY KEY,
+      username VARCHAR(255) NOT NULL
+    );`)
+    }
   }
   const mapper = await connect({
-    connectionString,
+    connectionString: connInfo.connectionString,
     log: fakeLogger,
     onDatabaseLoad,
     ignore: {},
@@ -61,26 +78,86 @@ test('[pg] uses tables from different schemas', { skip: !isPg }, async ({ pass, 
   pass()
 })
 
-test('[pg] should fail if two schemas has the same table', { skip: !isPg }, async ({ pass, teardown, equal }) => {
+test('find enums correctly using schemas', { skip: isSQLite }, async ({ pass, teardown, equal }) => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)
     teardown(() => db.dispose())
 
     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test1;`)
-    await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
+    if (isMysql || isMysql8) {
+      await db.query(sql`
+      CREATE TABLE IF NOT EXISTS \`test1\`.\`pages\` (
+        id SERIAL PRIMARY KEY,
+        title VARCHAR(255) NOT NULL,
+        type ENUM ('blank', 'non-blank')
+    );`)
+    } else if (isPg) {
+      await db.query(sql`
+      CREATE TYPE pagetype as enum ('blank', 'non-blank');
+      CREATE TABLE IF NOT EXISTS "test1"."pages" (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL,
+      type pagetype
+    );`)
+    } else {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL,
+      type ENUM ('blank', 'non-blank')
+    );`)
+    }
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {},
+    schema: ['test1']
+  })
+  const pageEntity = mapper.entities.page
+  equal(pageEntity.name, 'Page')
+  equal(pageEntity.singularName, 'page')
+  equal(pageEntity.pluralName, 'pages')
+  pass()
+})
+
+test('should fail if two schemas has the same table', { skip: isSQLite }, async ({ pass, teardown, equal }) => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    teardown(() => db.dispose())
+
+    await db.query(sql`CREATE SCHEMA IF NOT EXISTS test1;`)
+    if (isMysql || isMysql8) {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test1\`.\`pages\` (
       id SERIAL PRIMARY KEY,
       title VARCHAR(255) NOT NULL
     );`)
+    } else {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL
+    );`)
+    }
 
     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test2;`)
-    await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."pages" (
+
+    if (isMysql || isMysql8) {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test2\`.\`users\` (
       id SERIAL PRIMARY KEY,
       username VARCHAR(255) NOT NULL
     );`)
+    } else {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
+      id SERIAL PRIMARY KEY,
+      username VARCHAR(255) NOT NULL
+    );`)
+    }
   }
+
   try {
     await connect({
-      connectionString,
+      connectionString: connInfo.connectionString,
       log: fakeLogger,
       onDatabaseLoad,
       ignore: {},
@@ -92,3 +169,50 @@ test('[pg] should fail if two schemas has the same table', { skip: !isPg }, asyn
     equal(err.message, 'Conflicting table names: pages')
   }
 })
+
+// test('if schema is empty array, should load ', { skip: isSQLite }, async ({ pass, teardown, equal }) => {
+//   async function onDatabaseLoad (db, sql) {
+//     await clear(db, sql)
+//     teardown(() => db.dispose())
+
+//     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test1;`)
+//     if (isMysql || isMysql8) {
+//       await db.query(sql`CREATE TABLE IF NOT EXISTS \`test1\`.\`pages\` (
+//       id SERIAL PRIMARY KEY,
+//       title VARCHAR(255) NOT NULL
+//     );`)
+//     } else {
+//       await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
+//       id SERIAL PRIMARY KEY,
+//       title VARCHAR(255) NOT NULL
+//     );`)
+//     }
+
+//     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test2;`)
+
+//     if (isMysql || isMysql8) {
+//       await db.query(sql`CREATE TABLE IF NOT EXISTS \`test2\`.\`users\` (
+//       id SERIAL PRIMARY KEY,
+//       username VARCHAR(255) NOT NULL
+//     );`)
+//     } else {
+//       await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
+//       id SERIAL PRIMARY KEY,
+//       username VARCHAR(255) NOT NULL
+//     );`)
+//     }
+//   }
+//   const mapper = await connect({
+//     connectionString: connInfo.connectionString,
+//     log: fakeLogger,
+//     onDatabaseLoad,
+//     ignore: {},
+//     hooks: {},
+//     schema: []
+//   })
+
+//   console.log(mapper.entities)
+//   equal(Object.keys(mapper.entities).length, 0)
+
+//   pass()
+// })

--- a/packages/sql-mapper/test/schema.test.js
+++ b/packages/sql-mapper/test/schema.test.js
@@ -1,31 +1,39 @@
 const { test } = require('tap')
 const { connect } = require('..')
 
-const { connInfo, isSQLite, isMysql, isMysql8, isPg } = require('./helper')
+const { connInfo, isSQLite, isMysql, isMysql8, isPg, clear } = require('./helper')
 
 const fakeLogger = {
   trace: () => {},
   error: () => {}
 }
 
-const clear = async function (db, sql) {
-  try {
-    await db.query(sql`DROP TABLE test1.pages`)
-  } catch (err) {
-  }
-  try {
-    await db.query(sql`DROP TABLE test2.users`)
-  } catch (err) {
-  }
-  try {
-    await db.query(sql`DROP TABLE test2.pages`)
-  } catch (err) {
-  }
-  try {
-    await db.query(sql`DROP TYPE pagetype`)
-  } catch {
-  }
-}
+// const clear = async function (db, sql) {
+//   try {
+//     await db.query(sql`DROP TABLE test1.pages`)
+//   } catch (err) {
+//   }
+//   try {
+//     await db.query(sql`DROP TABLE test2.users`)
+//   } catch (err) {
+//   }
+//   try {
+//     await db.query(sql`DROP TABLE test2.pages`)
+//   } catch (err) {
+//   }
+//   try {
+//     await db.query(sql`DROP TABLE public.pages`)
+//   } catch (err) {
+//   }
+//   try {
+//     await db.query(sql`DROP TABLE public.posts`)
+//   } catch (err) {
+//   }
+//   try {
+//     await db.query(sql`DROP TYPE pagetype`)
+//   } catch {
+//   }
+// }
 
 test('uses tables from different schemas', { skip: isSQLite }, async ({ pass, teardown, equal }) => {
   async function onDatabaseLoad (db, sql) {
@@ -71,10 +79,12 @@ test('uses tables from different schemas', { skip: isSQLite }, async ({ pass, te
   equal(pageEntity.name, 'Page')
   equal(pageEntity.singularName, 'page')
   equal(pageEntity.pluralName, 'pages')
+  equal(pageEntity.schema, 'test1')
   const userEntity = mapper.entities.user
   equal(userEntity.name, 'User')
   equal(userEntity.singularName, 'user')
   equal(userEntity.pluralName, 'users')
+  equal(userEntity.schema, 'test2')
   pass()
 })
 
@@ -143,12 +153,12 @@ test('should fail if two schemas has the same table', { skip: isSQLite }, async 
     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test2;`)
 
     if (isMysql || isMysql8) {
-      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test2\`.\`users\` (
+      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test2\`.\`pages\` (
       id SERIAL PRIMARY KEY,
       username VARCHAR(255) NOT NULL
     );`)
     } else {
-      await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."pages" (
       id SERIAL PRIMARY KEY,
       username VARCHAR(255) NOT NULL
     );`)
@@ -170,49 +180,82 @@ test('should fail if two schemas has the same table', { skip: isSQLite }, async 
   }
 })
 
-// test('if schema is empty array, should load ', { skip: isSQLite }, async ({ pass, teardown, equal }) => {
-//   async function onDatabaseLoad (db, sql) {
-//     await clear(db, sql)
-//     teardown(() => db.dispose())
+test('if schema is empty array, should not load entities from tables in explicit schema', { skip: isSQLite }, async ({ pass, teardown, equal }) => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    teardown(() => db.dispose())
 
-//     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test1;`)
-//     if (isMysql || isMysql8) {
-//       await db.query(sql`CREATE TABLE IF NOT EXISTS \`test1\`.\`pages\` (
-//       id SERIAL PRIMARY KEY,
-//       title VARCHAR(255) NOT NULL
-//     );`)
-//     } else {
-//       await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
-//       id SERIAL PRIMARY KEY,
-//       title VARCHAR(255) NOT NULL
-//     );`)
-//     }
+    await db.query(sql`CREATE SCHEMA IF NOT EXISTS test1;`)
+    if (isMysql || isMysql8) {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test1\`.\`pages\` (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL
+    );`)
+    } else {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test1"."pages" (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL
+    );`)
+    }
 
-//     await db.query(sql`CREATE SCHEMA IF NOT EXISTS test2;`)
+    await db.query(sql`CREATE SCHEMA IF NOT EXISTS test2;`)
 
-//     if (isMysql || isMysql8) {
-//       await db.query(sql`CREATE TABLE IF NOT EXISTS \`test2\`.\`users\` (
-//       id SERIAL PRIMARY KEY,
-//       username VARCHAR(255) NOT NULL
-//     );`)
-//     } else {
-//       await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
-//       id SERIAL PRIMARY KEY,
-//       username VARCHAR(255) NOT NULL
-//     );`)
-//     }
-//   }
-//   const mapper = await connect({
-//     connectionString: connInfo.connectionString,
-//     log: fakeLogger,
-//     onDatabaseLoad,
-//     ignore: {},
-//     hooks: {},
-//     schema: []
-//   })
+    if (isMysql || isMysql8) {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS \`test2\`.\`users\` (
+      id SERIAL PRIMARY KEY,
+      username VARCHAR(255) NOT NULL
+    );`)
+    } else {
+      await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
+      id SERIAL PRIMARY KEY,
+      username VARCHAR(255) NOT NULL
+    );`)
+    }
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {},
+    schema: []
+  })
 
-//   console.log(mapper.entities)
-//   equal(Object.keys(mapper.entities).length, 0)
+  console.log(mapper.entities)
+  equal(Object.keys(mapper.entities).length, 0)
+  pass()
+})
 
-//   pass()
-// })
+test('[pg] if schema is empty array, should find entities only in default \'public\' schema', { skip: !isPg }, async ({ pass, teardown, equal }) => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    teardown(() => db.dispose())
+
+    await db.query(sql`CREATE TABLE IF NOT EXISTS pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL
+    );`)
+
+    await db.query(sql`CREATE SCHEMA IF NOT EXISTS test2;`)
+    await db.query(sql`CREATE TABLE IF NOT EXISTS "test2"."users" (
+      id SERIAL PRIMARY KEY,
+      username VARCHAR(255) NOT NULL
+    );`)
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {},
+    schema: []
+  })
+
+  equal(Object.keys(mapper.entities).length, 1)
+  const pageEntity = mapper.entities.page
+  equal(pageEntity.name, 'Page')
+  equal(pageEntity.singularName, 'page')
+  equal(pageEntity.pluralName, 'pages')
+  equal(pageEntity.schema, 'public')
+  pass()
+})


### PR DESCRIPTION
This fixes: https://github.com/platformatic/platformatic/issues/362

Basically, we use fully qualified names for tables (so `schema.table`) for every DB that supports schema (so no `sqlite`) 

Signed-off-by: marcopiraccini <marco.piraccini@gmail.com>