### PR TITLE
Add instruction to run migrations in manual setup

### DIFF
--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -236,6 +236,14 @@ supported configuration options.
 
 :::
 
+#### Apply your migrations
+
+In your project directory, use the Platformatic CLI to apply migrations:
+
+```bash
+npx platformatic db migrations apply
+```
+
 #### Start your API server
 
 In your project directory, use the Platformatic CLI to start your API server:


### PR DESCRIPTION
In the manual setup of Platformatic DB, instructions to run migrations is omitted and this PR adds that instruction.