### PR TITLE
Enforce @matteo.collina/worker as a devDep in service and db to retry the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
     - name: Run test suite core
       run: cd packages/db-core && pnpm test
     - name: Run test suite Platformatic DB
-      run: cd packages/db && pnpm rebuild && pnpm test
+      run: cd packages/db && pnpm test
 
   ci-db-authorization:
     needs: setup-node_modules
@@ -352,7 +352,7 @@ jobs:
           retry_on: error
           command: pnpm install --frozen-lockfile
       - name: Run test suite
-        run: cd packages/service && pnpm rebuild && pnpm test; cd ../..
+        run: cd packages/service && pnpm test; cd ../..
 
   playwright-e2e:
     needs: setup-node_modules

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@databases/pg": "^5.4.1",
     "@databases/sqlite": "^4.0.2",
+    "@matteo.collina/worker": "^3.0.0",
     "@platformatic/sql-graphql": "workspace:*",
     "ajv": "^8.12.0",
     "bindings": "^1.5.0",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "devDependencies": {
+    "@matteo.collina/worker": "^3.0.0",
     "bindings": "^1.5.0",
     "c8": "^7.13.0",
     "snazzy": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,7 @@ importers:
       '@fastify/deepmerge': ^1.3.0
       '@fastify/static': ^6.9.0
       '@fastify/swagger': ^8.3.1
+      '@matteo.collina/worker': ^3.0.0
       '@platformatic/config': workspace:*
       '@platformatic/db-authorization': workspace:*
       '@platformatic/db-core': workspace:*
@@ -261,6 +262,7 @@ importers:
     devDependencies:
       '@databases/pg': 5.4.1
       '@databases/sqlite': 4.0.2
+      '@matteo.collina/worker': 3.0.0
       '@platformatic/sql-graphql': link:../sql-graphql
       ajv: 8.12.0
       bindings: 1.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,7 @@ importers:
       '@fastify/swagger': ^8.3.1
       '@fastify/swagger-ui': ^1.4.0
       '@fastify/under-pressure': ^8.2.0
+      '@matteo.collina/worker': ^3.0.0
       '@mercuriusjs/federation': ^1.0.1
       '@platformatic/config': workspace:*
       '@platformatic/utils': workspace:*
@@ -530,6 +531,7 @@ importers:
       rfdc: 1.3.0
       ua-parser-js: 1.0.34
     devDependencies:
+      '@matteo.collina/worker': 3.0.0
       bindings: 1.5.0
       c8: 7.13.0
       snazzy: 9.0.0
@@ -3071,8 +3073,6 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-    dev: false
-    optional: true
 
   /@mdx-js/mdx/1.6.22:
     resolution: {integrity: sha512-AMxuLxPz2j5/6TpF/XSdKpQP1NlG0z11dFOlq+2IP/lSgl11GY8ji6S/rgsViN/L0BDvHvUMruRb7ub+24LUYA==}


### PR DESCRIPTION
I figured out that quite a few of the problems we had with stability of the CI were due to `@matteo.collina/worker` not installing properly because _the disk was busy_ and we could not download the node headers correctly. I think this would help solve some of those issues.