### PR TITLE
remove db references from service schemas

### DIFF
--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -169,7 +169,7 @@ const plugin = {
 }
 
 const metrics = {
-  $id: 'https://schemas.platformatic.dev/db/metrics',
+  $id: 'https://schemas.platformatic.dev/service/metrics',
   anyOf: [
     { type: 'boolean' },
     {
@@ -193,7 +193,7 @@ const metrics = {
 }
 
 const platformaticServiceSchema = {
-  $id: 'https://schemas.platformatic.dev/db',
+  $id: 'https://schemas.platformatic.dev/service',
   type: 'object',
   $defs: {
     plugin


### PR DESCRIPTION
Since db generally derives from service, and because this is the service schema, it seemed like these URLs should reference service instead of db.