### PR TITLE
Fix logo in README for npm

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-![The Platformatic logo](../../assets/banner-light.png 'The Platformatic logo')
+![The Platformatic logo](https://github.com/platformatic/platformatic/raw/HEAD/assets/banner-light.png 'The Platformatic logo')
 
 <p align="center">
   <br/>


### PR DESCRIPTION
The logo image URL in the README needs to be absolute for it to render correctly on npm. This will fix the broken image that's currently displaying on https://www.npmjs.com/package/platformatic.

![image](https://user-images.githubusercontent.com/2773428/224130094-0c80464f-5ddc-4f9e-841d-18f394b4695b.png)
