### PR TITLE
feat: add ignore http method support

### DIFF
--- a/docs/reference/sql-openapi/ignore.md
+++ b/docs/reference/sql-openapi/ignore.md
@@ -18,7 +18,24 @@ To ignore individual fields:
 app.register(require('@platformatic/sql-openapi'), {
   ignore: {
     categories: {
-      name: true
+      fields: {
+        name: true
+      }
+    }
+  }
+})
+```
+
+To ignore individual routes: 
+
+```javascript
+app.register(require('@platformatic/sql-openapi'), {
+  ignore: {
+    categories: {
+      routes: {
+        GET: ['/categories/'],
+        POST: ['/categories/:id']
+      }
     }
   }
 })

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -90,7 +90,27 @@ const core = {
             type: 'object',
             // TODO add support for column-level ignore
             additionalProperties: {
-              type: 'boolean'
+              oneOf: [{
+                type: 'boolean'
+              }, {
+                type: 'object',
+                properties: {
+                  routes: {
+                    type: 'object',
+                    additionalProperties: {
+                      type: 'array',
+                      items: { type: 'string' }
+                    }
+                  },
+                  fields: {
+                    type: 'object',
+                    additionalProperties: {
+                      type: 'boolean'
+                    }
+                  },
+                  additionalProperties: false
+                }
+              }]
             }
           }
         },

