### PR TITLE
ci: Always use commited pnpm lock-file in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - name: pnpm install
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Run test suite
       run: cd packages/cli && pnpm test
 
@@ -75,7 +75,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - name: pnpm install
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Builds the ra-data-rest
       run: pnpm run ra-data-rest build
     - name: Builds the dashboard
@@ -99,7 +99,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - name: pnpm install
-      run: pnpm install  
+      run: pnpm install --frozen-lockfile  
     - name: Run test suite config manager
       run: cd packages/config && pnpm test
 
@@ -120,7 +120,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - name: pnpm install
-      run: pnpm install  
+      run: pnpm install --frozen-lockfile  
     - name: pnpm install -g typescript
       run: pnpm install -g typescript 
     - name: Builds the ra-data-rest
@@ -150,7 +150,7 @@ jobs:
     - name: Start docker containers for testing
       run: docker-compose up -d postgresql
     - name: pnpm install
-      run: pnpm install  
+      run: pnpm install --frozen-lockfile  
     - name: Run test suite
       run: cd packages/db-authorization && pnpm test
 
@@ -169,7 +169,7 @@ jobs:
         node-version: 18
         cache: 'pnpm'
     - name: pnpm install
-      run: pnpm install  
+      run: pnpm install --frozen-lockfile  
     - name: Linting & Typescript for test suite sql-mapper
       run: |
         pnpm --filter="@platformatic/sql-mapper" run lint
@@ -211,7 +211,7 @@ jobs:
       run: docker-compose up -d ${{ matrix.db }}
       if: ${{ matrix.db != 'sqlite' }}
     - name: pnpm install
-      run: pnpm install  
+      run: pnpm install --frozen-lockfile  
     - name: Wait for DB
       run: sleep 10
       if: ${{ matrix.db != 'sqlite' }}
@@ -246,7 +246,7 @@ jobs:
     - name: Start redis containers for testing
       run: docker-compose up -d redis
     - name: pnpm install
-      run: pnpm install  
+      run: pnpm install --frozen-lockfile  
     - name: Wait for DB
       run: sleep 10
       if: ${{ matrix.db != 'sqlite' }}
@@ -269,7 +269,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       - name: pnpm install
-        run: pnpm install  
+        run: pnpm install --frozen-lockfile  
       - name: Run test suite
         run: cd packages/authenticate && pnpm test; cd ../..
 
@@ -289,7 +289,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       - name: pnpm install
-        run: pnpm install  
+        run: pnpm install --frozen-lockfile  
       - name: Run test suite
         run: cd packages/service && pnpm test; cd ../..
 
@@ -307,7 +307,7 @@ jobs:
     - name: Start docker containers for testing
       run: docker-compose up -d postgresql
     - name: pnpm install
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Builds the ra-data-rest
       run: pnpm run ra-data-rest build
     - name: Builds the dashboard


### PR DESCRIPTION
This will make sure that `ci.yml` workflow will always pick up the most recent-file committed in a given PR.

Per: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#pnpm

Unblocks: https://github.com/platformatic/platformatic/pull/472