### PR TITLE
service: adjust config after deepmerge()

### DIFF
--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -139,7 +139,7 @@ function adjustConfigBeforeMerge (cm) {
   // function that is not enumerable. Non-enumerables are not copied by
   // deepmerge(), so stash the logger here.
   if (typeof cm.server?.logger?.child === 'function' &&
-      !cm.server.logger.propertyIsEnumerable('child')) {
+      !Object.prototype.propertyIsEnumerable.call(cm.server.logger, 'child')) {
     stash.set('server.logger', cm.server.logger)
     cm.server.logger = null
   }

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -138,6 +138,7 @@ function adjustConfigBeforeMerge (cm) {
   // If a pino instance is passed as the logger, it will contain a child()
   // function that is not enumerable. Non-enumerables are not copied by
   // deepmerge(), so stash the logger here.
+  /* c8 ignore next 5 */
   if (typeof cm.server?.logger?.child === 'function' &&
       !Object.prototype.propertyIsEnumerable.call(cm.server.logger, 'child')) {
     stash.set('server.logger', cm.server.logger)
@@ -151,6 +152,7 @@ function adjustConfigAfterMerge (options, stash) {
   // Restore any config that needed to be stashed prior to merging.
   const pinoLogger = stash.get('server.logger')
 
+  /* c8 ignore next 3 */
   if (pinoLogger) {
     options.server.logger = pinoLogger
     options.configManager.current.server.logger = pinoLogger

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -142,6 +142,8 @@ function adjustConfigAfterMerge (options) {
   // If a pino instance is passed as the logger, it will contain a child
   // function that is not enumerable. Non-enumerables are not copied by
   // deepmerge(), so take care of it here.
+  // This is covered, but c8 says it is not, so ignore it.
+  /* c8 ignore next 3 */
   if (typeof cm.server?.logger?.child === 'function') {
     options.server.logger = cm.server.logger
   }

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -152,7 +152,7 @@ function adjustConfigAfterMerge (options, stash) {
   // Restore any config that needed to be stashed prior to merging.
   const pinoLogger = stash.get('server.logger')
 
-  /* c8 ignore next 3 */
+  /* c8 ignore next 4 */
   if (pinoLogger) {
     options.server.logger = pinoLogger
     options.configManager.current.server.logger = pinoLogger

--- a/packages/service/test/config.test.js
+++ b/packages/service/test/config.test.js
@@ -184,3 +184,31 @@ test('config reloads from a written file from a route', async ({ teardown, equal
     same(await res.body.text(), 'ciao mondo', 'response')
   }
 })
+
+test('config is adjusted to handle custom loggers', async (t) => {
+  const options = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: {
+        info () {},
+        error () {},
+        debug () {},
+        fatal () {},
+        warn () {},
+        trace () {}
+      }
+    }
+  }
+
+  let called = false
+  Object.defineProperty(options.server.logger, 'child', {
+    value: function child () {
+      called = true
+    },
+    enumerable: false
+  })
+
+  await buildServer(options)
+  t.equal(called, true)
+})


### PR DESCRIPTION
`deepmerge()` does not handle certain edge cases because it only copies enumerable properties. This commit adds a helper function to service that can be used to adjust for these edge cases.