### PR TITLE
Fix enum cases

### DIFF
--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -50,7 +50,7 @@ function constructGraph (app, entity, opts, ignore) {
     /* istanbul ignore next */
     if (field.enum) {
       const enumValues = field.enum.reduce((acc, enumValue) => {
-        acc[enumValue] = { value: enumValue }
+        acc[enumValue.replace(/-/g, '_')] = { value: enumValue }
         return acc
       }, {})
       const enumName = `${entityName}_${key}`

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -53,7 +53,8 @@ function constructGraph (app, entity, opts, ignore) {
         acc[enumValue] = { value: enumValue }
         return acc
       }, {})
-      meta.type = new graphql.GraphQLEnumType({ name: key, values: enumValues })
+      const enumName = `${entityName}_${key}`
+      meta.type = new graphql.GraphQLEnumType({ name: enumName, values: enumValues })
     } else {
       meta.type = sqlTypeToGraphQL(field.sqlType)
     }

--- a/packages/sql-graphql/test/simple.test.js
+++ b/packages/sql-graphql/test/simple.test.js
@@ -1017,7 +1017,7 @@ test('handle enums with dashed values', { skip: isSQLite }, async ({ pass, teard
       CREATE TABLE pages (
         id SERIAL PRIMARY KEY,
         enumName ENUM ('value-1', 'value-2')
-      );`);
+      );`)
     }
   }
   const app = fastify()
@@ -1055,10 +1055,9 @@ test('handle enums with dashed values', { skip: isSQLite }, async ({ pass, teard
   same(res.json(), {
     data: {
       savePage: {
-        id: 1, 
+        id: 1,
         enumName: 'value-1'
       }
     }
   })
-
 })


### PR DESCRIPTION
as noted here: https://github.com/platformatic/platformatic/issues/292#issuecomment-1323818962
There are two problems:
1) An error is thrown from graphql if enum values contain dashes
2) If two enum columns exist in two tables with same name it would throw an error in the schema  