### PR TITLE
fix(graphql): Name not start with letter or underscore

### DIFF
--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -50,6 +50,11 @@ function constructGraph (app, entity, opts, ignore) {
     /* istanbul ignore next */
     if (field.enum) {
       const enumValues = field.enum.reduce((acc, enumValue) => {
+        const valueStartsWithLetterOrUnderscore = !!enumValue.match(/^[_a-zA-Z]/g)
+        if (!valueStartsWithLetterOrUnderscore) {
+          enumValue = `_${enumValue}`
+        }
+
         acc[enumValue] = { value: enumValue }
         return acc
       }, {})

--- a/packages/sql-graphql/test/enum.test.js
+++ b/packages/sql-graphql/test/enum.test.js
@@ -20,16 +20,16 @@ test('should properly setup the enum types', { skip: isSQLite }, async ({ pass, 
         CREATE TYPE custom_enum AS ENUM('1', '2', '3');
 
         CREATE TABLE enum_tests (
-          "id" uuid NOT NULL,
-          "test_enum" custom_enum,
-          PRIMARY KEY ("id")
+          id INTEGER NOT NULL,
+          test_enum custom_enum,
+          PRIMARY KEY (id)
         );`)
       } else {
         await db.query(sql`
         CREATE TABLE enum_tests (
-          "id" uuid NOT NULL,
-          "test_enum" enum('1', '2', '3') DEFAULT NULL,
-          PRIMARY KEY ("id")
+          id INTEGER NOT NULL,
+          test_enum ENUM ('1', '2', '3') DEFAULT NULL,
+          PRIMARY KEY (id)
         );`)
       }
     }

--- a/packages/sql-graphql/test/enum.test.js
+++ b/packages/sql-graphql/test/enum.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const { test } = require('tap')
+const sqlGraphQL = require('..')
+const sqlMapper = require('@platformatic/sql-mapper')
+const fastify = require('fastify')
+const { clear, connInfo, isSQLite, isPg } = require('./helper')
+
+test('should properly setup the enum types', { skip: isSQLite }, async ({ pass, teardown, same }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isPg) {
+        await db.query(sql`
+        CREATE TYPE custom_enum AS ENUM('1', '2', '3');
+
+        CREATE TABLE enum_tests (
+          "id" uuid NOT NULL,
+          "test_enum" custom_enum,
+          PRIMARY KEY ("id")
+        );`)
+      } else {
+        await db.query(sql`
+        CREATE TABLE enum_tests (
+          "id" uuid NOT NULL,
+          "test_enum" enum('1', '2', '3') DEFAULT NULL,
+          PRIMARY KEY ("id")
+        );`)
+      }
+    }
+  })
+
+  app.register(sqlGraphQL)
+  teardown(app.close.bind(app))
+
+  try {
+    await app.ready()
+    same(true, true, 'Enum values are properly interpreted')
+  } catch (err) {
+    console.log(err)
+    same(true, false, 'Previous call should never fail')
+  }
+})

--- a/packages/sql-graphql/test/helper.js
+++ b/packages/sql-graphql/test/helper.js
@@ -116,4 +116,14 @@ module.exports.clear = async function (db, sql) {
     await db.query(sql`DROP TABLE generated_test`)
   } catch (err) {
   }
+
+  try {
+    await db.query(sql`DROP TABLE enum_tests`)
+  } catch (err) {
+  }
+
+  try {
+    await db.query(sql`DROP TYPE custom_enum`)
+  } catch (err) {
+  }
 }


### PR DESCRIPTION
Hi! 👋🏼 
If a column has an enum type and starts with a number, we have this error:
`GraphQLError: Names must start with [_a-zA-Z] but "123" does not.`

This code adds an underscore to the enum value we're going to use.