### PR TITLE
Adds minimum supported versions for databases

### DIFF
--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -42,10 +42,10 @@ Get up and running in 2 minutes using our
 
 ## Supported databases
 
-- [SQLite](https://www.sqlite.org/)
-- [PostgreSQL](https://www.postgresql.org/)
-- [MySQL](https://www.mysql.com/)
-- [MariaDB](https://mariadb.org/)
+- [SQLite](https://www.sqlite.org/) >= 5.1.4
+- [PostgreSQL](https://www.postgresql.org/) >= 15-alpine
+- [MySQL](https://www.mysql.com/) >= 5.7
+- [MariaDB](https://mariadb.org/) >= 10.11
 
 The required database driver is automatically inferred and loaded based on the
 value of the [`connectionString`](/reference/db/configuration.md#core)

--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -44,7 +44,7 @@ Get up and running in 2 minutes using our
 
 | Database                                  | Version  |
 |-------------------------------------------|----------|
-| [SQLite](https://www.sqlite.org/)         | 3        |
+| [SQLite](https://www.sqlite.org/)         | 3.        |
 | [PostgreSQL](https://www.postgresql.org/) | >= 15    |
 | [MySQL](https://www.mysql.com/)           | >= 5.7   |
 | [MariaDB](https://mariadb.org/)           | >= 10.11 |

--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -44,7 +44,7 @@ Get up and running in 2 minutes using our
 
 | Database                                  | Version  |
 |-------------------------------------------|----------|
-| [SQLite](https://www.sqlite.org/)         | 3.      |
+| [SQLite](https://www.sqlite.org/)         | 3        |
 | [PostgreSQL](https://www.postgresql.org/) | >= 15    |
 | [MySQL](https://www.mysql.com/)           | >= 5.7   |
 | [MariaDB](https://mariadb.org/)           | >= 10.11 |

--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -44,7 +44,7 @@ Get up and running in 2 minutes using our
 
 | Database                                  | Version  |
 |-------------------------------------------|----------|
-| [SQLite](https://www.sqlite.org/)         | 3.        |
+| [SQLite](https://www.sqlite.org/)         | 3.       |
 | [PostgreSQL](https://www.postgresql.org/) | >= 15    |
 | [MySQL](https://www.mysql.com/)           | >= 5.7   |
 | [MariaDB](https://mariadb.org/)           | >= 10.11 |

--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -43,7 +43,7 @@ Get up and running in 2 minutes using our
 ## Supported databases
 
 - [SQLite](https://www.sqlite.org/) >= 5.1.4
-- [PostgreSQL](https://www.postgresql.org/) >= 15-alpine
+- [PostgreSQL](https://www.postgresql.org/) >= 15
 - [MySQL](https://www.mysql.com/) >= 5.7
 - [MariaDB](https://mariadb.org/) >= 10.11
 

--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -42,10 +42,13 @@ Get up and running in 2 minutes using our
 
 ## Supported databases
 
-- [SQLite](https://www.sqlite.org/) >= 3
-- [PostgreSQL](https://www.postgresql.org/) >= 15
-- [MySQL](https://www.mysql.com/) >= 5.7
-- [MariaDB](https://mariadb.org/) >= 10.11
+| Database                                  | Version  |
+|-------------------------------------------|----------|
+| [SQLite](https://www.sqlite.org/)         | >= 3     |
+| [PostgreSQL](https://www.postgresql.org/) | >= 15    |
+| [MySQL](https://www.mysql.com/)           | >= 5.7   |
+| [MariaDB](https://mariadb.org/)           | >= 10.11 |
+
 
 The required database driver is automatically inferred and loaded based on the
 value of the [`connectionString`](/reference/db/configuration.md#core)

--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -44,7 +44,7 @@ Get up and running in 2 minutes using our
 
 | Database                                  | Version  |
 |-------------------------------------------|----------|
-| [SQLite](https://www.sqlite.org/)         | >= 3     |
+| [SQLite](https://www.sqlite.org/)         | 3.      |
 | [PostgreSQL](https://www.postgresql.org/) | >= 15    |
 | [MySQL](https://www.mysql.com/)           | >= 5.7   |
 | [MariaDB](https://mariadb.org/)           | >= 10.11 |

--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -42,7 +42,7 @@ Get up and running in 2 minutes using our
 
 ## Supported databases
 
-- [SQLite](https://www.sqlite.org/) >= 5.1.4
+- [SQLite](https://www.sqlite.org/) >= 3
 - [PostgreSQL](https://www.postgresql.org/) >= 15
 - [MySQL](https://www.mysql.com/) >= 5.7
 - [MariaDB](https://mariadb.org/) >= 10.11


### PR DESCRIPTION
This is related to #693. I retrieved the minimum required versions from the docker-compose file and from the GitHub actions.