### PR TITLE
fix(cli): Ensure that commands exist when calling them

### DIFF
--- a/packages/authenticate/authenticate.js
+++ b/packages/authenticate/authenticate.js
@@ -9,8 +9,8 @@ import { print } from './lib/utils.js'
 const program = commist()
 program.register('login', startLogin)
 
-export function login (argv) {
-  const result = program.parse(argv)
+export async function login (argv) {
+  const result = await program.parseAsync(argv)
   if (result) return startLogin(result, print).catch(exit)
 }
 

--- a/packages/cli/test/platformatic.test.js
+++ b/packages/cli/test/platformatic.test.js
@@ -21,7 +21,7 @@ test('version', async (t) => {
 
 test('db', async (t) => {
   try {
-    await execa('node', [cliPath, 'db'])
+    await execa('node', [cliPath, 'db', 'start'])
     t.fail('bug')
   } catch (err) {
     t.ok(err.stderr.includes('Missing config file'))
@@ -43,6 +43,34 @@ test('command not found', async (t) => {
     t.fail('bug')
   } catch (err) {
     t.ok(err.stdout.includes('Command not found: foo'))
+  }
+})
+
+test('subcommand not found', async (t) => {
+  try {
+    const rv = await execa('node', [cliPath, 'db', 'subfoo'])
+    console.log(rv.stdout)
+    t.fail('bug')
+  } catch (err) {
+    t.ok(err.stdout.includes('Command not found: subfoo'))
+  }
+})
+
+test('allows for minor typos in commands', async (t) => {
+  try {
+    await execa('node', [cliPath, 'dbx', 'start'])
+    t.fail('bug')
+  } catch (err) {
+    t.ok(err.stderr.includes('Missing config file'))
+  }
+})
+
+test('prints the help if command requires a subcommand', async (t) => {
+  try {
+    await execa('node', [cliPath, 'db'])
+    t.fail('bug')
+  } catch (err) {
+    t.equal(err.stdout + EOL, helpDB)
   }
 })
 

--- a/packages/db/db.mjs
+++ b/packages/db/db.mjs
@@ -7,7 +7,7 @@ import helpMe from 'help-me'
 import { readFile } from 'fs/promises'
 import { join } from 'desm'
 
-import start from './lib/start.mjs'
+import { start } from './lib/start.mjs'
 import { init } from './lib/init.mjs'
 import { compile } from './lib/compile.mjs'
 import { applyMigrations } from './lib/migrate.mjs'
@@ -22,7 +22,7 @@ const help = helpMe({
   ext: '.txt'
 })
 
-const program = commist({ maxDistance: 4 })
+const program = commist({ maxDistance: 2 })
 
 program.register('help', help.toStdout)
 program.register('help init', help.toStdout.bind(null, ['init']))
@@ -58,11 +58,9 @@ export async function runDB (argv) {
     process.exit(0)
   }
 
-  const result = program.parse(argv)
-
-  if (result) {
-    // We did have a command we did not match
-    return start(result)
+  return {
+    output: await program.parseAsync(argv),
+    help
   }
 }
 

--- a/packages/db/lib/start.mjs
+++ b/packages/db/lib/start.mjs
@@ -9,7 +9,7 @@ import { addLoggerToTheConfig } from '@platformatic/service'
 // TODO make sure coverage is reported for Windows
 // Currently C8 is not reporting it
 /* c8 ignore start */
-async function start (_args) {
+export async function start (_args) {
   const { configManager } = await loadConfig({
     string: ['to']
   }, _args, { watch: true })

--- a/packages/db/test/cli/auto-config.test.js
+++ b/packages/db/test/cli/auto-config.test.js
@@ -19,7 +19,7 @@ for (const fileType of fileTypes) {
       title VARCHAR(42)
     );`)
 
-    const child = execa('node', [cliPath], {
+    const child = execa('node', [cliPath, 'start'], {
       cwd: join(__dirname, '..', 'fixtures', 'auto-config', fileType)
     })
     const output = child.stdout.pipe(split(JSON.parse))

--- a/packages/db/test/cli/env.test.mjs
+++ b/packages/db/test/cli/env.test.mjs
@@ -25,6 +25,7 @@ test('env white list', async ({ equal, same, match, teardown }) => {
   );`)
   const child = execa('node', [
     cliPath,
+    'start',
     '--config',
     join(import.meta.url, '..', 'fixtures', 'env-whitelist.json'),
     '--allow-env',
@@ -78,6 +79,7 @@ test('env white list default values', async ({ equal, same, match, teardown }) =
   );`)
   const child = execa('node', [
     cliPath,
+    'start',
     '--config',
     join(import.meta.url, '..', 'fixtures', 'env-whitelist-default.json')
   ], {

--- a/packages/db/test/cli/helper.js
+++ b/packages/db/test/cli/helper.js
@@ -113,7 +113,7 @@ async function cleanSQLite (dbLocation, i = 0) {
 
 async function start (...args) {
   const { execa } = await import('execa')
-  const child = execa('node', [cliPath, ...args])
+  const child = execa('node', [cliPath, 'start', ...args])
   child.stderr.pipe(process.stdout)
   const output = child.stdout.pipe(split(function (line) {
     try {

--- a/packages/db/test/cli/validations.test.mjs
+++ b/packages/db/test/cli/validations.test.mjs
@@ -12,13 +12,13 @@ test('version', async (t) => {
 })
 
 test('missing config', async (t) => {
-  await t.rejects(execa('node', [cliPath]))
+  await t.rejects(execa('node', [cliPath, 'start']))
 })
 
 test('print validation errors', async ({ equal, plan }) => {
   plan(2)
   try {
-    await execa('node', [cliPath, '--config', join(import.meta.url, '..', 'fixtures', 'missing-required-values.json')])
+    await execa('node', [cliPath, 'start', '--config', join(import.meta.url, '..', 'fixtures', 'missing-required-values.json')])
   } catch (err) {
     equal(err.exitCode, 1)
     equal(err.stdout, `

--- a/packages/db/test/migrate/migrate.test.mjs
+++ b/packages/db/test/migrate/migrate.test.mjs
@@ -8,7 +8,7 @@ test('migrate up', async ({ equal, match, teardown }) => {
   const db = await connectAndResetDB()
   teardown(() => db.dispose())
 
-  const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('simple.json')])
+  const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('simple.json')])
   const sanitized = stripAnsi(stdout)
   match(sanitized, '001.do.sql')
 })
@@ -18,13 +18,13 @@ test('migrate up & down specifying a version with "to"', async ({ rejects, match
   teardown(() => db.dispose())
 
   {
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('simple.json')])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('simple.json')])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '001.do.sql')
   }
 
   {
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('simple.json'), '-t', '000'])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('simple.json'), '-t', '000'])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '001.undo.sql')
   }
