### PR TITLE
Add typescript templates create-platformatic-service in CLI

### DIFF
--- a/packages/create-platformatic/src/cli-options.mjs
+++ b/packages/create-platformatic/src/cli-options.mjs
@@ -1,0 +1,20 @@
+export const getRunPackageManagerInstall = pkgManager => {
+  return {
+    type: 'list',
+    name: 'runPackageManagerInstall',
+    message: `Do you want to run ${pkgManager} install?`,
+    default: true,
+    choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
+  }
+}
+
+export const getUseTypescript = typescript => {
+  return {
+    type: 'list',
+    when: !typescript,
+    name: 'useTypescript',
+    message: 'Do you want to use TypeScript?',
+    default: typescript,
+    choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
+  }
+}

--- a/packages/create-platformatic/src/create-package-json.mjs
+++ b/packages/create-platformatic/src/create-package-json.mjs
@@ -7,7 +7,7 @@ const packageJsonTemplate = (addTSBuild = false) => (`\
 {
   "scripts": {
     ${addTSBuild
-? ` "start": "yarn clean && platformatic {type} start",
+? `"start": "yarn clean && platformatic {type} start",
     "clean": "rm -fr ./dist",
     "build": "npx tsc"`
 : '"start": "platformatic {type} start"'}

--- a/packages/create-platformatic/src/create-package-json.mjs
+++ b/packages/create-platformatic/src/create-package-json.mjs
@@ -7,7 +7,7 @@ const packageJsonTemplate = (addTSBuild = false) => (`\
 {
   "scripts": {
     ${addTSBuild
-? `"start": "yarn clean && platformatic {type} start",
+? `"start": "npm run clean && platformatic {type} start",
     "clean": "rm -fr ./dist",
     "build": "npx tsc"`
 : '"start": "platformatic {type} start"'}

--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -13,6 +13,7 @@ import ora from 'ora'
 import createDB from './create-db.mjs'
 import askProjectDir from '../ask-project-dir.mjs'
 import { askCreateGHAction } from '../ghaction.mjs'
+import { getRunPackageManagerInstall, getUseTypescript } from '../cli-options.mjs'
 import mkdirp from 'mkdirp'
 
 export const createReadme = async (logger, dir = '.') => {
@@ -75,14 +76,9 @@ const createPlatformaticDB = async (_args) => {
     message: 'Do you want to create a plugin?',
     default: args.plugin,
     choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-  }, {
-    type: 'list',
-    when: !args.typescript,
-    name: 'useTypescript',
-    message: 'Do you want to use TypeScript?',
-    default: args.typescript,
-    choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-  }])
+  },
+  getUseTypescript(args.typescript)
+  ])
 
   // Create the project directory
   await mkdirp(projectDir)
