### PR TITLE
Use the published schemas instead of the local one

### DIFF
--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -101,7 +101,7 @@ const createPlatformaticDB = async (_args) => {
     typescript: useTypescript
   }
 
-  const env = await createDB(params, logger, projectDir)
+  const env = await createDB(params, logger, projectDir, version)
 
   const fastifyVersion = await getDependencyVersion('fastify')
 
@@ -160,17 +160,8 @@ const createPlatformaticDB = async (_args) => {
         spinner.succeed('...done!')
       }
     }
-    await execa(pkgManager, ['exec', 'platformatic', 'db', 'schema', 'config'], { cwd: projectDir })
-    logger.info('Configuration schema successfully created.')
   }
   await askCreateGHAction(logger, env, 'db', useTypescript, projectDir)
-
-  if (!runPackageManagerInstall) {
-    logger.warn(`You must run the following commands in the project folder to complete the setup:
-    - ${pkgManager} install
-    - npx platformatic db schema config
-`)
-  }
 }
 
 export default createPlatformaticDB

--- a/packages/create-platformatic/src/db/create-db.mjs
+++ b/packages/create-platformatic/src/db/create-db.mjs
@@ -1,4 +1,4 @@
-  import { writeFile, mkdir } from 'fs/promises'
+import { writeFile, mkdir } from 'fs/promises'
 import { join, relative, resolve } from 'path'
 import { findDBConfigFile, isFileAccessible } from '../utils.mjs'
 
@@ -94,7 +94,7 @@ PORT=${port}
 PLT_SERVER_LOGGER_LEVEL=info
 DATABASE_URL=${connectionString}
 `
-    return env
+  return env
 }
 
 const JS_PLUGIN_WITH_TYPES_SUPPORT = `\
