### PR TITLE
Add setup for schema store

### DIFF
--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -1,0 +1,38 @@
+name: Publish to Schema Store
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - name: pnpm install
+        run: pnpm install
+      - name: Creates output folder and generate the schemas
+        id: gen-schemas
+        run:  |
+              mkdir output
+              node packages/service/lib/schema.js > output/service
+              node packages/db/lib/schema.js > output/db
+              node -e "console.log('VERSION=v'+ require('./package.json').version)" >> $GITHUB_OUTPUT
+      - name: Pushes to schema store repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SCHEMAS_API_TOKEN_GITHUB }}
+        with:
+          source-directory: output/
+          destination-github-username: 'platformatic'
+          destination-repository-name: 'schemas'
+          user-email: hello@matteocollina.com
+          commit-message: added ${{ steps.gen-schemas.outputs.VERSION }}
+          target-branch: main
+          target-directory: ${{ steps.gen-schemas.outputs.VERSION }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformatic",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "private": true,
   "scripts": {
     "test": "pnpm -r --workspace-concurrency=1 test",

--- a/packages/authenticate/package.json
+++ b/packages/authenticate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/authenticate",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformatic",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Platformatic CLI",
   "main": "cli.js",
   "type": "module",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/config",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Platformatic DB Config Manager",
   "main": "index.js",
   "scripts": {

--- a/packages/create-platformatic/package.json
+++ b/packages/create-platformatic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-platformatic",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Create platformatic-db interactive tool",
   "repository": {
     "type": "git",

--- a/packages/db-authorization/package.json
+++ b/packages/db-authorization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db-authorization",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/db-core/package.json
+++ b/packages/db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db-core",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/db-dashboard/package.json
+++ b/packages/db-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db-dashboard",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "main": "index.js",
   "description": "Platformatic DB Dashboard",
   "repository": {

--- a/packages/db-ra-data-rest/package.json
+++ b/packages/db-ra-data-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db-ra-data-rest",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Platformatic DB React-Admin REST data provider",
   "repository": {
     "type": "git",

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -1,9 +1,11 @@
+#! /usr/bin/env node
 'use strict'
 
 const { metrics, server, plugins, watch } = require('@platformatic/service').schema
+const pkg = require('../package.json')
+const version = 'v' + pkg.version
 
 const core = {
-  $id: 'https://schemas.platformatic.dev/db/core',
   type: 'object',
   properties: {
     connectionString: {
@@ -156,7 +158,6 @@ const sharedAuthorizationRule = {
 }
 
 const authorization = {
-  $id: 'https://schemas.platformatic.dev/db/authorization',
   type: 'object',
   properties: {
     adminSecret: {
@@ -297,7 +298,6 @@ const authorization = {
 }
 
 const dashboard = {
-  $id: 'https://schemas.platformatic.dev/db/dashboard',
   anyOf: [
     { type: 'boolean' },
     {
@@ -314,7 +314,6 @@ const dashboard = {
 }
 
 const migrations = {
-  $id: 'https://schemas.platformatic.dev/db/migrations',
   type: 'object',
   properties: {
     dir: {
@@ -337,7 +336,6 @@ const migrations = {
 }
 
 const types = {
-  $id: 'https://schemas.platformatic.dev/db/types',
   type: 'object',
   properties: {
     autogenerate: {
@@ -348,7 +346,7 @@ const types = {
 }
 
 const platformaticDBschema = {
-  $id: 'https://schemas.platformatic.dev/db',
+  $id: `https://platformatic.dev/schemas/${version}/db`,
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
   properties: {
@@ -372,3 +370,7 @@ const platformaticDBschema = {
 }
 
 module.exports.schema = platformaticDBschema
+
+if (require.main === module) {
+  console.log(JSON.stringify(platformaticDBschema, null, 2))
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/db/test/cli/init.test.mjs
+++ b/packages/db/test/cli/init.test.mjs
@@ -18,6 +18,8 @@ const moviesMigrationUndo = `
 DROP TABLE movies;
 `
 
+const pkg = JSON.parse(await fs.readFile('../../package.json', 'utf8'))
+
 t.test('run db init with default options', async (t) => {
   const pathToFolder = await fs.mkdtemp(path.join(tmpdir(), 'init-1'))
   const pathToDbConfigFile = path.join(pathToFolder, 'platformatic.db.json')
@@ -58,7 +60,7 @@ t.test('run db init with default options', async (t) => {
   t.equal(migrationFileUndo, moviesMigrationUndo)
 
   const { $id, type, required } = parseConfigSchema
-  t.equal($id, 'https://schemas.platformatic.dev/db')
+  t.equal($id, `https://platformatic.dev/schemas/v${pkg.version}/db`)
   t.equal(type, 'object')
   t.has(required, ['core', 'server'])
 })

--- a/packages/db/test/cli/schema.test.mjs
+++ b/packages/db/test/cli/schema.test.mjs
@@ -6,6 +6,8 @@ import fs from 'fs/promises'
 import stripAnsi from 'strip-ansi'
 import jsonLanguageService from 'vscode-json-languageservice'
 
+const pkg = JSON.parse(await fs.readFile(join(import.meta.url, '..', '..', 'package.json'), 'utf8'))
+
 const dbLocation = join(import.meta.url, '..', 'fixtures', 'sqlite', 'db')
 
 test('print the graphql schema to stdout', async ({ matchSnapshot }) => {
@@ -43,7 +45,7 @@ test('generates the json schema config', async (t) => {
   const configSchema = await fs.readFile('platformatic.db.schema.json', 'utf8')
   const schema = JSON.parse(configSchema)
   const { $id, type } = schema
-  t.equal($id, 'https://schemas.platformatic.dev/db')
+  t.equal($id, `https://platformatic.dev/schemas/v${pkg.version}/db`)
   t.equal(type, 'object')
 
   const languageservice = jsonLanguageService.getLanguageService({

--- a/packages/db/test/schema.test.js
+++ b/packages/db/test/schema.test.js
@@ -6,7 +6,7 @@ const { schema } = require('../lib/schema')
 
 test('schema output', async (t) => {
   const { execa } = await import('execa')
-  const { stdout } = await execa('node', [join(__dirname, '..', 'lib', 'schema.js')])
+  const { stdout } = await execa(process.execPath, [join(__dirname, '..', 'lib', 'schema.js')])
 
   t.same(stdout, JSON.stringify(schema, null, 2))
 })

--- a/packages/db/test/schema.test.js
+++ b/packages/db/test/schema.test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { test } = require('tap')
+const { join } = require('path')
+const { schema } = require('../lib/schema')
+
+test('schema output', async (t) => {
+  const { execa } = await import('execa')
+  const { stdout } = await execa('node', [join(__dirname, '..', 'lib', 'schema.js')])
+
+  t.same(stdout, JSON.stringify(schema, null, 2))
+})

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -1,4 +1,10 @@
+#!/usr/bin/env node
+
 'use strict'
+
+const pkg = require('../package.json')
+const version = 'v' + pkg.version
+
 
 const cors = {
   type: 'object',
@@ -90,7 +96,6 @@ const cors = {
 }
 
 const server = {
-  $id: 'https://schemas.platformatic.dev/service/server',
   type: 'object',
   properties: {
     // TODO add support for level
@@ -125,7 +130,6 @@ const server = {
 }
 
 const watch = {
-  $id: 'https://schemas.platformatic.dev/service/watch',
   type: 'object',
   properties: {
     type: 'object',
@@ -194,7 +198,6 @@ const plugins = {
 }
 
 const metrics = {
-  $id: 'https://schemas.platformatic.dev/service/metrics',
   anyOf: [
     { type: 'boolean' },
     {
@@ -218,7 +221,7 @@ const metrics = {
 }
 
 const platformaticServiceSchema = {
-  $id: 'https://schemas.platformatic.dev/service',
+  $id: `https://platformatic.dev/schemas/${version}/service`,
   type: 'object',
   properties: {
     server,
@@ -244,3 +247,7 @@ module.exports.cors = cors
 module.exports.server = server
 module.exports.plugins = plugins
 module.exports.watch = watch
+
+if (require.main === module) {
+  console.log(JSON.stringify(platformaticServiceSchema, null, 2))
+}

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -5,7 +5,6 @@
 const pkg = require('../package.json')
 const version = 'v' + pkg.version
 
-
 const cors = {
   type: 'object',
   $comment: 'See https://github.com/fastify/fastify-cors',

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/service",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/service/test/cli/gen-schema.test.mjs
+++ b/packages/service/test/cli/gen-schema.test.mjs
@@ -6,6 +6,8 @@ import { generateJsonSchemaConfig } from '../../lib/gen-schema.js'
 import { join } from 'path'
 import jsonLanguageService from 'vscode-json-languageservice'
 
+const pkg = JSON.parse(await fs.readFile('../../package.json', 'utf8'))
+
 test('generateJsonSchemaConfig generates the file', async (t) => {
   const tmpDir = await mkdtempSync(join(tmpdir(), 'test-create-platformatic-'))
   process.chdir(tmpDir)
@@ -17,7 +19,7 @@ test('generateJsonSchemaConfig generates the file', async (t) => {
   t.has(required, ['server'])
   t.has(additionalProperties, { watch: {} })
   const { $id, type } = schema
-  t.equal($id, 'https://schemas.platformatic.dev/service')
+  t.equal($id, `https://platformatic.dev/schemas/v${pkg.version}/service`)
   t.equal(type, 'object')
 
   const languageservice = jsonLanguageService.getLanguageService({
@@ -29,7 +31,7 @@ test('generateJsonSchemaConfig generates the file', async (t) => {
   languageservice.configure({ allowComments: false, schemas: [{ fileMatch: ['*.data.json'], uri: $id }] })
 
   const jsonContent = `{
-    "$schema": "https://schemas.platformatic.dev/service",
+    "$schema": "https://platformatic.dev/schemas/v${pkg.version}/service",
     "server": {
       "hostname": "127.0.0.1",
       "port": 3000

--- a/packages/service/test/schema.test.js
+++ b/packages/service/test/schema.test.js
@@ -6,7 +6,7 @@ const { schema } = require('../lib/schema')
 
 test('schema output', async (t) => {
   const { execa } = await import('execa')
-  const { stdout } = await execa('node', [join(__dirname, '..', 'lib', 'schema.js')])
+  const { stdout } = await execa(process.execPath, [join(__dirname, '..', 'lib', 'schema.js')])
 
   t.same(stdout, JSON.stringify(schema, null, 2))
 })

--- a/packages/service/test/schema.test.js
+++ b/packages/service/test/schema.test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { test } = require('tap')
+const { join } = require('path')
+const { schema } = require('../lib/schema')
+
+test('schema output', async (t) => {
+  const { execa } = await import('execa')
+  const { stdout } = await execa('node', [join(__dirname, '..', 'lib', 'schema.js')])
+
+  t.same(stdout, JSON.stringify(schema, null, 2))
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/shared",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "main": "index.js",
   "description": "Platformatic DB Shared Resources",
   "repository": {

--- a/packages/sql-events/package.json
+++ b/packages/sql-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-events",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Emit events via MQEmitter",
   "main": "index.js",
   "scripts": {

--- a/packages/sql-graphql/package.json
+++ b/packages/sql-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-graphql",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Map SQL dbs to GraphQL",
   "main": "index.js",
   "scripts": {

--- a/packages/sql-json-schema-mapper/package.json
+++ b/packages/sql-json-schema-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-json-schema-mapper",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Map SQL entity to JSON schema",
   "main": "index.js",
   "scripts": {

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-mapper",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "A data mapper utility for SQL databases",
   "main": "mapper.js",
   "scripts": {

--- a/packages/sql-openapi/package.json
+++ b/packages/sql-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-openapi",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Map a SQL database to OpenAPI, for Fastify",
   "main": "index.js",
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/utils",
-  "version": "0.16.0",
+  "version": "0.17.0-dev",
   "description": "Platformatic DB Utils",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds the logic to automatically upload the configuration schemas to the schemas repository, which will automatically be published as https://platformatic.dev/schemas.

Therefore, each configuration schema will be published at https://platformatic.dev/schemas/v{version}/db and https://platformatic.dev/schemas/v{version}/db, where version is what is specified in `package.json`.

In this PR I have bumped the release to v0.17.0-dev to verify everything would work fine once landed on main.