@@ -110,13 +106,9 @@ const createPlatformaticDB = async (_args) => {
   await createGitignore(logger, projectDir)
   await createReadme(logger, projectDir)
 
-  const { runPackageManagerInstall } = await inquirer.prompt([{
-    type: 'list',
-    name: 'runPackageManagerInstall',
-    message: `Do you want to run ${pkgManager} install?`,
-    default: true,
-    choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-  }])
+  const { runPackageManagerInstall } = await inquirer.prompt([
+    getRunPackageManagerInstall(pkgManager)
+  ])
 
   if (runPackageManagerInstall) {
     const spinner = ora('Installing dependencies...').start()

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -14,6 +14,7 @@ import ora from 'ora'
 import createService from './create-service.mjs'
 import askProjectDir from '../ask-project-dir.mjs'
 import { askCreateGHAction } from '../ghaction.mjs'
+import { getRunPackageManagerInstall, getUseTypescript } from '../cli-options.mjs'
 import mkdirp from 'mkdirp'
 
 export const createReadme = async (logger, dir = '.') => {
@@ -51,20 +52,10 @@ const createPlatformaticService = async (_args) => {
 
   const projectDir = await askProjectDir(logger, '.')
 
-  const { runPackageManagerInstall, useTypescript } = await inquirer.prompt([{
-    type: 'list',
-    name: 'runPackageManagerInstall',
-    message: `Do you want to run ${pkgManager} install?`,
-    default: true,
-    choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-  }, {
-    type: 'list',
-    when: !args.typescript,
-    name: 'useTypescript',
-    message: 'Do you want to use TypeScript?',
-    default: args.typescript,
-    choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-  }])
+  const { runPackageManagerInstall, useTypescript } = await inquirer.prompt([
+    getRunPackageManagerInstall(pkgManager),
+    getUseTypescript(args.typescript)
+  ])
 
   // Create the project directory
   await mkdirp(projectDir)

--- a/packages/create-platformatic/src/service/create-service.mjs
+++ b/packages/create-platformatic/src/service/create-service.mjs
@@ -51,7 +51,7 @@ module.exports = async function (fastify, opts) {
 }
 `
 
-async function createService ({ hostname, port }, logger, currentDir = process.cwd(), version) {
+async function createService ({ hostname, port, typescript = false }, logger, currentDir = process.cwd(), version) {
   const accessibleConfigFilename = await findServiceConfigFile(currentDir)
 
   if (accessibleConfigFilename === undefined) {

--- a/packages/create-platformatic/src/service/create-service.mjs
+++ b/packages/create-platformatic/src/service/create-service.mjs
@@ -41,7 +41,15 @@ module.exports = async function (fastify, opts) {
 module.exports[Symbol.for('skip-override')] = true
 `
 
-const ROUTES_WITH_TYPES_SUPPORT = `\
+const TS_PLUGIN_WITH_TYPES_SUPPORT = `\
+import { FastifyInstance, FastifyPluginOptions } from 'fastify'
+
+export default async function (fastify: FastifyInstance, opts: FastifyPluginOptions) {
+  fastify.decorate('example', 'foobar')
+}
+`
+
+const JS_ROUTES_WITH_TYPES_SUPPORT = `\
 'use strict'
 /** @param {import('fastify').FastifyInstance} fastify */
 module.exports = async function (fastify, opts) {
@@ -50,6 +58,46 @@ module.exports = async function (fastify, opts) {
   })
 }
 `
+
+const TS_ROUTES_WITH_TYPES_SUPPORT = `\
+import { FastifyInstance, FastifyPluginOptions } from 'fastify'
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    example: string
+  }
+}
+
+export default async function (fastify: FastifyInstance, opts: FastifyPluginOptions) {
+  fastify.get('/', async (request, reply) => {
+    return { hello: fastify.example }
+  })
+}
+`
+
+async function generatePluginWithTypesSupport (logger, currentDir, isTypescript) {
+  await mkdir(join(currentDir, 'plugins'))
+  const pluginTemplate = isTypescript
+    ? TS_PLUGIN_WITH_TYPES_SUPPORT
+    : JS_PLUGIN_WITH_TYPES_SUPPORT
+  const pluginName = isTypescript
+    ? 'example.ts'
+    : 'example.js'
+  await writeFile(join(currentDir, 'plugins', pluginName), pluginTemplate)
+  logger.info('Plugins folder "plugins" successfully created.')
+}
+
+async function generateRouteWithTypesSupport (logger, currentDir, isTypescript) {
+  await mkdir(join(currentDir, 'routes'))
+  const routesTemplate = isTypescript
+    ? TS_ROUTES_WITH_TYPES_SUPPORT
+    : JS_ROUTES_WITH_TYPES_SUPPORT
+  const routesName = isTypescript
+    ? 'root.ts'
+    : 'root.js'
+  await writeFile(join(currentDir, 'routes', routesName), routesTemplate)
+  logger.info('Routes folder "routes" successfully created.')
+}
 
 async function createService ({ hostname, port, typescript = false }, logger, currentDir = process.cwd(), version) {
   const accessibleConfigFilename = await findServiceConfigFile(currentDir)
@@ -69,18 +117,14 @@ async function createService ({ hostname, port, typescript = false }, logger, cu
 
   const pluginFolderExists = await isFileAccessible('plugins', currentDir)
   if (!pluginFolderExists) {
-    await mkdir(join(currentDir, 'plugins'))
-    await writeFile(join(currentDir, 'plugins', 'example.js'), JS_PLUGIN_WITH_TYPES_SUPPORT)
-    logger.info('Plugins folder "plugins" successfully created.')
+    await generatePluginWithTypesSupport(logger, currentDir, typescript)
   } else {
     logger.info('Plugins folder "plugins" found, skipping creation of plugins folder.')
   }
 
   const routeFolderExists = await isFileAccessible('routes', currentDir)
   if (!routeFolderExists) {
-    await mkdir(join(currentDir, 'routes'))
-    await writeFile(join(currentDir, 'routes', 'root.js'), ROUTES_WITH_TYPES_SUPPORT)
-    logger.info('Routes folder "routes" successfully created.')
+    await generateRouteWithTypesSupport(logger, currentDir, typescript)
   } else {
     logger.info('Routes folder "routes" found, skipping creation of routes folder.')
   }

--- a/packages/create-platformatic/test/cli-options.test.mjs
+++ b/packages/create-platformatic/test/cli-options.test.mjs
@@ -1,0 +1,29 @@
+import { test } from 'tap'
+import { getRunPackageManagerInstall, getUseTypescript } from '../src/cli-options.mjs'
+
+test('getRunPackageManagerInstall', async ({ same }) => {
+  same(
+    getRunPackageManagerInstall('npm'),
+    {
+      type: 'list',
+      name: 'runPackageManagerInstall',
+      message: 'Do you want to run npm install?',
+      default: true,
+      choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
+    }
+  )
+})
+
+test('getUseTypescript', async ({ same }) => {
+  same(
+    getUseTypescript(true),
+    {
+      type: 'list',
+      when: false,
+      name: 'useTypescript',
+      message: 'Do you want to use TypeScript?',
+      default: true,
+      choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
+    }
+  )
+})

--- a/packages/create-platformatic/test/service/create-service.test.mjs
+++ b/packages/create-platformatic/test/service/create-service.test.mjs
@@ -23,7 +23,40 @@ const fakeLogger = {
   info: msg => log.push(msg)
 }
 
-test('creates service with no typescript', async ({ end, equal, same, ok }) => {
+test('creates service with typescript', async ({ equal, same, ok }) => {
+  const params = {
+    hostname: 'myhost',
+    port: 6666,
+    typescript: true
+  }
+
+  await createService(params, fakeLogger, tmpDir)
+
+  const pathToServiceConfigFile = join(tmpDir, 'platformatic.service.json')
+  const serviceConfigFile = readFileSync(pathToServiceConfigFile, 'utf8')
+  const serviceConfig = JSON.parse(serviceConfigFile)
+  const { server, plugin } = serviceConfig
+
+  equal(server.hostname, '{PLT_SERVER_HOSTNAME}')
+  equal(server.port, '{PORT}')
+
+  const pathToDbEnvFile = join(tmpDir, '.env')
+  dotenv.config({ path: pathToDbEnvFile })
+  equal(process.env.PLT_SERVER_HOSTNAME, 'myhost')
+  equal(process.env.PORT, '6666')
+  process.env = {}
+
+  const pathToDbEnvSampleFile = join(tmpDir, '.env.sample')
+  dotenv.config({ path: pathToDbEnvSampleFile })
+  equal(process.env.PLT_SERVER_HOSTNAME, 'myhost')
+  equal(process.env.PORT, '6666')
+
+  same(plugin, ['./plugins', './routes'])
+  ok(await isFileAccessible(join(tmpDir, 'plugins', 'example.ts')))
+  ok(await isFileAccessible(join(tmpDir, 'routes', 'root.ts')))
+})
+
+test('creates service with javascript', async ({ equal, same, ok }) => {
   const params = {
     hostname: 'myhost',
     port: 6666,
@@ -52,11 +85,11 @@ test('creates service with no typescript', async ({ end, equal, same, ok }) => {
   equal(process.env.PORT, '6666')
 
   same(plugin, ['./plugins', './routes'])
-  ok(isFileAccessible(join(tmpDir, 'plugins', 'examples.js')))
-  ok(isFileAccessible(join(tmpDir, 'routes', 'root.js')))
+  ok(await isFileAccessible(join(tmpDir, 'plugins', 'example.js')))
+  ok(await isFileAccessible(join(tmpDir, 'routes', 'root.js')))
 })
 
-test('creates project with configuration already present', async ({ end, equal, ok }) => {
+test('creates project with configuration already present', async ({ ok }) => {
   const pathToServiceConfigFileOld = join(tmpDir, 'platformatic.service.json')
   writeFileSync(pathToServiceConfigFileOld, JSON.stringify({ test: 'test' }))
   const params = {


### PR DESCRIPTION
Issue #628

This is a PR for adding typescript templates in create-platformatic-service CLI. CLI generates these templates if the user selects the TS option. I'm especially appreciated that if someone reviews it's the correct way to use TS with Fastify.

```typescript
const TS_PLUGIN_WITH_TYPES_SUPPORT = `\
import { FastifyInstance, FastifyPluginOptions } from 'fastify'
export default async function (fastify: FastifyInstance, opts: FastifyPluginOptions) {
  fastify.decorate('example', 'foobar')
}
`

const TS_ROUTES_WITH_TYPES_SUPPORT = `\
import { FastifyInstance, FastifyPluginOptions } from 'fastify'
declare module 'fastify' {
  interface FastifyInstance {
    example: string
  }
}
export default async function (fastify: FastifyInstance, opts: FastifyPluginOptions) {
  fastify.get('/', async (request, reply) => {
    return { hello: fastify.example }
  })
}
`
```