### PR TITLE
feat(config): Add schema JSON

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -199,9 +199,13 @@ https://oss.platformatic.dev/docs/reference/db/configuration.
 
 #### schema
 
-Generate the schema of your config file:
+Update the config schema file:
 
-* `schema config` - create / update the JSON schema config available on `platformatic.db.schema.json`
+* `schema config` - update the JSON schema config available on `platformatic.db.schema.json`
+
+Your configuration on `platformatic.db.json` has a schema defined to improve the developer experience and avoid mistakes when updating the configuration of Platformatic DB.
+When you run `platformatic db init`, a new JSON `$schema` property is added in `platformatic.db.schema.json`. This can allow your IDE to add suggestions (f.e. mandatory/missing fields, types, default values) by opening the config in `platformatic.db.json`.
+Running `platformatic db schema config` you can update your schema so that it matches well the latest changes available on your config.
 
 Generate a schema from the database and prints it to standard output:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -199,6 +199,10 @@ https://oss.platformatic.dev/docs/reference/db/configuration.
 
 #### schema
 
+Generate the schema of your config file:
+
+* `schema config` - create / update the JSON schema config available on `platformatic.db.schema.json`
+
 Generate a schema from the database and prints it to standard output:
 
 * `schema graphql` - generate the GraphQL schema

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -350,7 +350,7 @@ A **required** object with the following settings:
 - **`cors`** (`object`) — Configuration for Cross-Origin Resource Sharing (CORS) headers.
   - All options will be passed to the [`@fastify/cors`](https://github.com/fastify/fastify-cors) plugin.
 - **`logger`** (`object`) -- the [logger configuration](https://www.fastify.io/docs/latest/Reference/Server/#logger).
-- **`pluginTimeout** (`integer`) -- the milliseconds to wait for a Fastify plugin to load, see the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#plugintimeout) for more details.
+- **`pluginTimeout`** (`integer`) -- the milliseconds to wait for a Fastify plugin to load, see the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#plugintimeout) for more details.
 
 ### `authorization`
 

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -65,7 +65,7 @@ A **required** object with the following settings:
 - **`cors`** (`object`) — Configuration for Cross-Origin Resource Sharing (CORS) headers.
   - All options will be passed to the [`@fastify/cors`](https://github.com/fastify/fastify-cors) plugin.
 - **`logger`** (`object`) -- the [logger configuration](https://www.fastify.io/docs/latest/Reference/Server/#logger).
-- **`pluginTimeout** (`integer`) -- the milliseconds to wait for a Fastify plugin to load, see the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#plugintimeout) for more details.
+- **`pluginTimeout`** (`integer`) -- the milliseconds to wait for a Fastify plugin to load, see the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#plugintimeout) for more details.
 
 ### `metrics`
 

--- a/packages/db/db.mjs
+++ b/packages/db/db.mjs
@@ -13,7 +13,7 @@ import { compile } from './lib/compile.mjs'
 import { applyMigrations } from './lib/migrate.mjs'
 import { seed } from './lib/seed.mjs'
 import { generateTypes } from './lib/gen-types.mjs'
-import { printGraphQLSchema, printOpenAPISchema } from './lib/gen-schema.mjs'
+import { printGraphQLSchema, printOpenAPISchema, generateJsonSchemaConfig } from './lib/gen-schema.mjs'
 
 const help = helpMe({
   dir: join(import.meta.url, 'help'),
@@ -38,6 +38,7 @@ program.register('seed', seed)
 program.register('types', generateTypes)
 program.register('schema graphql', printGraphQLSchema)
 program.register('schema openapi', printOpenAPISchema)
+program.register('schema config', generateJsonSchemaConfig)
 program.register('schema', help.toStdout.bind(null, ['schema']))
 
 // TODO add help command

--- a/packages/db/help/schema.txt
+++ b/packages/db/help/schema.txt
@@ -1,3 +1,7 @@
+Generate the schema of your config file:
+
+* `schema config` - create / update the JSON schema config available on `platformatic.db.schema.json`
+
 Generate a schema from the database and prints it to standard output:
 
 * `schema graphql` - generate the GraphQL schema

--- a/packages/db/help/schema.txt
+++ b/packages/db/help/schema.txt
@@ -1,6 +1,10 @@
-Generate the schema of your config file:
+Update the config schema file:
 
-* `schema config` - create / update the JSON schema config available on `platformatic.db.schema.json`
+* `schema config` - update the JSON schema config available on `platformatic.db.schema.json`
+
+Your configuration on `platformatic.db.json` has a schema defined to improve the developer experience and avoid mistakes when updating the configuration of Platformatic DB.
+When you run `platformatic db init`, a new JSON `$schema` property is added in `platformatic.db.schema.json`. This can allow your IDE to add suggestions (f.e. mandatory/missing fields, types, default values) by opening the config in `platformatic.db.json`.
+Running `platformatic db schema config` you can update your schema so that it matches well the latest changes available on your config.
 
 Generate a schema from the database and prints it to standard output:
 

--- a/packages/db/lib/gen-schema.mjs
+++ b/packages/db/lib/gen-schema.mjs
@@ -2,9 +2,11 @@ import pino from 'pino'
 import pretty from 'pino-pretty'
 import Fastify from 'fastify'
 import graphql from 'graphql'
+import { writeFile } from 'fs/promises'
 import loadConfig from './load-config.mjs'
 import { createServerConfig } from '@platformatic/utils'
 import { platformaticDB } from '../index.js'
+import { schema as platformaticDBschema } from './schema.js'
 
 async function buildServer (_args, onServer) {
   const logger = pino(pretty({
@@ -52,4 +54,10 @@ function printOpenAPISchema (_args) {
   })
 }
 
-export { printGraphQLSchema, printOpenAPISchema }
+const filenameConfigJsonSchema = 'platformatic.db.schema.json'
+
+async function generateJsonSchemaConfig () {
+  await writeFile(filenameConfigJsonSchema, JSON.stringify(platformaticDBschema, null, 2))
+}
+
+export { printGraphQLSchema, printOpenAPISchema, generateJsonSchemaConfig, filenameConfigJsonSchema }

--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -6,6 +6,7 @@ import parseArgs from 'minimist'
 import { checkForDependencies, generateGlobalTypesFile } from './gen-types.mjs'
 import loadConfig from './load-config.mjs'
 import { findConfigFile, isFileAccessible } from './utils.js'
+import { schema as platformaticDBschema } from './schema.js'
 
 const connectionStrings = {
   postgres: 'postgres://postgres:postgres@localhost:5432/postgres',
@@ -26,121 +27,6 @@ CREATE TABLE IF NOT EXISTS movies (
 const moviesMigrationUndo = `
 -- Add SQL in this file to drop the database tables 
 DROP TABLE movies;
-`
-
-const jsonConfigDbSchema = `
-{
-  "title": "Platformatic DB config",
-  "type": "object",
-  "properties": {
-    "core": {
-      "type": "object",
-      "properties": {
-        "connectionString": { "type": "string" },
-        "schema": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "graphql": {
-          "default": true,
-          "type": ["boolean", "object"],
-          "properties": {
-            "graphiql": { "type": "boolean" }
-          }
-        },
-        "openapi": {
-          "default": true,
-          "type": ["boolean", "object"],
-          "properties": {
-            "prefix": { "type": "string" }
-          }
-        },
-        "ignore": {
-          "type": "object",
-          "properties": {
-            "versions": { "type": "boolean" }
-          }
-        },
-        "events": {
-          "default": true,
-          "type": ["boolean", "object"]
-        }
-      },
-      "required": ["connectionString"]
-    },
-    "dashboard": {
-      "type": ["boolean", "object"],
-      "properties": {
-        "rootPath": { "type": "boolean", "default": true }
-      }
-    },
-    "metrics": {
-      "type": ["boolean", "object"],
-      "properties": {
-        "hostname": { "type": "string" },
-        "port": { "type": "number" },
-        "auth": { "type": "object" }
-      }
-    },
-    "migrations": {
-      "type": "object",
-      "properties": {
-        "dir": { "type": "string" },
-        "autoApply": { "type": "boolean", "default": true }
-      }
-    },
-    "plugin": {
-      "type": ["object", "array", "string"],
-      "properties": {
-        "path": { "type": "string" },
-        "typescript": {
-          "type": "object",
-          "properties": {
-            "outDir": { "type": "string" }
-          }
-        },
-        "hotReload": { "type": "boolean", "default": true },
-        "options": { "type": "object" }
-      },
-      "required": ["path"]
-    },
-    "watch": {
-      "type": ["object", "boolean"],
-      "properties": {
-        "ignore": {
-          "type": ["array", "null"],
-          "default": null,
-          "items": { "type": "string" }
-        },
-        "allow": {
-          "type": ["array"],
-          "default": ["*.js", "**/*.js"],
-          "items": { "type": "string" }
-        }
-      }
-    },
-    "server": {
-      "type": ["object"],
-      "properties": {
-        "hostname": { "type": "string" },
-        "port": { "type": "number" },
-        "healthCheck": { "type": ["boolean", "object"] },
-        "cors": { "type": "object" },
-        "logger": { "type": "object" },
-        "pluginTimeout": { "type": "number" }
-      },
-      "required": ["hostname", "port"]
-    },
-    "authorization": {
-      "type": "object",
-      "properties": {
-        "adminSecret": { "type": "string" },
-        "rules": { "type": "array" }
-      }
-    }
-  },
-  "required": ["core", "server"]
-}
 `
 
 function getTsConfig (outDir) {
@@ -260,7 +146,7 @@ async function init (_args) {
   const accessibleConfigFilename = await findConfigFile(currentDir)
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(args)
-    await writeFile('platformatic.db.schema.json', jsonConfigDbSchema)
+    await writeFile('platformatic.db.schema.json', JSON.stringify(platformaticDBschema))
     await writeFile('platformatic.db.json', JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.db.json successfully created.')
   } else {

--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -29,6 +29,8 @@ const moviesMigrationUndo = `
 DROP TABLE movies;
 `
 
+const filenameSchema = 'platformatic.db.schema.json'
+
 function getTsConfig (outDir) {
   return {
     compilerOptions: {
@@ -56,7 +58,7 @@ function generateConfig (args) {
   const connectionString = connectionStrings[database]
 
   const config = {
-    $schema: './platformatic.db.schema.json',
+    $schema: `./${filenameSchema}`,
     server: { hostname, port },
     core: { connectionString, graphql: true },
     migrations: { dir: migrations },
@@ -146,7 +148,7 @@ async function init (_args) {
   const accessibleConfigFilename = await findConfigFile(currentDir)
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(args)
-    await writeFile('platformatic.db.schema.json', JSON.stringify(platformaticDBschema, null, 2))
+    await writeFile(filenameSchema, JSON.stringify(platformaticDBschema, null, 2))
     await writeFile('platformatic.db.json', JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.db.json successfully created.')
   } else {

--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -28,6 +28,121 @@ const moviesMigrationUndo = `
 DROP TABLE movies;
 `
 
+const jsonConfigDbSchema = `
+{
+  "title": "Platformatic DB config",
+  "type": "object",
+  "properties": {
+    "core": {
+      "type": "object",
+      "properties": {
+        "connectionString": { "type": "string" },
+        "schema": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "graphql": {
+          "default": true,
+          "type": ["boolean", "object"],
+          "properties": {
+            "graphiql": { "type": "boolean" }
+          }
+        },
+        "openapi": {
+          "default": true,
+          "type": ["boolean", "object"],
+          "properties": {
+            "prefix": { "type": "string" }
+          }
+        },
+        "ignore": {
+          "type": "object",
+          "properties": {
+            "versions": { "type": "boolean" }
+          }
+        },
+        "events": {
+          "default": true,
+          "type": ["boolean", "object"]
+        }
+      },
+      "required": ["connectionString"]
+    },
+    "dashboard": {
+      "type": ["boolean", "object"],
+      "properties": {
+        "rootPath": { "type": "boolean", "default": true }
+      }
+    },
+    "metrics": {
+      "type": ["boolean", "object"],
+      "properties": {
+        "hostname": { "type": "string" },
+        "port": { "type": "number" },
+        "auth": { "type": "object" }
+      }
+    },
+    "migrations": {
+      "type": "object",
+      "properties": {
+        "dir": { "type": "string" },
+        "autoApply": { "type": "boolean", "default": true }
+      }
+    },
+    "plugin": {
+      "type": ["object", "array", "string"],
+      "properties": {
+        "path": { "type": "string" },
+        "typescript": {
+          "type": "object",
+          "properties": {
+            "outDir": { "type": "string" }
+          }
+        },
+        "hotReload": { "type": "boolean", "default": true },
+        "options": { "type": "object" }
+      },
+      "required": ["path"]
+    },
+    "watch": {
+      "type": ["object", "boolean"],
+      "properties": {
+        "ignore": {
+          "type": ["array", "null"],
+          "default": null,
+          "items": { "type": "string" }
+        },
+        "allow": {
+          "type": ["array"],
+          "default": ["*.js", "**/*.js"],
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "server": {
+      "type": ["object"],
+      "properties": {
+        "hostname": { "type": "string" },
+        "port": { "type": "number" },
+        "healthCheck": { "type": ["boolean", "object"] },
+        "cors": { "type": "object" },
+        "logger": { "type": "object" },
+        "pluginTimeout": { "type": "number" }
+      },
+      "required": ["hostname", "port"]
+    },
+    "authorization": {
+      "type": "object",
+      "properties": {
+        "adminSecret": { "type": "string" },
+        "rules": { "type": "array" }
+      }
+    }
+  },
+  "required": ["core", "server"]
+}
+`
+
 function getTsConfig (outDir) {
   return {
     compilerOptions: {
@@ -55,6 +170,7 @@ function generateConfig (args) {
   const connectionString = connectionStrings[database]
 
   const config = {
+    $schema: './platformatic.db.schema.json',
     server: { hostname, port },
     core: { connectionString, graphql: true },
     migrations: { dir: migrations },
@@ -144,6 +260,7 @@ async function init (_args) {
   const accessibleConfigFilename = await findConfigFile(currentDir)
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(args)
+    await writeFile('platformatic.db.schema.json', jsonConfigDbSchema)
     await writeFile('platformatic.db.json', JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.db.json successfully created.')
   } else {

--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -146,7 +146,7 @@ async function init (_args) {
   const accessibleConfigFilename = await findConfigFile(currentDir)
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(args)
-    await writeFile('platformatic.db.schema.json', JSON.stringify(platformaticDBschema))
+    await writeFile('platformatic.db.schema.json', JSON.stringify(platformaticDBschema, null, 2))
     await writeFile('platformatic.db.json', JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.db.json successfully created.')
   } else {

--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -6,7 +6,7 @@ import parseArgs from 'minimist'
 import { checkForDependencies, generateGlobalTypesFile } from './gen-types.mjs'
 import loadConfig from './load-config.mjs'
 import { findConfigFile, isFileAccessible } from './utils.js'
-import { schema as platformaticDBschema } from './schema.js'
+import { generateJsonSchemaConfig, filenameConfigJsonSchema } from './gen-schema.mjs'
 
 const connectionStrings = {
   postgres: 'postgres://postgres:postgres@localhost:5432/postgres',
@@ -28,8 +28,6 @@ const moviesMigrationUndo = `
 -- Add SQL in this file to drop the database tables 
 DROP TABLE movies;
 `
-
-const filenameSchema = 'platformatic.db.schema.json'
 
 function getTsConfig (outDir) {
   return {
@@ -58,7 +56,7 @@ function generateConfig (args) {
   const connectionString = connectionStrings[database]
 
   const config = {
-    $schema: `./${filenameSchema}`,
+    $schema: `./${filenameConfigJsonSchema}`,
     server: { hostname, port },
     core: { connectionString, graphql: true },
     migrations: { dir: migrations },
@@ -148,7 +146,7 @@ async function init (_args) {
   const accessibleConfigFilename = await findConfigFile(currentDir)
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(args)
-    await writeFile(filenameSchema, JSON.stringify(platformaticDBschema, null, 2))
+    await generateJsonSchemaConfig()
     await writeFile('platformatic.db.json', JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.db.json successfully created.')
   } else {

--- a/packages/db/test/cli/gen-schema.test.mjs
+++ b/packages/db/test/cli/gen-schema.test.mjs
@@ -1,0 +1,13 @@
+import { test } from "tap"
+import fs from 'fs/promises'
+import { generateJsonSchemaConfig } from "../../lib/gen-schema.mjs"
+
+test("generateJsonSchemaConfig generates the file", async (t) => {
+  process.chdir("./test/tmp")
+  await generateJsonSchemaConfig()
+
+  const configSchema = await fs.readFile("platformatic.db.schema.json", "utf8")
+  const { required, additionalProperties } = JSON.parse(configSchema)
+  t.has(required, ['core', 'server'])
+  t.has(additionalProperties, { watch: {} })
+})

--- a/packages/db/test/cli/gen-schema.test.mjs
+++ b/packages/db/test/cli/gen-schema.test.mjs
@@ -1,12 +1,12 @@
-import { test } from "tap"
+import { test } from 'tap'
 import fs from 'fs/promises'
-import { generateJsonSchemaConfig } from "../../lib/gen-schema.mjs"
+import { generateJsonSchemaConfig } from '../../lib/gen-schema.mjs'
 
-test("generateJsonSchemaConfig generates the file", async (t) => {
-  process.chdir("./test/tmp")
+test('generateJsonSchemaConfig generates the file', async (t) => {
+  process.chdir('./test/tmp')
   await generateJsonSchemaConfig()
 
-  const configSchema = await fs.readFile("platformatic.db.schema.json", "utf8")
+  const configSchema = await fs.readFile('platformatic.db.schema.json', 'utf8')
   const { required, additionalProperties } = JSON.parse(configSchema)
   t.has(required, ['core', 'server'])
   t.has(additionalProperties, { watch: {} })

--- a/packages/db/test/cli/init.test.mjs
+++ b/packages/db/test/cli/init.test.mjs
@@ -52,9 +52,10 @@ t.test('run db init with default options', async (t) => {
   const migrationFileUndo = await fs.readFile(pathToMigrationFileUndo, 'utf8')
   t.equal(migrationFileUndo, moviesMigrationUndo)
 
-  const { title, type } = parseConfigSchema
-  t.equal(title, 'Platformatic DB config')
+  const { $id, type, required } = parseConfigSchema
+  t.equal($id, 'https://schemas.platformatic.dev/db')
   t.equal(type, 'object')
+  t.has(required, ['core', 'server'])
 })
 
 t.test('run init with default options twice', async (t) => {

--- a/packages/db/test/cli/init.test.mjs
+++ b/packages/db/test/cli/init.test.mjs
@@ -23,6 +23,7 @@ t.jobs = 10
 t.test('run db init with default options', async (t) => {
   const pathToFolder = await fs.mkdtemp(path.join(tmpdir(), 'init-1'))
   const pathToDbConfigFile = path.join(pathToFolder, 'platformatic.db.json')
+  const pathToConfigSchema = path.join(pathToFolder, 'platformatic.db.schema.json')
   const pathToMigrationFolder = path.join(pathToFolder, 'migrations')
   const pathToMigrationFileDo = path.join(pathToMigrationFolder, '001.do.sql')
   const pathToMigrationFileUndo = path.join(pathToMigrationFolder, '001.undo.sql')
@@ -32,8 +33,12 @@ t.test('run db init with default options', async (t) => {
   const dbConfigFile = await fs.readFile(pathToDbConfigFile, 'utf8')
   const dbConfig = JSON.parse(dbConfigFile)
 
-  const { server, core, migrations } = dbConfig
+  const configSchema = await fs.readFile(pathToConfigSchema, 'utf8')
+  const parseConfigSchema = JSON.parse(configSchema)
 
+  const { server, core, migrations, $schema } = dbConfig
+
+  t.equal($schema, './platformatic.db.schema.json')
   t.equal(server.hostname, '127.0.0.1')
   t.equal(server.port, 3042)
 
@@ -46,6 +51,10 @@ t.test('run db init with default options', async (t) => {
   t.equal(migrationFileDo, moviesMigrationDo)
   const migrationFileUndo = await fs.readFile(pathToMigrationFileUndo, 'utf8')
   t.equal(migrationFileUndo, moviesMigrationUndo)
+
+  const {title, type} = parseConfigSchema
+  t.equal(title, 'Platformatic DB config')
+  t.equal(type, 'object')
 })
 
 t.test('run init with default options twice', async (t) => {

--- a/packages/db/test/cli/init.test.mjs
+++ b/packages/db/test/cli/init.test.mjs
@@ -52,7 +52,7 @@ t.test('run db init with default options', async (t) => {
   const migrationFileUndo = await fs.readFile(pathToMigrationFileUndo, 'utf8')
   t.equal(migrationFileUndo, moviesMigrationUndo)
 
-  const {title, type} = parseConfigSchema
+  const { title, type } = parseConfigSchema
   t.equal(title, 'Platformatic DB config')
   t.equal(type, 'object')
 })

--- a/packages/db/test/cli/schema.test.mjs
+++ b/packages/db/test/cli/schema.test.mjs
@@ -1,16 +1,15 @@
-import fs from 'fs/promises'
 import { cliPath } from './helper.js'
 import { test } from 'tap'
 import { join } from 'desm'
 import { execa } from 'execa'
-import { rm } from 'fs/promises'
+import fs from 'fs/promises'
 import stripAnsi from 'strip-ansi'
 
 const dbLocation = join(import.meta.url, '..', 'fixtures', 'sqlite', 'db')
 
 test('print the graphql schema to stdout', async ({ matchSnapshot }) => {
   try {
-    await rm(dbLocation)
+    await fs.rm(dbLocation)
   } catch {
     // ignore
   }
@@ -24,7 +23,7 @@ test('print the graphql schema to stdout', async ({ matchSnapshot }) => {
 
 test('print the openapi schema to stdout', async ({ matchSnapshot }) => {
   try {
-    await rm(dbLocation)
+    await fs.rm(dbLocation)
   } catch {
     // ignore
   }
@@ -37,7 +36,7 @@ test('print the openapi schema to stdout', async ({ matchSnapshot }) => {
 })
 
 test('generates the json schema config', async (t) => {
-  process.chdir('./test/tmp');
+  process.chdir('./test/tmp')
   await execa('node', [cliPath, 'schema', 'config'])
 
   const configSchema = await fs.readFile('platformatic.db.schema.json', 'utf8')
@@ -48,7 +47,7 @@ test('generates the json schema config', async (t) => {
 
 test('print the help if schema type is missing', async ({ match }) => {
   try {
-    await rm(dbLocation)
+    await fs.rm(dbLocation)
   } catch {
     // ignore
   }

--- a/packages/db/test/cli/schema.test.mjs
+++ b/packages/db/test/cli/schema.test.mjs
@@ -1,3 +1,4 @@
+import fs from 'fs/promises'
 import { cliPath } from './helper.js'
 import { test } from 'tap'
 import { join } from 'desm'
@@ -33,6 +34,16 @@ test('print the openapi schema to stdout', async ({ matchSnapshot }) => {
   })
 
   matchSnapshot(stdout)
+})
+
+test('generates the json schema config', async (t) => {
+  process.chdir('./test/tmp');
+  await execa('node', [cliPath, 'schema', 'config'])
+
+  const configSchema = await fs.readFile('platformatic.db.schema.json', 'utf8')
+  const { $id, type } = JSON.parse(configSchema)
+  t.equal($id, 'https://schemas.platformatic.dev/db')
+  t.equal(type, 'object')
 })
 
 test('print the help if schema type is missing', async ({ match }) => {


### PR DESCRIPTION
### What?
The goal of this PR is to improve the developer experience and avoid mistakes when updating the configuration of Platformatic DB.

### How?
* Running `npx platformatic db init` now creates a JSON schema in `platformatic.db.schema.json`:
![Screenshot 2022-11-30 at 19 52 36](https://user-images.githubusercontent.com/3996291/204884413-a880cd7b-8a72-41d3-88fe-7b942aecd983.png)
* When opening the `platformatic.db.json` your IDE can now add suggestions thanks to the`$schema` property:
![image](https://user-images.githubusercontent.com/3996291/204884681-9b03b1f5-f780-4aca-8fd0-66d737597860.png)

![image](https://user-images.githubusercontent.com/3996291/204884754-2c760cba-9da1-418a-8273-3bae36897c3b.png)

![image](https://user-images.githubusercontent.com/3996291/204884819-7ba036f1-dcd8-4fd4-ad0c-c524f1c61216.png)
* You can now notice some suggestions like mandatory/missing fields, types, default values
* The config schema follows the documentation available [here](https://oss.platformatic.dev/docs/reference/db/configuration/)