### PR TITLE
fix(sql-openapi): Same FK with different names

### DIFF
--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -98,7 +98,6 @@ async function entityPlugin (app, opts) {
   })
 
   const mapRoutePathNamesReverseRelations = new Map()
-  let idxRoutePathNamesReverseRelations = 1
   // For every reverse relationship we create: entity/:entity_Id/target_entity
   for (const reverseRelationship of entity.reverseRelationships) {
     const targetEntityName = reverseRelationship.relation.entityName
@@ -116,8 +115,7 @@ async function entityPlugin (app, opts) {
       : targetEntity.pluralName
 
     if (mapRoutePathNamesReverseRelations.get(routePathName)) {
-      idxRoutePathNamesReverseRelations++
-      routePathName += idxRoutePathNamesReverseRelations
+      routePathName = camelcase(reverseRelationship.relation.constraint_name)
     } else {
       mapRoutePathNamesReverseRelations.set(routePathName, true)
     }
@@ -187,7 +185,6 @@ async function entityPlugin (app, opts) {
   }
 
   const mapRoutePathNamesRelations = new Map()
-  let idxRoutePathNamesRelations = 1
   // For every relationship we create: entity/:entity_Id/target_entity
   for (const relation of entity.relations) {
     const targetEntityName = relation.foreignEntityName
@@ -198,8 +195,7 @@ async function entityPlugin (app, opts) {
     // (or multiple relationships between the same entities). We might want to specify this in documentation, because can be confusing
     let targetRelation = relation.column_name.replace(/_id$/, '')
     if (mapRoutePathNamesRelations.get(targetRelation)) {
-      idxRoutePathNamesRelations++
-      targetRelation += idxRoutePathNamesRelations
+      targetRelation = camelcase(relation.constraint_name)
     } else {
       mapRoutePathNamesRelations.set(targetRelation, true)
     }

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -98,6 +98,7 @@ async function entityPlugin (app, opts) {
   })
 
   const mapRoutePathNamesReverseRelations = new Map()
+  let idxRoutePathNamesReverseRelations = 1
   // For every reverse relationship we create: entity/:entity_Id/target_entity
   for (const reverseRelationship of entity.reverseRelationships) {
     const targetEntityName = reverseRelationship.relation.entityName
@@ -115,7 +116,8 @@ async function entityPlugin (app, opts) {
       : targetEntity.pluralName
 
     if (mapRoutePathNamesReverseRelations.get(routePathName)) {
-      routePathName = camelcase(reverseRelationship.relation.constraint_name)
+      idxRoutePathNamesReverseRelations++
+      routePathName += idxRoutePathNamesReverseRelations
     } else {
       mapRoutePathNamesReverseRelations.set(routePathName, true)
     }
@@ -185,6 +187,7 @@ async function entityPlugin (app, opts) {
   }
 
   const mapRoutePathNamesRelations = new Map()
+  let idxRoutePathNamesRelations = 1
   // For every relationship we create: entity/:entity_Id/target_entity
   for (const relation of entity.relations) {
     const targetEntityName = relation.foreignEntityName
@@ -195,7 +198,8 @@ async function entityPlugin (app, opts) {
     // (or multiple relationships between the same entities). We might want to specify this in documentation, because can be confusing
     let targetRelation = relation.column_name.replace(/_id$/, '')
     if (mapRoutePathNamesRelations.get(targetRelation)) {
-      targetRelation = camelcase(relation.constraint_name)
+      idxRoutePathNamesRelations++
+      targetRelation += idxRoutePathNamesRelations
     } else {
       mapRoutePathNamesRelations.set(targetRelation, true)
     }

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -203,7 +203,7 @@ async function entityPlugin (app, opts) {
     } else {
       mapRoutePathNamesRelations.set(targetRelation, true)
     }
-    
+
     const targetEntitySchema = {
       $ref: targetEntity.name + '#'
     }
@@ -262,7 +262,6 @@ async function entityPlugin (app, opts) {
       return res[0]
       })
     } catch (error) /* istanbul ignore next */ {
-      console.log(entity.relations)
       app.log.error(error)
       app.log.info({ primaryKey, targetRelation, targetEntitySchema, targetEntityName, targetEntity, operationId })
       throw new Error('Unable to create the route for the PK col relationship')

--- a/packages/sql-openapi/test/same-fk-name.test.js
+++ b/packages/sql-openapi/test/same-fk-name.test.js
@@ -223,7 +223,7 @@ test('same foreign keys with different names', async ({ equal, same, teardown })
   {
     const res = await app.inject({
       method: 'GET',
-      url: '/editors/10/editorsFkClone'
+      url: '/editors/10/field2'
     })
     equal(res.statusCode, 200, 'the foreign key is duplicated, so an index has been automatically added')
     same(res.json(), {
@@ -245,7 +245,7 @@ test('same foreign keys with different names', async ({ equal, same, teardown })
   {
     const res = await app.inject({
       method: 'GET',
-      url: '/editors/20/editorsFkClone'
+      url: '/editors/20/field2'
     })
     equal(res.statusCode, 200, 'as in the test above, same fk, same result')
     same(res.json(), {
@@ -270,7 +270,7 @@ test('same foreign keys with different names', async ({ equal, same, teardown })
   {
     const res = await app.inject({
       method: 'GET',
-      url: '/owners/1/editorsFkClone'
+      url: '/owners/1/editorField2'
     })
     equal(res.statusCode, 200)
     same(res.json(), [

--- a/packages/sql-openapi/test/same-fk-name.test.js
+++ b/packages/sql-openapi/test/same-fk-name.test.js
@@ -1,0 +1,255 @@
+'use strict'
+
+const { clear, connInfo } = require('./helper')
+const { test } = require('tap')
+const fastify = require('fastify')
+const sqlMapper = require('@platformatic/sql-mapper')
+const sqlOpenAPI = require('..')
+
+test('same foreign keys with different names', async ({ equal, same, teardown }) => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+
+    await db.query(sql`CREATE TABLE owners (
+      id integer NOT NULL,
+      PRIMARY KEY (id)
+    );`)
+
+    await db.query(sql`CREATE TABLE editors (
+      id integer NOT NULL,
+      field integer NOT NULL,
+      PRIMARY KEY (id),
+      CONSTRAINT editors_fk FOREIGN KEY (field) REFERENCES owners (id),
+      CONSTRAINT editors_fk_clone FOREIGN KEY (field) REFERENCES owners (id)
+    );`)
+  }
+
+  const app = fastify()
+  try {
+    app.register(sqlMapper, {
+      ...connInfo,
+      onDatabaseLoad
+    })
+    app.register(sqlOpenAPI)
+    teardown(app.close.bind(app))
+
+    await app.ready()
+  } catch (error) {
+    equal(true, false, 'app should not crash')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/owners',
+      body: {
+        id: 1
+      }
+    })
+    equal(res.statusCode, 200, 'POST /owners status code')
+    same(res.json(), {
+      id: 1
+    }, 'POST /owners response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/owners',
+      body: {
+        id: 2
+      }
+    })
+    equal(res.statusCode, 200, 'POST /owners status code')
+    same(res.json(), {
+      id: 2
+    }, 'POST /owners response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/owners',
+      body: {
+        id: 3
+      }
+    })
+    equal(res.statusCode, 200, 'POST /owners status code')
+    same(res.json(), {
+      id: 3
+    }, 'POST /owners response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/editors',
+      body: {
+        id: 10,
+        field: 1
+      }
+    })
+    equal(res.statusCode, 200, 'POST /editors status code')
+    same(res.json(), {
+      id: 10,
+      field: 1
+    }, 'POST /editors response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/editors',
+      body: {
+        id: 20,
+        field: 2
+      }
+    })
+    equal(res.statusCode, 200, 'POST /editors status code')
+    same(res.json(), {
+      id: 20,
+      field: 2
+    }, 'POST /editors response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/editors',
+      body: {
+        id: 30,
+        field: 3
+      }
+    })
+    equal(res.statusCode, 200, 'POST /editors status code')
+    same(res.json(), {
+      id: 30,
+      field: 3
+    }, 'POST /editors response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/editors',
+      body: {
+        id: 40,
+        field: 'not existing'
+      }
+    })
+    equal(res.statusCode, 400, 'POST /editors status code')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/owners'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), [
+      { id: 1 },
+      { id: 2 },
+      { id: 3 }
+    ])
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/owners/1'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      id: 1
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/editors'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), [
+      {
+        id: 10,
+        field: 1
+      },
+      {
+        id: 20,
+        field: 2
+      },
+      {
+        id: 30,
+        field: 3
+      }
+    ])
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/editors/20'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      id: 20,
+      field: 2
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/editors/10/field'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      id: 1
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/editors/10/field'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      id: 1
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/editors/10/field2'
+    })
+    equal(res.statusCode, 200, 'the foreign key is duplicated, so an index has been automatically added')
+    same(res.json(), {
+      id: 1
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/editors/20/field'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      id: 2
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/editors/20/field2'
+    })
+    equal(res.statusCode, 200, 'as in the test above, same fk, same result')
+    same(res.json(), {
+      id: 2
+    })
+  }
+})

--- a/packages/sql-openapi/test/same-fk-name.test.js
+++ b/packages/sql-openapi/test/same-fk-name.test.js
@@ -223,7 +223,7 @@ test('same foreign keys with different names', async ({ equal, same, teardown })
   {
     const res = await app.inject({
       method: 'GET',
-      url: '/editors/10/field2'
+      url: '/editors/10/editorsFkClone'
     })
     equal(res.statusCode, 200, 'the foreign key is duplicated, so an index has been automatically added')
     same(res.json(), {
@@ -245,11 +245,39 @@ test('same foreign keys with different names', async ({ equal, same, teardown })
   {
     const res = await app.inject({
       method: 'GET',
-      url: '/editors/20/field2'
+      url: '/editors/20/editorsFkClone'
     })
     equal(res.statusCode, 200, 'as in the test above, same fk, same result')
     same(res.json(), {
       id: 2
     })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/owners/2/editorField'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), [
+      {
+        id: 20,
+        field: 2
+      }
+    ])
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/owners/1/editorsFkClone'
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), [
+      {
+        id: 10,
+        field: 1
+      }
+    ])
   }
 })


### PR DESCRIPTION
### Issue
If a table has multiple foreign keys that point to the exact same primary key, platformatic will fail with:
```
/platformatic/node_modules/.pnpm/find-my-way@7.3.1/node_modules/find-my-way/index.js:301
      throw new Error(`Method '${method}' already declared for route '${path}' with constraints '${JSON.stringify(constraints)}'`)
            ^

Error: Method 'GET' already declared for route '/mfaProcedures/:/factor' with constraints '{}'
    at Router._on (/platformatic/node_modules/.pnpm/find-my-way@7.3.1/node_modules/find-my-way/index.js:301:13)
    at Router.on (/platformatic/node_modules/.pnpm/find-my-way@7.3.1/node_modules/find-my-way/index.js:136:10)
    at Object.addNewRoute (/platformatic/node_modules/.pnpm/fastify@4.10.2/node_modules/fastify/lib/route.js:301:16)
    at Object.route (/platformatic/node_modules/.pnpm/fastify@4.10.2/node_modules/fastify/lib/route.js:217:19)
    at Object.prepareRoute (/platformatic/node_modules/.pnpm/fastify@4.10.2/node_modules/fastify/lib/route.js:150:18)
    at Object._get [as get] (/platformatic/node_modules/.pnpm/fastify@4.10.2/node_modules/fastify/fastify.js:249:34)
    at entityPlugin (/platformatic/packages/sql-openapi/lib/entity-to-routes.js:196:9)
    at Plugin.exec (/platformatic/node_modules/.pnpm/avvio@8.2.0/node_modules/avvio/plugin.js:130:19)
    at Boot.loadPlugin (/platformatic/node_modules/.pnpm/avvio@8.2.0/node_modules/avvio/plugin.js:272:10)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```

To simulate this issue, you can look at [the test](https://github.com/platformatic/platformatic/compare/main...rozzilla:platformatic:fix/sql-openapi/same-fk-name-with-different-names?expand=1#diff-f820d670f63205c3fadb1dfafb4de20fe29b9d8700bdadd19ee7a426d01e3bd0R18), creating 2 tables like:
```
CREATE TABLE owners (
      id integer NOT NULL,
      PRIMARY KEY (id)
    );

CREATE TABLE editors (
      id integer NOT NULL,
      field integer NOT NULL,
      PRIMARY KEY (id),
      CONSTRAINT editors_fk FOREIGN KEY (field) REFERENCES owners (id),
      CONSTRAINT editors_fk_clone FOREIGN KEY (field) REFERENCES owners (id)
    );
```

### Solution
* Handle this case, adding a numeric increment to the route created (see [the tests](https://github.com/platformatic/platformatic/pull/566/files#diff-f820d670f63205c3fadb1dfafb4de20fe29b9d8700bdadd19ee7a426d01e3bd0R228))
* Added tests for this case
* Catch the error and show useful debugging info