### PR TITLE
fix(tests): TypeScript config error

### DIFF
--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -60,7 +60,7 @@ async function platformaticService (app, opts, toLoad = []) {
 
   if (opts.plugins) {
     // if we don't have a fullPath, let's assume we are in a test and we can use the current working directory
-    const configPath = app.platformatic.configManager.fullPath || process.cwd()
+    const configPath = app.platformatic.configManager.fullPath || join(process.cwd(), 'platformatic.db.json')
     const tsConfigPath = join(dirname(configPath), 'tsconfig.json')
     /* c8 ignore next 21 */
     if (await isFileAccessible(tsConfigPath)) {

--- a/packages/service/test/cli/compile.test.mjs
+++ b/packages/service/test/cli/compile.test.mjs
@@ -253,3 +253,18 @@ t.test('should compile typescript plugin with start command with different cwd',
   }
   t.fail('should compile typescript plugin with start command')
 })
+
+t.test('valid tsconfig file inside an inner folder', async (t) => {
+  const testDir = path.join(urlDirname(import.meta.url), '..', 'fixtures', 'typescript-plugin')
+  const cwd = path.join(urlDirname(import.meta.url), '..', 'tmp', 'typescript-plugin-clone-7/inner-folder')
+
+  await cp(testDir, cwd, { recursive: true })
+
+  try {
+    await execa('node', [cliPath, 'compile'], { cwd })
+  } catch (err) {
+    t.fail('should not catch any error')
+  }
+
+  t.pass()
+})


### PR DESCRIPTION
I've recently had issues running typescript tests with Platformatic.
In short, when running Platformatic DB inside an inner folder, the `configPath` and `tsConfigPath` were correct:
```
// $: plt db start
{
  configPath: '/Users/rozzilla/fastify-poc/platformatic.db.json',
  tsConfigPath: '/Users/rozzilla/fastify-poc/tsconfig.json'
}
```

When running inside a test, instead, those 2 paths were wrong:
```
// $: test
{
  configPath: '/Users/rozzilla/fastify-poc',
  tsConfigPath: '/Users/rozzilla/tsconfig.json'
}
```

This PR fixes it.