### PR TITLE
fix: rename core property to db in guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ follow these steps to quickly create and start a platformatic db:
        "hostname": "127.0.0.1",
        "port": "3042"
      },
-     "core": {
+     "db": {
        "connectionString": "sqlite://./pages.db"
      },
      "migrations": {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -286,7 +286,7 @@ save the following as `platformatic.db.json`:
         "level": "info"
       }
     },
-    "core": {
+    "db": {
       "connectionString": "sqlite://./db"
     },
     "migrations": {

--- a/packages/db/help/start.txt
+++ b/packages/db/help/start.txt
@@ -16,7 +16,7 @@ save the following as `platformatic.db.json`:
         "level": "info"
       }
     },
-    "core": {
+    "db": {
       "connectionString": "sqlite://./db"
     },
     "migrations": {


### PR DESCRIPTION
```
 ~/Desktop/PROJEKTI/platform  npx platformatic db start                                                                            1 ↵  10086  22:01:42
┌─────────┬──────┬─────────────────────────────────────────────────────────────────────┐
│ (index) │ path │                               message                               │
├─────────┼──────┼─────────────────────────────────────────────────────────────────────┤
│    0    │ '/'  │     `must have required property 'db' {"missingProperty":"db"}`     │
│    1    │ '/'  │ 'must NOT have additional properties {"additionalProperty":"core"}' │
└─────────┴──────┴─────────────────────────────────────────────────────────────────────┘
```

There are some `json` files in project - but I am not sure about them