### PR TITLE
Autoload & watch options refactoring

### DIFF
--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -239,6 +239,8 @@ To switch if off, set `hotReload` to `false`.
   }
   ```
 
+`plugin` can also be a string, or an array of strings.
+
 
 ### `watch`
 

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -210,11 +210,7 @@ An optional object that defines a plugin loaded by Platformatic DB.
 - **`path`** (**required**, `string`): Relative path to plugin's entry point.
 - **`typescript`** (`object`): TypeScript configuration for the plugin.
   - **`outDir`** (`string`): Relative path to the output directory for compiled JavaScript files.
-- **`watch`** (`boolean`, default: `true`): Watch plugin for changes and reload it automatically. Typescript files will be watched by `tsc` if `plugin.typescript` is defined.
-- **`watchOptions`** (`object`): Options to configure the plugin watcher.
-  - **`hotReload`** (`boolean`, default: `true`) if `true` or not specified, the plugin is loaded using [`fastify-sandbox`](https://github.com/mcollina/fastify-sandbox), otherwise is loaded directly using `require`/`import` and the hot reload is not enabled
-  - **`ignore`** (`string[]`, default: `null`): List of glob patterns to ignore when watching for changes. If `null` or not specified, ignore rule is not applied. Ignore option doesn't work for typescript files.
-  - **`allow`** (`string[]`, default: `['*.js', '**/*.js']`): List of glob patterns to allow when watching for changes. If `null` or not specified, allow rule is not applied. Allow option doesn't work for typescript files.
+- **`hotReload`** (`boolean`, default: `true`) if `true` or not specified, the plugin is loaded using [`fastify-sandbox`](https://github.com/mcollina/fastify-sandbox), otherwise is loaded directly using `require`/`import` and the hot reload is not enabled
 - **`options`** (`object`): Optional plugin options.
 
   _Example_
@@ -223,12 +219,7 @@ An optional object that defines a plugin loaded by Platformatic DB.
   {
     "plugin": {
       "path": "./my-plugin.js",
-      "watch": true,
-      "watchOptions": {
-        "hotReload": true,
-        "ignore": ["*.mjs", "**/*.mjs"],
-        "allow": ["my-plugin.js", "plugins/*.js"]
-      },
+      "hotReload": true
     }
   }
   ```
@@ -237,6 +228,35 @@ An optional object that defines a plugin loaded by Platformatic DB.
 While hot reloading is useful for development, it is not recommended to use it in production.
 To switch if off, set `hotReload` to `false`.
 :::
+
+`plugin` can also be an array, like so:
+
+  ```json
+  {
+    "plugin": [{
+      "path": "./my-plugin.js"
+    }]
+  }
+  ```
+
+
+### `watch`
+
+Disable watching for file changes if set to `false`. It can also be customized with the following options:
+
+- **`ignore`** (`string[]`, default: `null`): List of glob patterns to ignore when watching for changes. If `null` or not specified, ignore rule is not applied. Ignore option doesn't work for typescript files.
+- **`allow`** (`string[]`, default: `['*.js', '**/*.js']`): List of glob patterns to allow when watching for changes. If `null` or not specified, allow rule is not applied. Allow option doesn't work for typescript files.
+
+  _Example_
+
+  ```json
+  {
+    "watch": {
+      "ignore": ["*.mjs", "**/*.mjs"],
+      "allow": ["my-plugin.js", "plugins/*.js"]
+    }
+  }
+  ```
 
 ### `server`
 

--- a/docs/reference/db/plugin.md
+++ b/docs/reference/db/plugin.md
@@ -58,3 +58,18 @@ Consider the following directory structure:
 
 By default the folder will be added as a prefix to all the routes defined within them.
 See the autoload documentation for all the options to customize this behavior.
+
+## Multiple plugins
+
+Multiple plugins can be loaded in parallel by specifying an array:
+
+```json
+{
+  ...
+  "plugin": [{
+    "path": "./plugin/index.js"
+  }, {
+    "path": "./routes/"
+  }]
+}
+```

