### PR TITLE
fix(graphql): Handle duplicated enum names

### DIFF
--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -59,7 +59,7 @@ function constructGraph (app, entity, opts, ignore) {
         return acc
       }, {})
       try {
-        const name = camelcase(entityName) + camelcase(key)
+        const name = camelcase([entityName, key])
         meta.type = new graphql.GraphQLEnumType({ name, values: enumValues })
       } catch (error) {
         app.log.error({ key, enumValues, entityName, table: entity.table, schema: entity.schema })

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -59,7 +59,7 @@ function constructGraph (app, entity, opts, ignore) {
         return acc
       }, {})
       try {
-        meta.type = new graphql.GraphQLEnumType({ name: key, values: enumValues })
+        meta.type = new graphql.GraphQLEnumType({ name: `${entityName}_${key}`, values: enumValues })
       } catch (error) {
         app.log.error({ key, enumValues, entityName, table: entity.table, schema: entity.schema })
         throw new Error('Unable to generate GraphQLEnumType')

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -59,7 +59,8 @@ function constructGraph (app, entity, opts, ignore) {
         return acc
       }, {})
       try {
-        meta.type = new graphql.GraphQLEnumType({ name: `${entityName}${key}`, values: enumValues })
+        const name = camelcase(entityName) + camelcase(key)
+        meta.type = new graphql.GraphQLEnumType({ name, values: enumValues })
       } catch (error) {
         app.log.error({ key, enumValues, entityName, table: entity.table, schema: entity.schema })
         throw new Error('Unable to generate GraphQLEnumType')

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -59,7 +59,7 @@ function constructGraph (app, entity, opts, ignore) {
         return acc
       }, {})
       try {
-        meta.type = new graphql.GraphQLEnumType({ name: `${entityName}_${key}`, values: enumValues })
+        meta.type = new graphql.GraphQLEnumType({ name: `${entityName}${key}`, values: enumValues })
       } catch (error) {
         app.log.error({ key, enumValues, entityName, table: entity.table, schema: entity.schema })
         throw new Error('Unable to generate GraphQLEnumType')

--- a/packages/sql-graphql/test/enum.test.js
+++ b/packages/sql-graphql/test/enum.test.js
@@ -46,3 +46,55 @@ test('should properly setup the enum types', { skip: isSQLite }, async ({ pass, 
     same(true, false, 'Previous call should never fail')
   }
 })
+
+test('should not fail if tables have duplicate enum names', { skip: isSQLite }, async ({ pass, teardown, same }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isPg) {
+        await db.query(sql`
+        CREATE TYPE custom_enum AS ENUM('1', '2', '3');
+        CREATE TYPE simple_enum AS ENUM('4', '5', '6');
+        
+        CREATE TABLE enum_tests (
+          id INTEGER NOT NULL,
+          test_enum custom_enum,
+          PRIMARY KEY (id)
+        );
+        CREATE TABLE simple_types (
+          pk INTEGER NOT NULL,
+          test_enum simple_enum,
+          PRIMARY KEY (pk)
+        );`)
+      } else {
+        await db.query(sql`
+        CREATE TABLE enum_tests (
+          id INTEGER NOT NULL,
+          test_enum ENUM ('1', '2', '3') DEFAULT NULL,
+          PRIMARY KEY (id)
+        );
+        CREATE TABLE simple_types (
+          pk INTEGER NOT NULL,
+          test_enum ENUM ('4', '5', '6') DEFAULT NULL,
+          PRIMARY KEY (pk)
+        );`)
+      }
+    }
+  })
+
+  app.register(sqlGraphQL)
+  teardown(app.close.bind(app))
+
+  try {
+    await app.ready()
+    same(true, true, 'test_enum is used twice but app not throws')
+  } catch (err) {
+    console.log(err)
+    same(true, false, 'Previous call should never fail')
+  }
+})


### PR DESCRIPTION
This PR fixes the case when two tables have the same enum name.

To reproduce, run `platformatic db start` using a table like this one (or see the test added):
```
        CREATE TABLE enum_tests (
          id INTEGER NOT NULL,
          test_enum ENUM ('1', '2', '3') DEFAULT NULL,
          PRIMARY KEY (id)
        );

        CREATE TABLE simple_types (
          pk INTEGER NOT NULL,
          test_enum ENUM ('4', '5', '6') DEFAULT NULL,
          PRIMARY KEY (pk)
        );
```