### PR TITLE
fix(db): Properly format entity type name

### DIFF
--- a/packages/db/lib/gen-types.mjs
+++ b/packages/db/lib/gen-types.mjs
@@ -4,6 +4,7 @@ import { mkdir, writeFile, readFile, readdir, unlink } from 'fs/promises'
 import { join as desmJoin } from 'desm'
 import pino from 'pino'
 import pretty from 'pino-pretty'
+import camelcase from 'camelcase'
 import dtsgenerator, { parseSchema } from 'dtsgenerator'
 import { mapSQLEntityToJSONSchema } from '@platformatic/sql-json-schema-mapper'
 import { setupDB, isFileAccessible } from './utils.js'
@@ -34,6 +35,7 @@ async function generateEntityType (entity) {
   jsonSchema.id = jsonSchema.$id
 
   const tsCode = await dtsgenerator.default({ contents: [parseSchema(jsonSchema)] })
+  entity.name = camelcase(entity.name).replace(/^\w/, c => c.toUpperCase())
   return tsCode + `\nexport { ${entity.name} };\n`
 }
 
@@ -131,7 +133,7 @@ async function writeFileIfChanged (filename, content) {
   return true
 }
 
-async function execute (logger, args, config) {
+async function execute (logger, _, config) {
   const { db, entities } = await setupDB(logger, config.core)
 
   const isTypeFolderExists = await isFileAccessible(TYPES_FOLDER_PATH)

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -49,6 +49,7 @@
     "@platformatic/sql-json-schema-mapper": "workspace:*",
     "@platformatic/utils": "workspace:*",
     "@platformatic/sql-mapper": "workspace:*",
+    "camelcase": "^6.3.0",
     "close-with-grace": "^1.1.0",
     "commist": "^3.2.0",
     "create-platformatic": "workspace:*",

--- a/packages/db/test/cli/gen-types.test.mjs
+++ b/packages/db/test/cli/gen-types.test.mjs
@@ -180,3 +180,26 @@ t.test('generate types on start', async ({ plan, equal, teardown, fail, pass }) 
     fail(err.stderr)
   }
 })
+
+t.test('correctly format entity type names', async (t) => {
+  const testDir = path.join(urlDirname(import.meta.url), '..', 'fixtures', 'chars-gen-types')
+  const cwd = path.join(urlDirname(import.meta.url), '..', 'tmp', 'chars-gen-types-clone')
+
+  await mkdir(cwd)
+  await cp(testDir, cwd, { recursive: true })
+
+  t.teardown(async () => {
+    await rm(cwd, { force: true, recursive: true })
+  })
+
+  try {
+    const child = await execa('node', [cliPath, 'migrations', 'apply'], { cwd })
+    t.equal(child.stdout.includes('Generated type for PltDb entity.'), true)
+  } catch (err) {
+    console.log(err.stdout)
+    console.log(err.stderr)
+    t.fail(err.stderr)
+  }
+
+  t.pass()
+})

--- a/packages/db/test/fixtures/chars-gen-types/index.d.ts
+++ b/packages/db/test/fixtures/chars-gen-types/index.d.ts
@@ -1,0 +1,1 @@
+// Need to Run tsd tests

--- a/packages/db/test/fixtures/chars-gen-types/index.test-d.ts
+++ b/packages/db/test/fixtures/chars-gen-types/index.test-d.ts
@@ -1,0 +1,14 @@
+/// <reference path="./global.d.ts" />
+
+import { expectType } from 'tsd'
+import { PltDb } from './types/PltDb'
+import { FastifyInstance, fastify } from 'fastify'
+
+const app: FastifyInstance = fastify()
+
+const graphs = await app.platformatic.entities.graph.find()
+expectType<PltDb[]>(graphs)
+
+const graph = graphs[0]
+expectType<number | undefined>(graph.id)
+expectType<string | null | undefined>(graph.name)

--- a/packages/db/test/fixtures/chars-gen-types/migrations/001.do.sql
+++ b/packages/db/test/fixtures/chars-gen-types/migrations/001.do.sql
@@ -1,0 +1,4 @@
+CREATE TABLE plt_db (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);

--- a/packages/db/test/fixtures/chars-gen-types/package.json
+++ b/packages/db/test/fixtures/chars-gen-types/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gen-types",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "types": "./index.d.ts",
+  "devDependencies": {
+    "@platformatic/sql-mapper": "workspace:*"
+  }
+}

--- a/packages/db/test/fixtures/chars-gen-types/platformatic.db.json
+++ b/packages/db/test/fixtures/chars-gen-types/platformatic.db.json
@@ -1,0 +1,22 @@
+{
+  "core": {
+    "connectionString": "sqlite://./db"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    }
+  },
+  "migrations": {
+    "dir": "./migrations",
+    "autoApply": true
+  },
+  "types": {
+    "autogenerate": true
+  },
+  "plugin": {
+    "path": "./plugin.js"
+  }
+}

--- a/packages/db/test/helper.js
+++ b/packages/db/test/helper.js
@@ -55,6 +55,7 @@ module.exports.clear = async function (db, sql) {
   await db.query(sql`DROP TABLE IF EXISTS posts;`)
   await db.query(sql`DROP TABLE IF EXISTS owners;`)
   await db.query(sql`DROP TABLE IF EXISTS categories;`)
+  await db.query(sql`DROP TABLE IF EXISTS plt_db;`)
 }
 
 async function createBasicPages (db, sql) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,7 @@ importers:
       '@platformatic/utils': workspace:*
       bindings: ^1.5.0
       c8: ^7.12.0
+      camelcase: ^6.3.0
       close-with-grace: ^1.1.0
       commist: ^3.2.0
       create-platformatic: workspace:*
@@ -222,6 +223,7 @@ importers:
       '@platformatic/sql-json-schema-mapper': link:../sql-json-schema-mapper
       '@platformatic/sql-mapper': link:../sql-mapper
       '@platformatic/utils': link:../utils
+      camelcase: 6.3.0
       close-with-grace: 1.1.0
       commist: 3.2.0
       create-platformatic: link:../create-platformatic


### PR DESCRIPTION
Currently, if a table has special chars like `-` in the name, the generated types are wrong.

To make an example, with [this](https://github.com/platformatic/platformatic/compare/main...rozzilla:platformatic:fix/db/properly-format-entity-type-name?expand=1#diff-7c7c99cb3cfdd787010537e474556d93f2ff0b24527adcc63b82710f674d6ad4R1) table, the following type is created:
```
declare interface PltDb {
    id: number;
    name?: string;
}

export { plt_db };
```
and this generates a TS error.

This PR creates a fix for this, applying the right formatting to the generated types.