### PR TITLE
feat(types): Generate better getSchema definition

### DIFF
--- a/packages/db/test/fixtures/typescript-plugin/global.d.ts
+++ b/packages/db/test/fixtures/typescript-plugin/global.d.ts
@@ -2,6 +2,19 @@ import { Entity } from '@platformatic/sql-mapper';
 import graphqlPlugin from '@platformatic/sql-graphql'
 import { Movie } from './types/Movie'
 
+declare module 'fastify' {
+  interface FastifyInstance {
+    getSchema(schemaId: 'Movie'): {
+      '$id': string,
+      title: string,
+      description: string,
+      type: string,
+      properties: object,
+      required: string[]
+    };
+  }
+}
+
 declare module '@platformatic/sql-mapper' {
   interface Entities {
     movie: Entity<Movie>,


### PR DESCRIPTION
By default, the type definition for the `fastify` method called `getSchema` is not narrowed down, since it accepts `string` as a parameter and `unknown` as a return value.

This PR overrides the type definition in the `global.d.ts`, making it more specific.

<img width="433" alt="image" src="https://user-images.githubusercontent.com/3996291/219819606-6b34cde7-478b-4cc1-aab5-e5a2f7d4cc16.png">


