### PR TITLE
Create now accepts current directory (default) 

### DIFF
--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -5,7 +5,7 @@ import { getPkgManager } from '../get-pkg-manager.mjs'
 import parseArgs from 'minimist'
 import { join } from 'path'
 import inquirer from 'inquirer'
-import { mkdir, readFile, writeFile } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 import pino from 'pino'
 import pretty from 'pino-pretty'
 import { execa, execaNode } from 'execa'
@@ -13,6 +13,7 @@ import ora from 'ora'
 import createDB from './create-db.mjs'
 import askProjectDir from '../ask-project-dir.mjs'
 import { askCreateGHAction } from '../ghaction.mjs'
+import mkdirp from 'mkdirp'
 
 export const createReadme = async (logger, dir = '.') => {
   const readmeFileName = join(dir, 'README.md')
@@ -58,7 +59,7 @@ const createPlatformaticDB = async (_args) => {
   const version = await getVersion()
   const pkgManager = getPkgManager()
 
-  const projectDir = await askProjectDir(logger, './my-api')
+  const projectDir = await askProjectDir(logger, '.')
 
   const wizardOptions = await inquirer.prompt([{
     type: 'list',
@@ -82,7 +83,7 @@ const createPlatformaticDB = async (_args) => {
   }])
 
   // Create the project directory
-  await mkdir(projectDir)
+  await mkdirp(projectDir)
 
   const generatePlugin = args.plugin || wizardOptions.generatePlugin
   const useTypescript = args.typescript || wizardOptions.useTypescript
@@ -158,7 +159,7 @@ const createPlatformaticDB = async (_args) => {
       }
     }
   }
-  await askCreateGHAction(logger, projectDir)
+  await askCreateGHAction(logger)
 }
 
 export default createPlatformaticDB

--- a/packages/create-platformatic/src/ghaction.mjs
+++ b/packages/create-platformatic/src/ghaction.mjs
@@ -78,13 +78,18 @@ export const createGHAction = async (logger, projectDir) => {
     const githubAction = await getGHAction()
     await writeFile(ghActionFilePath, githubAction)
     logger.info(`Github action file ${ghActionFilePath} successfully created.`)
+
+    const isGitDir = await isFileAccessible('.git', projectDir)
+    if (!isGitDir) {
+      logger.warn('No git repository found. The Github action won\'t be triggered.')
+    }
   } else {
     logger.info(`Github action file ${ghActionFilePath} found, skipping creation of github action file.`)
   }
 }
 
 /* c8 ignore next 12 */
-export const askCreateGHAction = async (logger, projectDir) => {
+export const askCreateGHAction = async (logger, projectDir = process.cwd()) => {
   const { githubAction } = await inquirer.prompt([{
     type: 'list',
     name: 'githubAction',

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -6,7 +6,7 @@ import { getPkgManager } from '../get-pkg-manager.mjs'
 import parseArgs from 'minimist'
 import { join } from 'path'
 import inquirer from 'inquirer'
-import { mkdir, readFile, writeFile } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 import pino from 'pino'
 import pretty from 'pino-pretty'
 import { execa } from 'execa'
@@ -14,6 +14,7 @@ import ora from 'ora'
 import createService from './create-service.mjs'
 import askProjectDir from '../ask-project-dir.mjs'
 import { askCreateGHAction } from '../ghaction.mjs'
+import mkdirp from 'mkdirp'
 
 export const createReadme = async (logger, dir = '.') => {
   const readmeFileName = join(dir, 'README.md')
@@ -48,10 +49,10 @@ const createPlatformaticService = async (_args) => {
   const version = await getVersion()
   const pkgManager = getPkgManager()
 
-  const projectDir = await askProjectDir(logger, './my-service')
+  const projectDir = await askProjectDir(logger, '.')
 
   // Create the project directory
-  await mkdir(projectDir)
+  await mkdirp(projectDir)
 
   const params = {
     hostname: args.hostname,
@@ -81,7 +82,7 @@ const createPlatformaticService = async (_args) => {
     spinner.succeed('...done!')
   }
 
-  await askCreateGHAction(logger, projectDir)
+  await askCreateGHAction(logger)
 }
 
 export default createPlatformaticService

--- a/packages/create-platformatic/test/utils.test.mjs
+++ b/packages/create-platformatic/test/utils.test.mjs
@@ -116,10 +116,30 @@ test('sleep', async ({ equal }) => {
   equal(end - start >= 100, true)
 })
 
-test('validatePath', async ({ end, equal, rejects }) => {
-  const ok = await validatePath('new-project')
-  equal(ok, true)
-  rejects(validatePath('test'), Error('Please, specify an empty directory or create a new one.'))
+test('validatePath', async ({ end, equal, rejects, ok }) => {
+  {
+    // new folder
+    const valid = await validatePath('new-project')
+    ok(valid)
+  }
+
+  {
+    // existing folder
+    const valid = await validatePath('test')
+    ok(valid)
+  }
+
+  {
+    // current folder
+    const valid = await validatePath('.')
+    ok(valid)
+  }
+
+  {
+    // not writeable folder
+    const valid = await validatePath('/')
+    ok(!valid)
+  }
 })
 
 test('getDependencyVersion', async ({ equal }) => {


### PR DESCRIPTION
Creates now:
- Accepts `.` as directory
- `.` is now the default
- The GH action is ALWAYS created in the folder where the `create` is launched, and a `warn` is logged if this is not a `git` repo. 

Signed-off-by: marcopiraccini <marco.piraccini@gmail.com>