### PR TITLE
service: add support for HTTPS keys and certs

### DIFF
--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -68,6 +68,9 @@ A **required** object with the following settings:
     it will be automatically converted
 - **`logger`** (`object`) -- the [logger configuration](https://www.fastify.io/docs/latest/Reference/Server/#logger).
 - **`pluginTimeout`** (`integer`) -- the milliseconds to wait for a Fastify plugin to load, see the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#plugintimeout) for more details.
+- **`https`** (`object`) - Configuration for HTTPS supporting the following options.
+  - `key` (**required**, `string`, `object`, or `array`) - If `key` is a string, it specifies the private key to be used. If `key` is an object, it must have a `path` property specifying the private key file. Multiple keys are supported by passing an array of keys.
+  - `cert` (**required**, `string`, `object`, or `array`) - If `cert` is a string, it specifies the certificate to be used. If `cert` is an object, it must have a `path` property specifying the certificate file. Multiple certificates are supported by passing an array of keys.
 
 ### `metrics`
 

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -193,6 +193,24 @@ function adjustConfigAfterMerge (options, stash) {
   }
 }
 
+async function adjustHttpsKeyAndCert (arg) {
+  if (typeof arg === 'string') {
+    return arg
+  }
+
+  if (!Array.isArray(arg)) {
+    // { path: pathToKeyOrCert }
+    return readFile(arg.path)
+  }
+
+  // Array of strings or objects.
+  for (let i = 0; i < arg.length; ++i) {
+    arg[i] = await adjustHttpsKeyAndCert(arg[i])
+  }
+
+  return arg
+}
+
 async function buildServer (options, app, ConfigManagerContructor) {
   app = app || platformaticService
   ConfigManagerContructor = ConfigManagerContructor || ConfigManager
@@ -208,6 +226,16 @@ async function buildServer (options, app, ConfigManagerContructor) {
     options = deepmerge({}, options, cm.current)
     options.configManager = cm
     adjustConfigAfterMerge(options, stash)
+
+    if (options.server.https) {
+      options.server.https.key = await adjustHttpsKeyAndCert(options.server.https.key)
+      options.server.https.cert = await adjustHttpsKeyAndCert(options.server.https.cert)
+      options.server = { ...options.server, ...options.server.https }
+      delete options.server.https
+      options.server.protocol = 'https'
+    } else {
+      options.server.protocol = 'http'
+    }
   }
   const serverConfig = createServerConfig(options)
 
@@ -217,9 +245,10 @@ async function buildServer (options, app, ConfigManagerContructor) {
 
   Object.defineProperty(handler, 'url', {
     get () {
+      const protocol = serverConfig.protocol
       const address = handler.address
       const port = handler.port
-      const url = `http://${address}:${port}`
+      const url = `${protocol}://${address}:${port}`
       return url
     }
   })

--- a/packages/service/lib/config.js
+++ b/packages/service/lib/config.js
@@ -35,6 +35,23 @@ class ServiceConfigManager extends ConfigManager {
     if (this.current.plugins?.paths) {
       this.current.plugins.paths = this.current.plugins.paths.map(fixPluginPath)
     }
+
+    const fixKeyAndCertPath = (arg) => {
+      if (Array.isArray(arg)) {
+        return arg.map(fixKeyAndCertPath)
+      }
+
+      if (typeof arg === 'object') {
+        arg.path = this._fixRelativePath(arg.path)
+      }
+
+      return arg
+    }
+
+    if (this.current.server?.https) {
+      this.current.server.https.key = fixKeyAndCertPath(this.current.server.https.key)
+      this.current.server.https.cert = fixKeyAndCertPath(this.current.server.https.cert)
+    }
   }
 
   _fixRelativePath (path) {

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -237,6 +237,67 @@ const server = {
         { type: 'integer' }
       ]
     },
+    https: {
+      type: 'object',
+      properties: {
+        key: {
+          anyOf: [
+            { type: 'string' },
+            {
+              type: 'object',
+              properties: {
+                path: { type: 'string' }
+              },
+              additionalProperties: false
+            },
+            {
+              type: 'array',
+              items: {
+                anyOf: [
+                  { type: 'string' },
+                  {
+                    type: 'object',
+                    properties: {
+                      path: { type: 'string' }
+                    },
+                    additionalProperties: false
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        cert: {
+          anyOf: [
+            { type: 'string' },
+            {
+              type: 'object',
+              properties: {
+                path: { type: 'string' }
+              },
+              additionalProperties: false
+            },
+            {
+              type: 'array',
+              items: {
+                anyOf: [
+                  { type: 'string' },
+                  {
+                    type: 'object',
+                    properties: {
+                      path: { type: 'string' }
+                    },
+                    additionalProperties: false
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      additionalProperties: false,
+      required: ['key', 'cert']
+    },
     cors
   },
   required: ['hostname', 'port']

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -21,6 +21,7 @@
     "@matteo.collina/worker": "^3.0.0",
     "bindings": "^1.5.0",
     "c8": "^7.13.0",
+    "self-cert": "^2.0.0",
     "snazzy": "^9.0.0",
     "split2": "^4.1.0",
     "standard": "^17.0.0",

--- a/packages/service/test/https.test.js
+++ b/packages/service/test/https.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const { mkdtempSync, writeFileSync } = require('fs')
+const { tmpdir } = require('os')
+const { join } = require('path')
+const selfCert = require('self-cert')
+const { test } = require('tap')
+const { Agent, setGlobalDispatcher, request } = require('undici')
+const { buildServer } = require('..')
+const { buildConfig } = require('./helper')
+
+test('supports https options', async ({ teardown, equal, same, plan }) => {
+  plan(6)
+
+  const { certificate, privateKey } = selfCert({})
+  const tmpDir = mkdtempSync(join(tmpdir(), 'plt-service-https-test-'))
+  const privateKeyPath = join(tmpDir, 'plt.key')
+  const certificatePath = join(tmpDir, 'plt.cert')
+
+  writeFileSync(privateKeyPath, privateKey)
+  writeFileSync(certificatePath, certificate)
+
+  setGlobalDispatcher(new Agent({
+    connect: {
+      rejectUnauthorized: false
+    }
+  }))
+
+  const server = await buildServer(buildConfig({
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      https: {
+        key: privateKey,
+        cert: [{ path: certificatePath }]
+      }
+    }
+  }))
+
+  teardown(server.stop)
+  await server.listen()
+
+  equal(server.url.startsWith('https://'), true)
+  let res = await (request(`${server.url}/`))
+  equal(res.statusCode, 200)
+  let body = await res.body.json()
+  same(body, { message: 'Welcome to Platformatic! Please visit https://oss.platformatic.dev' })
+
+  await server.restart()
+
+  equal(server.url.startsWith('https://'), true)
+  res = await (request(`${server.url}/`))
+  equal(res.statusCode, 200)
+  body = await res.body.json()
+  same(body, { message: 'Welcome to Platformatic! Please visit https://oss.platformatic.dev' })
+})

--- a/packages/service/test/https.test.js
+++ b/packages/service/test/https.test.js
@@ -2,7 +2,7 @@
 
 const { mkdtempSync, writeFileSync } = require('fs')
 const { tmpdir } = require('os')
-const { join } = require('path')
+const { isAbsolute, join, relative } = require('path')
 const selfCert = require('self-cert')
 const { test } = require('tap')
 const { Agent, setGlobalDispatcher, request } = require('undici')
@@ -10,12 +10,13 @@ const { buildServer } = require('..')
 const { buildConfig } = require('./helper')
 
 test('supports https options', async ({ teardown, equal, same, plan }) => {
-  plan(6)
+  plan(7)
 
   const { certificate, privateKey } = selfCert({})
   const tmpDir = mkdtempSync(join(tmpdir(), 'plt-service-https-test-'))
   const privateKeyPath = join(tmpDir, 'plt.key')
   const certificatePath = join(tmpDir, 'plt.cert')
+  const certificateRelativePath = relative(__dirname, certificatePath)
 
   writeFileSync(privateKeyPath, privateKey)
   writeFileSync(certificatePath, certificate)
@@ -32,7 +33,7 @@ test('supports https options', async ({ teardown, equal, same, plan }) => {
       port: 0,
       https: {
         key: privateKey,
-        cert: [{ path: certificatePath }]
+        cert: [{ path: certificateRelativePath }]
       }
     }
   }))
@@ -40,6 +41,7 @@ test('supports https options', async ({ teardown, equal, same, plan }) => {
   teardown(server.stop)
   await server.listen()
 
+  equal(isAbsolute(server.app.platformatic.configManager.current.server.https.cert[0].path), true)
   equal(server.url.startsWith('https://'), true)
   let res = await (request(`${server.url}/`))
   equal(res.statusCode, 200)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,6 +489,7 @@ importers:
       pino: ^8.11.0
       pino-pretty: ^10.0.0
       rfdc: ^1.3.0
+      self-cert: ^2.0.0
       snazzy: ^9.0.0
       split2: ^4.1.0
       standard: ^17.0.0
@@ -536,6 +537,7 @@ importers:
       '@matteo.collina/worker': 3.0.0
       bindings: 1.5.0
       c8: 7.13.0
+      self-cert: 2.0.0
       snazzy: 9.0.0
       split2: 4.1.0
       standard: 17.0.0
@@ -6582,6 +6584,10 @@ packages:
       path-type: 4.0.0
     dev: true
 
+  /discontinuous-range/1.0.0:
+    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+    dev: true
+
   /dlv/1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
@@ -6708,6 +6714,15 @@ packages:
       stream-shift: 1.0.1
     dev: true
 
+  /duplexify/4.1.2:
+    resolution: {integrity: sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==}
+    dependencies:
+      end-of-stream: 1.4.4
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.1
+    dev: true
+
   /eastasianwidth/0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -6715,6 +6730,14 @@ packages:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
       safe-buffer: 5.2.1
+
+  /edtf/4.4.1:
+    resolution: {integrity: sha512-sX/SYBF1y+K47wvHzPCnpfzbQrxQCGBm/wdY3rc8vsJgRuJfJLnaCYwMt1WYjeWLVTCoAeOQ1OWabtjqgl0Ouw==}
+    dependencies:
+      nearley: 2.20.1
+    optionalDependencies:
+      randexp: 0.5.3
+    dev: true
 
   /ee-first/1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -10346,6 +10369,10 @@ packages:
     resolution: {integrity: sha512-Mk9qDrvU44UUL0EBhbAA1phfQZ7aMZPjwtL7wkpiBzGh8dETGqfsh50mWoX9EkjDlkONlErWXArHCKfoxVg0Bw==}
     dev: true
 
+  /moo/0.5.2:
+    resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
+    dev: true
+
   /move-concurrently/1.0.1:
     resolution: {integrity: sha512-hdrFxZOycD/g6A6SoI2bB5NA/5NEqD0569+S47WZhPvm46sD50ZHdYaFmnua5lndde9rCHGjmfK7Z8BuCt/PcQ==}
     dependencies:
@@ -10385,6 +10412,11 @@ packages:
     dependencies:
       fastparallel: 2.4.1
       qlobber: 7.0.1
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: true
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -10475,6 +10507,16 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
+  /nearley/2.20.1:
+    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      moo: 0.5.2
+      railroad-diagrams: 1.0.0
+      randexp: 0.4.6
+    dev: true
+
   /negotiator/0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -10526,6 +10568,11 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+
+  /node-forge/1.3.1:
+    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+    engines: {node: '>= 6.13.0'}
+    dev: true
 
   /node-gyp/8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
@@ -10823,6 +10870,10 @@ packages:
 
   /oblivious-set/1.0.0:
     resolution: {integrity: sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==}
+
+  /on-exit-leak-free/0.2.0:
+    resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
+    dev: true
 
   /on-exit-leak-free/2.1.0:
     resolution: {integrity: sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==}
@@ -11213,6 +11264,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /pino-abstract-transport/0.5.0:
+    resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
+    dependencies:
+      duplexify: 4.1.2
+      split2: 4.1.0
+    dev: true
+
   /pino-abstract-transport/1.0.0:
     resolution: {integrity: sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==}
     dependencies:
@@ -11239,8 +11297,29 @@ packages:
       strip-json-comments: 3.1.1
     dev: false
 
+  /pino-std-serializers/4.0.0:
+    resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
+    dev: true
+
   /pino-std-serializers/6.1.0:
     resolution: {integrity: sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==}
+
+  /pino/7.11.0:
+    resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
+    hasBin: true
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.1.2
+      on-exit-leak-free: 0.2.0
+      pino-abstract-transport: 0.5.0
+      pino-std-serializers: 4.0.0
+      process-warning: 1.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.1.0
+      safe-stable-stringify: 2.4.2
+      sonic-boom: 2.8.0
+      thread-stream: 0.15.2
+    dev: true
 
   /pino/8.11.0:
     resolution: {integrity: sha512-Z2eKSvlrl2rH8p5eveNUnTdd4AjJk8tAsLkHYZQKGHP4WTh2Gi1cOSOs3eWPqaj+niS3gj4UkoreoaWgF3ZWYg==}
@@ -11494,6 +11573,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fromentries: 1.3.2
+    dev: true
+
+  /process-warning/1.0.0:
+    resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
     dev: true
 
   /process-warning/2.1.0:
@@ -11786,6 +11869,10 @@ packages:
       - react-native
     dev: true
 
+  /railroad-diagrams/1.0.0:
+    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
+    dev: true
+
   /ramda-adjunct/3.4.0_ramda@0.28.0:
     resolution: {integrity: sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==}
     engines: {node: '>=0.10.3'}
@@ -11797,6 +11884,14 @@ packages:
 
   /ramda/0.28.0:
     resolution: {integrity: sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==}
+    dev: true
+
+  /randexp/0.4.6:
+    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      discontinuous-range: 1.0.0
+      ret: 0.1.15
     dev: true
 
   /randexp/0.5.3:
@@ -12331,6 +12426,11 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /real-require/0.1.0:
+    resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
+    engines: {node: '>= 12.13.0'}
+    dev: true
+
   /real-require/0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
@@ -12664,6 +12764,13 @@ packages:
       tslib: 2.5.0
     dev: false
 
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: true
+
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -12730,6 +12837,17 @@ packages:
 
   /secure-json-parse/2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
+  /self-cert/2.0.0:
+    resolution: {integrity: sha512-dXulXTFP05tuc646sCBMd7jgnjZek1zRx+HwUJUeSf4A5JgdpXIp+aYyYI8MSWVxz7X8HIKCKcQRWM0DFe72IA==}
+    hasBin: true
+    dependencies:
+      abstract-logging: 2.0.1
+      edtf: 4.4.1
+      node-forge: 1.3.1
+      pino: 7.11.0
+      sade: 1.8.1
+    dev: true
 
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -12990,6 +13108,12 @@ packages:
       ip: 2.0.0
       smart-buffer: 4.2.0
     optional: true
+
+  /sonic-boom/2.8.0:
+    resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+    dependencies:
+      atomic-sleep: 1.0.0
+    dev: true
 
   /sonic-boom/3.2.1:
     resolution: {integrity: sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==}
@@ -13861,6 +13985,12 @@ packages:
     resolution: {integrity: sha512-5p1q2me8gQFl+GBHoFh0M8Y56XUV0Xl44f71X4HAzCZZI92V1BiBhYDAD4qudC04ZxYoaYCFjOrRoPkO/qzEng==}
     dependencies:
       promise: 6.1.0
+
+  /thread-stream/0.15.2:
+    resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
+    dependencies:
+      real-require: 0.1.0
+    dev: true
 
   /thread-stream/2.3.0:
     resolution: {integrity: sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==}


### PR DESCRIPTION
This commit updates service to support loading keys and certs as strings or from file.

Fixes #777 