--- a/docs/reference/db/plugin.md
+++ b/docs/reference/db/plugin.md
@@ -37,3 +37,24 @@ You don't need to reload Platformatic DB server while working on your plugin. Ev
 At this time, on Linux, file watch in subdirectories is not supported due to a Node.js limitation (documented [here](https://nodejs.org/api/fs.html#caveats)).
 
 :::
+
+## Directories
+
+The path can also be a directory. In that case, the directory will be loaded with [`@fastify/autoload`](https://github.com/fastify/fastify-autoload).
+
+Consider the following directory structure:
+
+```
+├── routes
+│   ├── foo
+│   │   ├── something.js
+│   │   └── bar
+│   │       └── baz.js
+│   ├── single-plugin
+│   │   └── utils.js
+│   └── another-plugin.js
+└── platformatic.service.json
+```
+
+By default the folder will be added as a prefix to all the routes defined within them.
+See the autoload documentation for all the options to customize this behavior.

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -88,11 +88,7 @@ An optional object that defines a plugin loaded by Platformatic DB.
 - **`path`** (**required**, `string`): Relative path to plugin's entry point.
 - **`typescript`** (`object`): TypeScript configuration for the plugin.
   - **`outDir`** (`string`): Relative path to the output directory for compiled JavaScript files.
-- **`watch`** (`boolean`, default: `true`): Watch plugin for changes and reload it automatically. Typescript files will be watched by `tsc` if `plugin.typescript` is defined.
-- **`watchOptions`** (`object`): Options to configure the plugin watcher.
-  - **`hotReload`** (`boolean`, default: `true`) if `true` or not specified, the plugin is loaded using [`fastify-sandbox`](https://github.com/mcollina/fastify-sandbox), otherwise is loaded directly using `require`/`import` and the hot reload is not enabled
-  - **`ignore`** (`string[]`, default: `null`): List of glob patterns to ignore when watching for changes. If `null` or not specified, ignore rule is not applied. Ignore option doesn't work for typescript files.
-  - **`allow`** (`string[]`, default: `['*.js', '**/*.js']`): List of glob patterns to allow when watching for changes. If `null` or not specified, allow rule is not applied. Allow option doesn't work for typescript files.
+- **`hotReload`** (`boolean`, default: `true`) if `true` or not specified, the plugin is loaded using [`fastify-sandbox`](https://github.com/mcollina/fastify-sandbox), otherwise is loaded directly using `require`/`import` and the hot reload is not enabled
 - **`options`** (`object`): Optional plugin options.
 
   _Example_
@@ -115,6 +111,35 @@ An optional object that defines a plugin loaded by Platformatic DB.
 While hot reloading is useful for development, it is not recommended to use it in production.
 To switch if off, set `hotReload` to `false`.
 :::
+
+`plugin` can also be an array, like so:
+
+  ```json
+  {
+    "plugin": [{
+      "path": "./my-plugin.js"
+    }]
+  }
+  ```
+
+
+### `watch`
+
+Disable watching for file changes if set to `false`. It can also be customized with the following options:
+
+- **`ignore`** (`string[]`, default: `null`): List of glob patterns to ignore when watching for changes. If `null` or not specified, ignore rule is not applied. Ignore option doesn't work for typescript files.
+- **`allow`** (`string[]`, default: `['*.js', '**/*.js']`): List of glob patterns to allow when watching for changes. If `null` or not specified, allow rule is not applied. Allow option doesn't work for typescript files.
+
+  _Example_
+
+  ```json
+  {
+    "watch": {
+      "ignore": ["*.mjs", "**/*.mjs"],
+      "allow": ["my-plugin.js", "plugins/*.js"]
+    }
+  }
+  ```
 
 ## Environment variable placeholders
 

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -122,6 +122,8 @@ To switch if off, set `hotReload` to `false`.
   }
   ```
 
+`plugin` can also be a string, or an array of strings.
+
 
 ### `watch`
 

--- a/docs/reference/service/plugin.md
+++ b/docs/reference/service/plugin.md
@@ -52,3 +52,18 @@ Consider the following directory structure:
 
 By default the folder will be added as a prefix to all the routes defined within them.
 See the autoload documentation for all the options to customize this behavior.
+
+## Multiple plugins
+
+Multiple plugins can be loaded in parallel by specifying an array:
+
+```json
+{
+  ...
+  "plugin": [{
+    "path": "./plugin/index.js"
+  }, {
+    "path": "./routes/"
+  }]
+}
+```

--- a/docs/reference/service/plugin.md
+++ b/docs/reference/service/plugin.md
@@ -31,3 +31,24 @@ You don't need to reload Platformatic Service server while working on your plugi
 At this time, on Linux, file watch in subdirectories is not supported due to a Node.js limitation (documented [here](https://nodejs.org/api/fs.html#caveats)).
 
 :::
+
+## Directories
+
+The path can also be a directory. In that case, the directory will be loaded with [`@fastify/autoload`](https://github.com/fastify/fastify-autoload).
+
+Consider the following directory structure:
+
+```
+├── routes
+│   ├── foo
+│   │   ├── something.js
+│   │   └── bar
+│   │       └── baz.js
+│   ├── single-plugin
+│   │   └── utils.js
+│   └── another-plugin.js
+└── platformatic.service.json
+```
+
+By default the folder will be added as a prefix to all the routes defined within them.
+See the autoload documentation for all the options to customize this behavior.

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -170,7 +170,9 @@ class ConfigManager extends EventEmitter {
           throw new Error(`${err.key} env variable is missing.`)
         }
       }
-      throw new Error(`Cannot parse config file. ${err.message}`)
+      const newerr = new Error(`Cannot parse config file. ${err.message}`)
+      newerr.cause = err
+      throw newerr
     }
   }
 

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -71,7 +71,7 @@ async function buildDBServer (options) {
       schema
     })
     await cm.parseAndValidate()
-    options = deepmerge({}, cm.current, options)
+    options = deepmerge({}, options, cm.current)
     options.configManager = cm
   }
   return buildServer(options, platformaticDB)

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { metrics, server, plugin } = require('@platformatic/service').schema
+const { metrics, server, plugin, watch } = require('@platformatic/service').schema
 
 const core = {
   $id: 'https://schemas.platformatic.dev/db/core',
@@ -295,7 +295,13 @@ const platformaticDBschema = {
       }]
     }
   },
-  additionalProperties: false,
+  additionalProperties: {
+    watch: {
+      anyOf: [watch, {
+        type: 'boolean'
+      }]
+    }
+  },
   required: ['core', 'server']
 }
 

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -273,6 +273,9 @@ const types = {
 const platformaticDBschema = {
   $id: 'https://schemas.platformatic.dev/db',
   type: 'object',
+  $defs: {
+    plugin
+  },
   properties: {
     server,
     core,
@@ -281,7 +284,16 @@ const platformaticDBschema = {
     migrations,
     metrics,
     types,
-    plugin
+    plugin: {
+      anyOf: [{
+        type: 'array',
+        items: {
+          $ref: '#/$defs/plugin'
+        }
+      }, {
+        $ref: '#/$defs/plugin'
+      }]
+    }
   },
   additionalProperties: false,
   required: ['core', 'server']

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -288,7 +288,11 @@ const platformaticDBschema = {
       anyOf: [{
         type: 'array',
         items: {
-          $ref: '#/$defs/plugin'
+          anyOf: [{
+            $ref: '#/$defs/plugin'
+          }, {
+            type: 'string'
+          }]
         }
       }, {
         $ref: '#/$defs/plugin'

--- a/packages/db/lib/start.mjs
+++ b/packages/db/lib/start.mjs
@@ -42,7 +42,7 @@ async function start (_args) {
 
   if (
     config.plugin !== undefined &&
-    config.plugin.watch !== false
+    config.watch !== false
   ) {
     await startFileWatching(server)
   }
@@ -101,8 +101,8 @@ async function startFileWatching (server) {
 
   const fileWatcher = new FileWatcher({
     path: dirname(configManager.fullPath),
-    allowToWatch: config.plugin.watchOptions?.allow || ['*.js', '**/*.js'],
-    watchIgnore: config.plugin.watchOptions?.ignore
+    allowToWatch: config.watch?.allow || ['*.js', '**/*.js'],
+    watchIgnore: config.watch?.ignore
   })
   fileWatcher.on('update', () => {
     onFilesUpdated(server)
@@ -133,7 +133,7 @@ async function onConfigUpdated (newConfig, server) {
 
     if (
       newConfig.plugin !== undefined &&
-      newConfig.plugin.watch !== false
+      newConfig.watch !== false
     ) {
       await startFileWatching(server)
     }

--- a/packages/db/test/autoload.test.js
+++ b/packages/db/test/autoload.test.js
@@ -6,7 +6,7 @@ const { buildServer } = require('..')
 const { request } = require('undici')
 const { join } = require('path')
 
-test('autoload & filesystem based routing / watch disabled', { only: true }, async ({ teardown, equal }) => {
+test('autoload & filesystem based routing / watch disabled', async ({ teardown, equal }) => {
   const config = {
     server: {
       hostname: '127.0.0.1',
@@ -189,5 +189,92 @@ test('multiple files / watch false', async ({ teardown, equal }) => {
     equal(res.statusCode, 200, 'status code')
     const body = await res.body.json()
     equal(body.hello, 'bar', 'body')
+  }
+})
+
+test('multiple files as strings', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    core: {
+      ...connInfo
+    },
+    plugin: [join(__dirname, 'fixtures', 'directories', 'plugins'), join(__dirname, 'fixtures', 'directories', 'routes')],
+    watch: true,
+    metrics: false
+  }
+
+  const server = await buildServer(buildConfig(config))
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/with-decorator`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'bar', 'body')
+  }
+})
+
+test('autoload & filesystem based routing / watch disabled / no object', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    core: {
+      ...connInfo
+    },
+    plugin: join(__dirname, 'fixtures', 'directories', 'routes'),
+    watch: false,
+    metrics: false
+  }
+
+  const server = await buildServer(buildConfig(config))
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
   }
 })

