### PR TITLE
Check filename is not null before handling restart

### DIFF
--- a/packages/utils/lib/file-watcher.js
+++ b/packages/utils/lib/file-watcher.js
@@ -43,6 +43,8 @@ class FileWatcher extends EventEmitter {
 
     const eventHandler = async () => {
       for await (const { eventType, filename } of fsWatcher) {
+        /* c8 ignore next */
+        if (filename === null) return
         const isTimeoutSet = updateTimeout === null
         const isTrackedEvent = ALLOWED_FS_EVENTS.includes(eventType)
         const isTrackedFile = this.shouldFileBeWatched(filename)


### PR DESCRIPTION
Simple fix for an issue reported on Windows by @tonysnowboardunderthebridge, that `filename` was `null` and that created a fatal error in this function
```js
isFileAllowed (fileName) {
  if (this.allowToWatch === null) return true
  return this.allowToWatch.some((allowedFile) => minimatch(fileName, allowedFile))
}
```

Signed-off-by: Leonardo Rossi <leonardo.rossi@gmail.com>