@@ -34,7 +34,7 @@ test('ignore versions', async ({ equal, match, teardown }) => {
   const db = await connectAndResetDB()
   teardown(() => db.dispose())
 
-  const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('simple.json')])
+  const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('simple.json')])
   const sanitized = stripAnsi(stdout)
   match(sanitized, '001.do.sql')
 })
@@ -45,7 +45,7 @@ test('migrations rollback', async ({ rejects, match, teardown }) => {
 
   {
     // apply all migrations
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('multiple-migrations.json')])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('multiple-migrations.json')])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '001.do.sql')
     match(sanitized, '002.do.sql')
@@ -54,25 +54,25 @@ test('migrations rollback', async ({ rejects, match, teardown }) => {
 
   // Down to no migrations applied
   {
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '003.undo.sql')
   }
 
   {
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '002.undo.sql')
   }
 
   {
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '001.undo.sql')
   }
 
   {
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('multiple-migrations.json'), '-r'])
     const sanitized = stripAnsi(stdout)
     match(sanitized, 'No migrations to rollback')
   }
@@ -80,7 +80,7 @@ test('migrations rollback', async ({ rejects, match, teardown }) => {
   // ...and back!
   {
     // apply all migrations
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('multiple-migrations.json')])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('multiple-migrations.json')])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '001.do.sql')
     match(sanitized, '002.do.sql')
