### PR TITLE
Docs/auth rules

### DIFF
--- a/docs/guides/securing-platformatic-db.md
+++ b/docs/guides/securing-platformatic-db.md
@@ -39,11 +39,36 @@ The data will still be available if the `X-PLATFORMATIC-ADMIN-SECRET` HTTP heade
 is specified when making HTTP calls, like so:
 
 ```bash
-$ curl -H 'X-PLATFORMATIC-ADMIN-SECRET: replaceWithSomethingRandomAndSecure' http://127.0.0.1:3042/pages
+curl -H 'X-PLATFORMATIC-ADMIN-SECRET: replaceWithSomethingRandomAndSecure' http://127.0.0.1:3042/pages
 ```
+
 
 :::info
 Configuring JWT or Web Hooks will have the same result of configuring an admin secret.
+:::
+
+## Authorization rules
+
+Rules can be provided based on entity and role in order to restrict access and provide fine grained access.
+To make an admin only query and save the `page` table / `page` entity using `adminSecret` this structure should be used in the `platformatic.db` configuration file:
+
+```
+  ...
+  "authorization": {
+    "adminSecret": "easy",
+    "rules": [{
+      "entity": "movie"
+      "role": "platformatic-admin",
+      "find": true,
+      "save": true,
+      "delete": false,
+      }
+    ]
+  }
+```
+
+:::info
+Note that the role of an admin user from `adminSecret` strategy is `platformatic-admin` by default.
 :::
 
 ## Read-only access to _anonymous_ users

--- a/docs/reference/db/authorization/rules.md
+++ b/docs/reference/db/authorization/rules.md
@@ -191,6 +191,24 @@ In this example, the `user` role can delete all the posts edited before yesterda
   })
 ```
 
+## Access validation on `entity mapper` for plugins
+
+To assert that a specific user with it's `role(s)` has the correct access rights to use entities on a `platformatic plugin` the context should be passed to the `entity mapper` in order to verify it's permissions like this:
+
+```js
+//plugin.js
+
+app.post('/', async (req, reply) => {
+  const ctx = req.createPlatformaticCtx()
+  
+  await app.platformatic.entities.movie.find({
+    where: { /*...*/ },
+    ctx
+  })
+})
+
+```
+
 
 ## Skip authorization rules
 

--- a/docs/reference/db/plugin.md
+++ b/docs/reference/db/plugin.md
@@ -24,6 +24,21 @@ You should export an async `function` which receives a parameters
 -
 You can always access Platformatic [data mapper](/reference/sql-mapper/introduction.md) through `app.platformatic` property.
 
+:::info
+To make sure that a user has the appropriate set of permissions to perform any action on an entity the `context` should be passed to the `entity mapper` operation like this:
+
+```js
+app.post('/', async (req, reply) => {
+  const ctx = req.createPlatformaticCtx()
+  
+  await app.platformatic.entities.movies.find({
+    where: { /*...*/ },
+    ctx
+  })
+})
+```
+:::
+
 Check some [examples](/guides/add-custom-functionality/introduction.md).
 
 ## Hot Reload


### PR DESCRIPTION
Add docs for context injection in `plugins` for entity mapper operations