### PR TITLE
docs(cli): Remove comment

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,12 +8,6 @@ import TOCInline from '@theme/TOCInline';
 
 # Platformatic CLI
 
-<!--
-WARNING: THIS DOCUMENTATION IS AUTOMATICALLY GENERATED. DO NOT MANUALLY EDIT IT.
-
-TO UPDATE THIS DOCUMENTATION, RUN: scripts/gen-cli-doc.mjs
--->
-
 ## Installation and usage
 
 Install the Platformatic CLI as a dependency for your project:

--- a/scripts/gen-cli-doc.mjs
+++ b/scripts/gen-cli-doc.mjs
@@ -12,12 +12,6 @@ import TOCInline from '@theme/TOCInline';
 
 # Platformatic CLI
 
-<!--
-WARNING: THIS DOCUMENTATION IS AUTOMATICALLY GENERATED. DO NOT MANUALLY EDIT IT.
-
-TO UPDATE THIS DOCUMENTATION, RUN: scripts/gen-cli-doc.mjs
--->
-
 ## Installation and usage
 
 Install the Platformatic CLI as a dependency for your project:


### PR DESCRIPTION
Looking at the documentation I found this:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/3996291/216573404-f3645639-18e5-4af6-bcc9-5b54bf5b28d2.png">

So this PR remove the comment that causes this.