### PR TITLE
Do not use GITHUB_TOKEN to create releases

### DIFF
--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -55,4 +55,4 @@ jobs:
       - name: 'Create release notes'
         run: |
           npm i @matteo.collina/release-notes -g
-          release-notes -a ${{ secrets.GITHUB_TOKEN }} -t ${{ inputs.version }} -r platformatic -o platformatic
+          release-notes -a ${{ secrets.GH_RELEASE_TOKEN }} -t ${{ inputs.version }} -r platformatic -o platformatic


### PR DESCRIPTION
Thanks to [this comment](https://github.com/orgs/community/discussions/16244#discussioncomment-5232285) we discovered that releases created by `github-actions` user, do not trigger action that have

```yaml
on:
  release:
    ...
```
So at the moment when creating release, all the workflows like Docker release, Discord announce etc... are not triggered.

Need to add a `GH_RELEASE_TOKEN` in this repository's secrets and @mcollina should fill it with it's token.
At the moment there is no way that the release author is an Organization, only an user can do that.