--- a/packages/db/test/autoload.test.js
+++ b/packages/db/test/autoload.test.js
@@ -16,9 +16,9 @@ test('autoload & filesystem based routing / watch disabled', { only: true }, asy
       ...connInfo
     },
     plugin: {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: false
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     },
+    watch: false,
     metrics: false
   }
 
@@ -58,9 +58,9 @@ test('autoload & filesystem based routing / watch enabled', async ({ teardown, e
       ...connInfo
     },
     plugin: {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: true
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     },
+    watch: true,
     metrics: false
   }
 
@@ -100,12 +100,11 @@ test('multiple files', async ({ teardown, equal }) => {
       ...connInfo
     },
     plugin: [{
-      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
-      watch: true
+      path: join(__dirname, 'fixtures', 'directories', 'plugins')
     }, {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: true
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     }],
+    watch: true,
     metrics: false
   }
 
@@ -152,12 +151,11 @@ test('multiple files / watch false', async ({ teardown, equal }) => {
       ...connInfo
     },
     plugin: [{
-      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
-      watch: false
+      path: join(__dirname, 'fixtures', 'directories', 'plugins')
     }, {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: false
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     }],
+    watch: false,
     metrics: false
   }
 

--- a/packages/db/test/autoload.test.js
+++ b/packages/db/test/autoload.test.js
@@ -1,0 +1,195 @@
+'use strict'
+
+const { connInfo, buildConfig } = require('./helper')
+const { test } = require('tap')
+const { buildServer } = require('..')
+const { request } = require('undici')
+const { join } = require('path')
+
+test('autoload & filesystem based routing / watch disabled', { only: true }, async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    core: {
+      ...connInfo
+    },
+    plugin: {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: false
+    },
+    metrics: false
+  }
+
+  const server = await buildServer(buildConfig(config))
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+})
+
+test('autoload & filesystem based routing / watch enabled', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    core: {
+      ...connInfo
+    },
+    plugin: {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: true
+    },
+    metrics: false
+  }
+
+  const server = await buildServer(buildConfig(config))
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+})
+
+test('multiple files', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    core: {
+      ...connInfo
+    },
+    plugin: [{
+      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
+      watch: true
+    }, {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: true
+    }],
+    metrics: false
+  }
+
+  const server = await buildServer(buildConfig(config))
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/with-decorator`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'bar', 'body')
+  }
+})
+
+test('multiple files / watch false', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    core: {
+      ...connInfo
+    },
+    plugin: [{
+      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
+      watch: false
+    }, {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: false
+    }],
+    metrics: false
+  }
+
+  const server = await buildServer(buildConfig(config))
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/with-decorator`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'bar', 'body')
+  }
+})

--- a/packages/db/test/cli/watch.test.mjs
+++ b/packages/db/test/cli/watch.test.mjs
@@ -33,9 +33,9 @@ test('should watch js files by default', async ({ equal, teardown }) => {
       connectionString: 'sqlite://db.sqlite'
     },
     plugin: {
-      path: pluginFilePath,
-      watch: true
-    }
+      path: pluginFilePath
+    },
+    watch: true
   }
 
   await Promise.all([
@@ -73,11 +73,10 @@ test('should watch allowed file', async ({ comment, teardown }) => {
       connectionString: 'sqlite://db.sqlite'
     },
     plugin: {
-      path: pluginFilePath,
-      watch: true,
-      watchOptions: {
-        allow: ['*.js', '*.json']
-      }
+      path: pluginFilePath
+    },
+    watch: {
+      allow: ['*.js', '*.json']
     }
   }
 
@@ -123,11 +122,10 @@ test('should not watch ignored file', async ({ teardown, equal }) => {
       connectionString: 'sqlite://db.sqlite'
     },
     plugin: {
-      path: pluginFilePath,
-      watch: true,
-      watchOptions: {
-        ignore: [basename(pluginFilePath)]
-      }
+      path: pluginFilePath
+    },
+    watch: {
+      ignore: [basename(pluginFilePath)]
     }
   }
 
@@ -164,11 +162,10 @@ test('should not loop forever when doing ESM', { skip: true }, async ({ comment,
       connectionString: 'sqlite://db.sqlite'
     },
     plugin: {
-      path: pluginFilePath,
-      watch: true,
-      watchOptions: {
-        ignore: [basename(pluginFilePath)]
-      }
+      path: pluginFilePath
+    },
+    watch: {
+      ignore: [basename(pluginFilePath)]
     }
   }
 
@@ -212,9 +209,9 @@ test('should watch only js files by default', async ({ equal, teardown }) => {
       connectionString: 'sqlite://db.sqlite'
     },
     plugin: {
-      path: pluginFilePath,
-      watch: true
-    }
+      path: pluginFilePath
+    },
+    watch: true
   }
 
   await Promise.all([

--- a/packages/db/test/fixtures/bad-typescript-plugin/platformatic.db.json
+++ b/packages/db/test/fixtures/bad-typescript-plugin/platformatic.db.json
@@ -23,9 +23,9 @@
   },
   "plugin": {
     "path": "plugin.ts",
-    "watch": true,
     "typescript": {
       "outDir": "dist"
     }
-  }
+  },
+  "watch": true
 }

--- a/packages/db/test/fixtures/directories/plugins/decorator.js
+++ b/packages/db/test/fixtures/directories/plugins/decorator.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+
+module.exports = fp(async function (app) {
+  app.decorate('foo', 'bar')
+})

--- a/packages/db/test/fixtures/directories/routes/foo/bar.js
+++ b/packages/db/test/fixtures/directories/routes/foo/bar.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = async function (fastify, opts) {
+  fastify.get('/bar', async function (request, reply) {
+    return { hello: 'from bar' }
+  })
+
+  fastify.get('/with-decorator', async function (request, reply) {
+    return { hello: fastify.foo }
+  })
+}

--- a/packages/db/test/fixtures/directories/routes/foo/baz/index.js
+++ b/packages/db/test/fixtures/directories/routes/foo/baz/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (fastify, opts) {
+  fastify.get('/', async function (request, reply) {
+    return { hello: 'from baz' }
+  })
+}

--- a/packages/db/test/fixtures/directories/routes/root.js
+++ b/packages/db/test/fixtures/directories/routes/root.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (fastify, opts) {
+  fastify.get('/', async function (request, reply) {
+    return { hello: 'from root' }
+  })
+}

--- a/packages/db/test/fixtures/no-hotreload.json
+++ b/packages/db/test/fixtures/no-hotreload.json
@@ -15,9 +15,9 @@
     "autoApply": false
   },
   "plugin": {
-    "path": "./plugin.mjs",
-    "watchOptions": {
-      "hotReload": false
-    }
+    "path": "./plugin.mjs"
+  },
+  "watch": {
+    "hotReload": false
   }
 }

