### PR TITLE
Add the correct env in gh action

### DIFF
--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -99,7 +99,7 @@ const createPlatformaticDB = async (_args) => {
     typescript: useTypescript
   }
 
-  await createDB(params, logger, projectDir)
+  const env = await createDB(params, logger, projectDir)
 
   const fastifyVersion = await getDependencyVersion('fastify')
 
@@ -159,7 +159,7 @@ const createPlatformaticDB = async (_args) => {
       }
     }
   }
-  await askCreateGHAction(logger)
+  await askCreateGHAction(logger, env, 'db')
 }
 
 export default createPlatformaticDB

--- a/packages/create-platformatic/src/db/create-db.mjs
+++ b/packages/create-platformatic/src/db/create-db.mjs
@@ -187,6 +187,13 @@ async function createDB ({ hostname, database = 'sqlite', port, migrations = 'mi
   if (plugin) {
     await generatePluginWithTypesSupport(logger, currentDir, typescript)
   }
+
+  return {
+    DATABASE_URL: connectionStrings[database],
+    PLT_SERVER_LOGGER_LEVEL: 'info',
+    PORT: port,
+    PLT_SERVER_HOSTNAME: hostname
+  }
 }
 
 export default createDB

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -59,7 +59,7 @@ const createPlatformaticService = async (_args) => {
     port: args.port
   }
 
-  await createService(params, logger, projectDir)
+  const env = await createService(params, logger, projectDir)
 
   const fastifyVersion = await getDependencyVersion('fastify')
 
@@ -82,7 +82,7 @@ const createPlatformaticService = async (_args) => {
     spinner.succeed('...done!')
   }
 
-  await askCreateGHAction(logger)
+  await askCreateGHAction(logger, env, 'service')
 }
 
 export default createPlatformaticService

--- a/packages/create-platformatic/src/service/create-service.mjs
+++ b/packages/create-platformatic/src/service/create-service.mjs
@@ -83,6 +83,12 @@ async function createService ({ hostname, port }, logger, currentDir = process.c
   } else {
     logger.info('Routes folder "routes" found, skipping creation of routes folder.')
   }
+
+  return {
+    PLT_SERVER_LOGGER_LEVEL: 'info',
+    PORT: port,
+    PLT_SERVER_HOSTNAME: hostname
+  }
 }
 
 export default createService

--- a/packages/create-platformatic/test/ghaction.test.mjs
+++ b/packages/create-platformatic/test/ghaction.test.mjs
@@ -24,8 +24,13 @@ afterEach(async () => {
   await rmdir(tmpDir, { recursive: true, force: true })
 })
 
+const env = {
+  DATABASE_URL: 'mydbconnetionstring',
+  PLT_SERVER_LOGGER_LEVEL: 'info'
+}
+
 test('creates gh action', async ({ end, equal }) => {
-  await createGHAction(fakeLogger, tmpDir)
+  await createGHAction(fakeLogger, env, 'db', tmpDir)
   equal(log[0], `Github action file ${tmpDir}/.github/workflows/platformatic-deploy.yml successfully created.`)
   const accessible = await isFileAccessible(join(tmpDir, '.github/workflows/platformatic-deploy.yml'))
   equal(accessible, true)
@@ -35,12 +40,12 @@ test('do not create gitignore file because already present', async ({ end, equal
   await mkdirp(join(tmpDir, '.github', 'workflows'))
   const ghaction = join(tmpDir, '.github', 'workflows', 'platformatic-deploy.yml')
   await writeFile(ghaction, 'TEST')
-  await createGHAction(fakeLogger, tmpDir)
+  await createGHAction(fakeLogger, env, 'db', tmpDir)
   equal(log[0], `Github action file ${tmpDir}/.github/workflows/platformatic-deploy.yml found, skipping creation of github action file.`)
 })
 
 test('creates gh action with a warn if a .git folder is not present', async ({ end, equal }) => {
-  await createGHAction(fakeLogger, tmpDir)
+  await createGHAction(fakeLogger, env, 'db', tmpDir)
   equal(log[0], `Github action file ${tmpDir}/.github/workflows/platformatic-deploy.yml successfully created.`)
   const accessible = await isFileAccessible(join(tmpDir, '.github/workflows/platformatic-deploy.yml'))
   equal(accessible, true)
@@ -49,7 +54,7 @@ test('creates gh action with a warn if a .git folder is not present', async ({ e
 
 test('creates gh action without a warn if a .git folder is present', async ({ end, equal }) => {
   await mkdirp(join(tmpDir, '.git'))
-  await createGHAction(fakeLogger, tmpDir)
+  await createGHAction(fakeLogger, env, 'db', tmpDir)
   equal(log[0], `Github action file ${tmpDir}/.github/workflows/platformatic-deploy.yml successfully created.`)
   const accessible = await isFileAccessible(join(tmpDir, '.github/workflows/platformatic-deploy.yml'))
   equal(accessible, true)


### PR DESCRIPTION
Example:
```
name: Deploy Platformatic application to the cloud
on:
  pull_request:
    paths-ignore:
      - 'docs/**'
      - '**.md'

jobs:
  build_and_deploy:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout application project repository
        uses: actions/checkout@v3
      - name: npm install --omit=dev
        run: npm install --omit=dev
      - name: Deploy project
        uses: platformatic/onestep@latest
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          platformatic_api_key: ${{ secrets.PLATFORMATIC_API_KEY }}
          platformatic_config_path: ./platformatic.db.json
        env:
          DATABASE_URL: sqlite://./db.sqlite 
          PLT_SERVER_LOGGER_LEVEL: info 
          PORT: 3042 
          PLT_SERVER_HOSTNAME: 127.0.0.1 
```