### PR TITLE
chore: fix typo in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
-coverate
+coverage
 .nyc_output


### PR DESCRIPTION
As titled.