### PR TITLE
feat: set accept-encoding header for the webhook request

### DIFF
--- a/packages/db-authorization/lib/webhook.js
+++ b/packages/db-authorization/lib/webhook.js
@@ -29,7 +29,10 @@ module.exports = fp(async function (app, opts) {
     const res = await pool.request({
       path,
       method: 'POST',
-      headers,
+      headers: {
+        ...headers,
+        'accept-encoding': 'identity'
+      },
       body
     })
 


### PR DESCRIPTION
Fix: #329 