### PR TITLE
feat(sql-graphql): Enhance error logging for FK errors

### DIFF
--- a/packages/sql-graphql/lib/relationship.js
+++ b/packages/sql-graphql/lib/relationship.js
@@ -23,7 +23,7 @@ module.exports = function establishRelations (app, relations, resolvers, loaders
 
     const current = entitiesTypeMap[entityName]
     const foreign = entitiesTypeMap[foreignEntityName]
-    assert(foreign !== undefined, `No foreign table named "${foreign_table_name}" was found ${enhanceAssertLogMsg}`)
+    assert(foreign !== undefined, `No foreign table named "${foreign_table_name}" was found ${enhanceAssertLogMsg}. Relation: ${JSON.stringify(relation, null, 2)}`)
 
     // current to foreign, we skip this if the foreign table has a composite primary key
     // TODO implement support for this case

--- a/packages/sql-graphql/test/helper.js
+++ b/packages/sql-graphql/test/helper.js
@@ -128,12 +128,32 @@ module.exports.clear = async function (db, sql) {
   }
 
   try {
+    await db.query(sql`DROP TABLE test4.books`)
+  } catch (err) {
+  }
+
+  try {
+    await db.query(sql`DROP TABLE test3.authors`)
+  } catch (err) {
+  }
+
+  try {
     await db.query(sql`DROP TABLE test2.books`)
   } catch (err) {
   }
 
   try {
     await db.query(sql`DROP TABLE test1.authors`)
+  } catch (err) {
+  }
+
+  try {
+    await db.query(sql`DROP SCHEMA test4`)
+  } catch (err) {
+  }
+
+  try {
+    await db.query(sql`DROP SCHEMA test3`)
   } catch (err) {
   }
 


### PR DESCRIPTION
Regarding this [issue](https://github.com/platformatic/platformatic/issues/458), the logging info added on this PR was crucial in understanding what's going wrong.

To replicate this scenario, you can look at the [tests](https://github.com/platformatic/platformatic/compare/main...rozzilla:platformatic:feat/sql-graphql/enhance-error-logging-for-fk-errors?expand=1#diff-dbdd48775f4c0dc2369209c0cfb588239aad4bd4cb4049e60c8486b0467db07eR169).

I had to add 2 new schemas and 2 new tables to create proper tests for this error.