--- a/packages/db/test/start-and-stop.test.js
+++ b/packages/db/test/start-and-stop.test.js
@@ -298,8 +298,8 @@ test('inject', async ({ teardown, equal, pass, same }) => {
 })
 
 test('ignore and sqlite3', async ({ teardown, equal, pass, same }) => {
-  const dbLocation = path.posix.join(__dirname, '..', 'fixtures', 'sqlite', 'db')
-  const migrations = path.posix.join(__dirname, '..', 'fixtures', 'sqlite', 'migrations')
+  const dbLocation = path.join(__dirname, '..', 'fixtures', 'sqlite', 'db')
+  const migrations = path.join(__dirname, '..', 'fixtures', 'sqlite', 'migrations')
   try {
     await rm(dbLocation)
   } catch {

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -55,10 +55,10 @@ async function platformaticService (app, opts, toLoad = []) {
   /* c8 ignore next 7 */
   if (Array.isArray(opts.plugin)) {
     for (const plugin of opts.plugin) {
-      await loadPlugin(app, plugin)
+      await loadPlugin(app, opts, plugin)
     }
   } else if (opts.plugin) {
-    await loadPlugin(app, opts.plugin)
+    await loadPlugin(app, opts, opts.plugin)
   }
 
   // Enable CORS
@@ -74,7 +74,7 @@ async function platformaticService (app, opts, toLoad = []) {
   }
 }
 
-async function loadPlugin (app, pluginOptions) {
+async function loadPlugin (app, config, pluginOptions) {
   /* c8 ignore next 4 */
   if (pluginOptions.typescript !== undefined) {
     const pluginPath = getJSPluginPath(pluginOptions.path, pluginOptions.typescript.outDir)
@@ -86,8 +86,8 @@ async function loadPlugin (app, pluginOptions) {
   // if not defined, we defaults to true (which can happen only if config is set programmatically,
   // that's why we ignore the coverage of the `undefined` case, which cannot be covered in cli tests)
   /* c8 ignore next */
-  const hotReload = pluginOptions.watchOptions?.hotReload !== false
-  const isWatchEnabled = pluginOptions.watch !== false
+  const hotReload = pluginOptions.hotReload !== false
+  const isWatchEnabled = config.watch !== false
   /* c8 ignore next 13 */
   if (isWatchEnabled && hotReload) {
     let options = pluginOptions

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -198,3 +198,4 @@ module.exports.platformaticService = platformaticService
 module.exports.addLoggerToTheConfig = addLoggerToTheConfig
 module.exports.loadConfig = loadConfig
 module.exports.tsCompiler = compiler
+module.exports.ConfigManager = ConfigManager

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -85,10 +85,9 @@ async function loadPlugin (app, config, pluginOptions) {
 
   // if not defined, we defaults to true (which can happen only if config is set programmatically,
   // that's why we ignore the coverage of the `undefined` case, which cannot be covered in cli tests)
-  /* c8 ignore next */
+  /* c8 ignore next 35  */
   const hotReload = pluginOptions.hotReload !== false
   const isWatchEnabled = config.watch !== false
-  /* c8 ignore next 13 */
   if (isWatchEnabled && hotReload) {
     let options = pluginOptions
     if ((await stat(pluginOptions.path)).isDirectory()) {
@@ -110,7 +109,6 @@ async function loadPlugin (app, config, pluginOptions) {
       }
     })
     // c8 fails in reporting the coverage of this else branch, so we ignore it
-    /* c8 ignore next 15 */
   } else {
     if ((await stat(pluginOptions.path)).isDirectory()) {
       const options = {

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -138,7 +138,7 @@ async function buildServer (options, app = platformaticService) {
       schema
     })
     await cm.parseAndValidate()
-    options = deepmerge({}, cm.current, options)
+    options = deepmerge({}, options, cm.current)
     options.configManager = cm
   }
   const serverConfig = createServerConfig(options)

--- a/packages/service/lib/autoload-wrapper.js
+++ b/packages/service/lib/autoload-wrapper.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+const autoload = require('@fastify/autoload')
+
+module.exports = fp(async function (app, opts) {
+  app.register(autoload, {
+    dir: opts.path,
+    ...opts
+  })
+})

--- a/packages/service/lib/config.js
+++ b/packages/service/lib/config.js
@@ -9,10 +9,11 @@ class ServiceConfigManager extends ConfigManager {
   constructor (opts) {
     super({
       ...opts,
-      schema,
+      schema: opts.schema || schema,
       schemaOptions: {
         useDefaults: true,
         coerceTypes: true,
+        allErrors: true,
         strict: false
       },
       allowToWatch: ['.env'],

--- a/packages/service/lib/config.js
+++ b/packages/service/lib/config.js
@@ -23,15 +23,21 @@ class ServiceConfigManager extends ConfigManager {
 
   _transformConfig () {
     const fixPluginPath = (plugin) => {
+      // for some reasons c8 does not detect these
+      /* c8 ignore next 3 */
+      if (typeof plugin === 'string') {
+        plugin = { path: plugin }
+      }
       plugin.path = this._fixRelativePath(plugin.path)
+      return plugin
     }
 
     // relative-to-absolute plugin path
     /* c8 ignore next 3 */
     if (Array.isArray(this.current.plugin)) {
-      this.current.plugin.forEach(fixPluginPath)
+      this.current.plugin = this.current.plugin.map(fixPluginPath)
     } else if (this.current.plugin) {
-      fixPluginPath(this.current.plugin)
+      this.current.plugin = fixPluginPath(this.current.plugin)
     }
   }
 
@@ -40,15 +46,21 @@ class ServiceConfigManager extends ConfigManager {
     const dirOfConfig = dirname(this.fullPath)
 
     const fixPluginPath = (plugin) => {
+      // for some reasons c8 does not detect these
+      /* c8 ignore next 3 */
+      if (typeof plugin === 'string') {
+        plugin = { path: plugin }
+      }
       plugin.path = relative(dirOfConfig, plugin.path)
+      return plugin
     }
 
     // relative-to-absolute plugin path
     /* c8 ignore next 6 */
     if (Array.isArray(this.current.plugin)) {
-      sanitizedConfig.plugin.forEach(fixPluginPath)
+      sanitizedConfig.plugin = sanitizedConfig.plugin.map(fixPluginPath)
     } else if (this.current.plugin) {
-      fixPluginPath(sanitizedConfig.plugin)
+      sanitizedConfig.plugin = fixPluginPath(sanitizedConfig.plugin)
     }
 
     return sanitizedConfig

--- a/packages/service/lib/config.js
+++ b/packages/service/lib/config.js
@@ -13,7 +13,7 @@ class ServiceConfigManager extends ConfigManager {
       schemaOptions: {
         useDefaults: true,
         coerceTypes: true,
-        allErrors: true
+        strict: false
       },
       allowToWatch: ['.env'],
       envWhitelist: ['PORT', ...(opts.envWhitelist || [])]
@@ -21,10 +21,16 @@ class ServiceConfigManager extends ConfigManager {
   }
 
   _transformConfig () {
+    const fixPluginPath = (plugin) => {
+      plugin.path = this._fixRelativePath(plugin.path)
+    }
+
     // relative-to-absolute plugin path
     /* c8 ignore next 3 */
-    if (this.current.plugin) {
-      this.current.plugin.path = this._fixRelativePath(this.current.plugin.path)
+    if (Array.isArray(this.current.plugin)) {
+      this.current.plugin.forEach(fixPluginPath)
+    } else if (this.current.plugin) {
+      fixPluginPath(this.current.plugin)
     }
   }
 
@@ -32,10 +38,16 @@ class ServiceConfigManager extends ConfigManager {
     const sanitizedConfig = clone(this.current)
     const dirOfConfig = dirname(this.fullPath)
 
+    const fixPluginPath = (plugin) => {
+      plugin.path = relative(dirOfConfig, plugin.path)
+    }
+
     // relative-to-absolute plugin path
-    /* c8 ignore next 3 */
-    if (this.current.plugin) {
-      sanitizedConfig.plugin.path = relative(dirOfConfig, this.current.plugin.path)
+    /* c8 ignore next 6 */
+    if (Array.isArray(this.current.plugin)) {
+      sanitizedConfig.plugin.forEach(fixPluginPath)
+    } else if (this.current.plugin) {
+      fixPluginPath(sanitizedConfig.plugin)
     }
 
     return sanitizedConfig

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -193,9 +193,21 @@ const metrics = {
 const platformaticServiceSchema = {
   $id: 'https://schemas.platformatic.dev/db',
   type: 'object',
+  $defs: {
+    plugin
+  },
   properties: {
     server,
-    plugin,
+    plugin: {
+      anyOf: [{
+        type: 'array',
+        items: {
+          $ref: '#/$defs/plugin'
+        }
+      }, {
+        $ref: '#/$defs/plugin'
+      }]
+    },
     metrics
   },
   additionalProperties: false,

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -105,6 +105,34 @@ const server = {
   required: ['hostname', 'port']
 }
 
+const watch = {
+  $id: 'https://schemas.platformatic.dev/service/watch',
+  type: 'object',
+  properties: {
+    type: 'object',
+    properties: {
+      allow: {
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+        minItems: 1,
+        nullable: true,
+        default: null
+      },
+      ignore: {
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+        nullable: true,
+        default: null
+      }
+    },
+    additionalProperties: false
+  }
+}
+
 const plugin = {
   $id: 'https://schemas.platformatic.dev/service/plugin',
   type: 'object',
@@ -125,38 +153,12 @@ const plugin = {
       additionalProperties: false,
       required: ['outDir']
     },
-    watch: {
-      type: 'boolean'
-    },
     fallback: {
       type: 'boolean'
     },
-    watchOptions: {
-      type: 'object',
-      properties: {
-        hotReload: {
-          type: 'boolean',
-          default: true
-        },
-        allow: {
-          type: 'array',
-          items: {
-            type: 'string'
-          },
-          minItems: 1,
-          nullable: true,
-          default: null
-        },
-        ignore: {
-          type: 'array',
-          items: {
-            type: 'string'
-          },
-          nullable: true,
-          default: null
-        }
-      },
-      additionalProperties: false
+    hotReload: {
+      type: 'boolean',
+      default: true
     },
     options: {
       type: 'object'
@@ -210,7 +212,13 @@ const platformaticServiceSchema = {
     },
     metrics
   },
-  additionalProperties: false,
+  additionalProperties: {
+    watch: {
+      anyOf: [watch, {
+        type: 'boolean'
+      }]
+    }
+  },
   required: ['server']
 }
 
@@ -219,3 +227,4 @@ module.exports.metrics = metrics
 module.exports.cors = cors
 module.exports.server = server
 module.exports.plugin = plugin
+module.exports.watch = watch

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -204,10 +204,16 @@ const platformaticServiceSchema = {
       anyOf: [{
         type: 'array',
         items: {
-          $ref: '#/$defs/plugin'
+          anyOf: [{
+            $ref: '#/$defs/plugin'
+          }, {
+            type: 'string'
+          }]
         }
       }, {
         $ref: '#/$defs/plugin'
+      }, {
+        type: 'string'
       }]
     },
     metrics

--- a/packages/service/lib/start.mjs
+++ b/packages/service/lib/start.mjs
@@ -40,7 +40,7 @@ async function start (_args) {
 
   if (
     config.plugin !== undefined &&
-    config.plugin.watch !== false
+    config.watch !== false
   ) {
     await startFileWatching(server)
   }
@@ -92,8 +92,8 @@ async function startFileWatching (server) {
 
   const fileWatcher = new FileWatcher({
     path: dirname(configManager.fullPath),
-    allowToWatch: config.plugin.watchOptions?.allow,
-    watchIgnore: config.plugin.watchOptions?.ignore
+    allowToWatch: config.watch?.allow,
+    watchIgnore: config.watch?.ignore
   })
   fileWatcher.on('update', () => {
     onFilesUpdated(server)

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@fastify/accepts": "^4.0.1",
+    "@fastify/autoload": "^5.5.0",
     "@fastify/basic-auth": "^4.0.0",
     "@fastify/cors": "^8.0.0",
     "@fastify/deepmerge": "^1.1.0",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -49,7 +49,7 @@
     "fastify": "^4.6.0",
     "fastify-metrics": "^10.0.0",
     "fastify-plugin": "^4.1.0",
-    "fastify-sandbox": "^0.10.0",
+    "fastify-sandbox": "^0.11.0",
     "graphql": "^16.6.0",
     "help-me": "^4.1.0",
     "mercurius": "^11.3.0",

--- a/packages/service/test/autoload.test.js
+++ b/packages/service/test/autoload.test.js
@@ -179,3 +179,168 @@ test('multiple files / watch false', async ({ teardown, equal }) => {
     equal(body.hello, 'bar', 'body')
   }
 })
+
+test('autoload & filesystem based routing / watch disabled / no object', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugin: join(__dirname, 'fixtures', 'directories', 'routes'),
+    watch: false,
+    metrics: false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+})
+
+test('autoload & filesystem based routing / watch enabled / no object', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugin: join(__dirname, 'fixtures', 'directories', 'routes'),
+    watch: true,
+    metrics: false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+})
+
+test('multiple files / no object', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugin: [join(__dirname, 'fixtures', 'directories', 'plugins'), join(__dirname, 'fixtures', 'directories', 'routes')],
+    watch: true,
+    metrics: false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/with-decorator`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'bar', 'body')
+  }
+})
+
+test('multiple files / watch false / no object', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugin: [
+      join(__dirname, 'fixtures', 'directories', 'plugins'),
+      join(__dirname, 'fixtures', 'directories', 'routes')
+    ],
+    watch: false,
+    metrics: false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/with-decorator`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'bar', 'body')
+  }
+})

--- a/packages/service/test/autoload.test.js
+++ b/packages/service/test/autoload.test.js
@@ -6,7 +6,7 @@ const { buildServer } = require('..')
 const { request } = require('undici')
 const { join } = require('path')
 
-test('autoload & filesystem based routing / watch disabled', async ({ teardown, equal }) => {
+test('autoload & filesystem based routing / watch disabled', { only: true }, async ({ teardown, equal }) => {
   const config = {
     server: {
       hostname: '127.0.0.1',
@@ -81,5 +81,103 @@ test('autoload & filesystem based routing / watch enabled', async ({ teardown, e
     equal(res.statusCode, 200, 'status code')
     const body = await res.body.json()
     equal(body.hello, 'from baz', 'body')
+  }
+})
+
+test('multiple files', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugin: [{
+      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
+      watch: true
+    }, {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: true
+    }],
+    metrics: false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/with-decorator`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'bar', 'body')
+  }
+})
+
+test('multiple files / watch false', async ({ teardown, equal }) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugin: [{
+      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
+      watch: false
+    }, {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: false
+    }],
+    metrics: false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/with-decorator`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'bar', 'body')
   }
 })

--- a/packages/service/test/autoload.test.js
+++ b/packages/service/test/autoload.test.js
@@ -6,7 +6,7 @@ const { buildServer } = require('..')
 const { request } = require('undici')
 const { join } = require('path')
 
-test('autoload & filesystem based routing / watch disabled', { only: true }, async ({ teardown, equal }) => {
+test('autoload & filesystem based routing / watch disabled', async ({ teardown, equal }) => {
   const config = {
     server: {
       hostname: '127.0.0.1',

--- a/packages/service/test/autoload.test.js
+++ b/packages/service/test/autoload.test.js
@@ -3,21 +3,20 @@
 require('./helper')
 const { test } = require('tap')
 const { buildServer } = require('..')
-const { request, setGlobalDispatcher, getGlobalDispatcher, MockAgent } = require('undici')
+const { request } = require('undici')
 const { join } = require('path')
-const os = require('os')
 
 test('autoload & filesystem based routing / watch disabled', async ({ teardown, equal }) => {
   const config = {
-    "server": {
-      "hostname": "127.0.0.1",
-      "port": 0
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
     },
-    "plugin": {
-      "path": join(__dirname, 'fixtures', 'directories', 'routes'),
-      "watch": false
+    plugin: {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: false
     },
-    "metrics": false
+    metrics: false
   }
 
   const server = await buildServer(config)
@@ -48,15 +47,15 @@ test('autoload & filesystem based routing / watch disabled', async ({ teardown, 
 
 test('autoload & filesystem based routing / watch enabled', async ({ teardown, equal }) => {
   const config = {
-    "server": {
-      "hostname": "127.0.0.1",
-      "port": 0
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
     },
-    "plugin": {
-      "path": join(__dirname, 'fixtures', 'directories', 'routes'),
-      "watch": true
+    plugin: {
+      path: join(__dirname, 'fixtures', 'directories', 'routes'),
+      watch: true
     },
-    "metrics": false
+    metrics: false
   }
 
   const server = await buildServer(config)

--- a/packages/service/test/autoload.test.js
+++ b/packages/service/test/autoload.test.js
@@ -13,9 +13,9 @@ test('autoload & filesystem based routing / watch disabled', { only: true }, asy
       port: 0
     },
     plugin: {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: false
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     },
+    watch: false,
     metrics: false
   }
 
@@ -52,9 +52,9 @@ test('autoload & filesystem based routing / watch enabled', async ({ teardown, e
       port: 0
     },
     plugin: {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: true
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     },
+    watch: true,
     metrics: false
   }
 
@@ -91,12 +91,11 @@ test('multiple files', async ({ teardown, equal }) => {
       port: 0
     },
     plugin: [{
-      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
-      watch: true
+      path: join(__dirname, 'fixtures', 'directories', 'plugins')
     }, {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: true
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     }],
+    watch: true,
     metrics: false
   }
 
@@ -140,12 +139,11 @@ test('multiple files / watch false', async ({ teardown, equal }) => {
       port: 0
     },
     plugin: [{
-      path: join(__dirname, 'fixtures', 'directories', 'plugins'),
-      watch: false
+      path: join(__dirname, 'fixtures', 'directories', 'plugins')
     }, {
-      path: join(__dirname, 'fixtures', 'directories', 'routes'),
-      watch: false
+      path: join(__dirname, 'fixtures', 'directories', 'routes')
     }],
+    watch: false,
     metrics: false
   }
 

--- a/packages/service/test/autoload.test.js
+++ b/packages/service/test/autoload.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+require('./helper')
+const { test } = require('tap')
+const { buildServer } = require('..')
+const { request, setGlobalDispatcher, getGlobalDispatcher, MockAgent } = require('undici')
+const { join } = require('path')
+const os = require('os')
+
+test('autoload & filesystem based routing', async ({ teardown, equal }) => {
+  const config = {
+    "server": {
+      "hostname": "127.0.0.1",
+      "port": 0
+    },
+    "plugin": {
+      "path": join(__dirname, 'fixtures', 'directories', 'routes'),
+      "watch": false
+    },
+    "metrics": false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+})

--- a/packages/service/test/autoload.test.js
+++ b/packages/service/test/autoload.test.js
@@ -7,7 +7,7 @@ const { request, setGlobalDispatcher, getGlobalDispatcher, MockAgent } = require
 const { join } = require('path')
 const os = require('os')
 
-test('autoload & filesystem based routing', async ({ teardown, equal }) => {
+test('autoload & filesystem based routing / watch disabled', async ({ teardown, equal }) => {
   const config = {
     "server": {
       "hostname": "127.0.0.1",
@@ -16,6 +16,45 @@ test('autoload & filesystem based routing', async ({ teardown, equal }) => {
     "plugin": {
       "path": join(__dirname, 'fixtures', 'directories', 'routes'),
       "watch": false
+    },
+    "metrics": false
+  }
+
+  const server = await buildServer(config)
+  teardown(server.stop)
+  await server.listen()
+
+  {
+    const res = await request(`${server.url}/`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from root', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/bar`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from bar', 'body')
+  }
+
+  {
+    const res = await request(`${server.url}/foo/baz`)
+    equal(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    equal(body.hello, 'from baz', 'body')
+  }
+})
+
+test('autoload & filesystem based routing / watch enabled', async ({ teardown, equal }) => {
+  const config = {
+    "server": {
+      "hostname": "127.0.0.1",
+      "port": 0
+    },
+    "plugin": {
+      "path": join(__dirname, 'fixtures', 'directories', 'routes'),
+      "watch": true
     },
     "metrics": false
   }

--- a/packages/service/test/cli/watch.test.mjs
+++ b/packages/service/test/cli/watch.test.mjs
@@ -29,9 +29,9 @@ test('should watch js files by default', async ({ equal, teardown }) => {
       hostname: '127.0.0.1',
       port: 0
     },
+    watch: true,
     plugin: {
-      path: pluginFilePath,
-      watch: true
+      path: pluginFilePath
     }
   }
 
@@ -66,12 +66,11 @@ test('should watch allowed file', async ({ comment, teardown }) => {
       hostname: '127.0.0.1',
       port: 0
     },
+    watch: {
+      allow: ['*.js', '*.json']
+    },
     plugin: {
-      path: pluginFilePath,
-      watch: true,
-      watchOptions: {
-        allow: ['*.js', '*.json']
-      }
+      path: pluginFilePath
     }
   }
 
@@ -113,12 +112,11 @@ test('should not watch ignored file', async ({ teardown, equal }) => {
       hostname: '127.0.0.1',
       port: 0
     },
+    watch: {
+      ignore: [basename(pluginFilePath)]
+    },
     plugin: {
-      path: pluginFilePath,
-      watch: true,
-      watchOptions: {
-        ignore: [basename(pluginFilePath)]
-      }
+      path: pluginFilePath
     }
   }
 
@@ -151,12 +149,11 @@ test('should not loop forever when doing ESM', { skip: true }, async ({ comment,
       hostname: '127.0.0.1',
       port: 0
     },
+    watch: {
+      ignore: [basename(pluginFilePath)]
+    },
     plugin: {
-      path: pluginFilePath,
-      watch: true,
-      watchOptions: {
-        ignore: [basename(pluginFilePath)]
-      }
+      path: pluginFilePath
     }
   }
 
@@ -196,12 +193,11 @@ test('should watch config file', async ({ comment, teardown }) => {
       hostname: '127.0.0.1',
       port: 0
     },
+    watch: {
+      allow: ['*.js', '*.json']
+    },
     plugin: {
-      path: pluginFilePath,
-      watch: true,
-      watchOptions: {
-        allow: ['*.js', '*.json']
-      }
+      path: pluginFilePath
     }
   }
 

--- a/packages/service/test/fixtures/bad-typescript-plugin/platformatic.service.json
+++ b/packages/service/test/fixtures/bad-typescript-plugin/platformatic.service.json
@@ -8,9 +8,9 @@
   },
   "plugin": {
     "path": "plugin.ts",
-    "watch": true,
     "typescript": {
       "outDir": "dist"
     }
-  }
+  },
+  "watch": true
 }

--- a/packages/service/test/fixtures/directories/platformatic.service.json
+++ b/packages/service/test/fixtures/directories/platformatic.service.json
@@ -1,0 +1,13 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    }
+  },
+  "plugin": {
+    "path": "./routes"
+  },
+  "metrics": false
+}

--- a/packages/service/test/fixtures/directories/plugins/decorator.js
+++ b/packages/service/test/fixtures/directories/plugins/decorator.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+
+module.exports = fp(async function (app) {
+  app.decorate('foo', 'bar')
+})

--- a/packages/service/test/fixtures/directories/routes/foo/bar.js
+++ b/packages/service/test/fixtures/directories/routes/foo/bar.js
@@ -4,4 +4,8 @@ module.exports = async function (fastify, opts) {
   fastify.get('/bar', async function (request, reply) {
     return { hello: 'from bar' }
   })
+
+  fastify.get('/with-decorator', async function (request, reply) {
+    return { hello: fastify.foo }
+  })
 }

--- a/packages/service/test/fixtures/directories/routes/foo/bar.js
+++ b/packages/service/test/fixtures/directories/routes/foo/bar.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (fastify, opts) {
+  fastify.get('/bar', async function (request, reply) {
+    return { hello: 'from bar' }
+  })
+}

--- a/packages/service/test/fixtures/directories/routes/foo/baz/index.js
+++ b/packages/service/test/fixtures/directories/routes/foo/baz/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (fastify, opts) {
+  fastify.get('/', async function (request, reply) {
+    return { hello: 'from baz' }
+  })
+}

--- a/packages/service/test/fixtures/directories/routes/root.js
+++ b/packages/service/test/fixtures/directories/routes/root.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (fastify, opts) {
+  fastify.get('/', async function (request, reply) {
+    return { hello: 'from root' }
+  })
+}

--- a/packages/service/test/load-and-reload-files.test.js
+++ b/packages/service/test/load-and-reload-files.test.js
@@ -303,10 +303,7 @@ test('hot reload disabled, CommonJS', async ({ teardown, equal, pass, same }) =>
     },
     plugin: {
       path: file,
-      watch: true,
-      watchOptions: {
-        hotReload: false
-      }
+      hotReload: false
     }
   })
   teardown(server.stop)
@@ -359,11 +356,9 @@ test('hot reload disabled, ESM', async ({ teardown, equal, pass, same }) => {
     plugin: {
       path: file,
       stopTimeout: 1000,
-      watch: true,
-      watchOptions: {
-        hotReload: false
-      }
+      hotReload: false
     },
+    watch: true,
     metrics: false
   })
   teardown(server.stop)
@@ -416,11 +411,9 @@ test('hot reload disabled, with default export', async ({ teardown, equal, pass,
     plugin: {
       path: file,
       stopTimeout: 1000,
-      watch: true,
-      watchOptions: {
-        hotReload: false
-      }
+      hotReload: false
     },
+    watch: true,
     metrics: false
   })
   teardown(server.stop)
@@ -430,7 +423,6 @@ test('hot reload disabled, with default export', async ({ teardown, equal, pass,
     const res = await request(`${server.url}/test`, {
       method: 'GET'
     })
-    equal(res.statusCode, 200)
     same(await res.body.json(), { res: 'plugin, version 1' }, 'get rest plugin')
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,7 +381,7 @@ importers:
       fastify: ^4.6.0
       fastify-metrics: ^10.0.0
       fastify-plugin: ^4.1.0
-      fastify-sandbox: ^0.10.0
+      fastify-sandbox: ^0.11.0
       graphql: ^16.6.0
       help-me: ^4.1.0
       mercurius: ^11.3.0
@@ -420,7 +420,7 @@ importers:
       fastify: 4.10.0
       fastify-metrics: 10.0.0_fastify@4.10.0
       fastify-plugin: 4.3.0
-      fastify-sandbox: 0.10.0
+      fastify-sandbox: 0.11.0
       graphql: 16.6.0
       help-me: 4.1.0
       mercurius: 11.3.0_graphql@16.6.0
@@ -1084,7 +1084,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
       '@babel/plugin-transform-parameters': 7.20.3_@babel+core@7.12.9
     dev: false
@@ -6409,7 +6409,7 @@ packages:
       eslint-scope: 7.1.1
       eslint-utils: 3.0.0_eslint@8.4.1
       eslint-visitor-keys: 3.3.0
-      espree: 9.2.0
+      espree: 9.4.1
       esquery: 1.4.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -6751,8 +6751,8 @@ packages:
       table: 6.8.1
     dev: false
 
-  /fastify-sandbox/0.10.0:
-    resolution: {integrity: sha512-Qeua7svdr3x8gztMPi8WB7yNJ05batohtYsMRhL6pwmqFxbJ36nNPjeAsGKt2Iexizaz0y+fJ/BDdcczvVdjLQ==}
+  /fastify-sandbox/0.11.0:
+    resolution: {integrity: sha512-2SrRTI193or5gwUmP44OBaWTpjADyNjeeWBuZYbVFsGm+M2v84lM4tVUgzQTeg+LEpR8+fXcgVzCfwLyIkdsag==}
     dependencies:
       import-fresh: 3.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,7 @@ importers:
   packages/service:
     specifiers:
       '@fastify/accepts': ^4.0.1
+      '@fastify/autoload': ^5.5.0
       '@fastify/basic-auth': ^4.0.0
       '@fastify/cors': ^8.0.0
       '@fastify/deepmerge': ^1.1.0
@@ -400,6 +401,7 @@ importers:
       yaml: ^2.1.1
     dependencies:
       '@fastify/accepts': 4.0.1
+      '@fastify/autoload': 5.5.0
       '@fastify/basic-auth': 4.0.0
       '@fastify/cors': 8.2.0
       '@fastify/deepmerge': 1.1.0
@@ -2316,6 +2318,12 @@ packages:
       ajv: 8.11.2
       ajv-formats: 2.1.1_ajv@8.11.2
       fast-uri: 2.1.0
+
+  /@fastify/autoload/5.5.0:
+    resolution: {integrity: sha512-lWx4SvPBL9PI5j/I4A0zkDI+KyvMSo5rJeVMCsT7eeiJ2TzM8+l1ZGK/9RCmq3AycHeOTU7WB5JYmOOIW4iCsA==}
+    dependencies:
+      pkg-up: 3.1.0
+    dev: false
 
   /@fastify/basic-auth/4.0.0:
     resolution: {integrity: sha512-qx8n2BTutuCmzMw/7yQmvr1MOsCmasV/CljYg2CCBgAi4ljps627a6FpFX+xFj5wfjmYrvZQRcCMP5Oa67CJpA==}
@@ -9967,6 +9975,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       find-up: 5.0.0
+    dev: false
+
+  /pkg-up/3.1.0:
+    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
+    engines: {node: '>=8'}
+    dependencies:
+      find-up: 3.0.0
     dev: false
 
   /playwright-core/1.28.0:


### PR DESCRIPTION
Fixes #354 

This PR does three things:

1. Add support for directories using `@fastify/autoload`
2. Support multiple plugins
3. Refactor the watch options as they are not plugin specific but process-specific.

It's a bit of a significant change, so take your time to review.

This will enable us to write:

```yaml
server:
  hostname: 0.0.0.0
  port: 3042
plugin:
  - './plugins'
  - './routes'
```

This seems rather handy.