--- a/packages/sql-openapi/index.js
+++ b/packages/sql-openapi/index.js
@@ -41,7 +41,8 @@ async function setupOpenAPI (app, opts) {
   })
 
   for (const entity of Object.values(app.platformatic.entities)) {
-    const entitySchema = mapSQLEntityToJSONSchema(entity, ignore[entity.pluralName])
+    const ignoredFields = ignore[entity.pluralName]?.fields
+    const entitySchema = mapSQLEntityToJSONSchema(entity, ignoredFields)
     // TODO remove reverseRelationships from the entity
     /* istanbul ignore next */
     entity.reverseRelationships = entity.reverseRelationships || []

--- a/packages/sql-openapi/index.js
+++ b/packages/sql-openapi/index.js
@@ -79,7 +79,7 @@ async function setupOpenAPI (app, opts) {
       app.register(manyToMany, {
         entity,
         prefix: localPrefix,
-        ignore
+        ignore: ignore[entity.pluralName] || {}
       })
     }
   }

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -39,150 +39,156 @@ function generateArgs (entity, ignore) {
 
 module.exports.generateArgs = generateArgs
 
-function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, entitySchema, fields) {
-  app.get('/', {
-    schema: {
-      operationId: 'get' + capitalize(entity.pluralName),
-      querystring: {
-        type: 'object',
-        properties: {
-          limit: { type: 'integer', description: 'Limit will be applied by default if not passed. If the provided value exceeds the maximum allowed value a validation error will be thrown' },
-          offset: { type: 'integer' },
-          totalCount: { type: 'boolean', default: false },
-          fields,
-          ...whereArgs,
-          ...orderByArgs
+function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, entitySchema, fields, ignoredRoutes) {
+  if (!ignoredRoutes.GET?.includes(app.prefix + '/')) {
+    app.get('/', {
+      schema: {
+        operationId: 'get' + capitalize(entity.pluralName),
+        querystring: {
+          type: 'object',
+          properties: {
+            limit: { type: 'integer', description: 'Limit will be applied by default if not passed. If the provided value exceeds the maximum allowed value a validation error will be thrown' },
+            offset: { type: 'integer' },
+            totalCount: { type: 'boolean', default: false },
+            fields,
+            ...whereArgs,
+            ...orderByArgs
+          },
+          additionalProperties: false
         },
-        additionalProperties: false
-      },
-      response: {
-        200: {
-          type: 'array',
-          items: entitySchema
-        }
-      }
-    }
-  }, async function (request, reply) {
-    const query = request.query
-    const { limit, offset, fields } = query
-    const queryKeys = Object.keys(query)
-    const where = {}
-    const orderBy = []
-
-    for (let i = 0; i < queryKeys.length; i++) {
-      const key = queryKeys[i]
-
-      if (key.startsWith('where.')) {
-        const [, field, modifier] = key.split('.')
-        where[field] ||= {}
-        let value = query[key]
-        if (modifier === 'in' || modifier === 'nin') {
-          // TODO handle escaping of ,
-          value = query[key].split(',')
-          if (mapSQLTypeToOpenAPIType(entity.fields[field].sqlType) === 'integer') {
-            value = value.map((v) => parseInt(v))
+        response: {
+          200: {
+            type: 'array',
+            items: entitySchema
           }
         }
-        where[field][modifier] = value
-      } else if (key.startsWith('orderby.')) {
-        const [, field] = key.split('.')
-        orderBy[field] ||= {}
-        orderBy.push({ field, direction: query[key] })
       }
-    }
-
-    const ctx = { app: this, reply }
-    const res = await entity.find({ limit, offset, fields, orderBy, where, ctx })
-
-    // X-Total-Count header
-    if (query.totalCount) {
-      let totalCount
-      if ((((offset ?? 0) === 0) || (res.length > 0)) && ((limit !== undefined) && (res.length < limit))) {
-        totalCount = (offset ?? 0) + res.length
-      } else {
-        totalCount = await entity.count({ where, ctx })
-      }
-      reply.header('X-Total-Count', totalCount)
-    }
-
-    return res
-  })
-
-  app.post('/', {
-    schema: {
-      body: entitySchema,
-      response: {
-        200: entitySchema
-      }
-    },
-    links: {
-      200: entityLinks
-    }
-  }, async function (request, reply) {
-    const ctx = { app: this, reply }
-    const res = await entity.save({ input: request.body, ctx })
-    reply.header('location', `${app.prefix}/${res.id}`)
-    return res
-  })
-
-  app.put('/', {
-    schema: {
-      body: entitySchema,
-      querystring: {
-        type: 'object',
-        properties: {
-          fields,
-          ...whereArgs
-        },
-        additionalProperties: false
-      },
-      response: {
-        200: {
-          type: 'array',
-          items: entitySchema
-        }
-      }
-    },
-    links: {
-      200: entityLinks
-    },
-    async handler (request, reply) {
-      const ctx = { app: this, reply }
+    }, async function (request, reply) {
       const query = request.query
+      const { limit, offset, fields } = query
       const queryKeys = Object.keys(query)
       const where = {}
+      const orderBy = []
 
       for (let i = 0; i < queryKeys.length; i++) {
         const key = queryKeys[i]
+
         if (key.startsWith('where.')) {
           const [, field, modifier] = key.split('.')
           where[field] ||= {}
           let value = query[key]
           if (modifier === 'in' || modifier === 'nin') {
-            // TODO handle escaping of ,
+          // TODO handle escaping of ,
             value = query[key].split(',')
             if (mapSQLTypeToOpenAPIType(entity.fields[field].sqlType) === 'integer') {
               value = value.map((v) => parseInt(v))
             }
           }
           where[field][modifier] = value
+        } else if (key.startsWith('orderby.')) {
+          const [, field] = key.split('.')
+          orderBy[field] ||= {}
+          orderBy.push({ field, direction: query[key] })
         }
       }
 
-      const res = await entity.updateMany({
-        input: {
-          ...request.body
-        },
-        where,
-        fields: request.query.fields,
-        ctx
-      })
-      // TODO: Should find a way to test this line
-      // if (!res) return reply.callNotFound()
-      reply.header('location', `${app.prefix}`)
+      const ctx = { app: this, reply }
+      const res = await entity.find({ limit, offset, fields, orderBy, where, ctx })
+
+      // X-Total-Count header
+      if (query.totalCount) {
+        let totalCount
+        if ((((offset ?? 0) === 0) || (res.length > 0)) && ((limit !== undefined) && (res.length < limit))) {
+          totalCount = (offset ?? 0) + res.length
+        } else {
+          totalCount = await entity.count({ where, ctx })
+        }
+        reply.header('X-Total-Count', totalCount)
+      }
+
       return res
-    }
-  })
+    })
+  }
+
+  if (!ignoredRoutes.POST?.includes(app.prefix + '/')) {
+    app.post('/', {
+      schema: {
+        body: entitySchema,
+        response: {
+          200: entitySchema
+        }
+      },
+      links: {
+        200: entityLinks
+      }
+    }, async function (request, reply) {
+      const ctx = { app: this, reply }
+      const res = await entity.save({ input: request.body, ctx })
+      reply.header('location', `${app.prefix}/${res.id}`)
+      return res
+    })
+  }
+
+  if (!ignoredRoutes.PUT?.includes(app.prefix + '/')) {
+    app.put('/', {
+      schema: {
+        body: entitySchema,
+        querystring: {
+          type: 'object',
+          properties: {
+            fields,
+            ...whereArgs
+          },
+          additionalProperties: false
+        },
+        response: {
+          200: {
+            type: 'array',
+            items: entitySchema
+          }
+        }
+      },
+      links: {
+        200: entityLinks
+      },
+      async handler (request, reply) {
+        const ctx = { app: this, reply }
+        const query = request.query
+        const queryKeys = Object.keys(query)
+        const where = {}
+
+        for (let i = 0; i < queryKeys.length; i++) {
+          const key = queryKeys[i]
+          if (key.startsWith('where.')) {
+            const [, field, modifier] = key.split('.')
+            where[field] ||= {}
+            let value = query[key]
+            if (modifier === 'in' || modifier === 'nin') {
+            // TODO handle escaping of ,
+              value = query[key].split(',')
+              if (mapSQLTypeToOpenAPIType(entity.fields[field].sqlType) === 'integer') {
+                value = value.map((v) => parseInt(v))
+              }
+            }
+            where[field][modifier] = value
+          }
+        }
+
+        const res = await entity.updateMany({
+          input: {
+            ...request.body
+          },
+          where,
+          fields: request.query.fields,
+          ctx
+        })
+        // TODO: Should find a way to test this line
+        // if (!res) return reply.callNotFound()
+        reply.header('location', `${app.prefix}`)
+        return res
+      }
+    })
+  }
 }
 
 module.exports.rootEntityRoutes = rootEntityRoutes

--- a/packages/sql-openapi/test/helper.js
+++ b/packages/sql-openapi/test/helper.js
@@ -37,6 +37,16 @@ module.exports.clear = async function (db, sql) {
   }
 
   try {
+    await db.query(sql`DROP TABLE pages_tags`)
+  } catch {
+  }
+
+  try {
+    await db.query(sql`DROP TABLE tags`)
+  } catch {
+  }
+
+  try {
     await db.query(sql`DROP TABLE pages`)
   } catch (err) {
   }

--- a/packages/sql-openapi/test/ignore-routes.test.js
+++ b/packages/sql-openapi/test/ignore-routes.test.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const fastify = require('fastify')
 const sqlOpenAPI = require('..')
 const sqlMapper = require('@platformatic/sql-mapper')
-const { clear, connInfo, isSQLite } = require('./helper')
+const { clear, connInfo, isSQLite, isMysql, isMariaDB } = require('./helper')
 
 async function createBasicPages (db, sql) {
   if (isSQLite) {
@@ -18,16 +18,34 @@ async function createBasicPages (db, sql) {
       category_id INTEGER,
       CONSTRAINT category_fk FOREIGN KEY (category_id) REFERENCES categories (id)
     );`)
+    await db.query(sql`CREATE TABLE tags (
+      id INTEGER PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+    await db.query(sql`CREATE TABLE pages_tags (
+      page_id INTEGER REFERENCES pages (id),
+      tag_id INTEGER REFERENCES tags (id),
+      PRIMARY KEY (page_id, tag_id)
+    );`)
   } else {
     await db.query(sql`CREATE TABLE categories (
-      id SERIAL PRIMARY KEY,
+      id INTEGER PRIMARY KEY,
       name VARCHAR(42)
     );`)
     await db.query(sql`CREATE TABLE pages (
-      id SERIAL PRIMARY KEY,
+      id INTEGER PRIMARY KEY,
       title VARCHAR(42),
       category_id INTEGER,
-      CONSTRAINT category_fk FOREIGN KEY (category_id) REFERENCES categories (id)
+      FOREIGN KEY (category_id) REFERENCES categories(id)
+    );`)
+    await db.query(sql`CREATE TABLE tags (
+      id INTEGER PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+    await db.query(sql`CREATE TABLE pages_tags (
+      page_id INTEGER REFERENCES pages (id),
+      tag_id INTEGER REFERENCES tags (id),
+      PRIMARY KEY (page_id, tag_id)
     );`)
   }
 }
@@ -101,9 +119,71 @@ test('ignore entity GET route', async ({ pass, teardown, equal, ok }) => {
   const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
 
   ok(rootEntityMethods.includes('get'), 'GET /pages/ is not ignored')
-  ok(!entityMethods.includes('get'), true, 'GET /pages/{id} is ignored')
+  ok(!entityMethods.includes('get'), 'GET /pages/{id} is ignored')
 
   ok(openApiDocs.paths['/pages/{id}/category'], 'GET /pages/{id}/category is not ignored')
+})
+
+test('ignore entity references routes', async ({ pass, teardown, equal, ok }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+
+  // TODO: remove after fixing mysql many-to-many
+  const manyToManyURL = (isMysql && !isMariaDB)
+    ? '/pagesTags/pageId/:pageId/tagId/:tagId'
+    : '/pagesTags/page/:pageId/tag/:tagId'
+
+  app.register(sqlOpenAPI, {
+    ignore: {
+      pagesTags: {
+        routes: {
+          POST: ['/pagesTags/'],
+          GET: [manyToManyURL],
+          PUT: [manyToManyURL],
+          DELETE: [manyToManyURL]
+        }
+      },
+      categories: {
+        routes: {
+          GET: ['/categories/:id/pages']
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const { statusCode, body } = await app.inject({ method: 'GET', url: '/documentation/json' })
+  equal(statusCode, 200, 'GET /documentation/json status code')
+
+  const openApiDocs = JSON.parse(body)
+
+  // TODO: remove after fixing mysql many-to-many
+  const manyToManySwaggerURL = (isMysql && !isMariaDB)
+    ? '/pagesTags/pageId/{pageId}/tagId/{tagId}'
+    : '/pagesTags/page/{pageId}/tag/{tagId}'
+
+  const rootEntityMethods = Object.keys(openApiDocs.paths['/pagesTags/'])
+  const entityMethods = Object.keys(openApiDocs.paths[manyToManySwaggerURL])
+
+  ok(rootEntityMethods.includes('get'), 'GET /pagesTags/ is not ignored')
+  ok(!rootEntityMethods.includes('post'), 'POST /pagesTags/ is ignored')
+
+  ok(entityMethods.includes('post'), 'POST /pagesTags/page/{pageId/tag/{tagId} is not ignored')
+  ok(!entityMethods.includes('get'), 'GET /pagesTags/page/{pageId/tag/{tagId} is ignored')
+  ok(!entityMethods.includes('put'), 'PUT /pagesTags/page/{pageId/tag/{tagId} is ignored')
+  ok(!entityMethods.includes('delete'), 'DELETE /pagesTags/page/{pageId/tag/{tagId} is ignored')
+
+  ok(!openApiDocs.paths['/categories/:id/pages'], 'GET /categories/:id/pages is ignored')
 })
 
 test('ignore all GET routes', async ({ pass, teardown, equal, ok }) => {
@@ -137,13 +217,13 @@ test('ignore all GET routes', async ({ pass, teardown, equal, ok }) => {
   const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
   const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
 
-  equal(rootEntityMethods.includes('get'), false, 'GET /pages/ is ignored')
-  equal(entityMethods.includes('get'), false, 'GET /pages/{id} is ignored')
+  ok(!rootEntityMethods.includes('get'), 'GET /pages/ is ignored')
+  ok(!entityMethods.includes('get'), 'GET /pages/{id} is ignored')
 
-  equal(openApiDocs.paths['/pages/{id}/category'], undefined, 'GET /pages/{id}/category is ignored')
+  ok(!openApiDocs.paths['/pages/{id}/category'], 'GET /pages/{id}/category is ignored')
 })
 
-test('ignore POST methods', async ({ pass, teardown, equal }) => {
+test('ignore POST methods', async ({ pass, teardown, equal, ok }) => {
   const app = fastify()
   app.register(sqlMapper, {
     ...connInfo,
@@ -174,11 +254,11 @@ test('ignore POST methods', async ({ pass, teardown, equal }) => {
   const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
   const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
 
-  equal(rootEntityMethods.includes('post'), false, 'POST /pages/ is ignored')
-  equal(entityMethods.includes('post'), false, 'POST /pages/{id} is ignored')
+  ok(!rootEntityMethods.includes('post'), 'POST /pages/ is ignored')
+  ok(!entityMethods.includes('post'), 'POST /pages/{id} is ignored')
 })
 
-test('ignore PUT methods', async ({ pass, teardown, equal }) => {
+test('ignore PUT methods', async ({ pass, teardown, equal, ok }) => {
   const app = fastify()
   app.register(sqlMapper, {
     ...connInfo,
@@ -209,11 +289,11 @@ test('ignore PUT methods', async ({ pass, teardown, equal }) => {
   const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
   const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
 
-  equal(rootEntityMethods.includes('put'), false, 'PUT /pages/ is ignored')
-  equal(entityMethods.includes('put'), false, 'PUT /pages/{id} is ignored')
+  ok(!rootEntityMethods.includes('put'), 'PUT /pages/ is ignored')
+  ok(!entityMethods.includes('put'), 'PUT /pages/{id} is ignored')
 })
 
-test('ignore DELETE methods', async ({ pass, teardown, equal }) => {
+test('ignore DELETE methods', async ({ pass, teardown, equal, ok }) => {
   const app = fastify()
   app.register(sqlMapper, {
     ...connInfo,
@@ -242,5 +322,5 @@ test('ignore DELETE methods', async ({ pass, teardown, equal }) => {
 
   const openApiDocs = JSON.parse(body)
   const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
-  equal(entityMethods.includes('delete'), false, 'DELETE /pages/{id} is ignored')
+  ok(!entityMethods.includes('delete'), 'DELETE /pages/{id} is ignored')
 })

--- a/packages/sql-openapi/test/ignore-routes.test.js
+++ b/packages/sql-openapi/test/ignore-routes.test.js
@@ -1,0 +1,246 @@
+'use strict'
+
+const { test } = require('tap')
+const fastify = require('fastify')
+const sqlOpenAPI = require('..')
+const sqlMapper = require('@platformatic/sql-mapper')
+const { clear, connInfo, isSQLite } = require('./helper')
+
+async function createBasicPages (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE categories (
+      id INTEGER PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+    await db.query(sql`CREATE TABLE pages (
+      id INTEGER PRIMARY KEY,
+      title VARCHAR(42),
+      category_id INTEGER,
+      CONSTRAINT category_fk FOREIGN KEY (category_id) REFERENCES categories (id)
+    );`)
+  } else {
+    await db.query(sql`CREATE TABLE categories (
+      id SERIAL PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+    await db.query(sql`CREATE TABLE pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(42),
+      category_id INTEGER,
+      CONSTRAINT category_fk FOREIGN KEY (category_id) REFERENCES categories (id)
+    );`)
+  }
+}
+
+test('ignore root GET route', async ({ pass, teardown, equal, ok }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      pages: {
+        routes: {
+          GET: ['/pages/']
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const { statusCode, body } = await app.inject({ method: 'GET', url: '/documentation/json' })
+  equal(statusCode, 200, 'GET /documentation/json status code')
+
+  const openApiDocs = JSON.parse(body)
+  const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
+  const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
+
+  ok(!rootEntityMethods.includes('get'), 'GET /pages/ is ignored')
+  ok(entityMethods.includes('get'), true, 'GET /pages/{id} is not ignored')
+
+  ok(openApiDocs.paths['/pages/{id}/category'], 'GET /pages/{id}/category is not ignored')
+})
+
+test('ignore entity GET route', async ({ pass, teardown, equal, ok }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      pages: {
+        routes: {
+          GET: ['/pages/:id']
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const { statusCode, body } = await app.inject({ method: 'GET', url: '/documentation/json' })
+  equal(statusCode, 200, 'GET /documentation/json status code')
+
+  const openApiDocs = JSON.parse(body)
+  const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
+  const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
+
+  ok(rootEntityMethods.includes('get'), 'GET /pages/ is not ignored')
+  ok(!entityMethods.includes('get'), true, 'GET /pages/{id} is ignored')
+
+  ok(openApiDocs.paths['/pages/{id}/category'], 'GET /pages/{id}/category is not ignored')
+})
+
+test('ignore all GET routes', async ({ pass, teardown, equal, ok }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      pages: {
+        routes: {
+          GET: ['/pages/', '/pages/:id', '/pages/:id/category']
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const { statusCode, body } = await app.inject({ method: 'GET', url: '/documentation/json' })
+  equal(statusCode, 200, 'GET /documentation/json status code')
+
+  const openApiDocs = JSON.parse(body)
+  const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
+  const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
+
+  equal(rootEntityMethods.includes('get'), false, 'GET /pages/ is ignored')
+  equal(entityMethods.includes('get'), false, 'GET /pages/{id} is ignored')
+
+  equal(openApiDocs.paths['/pages/{id}/category'], undefined, 'GET /pages/{id}/category is ignored')
+})
+
+test('ignore POST methods', async ({ pass, teardown, equal }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      pages: {
+        routes: {
+          POST: ['/pages/', '/pages/:id']
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const { statusCode, body } = await app.inject({ method: 'GET', url: '/documentation/json' })
+  equal(statusCode, 200, 'GET /documentation/json status code')
+
+  const openApiDocs = JSON.parse(body)
+  const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
+  const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
+
+  equal(rootEntityMethods.includes('post'), false, 'POST /pages/ is ignored')
+  equal(entityMethods.includes('post'), false, 'POST /pages/{id} is ignored')
+})
+
+test('ignore PUT methods', async ({ pass, teardown, equal }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      pages: {
+        routes: {
+          PUT: ['/pages/', '/pages/:id']
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const { statusCode, body } = await app.inject({ method: 'GET', url: '/documentation/json' })
+  equal(statusCode, 200, 'GET /documentation/json status code')
+
+  const openApiDocs = JSON.parse(body)
+  const rootEntityMethods = Object.keys(openApiDocs.paths['/pages/'])
+  const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
+
+  equal(rootEntityMethods.includes('put'), false, 'PUT /pages/ is ignored')
+  equal(entityMethods.includes('put'), false, 'PUT /pages/{id} is ignored')
+})
+
+test('ignore DELETE methods', async ({ pass, teardown, equal }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      pages: {
+        routes: {
+          DELETE: ['/pages/:id']
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const { statusCode, body } = await app.inject({ method: 'GET', url: '/documentation/json' })
+  equal(statusCode, 200, 'GET /documentation/json status code')
+
+  const openApiDocs = JSON.parse(body)
+  const entityMethods = Object.keys(openApiDocs.paths['/pages/{id}'])
+  equal(entityMethods.includes('delete'), false, 'DELETE /pages/{id} is ignored')
+})

--- a/packages/sql-openapi/test/ignore.test.js
+++ b/packages/sql-openapi/test/ignore.test.js
@@ -145,7 +145,9 @@ test('ignore a column in OpenAPI', async ({ pass, teardown, equal, same }) => {
   app.register(sqlOpenAPI, {
     ignore: {
       categories: {
-        name: true
+        fields: {
+          name: true
+        }
       }
     }
   })


### PR DESCRIPTION
Close #673

This PR is not ready. I want to discuss the params format. Ignoring the HTTP method is too powerful because we have more than one route for each HTTP method. We should be able to ignore routes.

Example: 
```js
app.register(require('@platformatic/sql-openapi'), {
  ignore: {
    categories: {
       fields: ['name'],
       routes: {
         'GET': ['/categories', '/categories/:id', '/categories/:id/relation'],
         'POST': ['/categories/:id']
       }
     }
  }
})
```

cc @mcollina @marcopiraccini @simonplend 