### PR TITLE
chore(service): Improve error message

### DIFF
--- a/packages/service/lib/load-config.js
+++ b/packages/service/lib/load-config.js
@@ -37,7 +37,12 @@ async function loadConfig (minimistConfig, _args, configOpts = {}, Manager = Con
     }
     await access(args.config)
   } catch (err) {
-    console.error('Missing config file')
+    console.error(`
+Missing config file!
+Be sure to have a config file with one of the following names: ${ourConfigFiles.join("\n")}
+In alternative run "npm create platformatic@latest" to generate a basic plt service config.
+Error: ${err}
+`)
     process.exit(1)
   }
 

--- a/packages/service/lib/load-config.js
+++ b/packages/service/lib/load-config.js
@@ -39,7 +39,7 @@ async function loadConfig (minimistConfig, _args, configOpts = {}, Manager = Con
   } catch (err) {
     console.error(`
 Missing config file!
-Be sure to have a config file with one of the following names: ${ourConfigFiles.join("\n")}
+Be sure to have a config file with one of the following names: ${ourConfigFiles.join('\n')}
 In alternative run "npm create platformatic@latest" to generate a basic plt service config.
 Error: ${err}
 `)


### PR DESCRIPTION
Related to https://github.com/platformatic/platformatic/issues/523, this PR changes the error message from `Missing config file` to:
```
Missing config file!
Be sure to have a config file with one of the following names: platformatic.service.json
platformatic.service.json5
platformatic.service.yaml
platformatic.service.yml
platformatic.service.toml
platformatic.service.tml
In alternative run "npm create platformatic@latest" to generate a basic plt service config.
Error: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
```