### PR TITLE
Multiline env variabiles and JWT schema fix

### DIFF
--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -139,7 +139,13 @@ class ConfigManager extends EventEmitter {
       env = { ...env, ...parsed }
     }
     this.env = this.purgeEnv(env)
-    return this.pupa(configString, this.env)
+
+    const escapeNewlines = ({ value }) => {
+      if (!value) return value
+      return value.replace(/\n/g, '\\n')
+    }
+
+    return this.pupa(configString, this.env, { transform: escapeNewlines })
   }
 
   _transformConfig () {}

--- a/packages/config/test/placeholders.test.js
+++ b/packages/config/test/placeholders.test.js
@@ -83,3 +83,29 @@ test('throws if not all placeholders are defined', async ({ plan, same, throws }
     same(err.message, 'Missing a value for the placeholder: PLT_PLUGIN')
   }
 })
+
+test('transform placeholders with newlines', async ({ plan, same }) => {
+  const cm = new ConfigManager({
+    source: './file.json',
+    env: {
+      PLT_FOO: 'bar\nbar2\nbar3',
+      PLT_USERNAME: 'john\njohn2'
+    }
+  })
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: '3042',
+      replace: '{PLT_FOO}'
+    }
+  }
+
+  const res = await cm.replaceEnv(JSON.stringify(config))
+  same(JSON.parse(res), {
+    server: {
+      hostname: '127.0.0.1',
+      port: '3042',
+      replace: 'bar\nbar2\nbar3'
+    }
+  })
+})

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -103,10 +103,17 @@ const authorization = {
     },
     jwt: {
       type: 'object',
+      additionalProperties: true,
       properties: {
         secret: {
-          type: 'string',
-          description: 'the shared secret for JWT'
+          oneOf: [{
+            type: 'string',
+            description: 'the shared secret for JWT'
+          }, {
+            type: 'object',
+            description: 'the JWT secret configuration (see: https://github.com/fastify/fastify-jwt#secret-required)',
+            additionalProperties: true
+          }]
         },
         namespace: {
           type: 'string',


### PR DESCRIPTION
Fixes: https://github.com/platformatic/platformatic/issues/370

`.env` values with new lines must be in one line with `\n`
For these cases (private'public keys)  we might need to have a placeholder system that can load configuration from files. 

Signed-off-by: marcopiraccini <marco.piraccini@gmail.com>