### PR TITLE
Validate config replaces `outDir` with absolute path

### DIFF
--- a/packages/db/lib/config.js
+++ b/packages/db/lib/config.js
@@ -14,6 +14,10 @@ class DBConfigManager extends ConfigManager {
     })
   }
 
+  _fixRelativePath (path) {
+    return resolve(dirname(this.fullPath), path)
+  }
+
   _transformConfig () {
     super._transformConfig.call(this)
     const dirOfConfig = dirname(this.fullPath)
@@ -41,6 +45,10 @@ class DBConfigManager extends ConfigManager {
         [this.current.migrations.table || migrationsTableName]: true
       }, this.current.core.ignore)
     }
+
+    if (this.current.plugin?.typescript?.outDir) {
+      this.current.plugin.typescript.outDir = this._fixRelativePath(this.current.plugin.typescript.outDir)
+    }
   }
 
   _sanitizeConfig () {
@@ -54,7 +62,6 @@ class DBConfigManager extends ConfigManager {
         sanitizedConfig.core.connectionString = 'sqlite://' + originalSqlitePath
       }
     }
-
     // absolute-to-relative migrations path
     if (this.current.migrations && isAbsolute(this.current.migrations.dir)) {
       sanitizedConfig.migrations.dir = relative(dirOfConfig, this.current.migrations.dir)

--- a/packages/db/test/config.test.js
+++ b/packages/db/test/config.test.js
@@ -389,3 +389,20 @@ test('config reloads from a written file', async ({ teardown, equal, pass, same 
     same(await res.body.text(), 'ciao mondo', 'response')
   }
 })
+
+test('should transform the migrations and typescript outDir to absolute path', async ({ teardown, equal }) => {
+  const configPath = join(__dirname, 'fixtures', 'typescript-config.json')
+  const configFile = await readFile(configPath, 'utf8')
+
+  teardown(() => writeFile(configPath, configFile))
+
+  const cm = new DBConfigManager({
+    source: configPath,
+    schema: {}
+  })
+  await cm.parseAndValidate()
+  const config = cm.current
+
+  equal(config.migrations.dir, join(__dirname, 'fixtures', 'migrations'))
+  equal(config.plugin.typescript.outDir, join(__dirname, 'fixtures', 'dist'))
+})

--- a/packages/db/test/fixtures/typescript-config.json
+++ b/packages/db/test/fixtures/typescript-config.json
@@ -1,0 +1,18 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 3042
+  },
+  "core": {
+    "connectionString": "postgresql://db.antani"
+  },
+  "migrations": {
+    "dir": "./migrations"
+  },
+  "plugin": {
+    "path": "plugin.ts",
+    "typescript": {
+      "outDir": "dist"
+    }
+  }
+}


### PR DESCRIPTION
Not sure we need this, so creating a draft. 
Also, if we decide to do this, we need to do the same for `service`