### PR TITLE
feat: global hot reload setting in cli

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -324,7 +324,8 @@ By sending the SIGUSR2 signal, the server can be reloaded.
 
 Options:
 
-  -c, --config FILE      Specify a configuration file to use
+  * `-c, --config FILE` - Specify a configuration file to use
+  * `--hot-reload <boolean>` - All individual plugin hot reload settings will be overridden by global hot reload
 
 If not specified, the configuration specified will be loaded from `platformatic.db.json`,
 `platformatic.db.yml`, or `platformatic.db.tml` in the current directory. You can find more details about

--- a/packages/db/lib/start.mjs
+++ b/packages/db/lib/start.mjs
@@ -19,7 +19,10 @@ export async function start (_args) {
   }))
 
   const { configManager } = await loadConfig({
-    string: ['to']
+    string: ['to', 'hot-reload'],
+    alias: {
+      hotReload: ['hot-reload']
+    }
   }, _args, { watch: true })
 
   const config = configManager.current

--- a/packages/db/test/cli/start.test.mjs
+++ b/packages/db/test/cli/start.test.mjs
@@ -256,3 +256,17 @@ test('start with hotreload disabled', async ({ equal, same, match, teardown }) =
   match(url, /http:\/\/127.0.0.1:[0-9]+/)
   child.kill('SIGINT')
 })
+
+test('start with hotreload enabled', async ({ equal, same, match, teardown }) => {
+  const db = await connectAndResetDB()
+  teardown(() => db.dispose())
+
+  await db.query(db.sql`CREATE TABLE pages (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(42)
+  );`)
+
+  const { child, url } = await start('-c', join(import.meta.url, '..', 'fixtures', 'simple.json'), '--hot-reload', true)
+  match(url, /http:\/\/127.0.0.1:[0-9]+/)
+  child.kill('SIGINT')
+})

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -107,8 +107,9 @@ async function loadPlugin (app, config, pluginOptions) {
 
   // if not defined, we defaults to true (which can happen only if config is set programmatically,
   // that's why we ignore the coverage of the `undefined` case, which cannot be covered in cli tests)
+  // all individual plugin hot reload settings will be overloaded by global hot reload
   /* c8 ignore next 35  */
-  const hotReload = pluginOptions.hotReload !== false
+  const hotReload = config.hotReload ?? pluginOptions.hotReload !== false
   const isWatchEnabled = config.watch !== false
   if (isWatchEnabled && hotReload) {
     let options = pluginOptions

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -249,6 +249,9 @@ const platformaticServiceSchema = {
       anyOf: [watch, {
         type: 'boolean'
       }]
+    },
+    hotReload: {
+      type: 'boolean'
     }
   },
   required: ['server']


### PR DESCRIPTION
#670 

If I got this correctly one more thing would be to add test.
I wanted to add test in `start.test.mjs` something like https://github.com/platformatic/platformatic/blob/e9f7daaf620ff10562eea9b10b443066e661138d/packages/db/test/cli/start.test.mjs#L246

But seems like this one is already failing ?
```js
 FAIL ​ test/cli/start.test.mjs
 ✖ test unfinished

  test: start with hotreload disabled
  stack: |
    file://test/cli/start.test.mjs:246:1
  at:
    line: 246
    column: 1
    file: file://test/cli/start.test.mjs
```

Is `no-hotreload.json` correct since I can't find that 

```
  "watch": {
    "hotReload": false
  }
```
is valid setting?