### PR TITLE
Feat/types/generate better get schema return

### DIFF
--- a/packages/db/test/fixtures/typescript-plugin/global.d.ts
+++ b/packages/db/test/fixtures/typescript-plugin/global.d.ts
@@ -2,6 +2,7 @@ import { Entity } from '@platformatic/sql-mapper';
 import graphqlPlugin from '@platformatic/sql-graphql'
 import { EntityTypes, Movie } from './types'
 
+
 declare module 'fastify' {
   interface FastifyInstance {
     getSchema<T extends 'Movie'>(schemaId: T): {

--- a/packages/db/test/fixtures/typescript-plugin/global.d.ts
+++ b/packages/db/test/fixtures/typescript-plugin/global.d.ts
@@ -1,15 +1,17 @@
 import { Entity } from '@platformatic/sql-mapper';
 import graphqlPlugin from '@platformatic/sql-graphql'
-import { Movie } from './types/Movie'
+import { EntityTypes, Movie } from './types'
 
 declare module 'fastify' {
   interface FastifyInstance {
-    getSchema(schemaId: 'Movie'): {
+    getSchema<T extends 'Movie'>(schemaId: T): {
       '$id': string,
       title: string,
       description: string,
       type: string,
-      properties: object,
+      properties: {
+        [x in keyof EntityTypes[T]]: { type: string, nullable?: boolean }
+      },
       required: string[]
     };
   }

--- a/packages/db/test/fixtures/typescript-plugin/types/index.d.ts
+++ b/packages/db/test/fixtures/typescript-plugin/types/index.d.ts
@@ -1,0 +1,7 @@
+import { Movie } from './Movie'
+
+interface EntityTypes {
+    Movie: Movie
+}
+
+export { EntityTypes, Movie }


### PR DESCRIPTION
Just like #700 this PR  aims to make getSchema more specific by inferring the properties of the entity.

This PR overrides the type definition in the `global.d.ts`  and globs the ./types/{name} imports into a single `index.d.ts`.

![2023-02-24-010137_3440x1440_scrot](https://user-images.githubusercontent.com/56308724/221059098-cecc85a4-4dbe-4624-9022-65b5cebc14c8.png)

I made the change as small as possible so others can expand upon this as I am a bit lost with JSON schema