### PR TITLE
fix(dashboard): Active selector

### DIFF
--- a/packages/db-dashboard/src/components/Navbar.jsx
+++ b/packages/db-dashboard/src/components/Navbar.jsx
@@ -11,7 +11,7 @@ export default function Navbar () {
   return (
     <div className={styles.list}>
       <div>
-        <NavLink className={getListItemClass} data-testid='dashboard-link' to={dashboardPath}>Dashboard</NavLink>
+        <NavLink className={getListItemClass} data-testid='dashboard-link' to={dashboardPath + '/'}>Dashboard</NavLink>
       </div>
       <div>
         <NavLink className={getListItemClass} data-testid='graphiql-link' to={dashboardPath + '/graphiql'}>GraphiQL</NavLink>


### PR DESCRIPTION
Current bug:
![image](https://user-images.githubusercontent.com/3996291/219648149-d2e9d0a3-3de9-464c-9f44-c20934e5b371.png)

![image](https://user-images.githubusercontent.com/3996291/219648214-83dbd82a-d5e1-400a-9bb4-e4b4aa86be2f.png)

Now:
![image](https://user-images.githubusercontent.com/3996291/219648358-ba4f2df2-dff2-4ed1-8fb3-ac47ab5a8b64.png)

![image](https://user-images.githubusercontent.com/3996291/219648295-214a2bdb-8c92-445f-b910-c9bac3252cf3.png)

Explanation of the 1-line fix: now `react-router-dom` can properly detect if the `NavLink` is active or not, since we append `/` to it 😉 