### PR TITLE
fix: break in production environments

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,6 @@
   ],
   "devDependencies": {
     "c8": "^7.12.0",
-    "desm": "^1.3.0",
     "execa": "^6.1.0",
     "snazzy": "^9.0.0",
     "split2": "^4.1.0",
@@ -45,6 +44,7 @@
     "@platformatic/service": "workspace:*",
     "colorette": "^2.0.19",
     "commist": "^3.2.0",
+    "desm": "^1.3.0",
     "help-me": "^4.2.0",
     "minimist": "^1.2.7"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,11 +62,11 @@ importers:
       '@platformatic/service': link:../service
       colorette: 2.0.19
       commist: 3.2.0
+      desm: 1.3.0
       help-me: 4.2.0
       minimist: 1.2.7
     devDependencies:
       c8: 7.12.0
-      desm: 1.3.0
       execa: 6.1.0
       snazzy: 9.0.0
       split2: 4.1.0


### PR DESCRIPTION
desm was saved in devDeps, hopefully this is an ok fix.

Signed-off-by: MzUgM <108896003+MzUgM@users.noreply.github.com>