### PR TITLE
fix: hide call stack on migration errors

### DIFF
--- a/packages/db/lib/migrate.mjs
+++ b/packages/db/lib/migrate.mjs
@@ -12,7 +12,7 @@ import { utimesSync } from 'fs'
 async function execute (logger, args, config) {
   const migrationsConfig = config.migrations
   if (migrationsConfig === undefined) {
-    throw new MigrateError('Missing migrations in config file')
+    throw new MigrateError('Missing "migrations" section in config file')
   }
 
   const migrator = new Migrator(migrationsConfig, config.core, logger)
@@ -23,9 +23,6 @@ async function execute (logger, args, config) {
     } else {
       await migrator.applyMigrations(args.to)
     }
-  } catch (error) {
-    logger.error(error)
-    throw error
   } finally {
     await migrator.close()
   }

--- a/packages/db/test/cli/gen-migration.test.mjs
+++ b/packages/db/test/cli/gen-migration.test.mjs
@@ -88,7 +88,7 @@ test('throws if there is no migrations in the config', async ({ match }) => {
   const child = execa('node', [cliPath, 'migrations', 'create', '-c', configFilePath], { cwd })
   const output = child.stdout.pipe(split())
   const [data] = await once(output, 'data')
-  match(data, /Missing migrations in config file/)
+  match(data, /Missing "migrations" section in config file/)
 })
 
 test('throws if migrations directory does not exist', async ({ match }) => {

--- a/packages/db/test/cli/migrate.test.mjs
+++ b/packages/db/test/cli/migrate.test.mjs
@@ -92,7 +92,7 @@ test('throws if migrations directory does not exist', async ({ match }) => {
   const child = execa('node', [cliPath, 'start', '-c', getFixturesConfigFileLocation('invalid-migrations-directory.json')])
   const output = child.stdout.pipe(split())
   const [data] = await once(output, 'data')
-  match(data, /MigrateError: Migrations directory (.*) does not exist/)
+  match(data, /Migrations directory (.*) does not exist/)
 })
 
 test('do not run migrations by default', async ({ equal, teardown }) => {


### PR DESCRIPTION
Fix #574 