### PR TITLE
fix(sql-graphql): Enum with special chars

### DIFF
--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -49,13 +49,19 @@ function constructGraph (app, entity, opts, ignore) {
     // sqlite doesn't support enums
     /* istanbul ignore next */
     if (field.enum) {
-      const enumValues = field.enum.reduce((acc, enumValue) => {
-        const valueStartsWithLetterOrUnderscore = !!enumValue.match(/^[_a-zA-Z]/g)
-        if (!valueStartsWithLetterOrUnderscore) {
-          enumValue = `_${enumValue}`
+      const enumValues = field.enum.reduce((acc, enumValue, index) => {
+        let key = enumValue.replace(/[^\w\s]/g, '_')
+
+        const keyStartsWithLetterOrUnderscore = !!key.match(/^[_a-zA-Z]/g)
+        if (!keyStartsWithLetterOrUnderscore) {
+          key = `_${key}`
         }
 
-        acc[enumValue.replace(/[^\w\s]/g, '_')] = { value: enumValue }
+        if (key.startsWith('__')) {
+          key = key.replace('__', `enum${++index}`)
+        }
+
+        acc[key] = { value: enumValue }
         return acc
       }, {})
       try {

--- a/packages/sql-graphql/test/enum.test.js
+++ b/packages/sql-graphql/test/enum.test.js
@@ -98,3 +98,128 @@ test('should not fail if tables have duplicate enum names', { skip: isSQLite }, 
     same(true, false, 'Previous call should never fail')
   }
 })
+
+test('should not fail if tables have enum with special characters', { skip: isSQLite }, async ({ pass, teardown, same, equal }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isPg) {
+        await db.query(sql`
+          CREATE TYPE custom_enum AS ENUM('.', ',');
+
+          CREATE TABLE enum_tests (
+            id INTEGER NOT NULL,
+            test_enum custom_enum,
+            PRIMARY KEY (id)
+          );
+        `)
+      } else {
+        await db.query(sql`
+          CREATE TABLE enum_tests (
+            id INTEGER NOT NULL,
+            test_enum ENUM ('.', ',') DEFAULT NULL,
+            PRIMARY KEY (id)
+          );
+        `)
+      }
+    }
+  })
+
+  app.register(sqlGraphQL)
+  teardown(app.close.bind(app))
+
+  try {
+    await app.ready()
+    same(true, true, 'custom_enum have special chars, but app does not throws')
+  } catch (err) {
+    console.log(err)
+    same(true, false, 'Previous call should never fail')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+            mutation ($input: EnumTestInput!) {
+              saveEnumTest(input: $input) {
+                id
+              }
+            }
+          `,
+        variables: { input: { id: 1 } }
+      }
+    })
+    equal(res.statusCode, 200)
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+            mutation ($input: EnumTestInput!) {
+              saveEnumTest(input: $input) {
+                id
+              }
+            }
+          `,
+        variables: { input: { id: 2 } }
+      }
+    })
+    equal(res.statusCode, 200)
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+            query { enumTests { id } }
+          `
+      }
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), { data: { enumTests: [{ id: 1 }, { id: 2 }] } })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+            mutation ($input: EnumTestWhereArgumentsid!) {
+              deleteEnumTests(where: {id: $input}) {
+                id
+              }
+            }
+          `,
+        variables: { input: { eq: 1 } }
+      }
+    })
+    equal(res.statusCode, 200)
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+            query { enumTests { id } }
+          `
+      }
+    })
+    equal(res.statusCode, 200)
+    same(res.json(), { data: { enumTests: [{ id: 2 }] } })
+  }
+})


### PR DESCRIPTION
Fix for https://github.com/platformatic/platformatic/issues/568.
Testing this, I also confirm that mutations for enums with special characters fail (as mentioned [here](https://github.com/platformatic/platformatic/pull/403#issuecomment-1377130428)).