### PR TITLE
feat(sql-mapper): Enhance error message

### DIFF
--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -117,7 +117,7 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize = 10, 
       const entity = await buildEntity(db, sql, log, table, queries, autoTimestamp, schema, useSchema, ignore[table] || {}, limit)
       // Check for primary key of all entities
       if (entity.primaryKeys.size === 0) {
-        throw Error(`Cannot find any primary keys for ${entity.name} entity`)
+        throw Error(`Cannot find any primary keys for ${entity.name} entity: ${JSON.stringify(entity)}`)
       }
 
       entities[entity.singularName] = entity


### PR DESCRIPTION
Signed-off-by: Roberto Bianchi <roberto.bianchi@spendesk.com>

Related to [this issue](https://github.com/platformatic/platformatic/issues/459), the goal of this PR is to have more details in case the check for the primary key of all entities fails.
It will simplify the debugging, giving info regarding schema, fields and other DB data.

The message will change from `Error: Cannot find any primary keys for AnonymousCard` to
```
Cannot find any primary keys for AnonymousCard entity: {"name":"AnonymousCard","singularName":"anonymousCard","pluralName":"anonymousCards","primaryKeys":{},"table":"anonymous_cards","schema":"my_clone_schema","fields":{"id":{"sqlType":"varchar","isNullable":true,"camelcase":"id"} ...
```