@@ -97,7 +97,7 @@ test('after a migration, platformatic config is touched', async ({ rejects, matc
   fs.utimesSync(getFixturesConfigFileLocation('simple.json'), d, d)
   const { mtime: mtimePrev } = fs.statSync(getFixturesConfigFileLocation('simple.json'))
   {
-    const { stdout } = await execa('node', [cliPath, '-c', getFixturesConfigFileLocation('simple.json')])
+    const { stdout } = await execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('simple.json')])
     const sanitized = stripAnsi(stdout)
     match(sanitized, '001.do.sql')
 

--- a/packages/db/test/migrate/validations.test.mjs
+++ b/packages/db/test/migrate/validations.test.mjs
@@ -3,24 +3,24 @@ import { execa } from 'execa'
 import { cliPath, connectAndResetDB, getFixturesConfigFileLocation } from './helper.mjs'
 
 test('missing config', async (t) => {
-  await t.rejects(execa('node', [cliPath]))
+  await t.rejects(execa('node', [cliPath, 'start']))
 })
 
 test('missing connectionString', async (t) => {
-  await t.rejects(execa('node', [cliPath, '-c', getFixturesConfigFileLocation('no-connectionString.json')]))
+  await t.rejects(execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('no-connectionString.json')]))
 })
 
 test('missing migrations', async (t) => {
-  await t.rejects(execa('node', [cliPath, '-c', getFixturesConfigFileLocation('no-migrations.json')]))
+  await t.rejects(execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('no-migrations.json')]))
 })
 
 test('missing migrations.dir', async (t) => {
-  await t.rejects(execa('node', [cliPath, '-c', getFixturesConfigFileLocation('no-migrations-dir.json')]))
+  await t.rejects(execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('no-migrations-dir.json')]))
 })
 
 test('not applied migrations', async (t) => {
   const db = await connectAndResetDB()
   t.teardown(() => db.dispose())
 
-  await t.rejects(execa('node', [cliPath, '-c', getFixturesConfigFileLocation('bad-migrations.json')]))
+  await t.rejects(execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('bad-migrations.json')]))
 })

--- a/packages/service/service.mjs
+++ b/packages/service/service.mjs
@@ -17,7 +17,7 @@ const help = helpMe({
   ext: '.txt'
 })
 
-const program = commist({ maxDistance: 4 })
+const program = commist({ maxDistance: 2 })
 
 program.register('help', help.toStdout)
 program.register('help start', help.toStdout.bind(null, ['start']))
@@ -39,11 +39,9 @@ export async function runService (argv) {
     process.exit(0)
   }
 
-  const result = program.parse(argv)
-
-  if (result) {
-    // We did have a command we did not match
-    return start(result)
+  return {
+    output: await program.parseAsync(argv),
+    help
   }
 }
 

--- a/packages/service/test/cli/helper.mjs
+++ b/packages/service/test/cli/helper.mjs
@@ -23,7 +23,7 @@ setGlobalDispatcher(new Agent({
 export const cliPath = join(import.meta.url, '..', '..', 'service.mjs')
 
 export async function start (...args) {
-  const child = execa('node', [cliPath, ...args])
+  const child = execa('node', [cliPath, 'start', ...args])
   child.stderr.pipe(process.stdout)
 
   const output = child.stdout.pipe(split(function (line) {

--- a/packages/service/test/cli/validations.test.mjs
+++ b/packages/service/test/cli/validations.test.mjs
@@ -12,13 +12,13 @@ test('version', async (t) => {
 })
 
 test('missing config', async (t) => {
-  await t.rejects(execa('node', [cliPath]))
+  await t.rejects(execa('node', [cliPath, 'start']))
 })
 
 test('print validation errors', async ({ equal, plan }) => {
   plan(2)
   try {
-    await execa('node', [cliPath, '--config', join(import.meta.url, '..', 'fixtures', 'missing-property.config.json')])
+    await execa('node', [cliPath, 'start', '--config', join(import.meta.url, '..', 'fixtures', 'missing-property.config.json')])
   } catch (err) {
     equal(err.exitCode, 1)
     equal(err.stdout, `

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2561,7 +2561,7 @@ packages:
       debug: 4.3.4
       espree: 9.4.1
       globals: 13.19.0
-      ignore: 5.2.1
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -6443,7 +6443,7 @@ packages:
       eslint: 8.30.0
       eslint-plugin-es: 4.1.0_eslint@8.30.0
       eslint-utils: 3.0.0_eslint@8.30.0
-      ignore: 5.2.1
+      ignore: 5.2.4
       is-core-module: 2.11.0
       minimatch: 3.1.2
       resolve: 1.22.1
@@ -6572,7 +6572,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.19.0
       grapheme-splitter: 1.0.4
-      ignore: 5.2.1
+      ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
@@ -7525,7 +7525,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -7536,7 +7536,7 @@ packages:
     dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
     dev: true
@@ -7972,8 +7972,8 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /ignore/5.2.1:
-    resolution: {integrity: sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==}
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -9553,7 +9553,6 @@ packages:
 
   /nan/2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
-    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
~Using `process.exitCode = 1` is unfortunate, but otherwise there is no way to test the subcommand output, due to mixed usage of sync/async code under the hood.~ _fixed thanks to `3.2.0` update of `commist`_.

~Currently blocked by https://github.com/mcollina/help-me/pull/16~

Fixes https://github.com/platformatic/platformatic/issues/450
Replaces https://github.com/platformatic/platformatic/pull/462