### PR TITLE
reduce duplication in buildServer()

### DIFF
--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -62,18 +62,9 @@ async function platformaticDB (app, opts) {
 }
 
 platformaticDB[Symbol.for('skip-override')] = true
+platformaticDB.schema = schema
 
 async function buildDBServer (options) {
-  if (!options.configManager) {
-    // instantiate a new config manager from current options
-    const cm = new ConfigManager({
-      source: options,
-      schema
-    })
-    await cm.parseAndValidate()
-    options = deepmerge({}, options, cm.current)
-    options.configManager = cm
-  }
   return buildServer(options, platformaticDB)
 }
 

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -4,7 +4,7 @@ const core = require('@platformatic/db-core')
 const auth = require('@platformatic/db-authorization')
 const dashboard = require('@platformatic/db-dashboard')
 const { platformaticService, buildServer } = require('@platformatic/service')
-const { deepmerge, isKeyEnabled } = require('@platformatic/utils')
+const { isKeyEnabled } = require('@platformatic/utils')
 const { schema } = require('./lib/schema')
 const ConfigManager = require('./lib/config.js')
 

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -146,6 +146,7 @@ async function loadPlugin (app, config, pluginOptions) {
 }
 
 platformaticService[Symbol.for('skip-override')] = true
+platformaticService.schema = schema
 
 function adjustConfigBeforeMerge (cm) {
   // This function and adjustConfigAfterMerge() are needed because there are
@@ -183,7 +184,7 @@ async function buildServer (options, app = platformaticService) {
     // instantiate a new config manager from current options
     const cm = new ConfigManager({
       source: options,
-      schema
+      schema: app?.schema ?? schema
     })
     await cm.parseAndValidate()
     const stash = adjustConfigBeforeMerge(cm.current)


### PR DESCRIPTION
Attach the schema to the app so that `buildServer()` can access it. With this change, the config manager related code can be isolated in one place.