@@ -146,7 +146,7 @@ async function createDB ({ hostname, database = 'sqlite', port, migrations = 'mi
   }
 
   const migrationsFolderName = migrations
-    if (createMigrations) {
+  if (createMigrations) {
     const isMigrationFolderExists = await isFileAccessible(migrationsFolderName, currentDir)
     if (!isMigrationFolderExists) {
       await mkdir(join(currentDir, migrationsFolderName))

--- a/packages/create-platformatic/src/db/create-db.mjs
+++ b/packages/create-platformatic/src/db/create-db.mjs
@@ -1,4 +1,4 @@
-import { writeFile, mkdir } from 'fs/promises'
+  import { writeFile, mkdir } from 'fs/promises'
 import { join, relative, resolve } from 'path'
 import { findDBConfigFile, isFileAccessible } from '../utils.mjs'
 
@@ -47,9 +47,9 @@ function getTsConfig (outDir) {
 const getPluginName = (isTypescript) => isTypescript === true ? 'plugin.ts' : 'plugin.js'
 const TS_OUT_DIR = 'dist'
 
-function generateConfig (migrations, plugin, types, typescript) {
+function generateConfig (migrations, plugin, types, typescript, version) {
   const config = {
-    $schema: './platformatic.db.schema.json',
+    $schema: `https://platformatic.dev/schemas/v${version}/db`,
     server: {
       hostname: '{PLT_SERVER_HOSTNAME}',
       port: '{PORT}',
@@ -94,7 +94,7 @@ PORT=${port}
 PLT_SERVER_LOGGER_LEVEL=info
 DATABASE_URL=${connectionString}
 `
-  return env
+    return env
 }
 
 const JS_PLUGIN_WITH_TYPES_SUPPORT = `\
@@ -129,11 +129,11 @@ async function generatePluginWithTypesSupport (logger, currentDir, isTypescript)
   logger.info(`Plugin file created at ${relative(currentDir, pluginPath)}`)
 }
 
-async function createDB ({ hostname, database = 'sqlite', port, migrations = 'migrations', plugin = true, types = true, typescript = false }, logger, currentDir) {
+async function createDB ({ hostname, database = 'sqlite', port, migrations = 'migrations', plugin = true, types = true, typescript = false }, logger, currentDir, version) {
   const createMigrations = !!migrations // If we don't define a migrations folder, we don't create it
   const accessibleConfigFilename = await findDBConfigFile(currentDir)
   if (accessibleConfigFilename === undefined) {
-    const config = generateConfig(migrations, plugin, types, typescript)
+    const config = generateConfig(migrations, plugin, types, typescript, version)
     await writeFile(join(currentDir, 'platformatic.db.json'), JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.db.json successfully created.')
 
@@ -146,7 +146,7 @@ async function createDB ({ hostname, database = 'sqlite', port, migrations = 'mi
   }
 
   const migrationsFolderName = migrations
-  if (createMigrations) {
+    if (createMigrations) {
     const isMigrationFolderExists = await isFileAccessible(migrationsFolderName, currentDir)
     if (!isMigrationFolderExists) {
       await mkdir(join(currentDir, migrationsFolderName))

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -9,7 +9,7 @@ import inquirer from 'inquirer'
 import { readFile, writeFile } from 'fs/promises'
 import pino from 'pino'
 import pretty from 'pino-pretty'
-import { execa, execaNode } from 'execa'
+import { execa } from 'execa'
 import ora from 'ora'
 import createService from './create-service.mjs'
 import askProjectDir from '../ask-project-dir.mjs'
@@ -59,7 +59,7 @@ const createPlatformaticService = async (_args) => {
     port: args.port
   }
 
-  const env = await createService(params, logger, projectDir)
+  const env = await createService(params, logger, projectDir, version)
 
   const fastifyVersion = await getDependencyVersion('fastify')
 
@@ -81,19 +81,6 @@ const createPlatformaticService = async (_args) => {
     const spinner = ora('Installing dependencies...').start()
     await execa(pkgManager, ['install'], { cwd: projectDir })
     spinner.succeed('...done!')
-    try {
-      await execaNode('./node_modules/@platformatic/service/service.mjs', [], { cwd: projectDir })
-    } catch (err) {
-      console.log(err)
-    }
-    logger.info('Configuration schema successfully created.')
-  }
-
-  if (!runPackageManagerInstall) {
-    logger.warn(`You must run the following commands in the project folder to complete the setup:
-    - ${pkgManager} install
-    - npx platformatic service schema config
-`)
   }
 
   // We don't have the option for TS (yet) so we don't run build on TS

--- a/packages/create-platformatic/src/service/create-service.mjs
+++ b/packages/create-platformatic/src/service/create-service.mjs
@@ -2,14 +2,14 @@ import { writeFile, mkdir } from 'fs/promises'
 import { join } from 'path'
 import { findServiceConfigFile, isFileAccessible } from '../utils.mjs'
 
-function generateConfig () {
+function generateConfig (version) {
   const plugin = [
     './plugins',
     './routes'
   ]
 
   const config = {
-    $schema: './platformatic.service.schema.json',
+    $schema: `https://platformatic.dev/schemas/v${version}/service`,
     server: {
       hostname: '{PLT_SERVER_HOSTNAME}',
       port: '{PORT}',
@@ -51,11 +51,11 @@ module.exports = async function (fastify, opts) {
 }
 `
 
-async function createService ({ hostname, port }, logger, currentDir = process.cwd()) {
+async function createService ({ hostname, port }, logger, currentDir = process.cwd(), version) {
   const accessibleConfigFilename = await findServiceConfigFile(currentDir)
 
   if (accessibleConfigFilename === undefined) {
-    const config = generateConfig()
+    const config = generateConfig(version)
     await writeFile(join(currentDir, 'platformatic.service.json'), JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.service.json successfully created.')
 

--- a/packages/db/lib/init.mjs
+++ b/packages/db/lib/init.mjs
@@ -4,15 +4,18 @@ import { checkForDependencies, generateGlobalTypesFile } from './gen-types.mjs'
 import loadConfig from './load-config.mjs'
 import { generateJsonSchemaConfig } from './gen-schema.mjs'
 import { createDB, parseDBArgs } from 'create-platformatic'
+import { join } from 'desm'
+import { readFile } from 'fs/promises'
 
 async function init (_args) {
+  const version = JSON.parse(await readFile(join(import.meta.url, '../package.json'))).version
   const logger = pino(pretty({
     translateTime: 'SYS:HH:MM:ss',
     ignore: 'hostname,pid'
   }))
 
   const args = parseDBArgs(_args)
-  await createDB(args, logger, process.cwd())
+  await createDB(args, logger, process.cwd(), version)
 
   // We need to do these here because platformatic-creator has NO dependencies to `db`.
   await generateJsonSchemaConfig()

--- a/packages/db/test/cli/init.test.mjs
+++ b/packages/db/test/cli/init.test.mjs
@@ -37,7 +37,7 @@ t.test('run db init with default options', async (t) => {
 
   const { server, core, migrations, $schema } = dbConfig
 
-  t.equal($schema, './platformatic.db.schema.json')
+  t.equal($schema, `https://platformatic.dev/schemas/v${pkg.version}/db`)
 
   t.equal(server.hostname, '{PLT_SERVER_HOSTNAME}')
   t.equal(server.port, '{PORT}')


### PR DESCRIPTION
All the new generated config files will now use the public schema instead of the locally generated one.