### PR TITLE
docs: fix typo in guide for prisma database provider init option

### DIFF
--- a/docs/guides/prisma.md
+++ b/docs/guides/prisma.md
@@ -48,7 +48,7 @@ This command does the following:
 You can specify your preferred database provider using the `--datasource-provider` flag, followed by the name of the provider: 
 
 ```bash
-npx prisma init --datasource-provider postgres # or sqlite, mysql, sqlserver, cockroachdb
+npx prisma init --datasource-provider postgresql # or sqlite, mysql, sqlserver, cockroachdb
 ```
 
 Prisma uses the `DATABASE_URL` environment variable to connect to your database to sync your database and Prisma schema. It also uses the variable to connect to your database to run your Prisma Client queries. 


### PR DESCRIPTION
# Description

This fixes a simple typo in the "Integrate Prisma with Platformatic DB" guide, see https://oss.platformatic.dev/docs/guides/prisma#setup-prisma.

When running the specified init command:

```bash
npx prisma init --datasource-provider postgres # or sqlite, mysql, sqlserver, cockroachdb
```

I get the following error:
```
Error: Provider "postgres" is invalid or not supported. Try again with "postgresql", "mysql", "sqlite", "sqlserver", "mongodb" or "cockroachdb".
```

The command should be:
```bash
npx prisma init --datasource-provider postgresql # or sqlite, mysql, sqlserver, cockroachdb
```

See init arguments on prisma docs: https://www.prisma.io/docs/reference/api-reference/command-reference#arguments