### PR TITLE
Further fix on the warn messages if npm install is not done

### DIFF
--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -166,7 +166,7 @@ const createPlatformaticDB = async (_args) => {
   if (!runPackageManagerInstall) {
     logger.warn(`You must run the following commands in the project folder to complete the setup:
     - ${pkgManager} install
-    - npx platformatic db schema config > ./platformatic.db.schema.json
+    - npx platformatic db schema config
 `)
   }
 }


### PR DESCRIPTION
`npx platformatic db schema config` does not send the schema to stdout, but creates the schema file directly,  so the ridirection is wrong. 

Signed-off-by: marcopiraccini <marco.piraccini@gmail.com>