### PR TITLE
feat(graphql): Enhance error handling enum type

### DIFF
--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -56,7 +56,7 @@ function constructGraph (app, entity, opts, ignore) {
       try {
         meta.type = new graphql.GraphQLEnumType({ name: key, values: enumValues })
       } catch (error) {
-        console.error({ key, enumValues, entityName, table: entity.table, schema: entity.schema })
+        app.log.error({ key, enumValues, entityName, table: entity.table, schema: entity.schema })
         throw new Error('Unable to generate GraphQLEnumType')
       }
     } else {

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -53,7 +53,12 @@ function constructGraph (app, entity, opts, ignore) {
         acc[enumValue] = { value: enumValue }
         return acc
       }, {})
-      meta.type = new graphql.GraphQLEnumType({ name: key, values: enumValues })
+      try {
+        meta.type = new graphql.GraphQLEnumType({ name: key, values: enumValues })
+      } catch (error) {
+        console.error({ key, enumValues, entityName, table: entity.table, schema: entity.schema })
+        throw new Error('Unable to generate GraphQLEnumType')
+      }
     } else {
       meta.type = sqlTypeToGraphQL(field.sqlType)
     }


### PR DESCRIPTION
Related to this [issue](https://github.com/platformatic/platformatic/issues/507), this code change enables to add more logging info in case of an error generating the `GraphQLEnumType`.