### PR TITLE
feat(#847): add 'or' condition on where clause

### DIFF
--- a/docs/reference/sql-mapper/entities/api.md
+++ b/docs/reference/sql-mapper/entities/api.md
@@ -70,6 +70,52 @@ The `where` object's key is the field you want to check, the value is a key/valu
 }
 ```
 
+Where clause operations are by default combined with the `AND` operator. To combine them with the `OR` operator, use the `or` key.
+
+#### Select all rows with id 1 or 3
+```
+{
+  ...
+  "where": {
+    or: [
+      {
+        id: {
+          eq: 1
+        }
+      },
+      {
+        id: {
+          eq: 3
+        }
+      }
+    ]
+  }
+}
+```
+### Select all rows with id 1 or 3 and title like 'foo%'
+```
+{
+  ...
+  "where": {
+    or: [
+      {
+        id: {
+          eq: 1
+        }
+      },
+      {
+        id: {
+          eq: 3
+        }
+      }
+    ],
+    title: {
+      like: 'foo%'
+    }
+  }
+}
+```
+
 ## Reference
 
 ### `find`

--- a/docs/reference/sql-openapi/api.md
+++ b/docs/reference/sql-openapi/api.md
@@ -70,6 +70,21 @@ $ curl -X 'GET' \
   -H 'accept: application/json'
 ```
 
+Where clause operations are by default combined with the `AND` operator. To create an `OR` condition use the `where.or` query param.
+
+Each `where.or` query param can contain multiple conditions separated by a `|` (pipe).
+
+The `where.or` conditions are similar to the `where` conditions, except that they don't have the `where` prefix.
+
+_Example_
+
+If you want to get the `posts` where `counter = 10` `OR` `counter > 30` you can make an HTTP request like this:
+
+```bash
+$ curl -X 'GET' \
+  'http://localhost:3042/pages/?where.or=(counter.eq=10|counter.gte=30)' \
+  -H 'accept: application/json'
+```
 ## OrderBy clause
 
 You can define the ordering of the returned rows within your REST API calls with the `orderby` clause using the following pattern:

--- a/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/env.test.mjs.test.cjs
@@ -40,6 +40,7 @@ enum OrderByDirection {
 input PageWhereArguments {
   id: PageWhereArgumentsid
   title: PageWhereArgumentstitle
+  or: [PageWhereArgumentsOr]
 }
 
 input PageWhereArgumentsid {
@@ -64,6 +65,11 @@ input PageWhereArgumentstitle {
   like: String
   in: [String]
   nin: [String]
+}
+
+input PageWhereArgumentsOr {
+  id: PageWhereArgumentsid
+  title: PageWhereArgumentstitle
 }
 
 type pagesCount {

--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -316,6 +316,17 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
           },
           {
             "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "in": "query",
+            "name": "where.or",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string",
               "enum": [
                 "asc",
@@ -549,6 +560,17 @@ exports['test/cli/schema.test.mjs TAP print the openapi schema to stdout > must 
             },
             "in": "query",
             "name": "where.name.nin",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "in": "query",
+            "name": "where.or",
             "required": false
           }
         ],

--- a/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
+++ b/packages/db/tap-snapshots/test/cli/schema.test.mjs.test.cjs
@@ -40,6 +40,7 @@ enum OrderByDirection {
 input GraphWhereArguments {
   id: GraphWhereArgumentsid
   name: GraphWhereArgumentsname
+  or: [GraphWhereArgumentsOr]
 }
 
 input GraphWhereArgumentsid {
@@ -64,6 +65,11 @@ input GraphWhereArgumentsname {
   like: String
   in: [String]
   nin: [String]
+}
+
+input GraphWhereArgumentsOr {
+  id: GraphWhereArgumentsid
+  name: GraphWhereArgumentsname
 }
 
 type graphsCount {

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -99,27 +99,39 @@ function constructGraph (app, entity, opts, ignore) {
     return ['and', key]
   }).flat())].join('_'))
 
+  const whereFields = Object.keys(fields).reduce((acc, field) => {
+    acc[field] = {
+      type: new graphql.GraphQLInputObjectType({
+        name: `${entityName}WhereArguments${field}`,
+        fields: {
+          eq: { type: fields[field].type },
+          neq: { type: fields[field].type },
+          gt: { type: fields[field].type },
+          gte: { type: fields[field].type },
+          lt: { type: fields[field].type },
+          lte: { type: fields[field].type },
+          like: { type: fields[field].type },
+          in: { type: new graphql.GraphQLList(fields[field].type) },
+          nin: { type: new graphql.GraphQLList(fields[field].type) }
+        }
+      })
+    }
+    return acc
+  }, {})
+
   const whereArgType = new graphql.GraphQLInputObjectType({
     name: `${entityName}WhereArguments`,
-    fields: Object.keys(fields).reduce((acc, field) => {
-      acc[field] = {
-        type: new graphql.GraphQLInputObjectType({
-          name: `${entityName}WhereArguments${field}`,
+    fields: {
+      ...whereFields,
+      or: {
+        type: new graphql.GraphQLList(new graphql.GraphQLInputObjectType({
+          name: `${entityName}WhereArgumentsOr`,
           fields: {
-            eq: { type: fields[field].type },
-            neq: { type: fields[field].type },
-            gt: { type: fields[field].type },
-            gte: { type: fields[field].type },
-            lt: { type: fields[field].type },
-            lte: { type: fields[field].type },
-            like: { type: fields[field].type },
-            in: { type: new graphql.GraphQLList(fields[field].type) },
-            nin: { type: new graphql.GraphQLList(fields[field].type) }
+            ...whereFields
           }
-        })
+        }))
       }
-      return acc
-    }, {})
+    }
   })
 
   queryTopFields[getBy] = {

--- a/packages/sql-graphql/test/or.test.js
+++ b/packages/sql-graphql/test/or.test.js
@@ -278,7 +278,7 @@ test('list', async ({ pass, teardown, same, equal }) => {
       body: {
         query: `
           query {
-            posts(where: { or: [ { id: { in: [10, 20] } }, { id: { in: [20, 30] } } ] }) {
+            posts(where: { or: [ { counter: { in: [10, 20] } }, { counter: { in: [20, 30] } } ] }) {
               id
               title
               longText
@@ -292,7 +292,9 @@ test('list', async ({ pass, teardown, same, equal }) => {
     same(res.json(), {
       data: {
         posts: [
-          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 }
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+          { id: '2', title: 'Cat', longText: 'Bar', counter: 20 },
+          { id: '3', title: 'Mouse', longText: 'Baz', counter: 30 }
         ]
       }
     }, 'posts response')

--- a/packages/sql-graphql/test/or.test.js
+++ b/packages/sql-graphql/test/or.test.js
@@ -270,4 +270,31 @@ test('list', async ({ pass, teardown, same, equal }) => {
       }
     }, 'posts response')
   }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { or: [ { id: { in: [10, 20] } }, { id: { in: [20, 30] } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 }
+        ]
+      }
+    }, 'posts response')
+  }
 })

--- a/packages/sql-graphql/test/or.test.js
+++ b/packages/sql-graphql/test/or.test.js
@@ -1,0 +1,273 @@
+'use strict'
+
+const { test } = require('tap')
+const sqlGraphQL = require('..')
+const sqlMapper = require('@platformatic/sql-mapper')
+const fastify = require('fastify')
+const { clear, connInfo, isSQLite } = require('./helper')
+
+test('list', async ({ pass, teardown, same, equal }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      }
+    }
+  })
+  app.register(sqlGraphQL)
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  const posts = [{
+    title: 'Dog',
+    longText: 'Foo',
+    counter: 10
+  }, {
+    title: 'Cat',
+    longText: 'Bar',
+    counter: 20
+  }, {
+    title: 'Mouse',
+    longText: 'Baz',
+    counter: 30
+  }, {
+    title: 'Duck',
+    longText: 'A duck tale',
+    counter: 40
+  }]
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+            mutation batch($inputs : [PostInput]!) {
+              insertPosts(inputs: $inputs) {
+                id
+                title
+              }
+            }
+          `,
+        variables: {
+          inputs: posts
+        }
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { or: [ { title: { eq: "Dog" } }, { title: { eq: "Cat" } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+          { id: '2', title: 'Cat', longText: 'Bar', counter: 20 }
+        ]
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { id: { eq: 1 }, or: [ { title: { eq: "Dog" } }, { title: { eq: "Cat" } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 }
+        ]
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { or: [ { counter: { eq: 10 } }, { counter: { eq: 20 } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+          { id: '2', title: 'Cat', longText: 'Bar', counter: 20 }
+        ]
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { or: [ { counter: { eq: 10 } }, { counter: { gte: 30 } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+          { id: '3', title: 'Mouse', longText: 'Baz', counter: 30 },
+          { id: '4', title: 'Duck', longText: 'A duck tale', counter: 40 }
+        ]
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { or: [ { title: { eq: "Dog" } }, { title: { eq: "Duck" } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+          { id: '4', title: 'Duck', longText: 'A duck tale', counter: 40 }
+        ]
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { or: [ { title: { eq: "Dog" } }, { longText: { eq: "Baz" } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+          { id: '3', title: 'Mouse', longText: 'Baz', counter: 30 }
+        ]
+      }
+    }, 'posts response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { counter: { in: [10, 20] }, or: [ { title: { eq: "Dog" } }, { longText: { eq: "Baz" } } ] }) {
+              id
+              title
+              longText
+              counter
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'posts status code')
+    same(res.json(), {
+      data: {
+        posts: [
+          { id: '1', title: 'Dog', longText: 'Foo', counter: 10 }
+        ]
+      }
+    }, 'posts response')
+  }
+})

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -206,6 +206,15 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKeys, relation
     const where = opts.where || {}
     const criteria = []
     for (const key of Object.keys(where)) {
+      if (key === 'or') {
+        const orCriteria = []
+        for (const orPart of where[key]) {
+          const cret = computeCriteria({ where: orPart })
+          orCriteria.push(sql`(${sql.join(cret, sql` AND `)})`)
+        }
+        criteria.push(sql`(${sql.join(orCriteria, sql` OR `)})`)
+        continue
+      }
       const value = where[key]
       const field = inputToFieldMap[key]
       for (const key of Object.keys(value)) {

--- a/packages/sql-mapper/test/or.test.js
+++ b/packages/sql-mapper/test/or.test.js
@@ -1,0 +1,193 @@
+'use strict'
+
+const { test } = require('tap')
+const { connect } = require('..')
+const { clear, connInfo, isSQLite, isMysql } = require('./helper')
+const fakeLogger = {
+  trace: () => { },
+  error: () => { }
+}
+
+test('where clause with or operation', async ({ pass, teardown, same }) => {
+  const mapper = await connect({
+    ...connInfo,
+    autoTimestamp: true,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      teardown(() => db.dispose())
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else if (isMysql) {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      }
+    }
+  })
+
+  const entity = mapper.entities.post
+
+  const posts = [{
+    title: 'Dog',
+    longText: 'Foo',
+    counter: 10
+  }, {
+    title: 'Cat',
+    longText: 'Bar',
+    counter: 20
+  }, {
+    title: 'Mouse',
+    longText: 'Baz',
+    counter: 30
+  }, {
+    title: 'Duck',
+    longText: 'A duck tale',
+    counter: 40
+  }]
+
+  await entity.insert({
+    inputs: posts
+  })
+
+  {
+    const data = await entity.find({
+      where: {
+        or: [
+          {
+            counter: {
+              eq: 10
+            }
+          },
+          {
+            counter: {
+              eq: 20
+            }
+          }
+        ]
+      }
+    })
+
+    same(data, [
+      { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+      { id: '2', title: 'Cat', longText: 'Bar', counter: 20 }
+    ])
+  }
+
+  {
+    const data = await entity.find({
+      where: {
+        or: [
+          {
+            counter: {
+              eq: 20
+            }
+          },
+          {
+            counter: {
+              gte: 30
+            }
+          }
+        ]
+      }
+    })
+
+    same(data, [
+      { id: '2', title: 'Cat', longText: 'Bar', counter: 20 },
+      { id: '3', title: 'Mouse', longText: 'Baz', counter: 30 },
+      { id: '4', title: 'Duck', longText: 'A duck tale', counter: 40 }
+    ])
+  }
+
+  {
+    const data = await entity.find({
+      where: {
+        or: [
+          {
+            title: {
+              eq: 'Dog'
+            }
+          },
+          {
+            title: {
+              eq: 'Duck'
+            }
+          }
+        ]
+      }
+    })
+
+    same(data, [
+      { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+      { id: '4', title: 'Duck', longText: 'A duck tale', counter: 40 }
+    ])
+  }
+
+  {
+    const data = await entity.find({
+      where: {
+        or: [
+          {
+            title: {
+              eq: 'Dog'
+            }
+          },
+          {
+            longText: {
+              eq: 'Baz'
+            }
+          }
+        ]
+      }
+    })
+
+    same(data, [
+      { id: '1', title: 'Dog', longText: 'Foo', counter: 10 },
+      { id: '3', title: 'Mouse', longText: 'Baz', counter: 30 }
+    ])
+  }
+
+  {
+    const data = await entity.find({
+      where: {
+        counter: {
+          in: [10, 20]
+        },
+        or: [
+          {
+            title: {
+              eq: 'Dog'
+            }
+          },
+          {
+            longText: {
+              eq: 'Baz'
+            }
+          }
+        ]
+      }
+    })
+
+    same(data, [
+      { id: '1', title: 'Dog', longText: 'Foo', counter: 10 }
+    ])
+  }
+})

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -84,35 +84,35 @@ function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, ent
 
     for (let i = 0; i < queryKeys.length; i++) {
       const key = queryKeys[i]
+      if (key.startsWith('where.or')) {
+        const orParam = query[key][0]
+        // NOTE: Remove the first and last character which are the brackets
+        // each or condition is separated by a pipe '|'
+        // the conditions inside the or statement are the same as it would normally be in the where statement
+        // except that the field name is not prefixed with 'where.'
+        // e.g. where.or=(name.eq=foo|name.eq=bar)
+        // e.g. where.or=(name.eq=foo|name.eq=bar|name.eq=baz)
+        //
+        // Also, the or statement supports in and nin operators
+        // e.g. where.or=(name.in=foo,bar|name.eq=baz)
+        const parsed = orParam.substring(1, orParam.length - 1).split('|').map((v) => v.split('=')).reduce((acc, [k, v]) => {
+          const [field, modifier] = k.split('.')
+          if (modifier === 'in' || modifier === 'nin') {
+            // TODO handle escaping of ,
+            v = v.split(',')
+            /* istanbul ignore next */
+            if (mapSQLTypeToOpenAPIType(entity.fields[field].sqlType) === 'integer') {
+              v = v.map((v) => parseInt(v))
+            }
+          }
+          acc.push({ [field]: { [modifier]: v } })
+          return acc
+        }, [])
+        where.or = parsed
+        continue
+      }
 
       if (key.startsWith('where.')) {
-        if (key.startsWith('where.or')) {
-          const orParam = query[key][0]
-          // NOTE: Remove the first and last character which are the brackets
-          // each or condition is separated by a pipe '|'
-          // the conditions inside the or statement are the same as it would normally be in the where statement
-          // except that the field name is not prefixed with 'where.'
-          // e.g. where.or=(name.eq=foo|name.eq=bar)
-          // e.g. where.or=(name.eq=foo|name.eq=bar|name.eq=baz)
-          //
-          // Also, the or statement supports in and nin operators
-          // e.g. where.or=(name.in=foo,bar|name.eq=baz)
-          const parsed = orParam.substring(1, orParam.length - 1).split('|').map((v) => v.split('=')).reduce((acc, [k, v]) => {
-            const [field, modifier] = k.split('.')
-            if (modifier === 'in' || modifier === 'nin') {
-              // TODO handle escaping of ,
-              v = v.split(',')
-              /* istanbul ignore next */
-              if (mapSQLTypeToOpenAPIType(entity.fields[field].sqlType) === 'integer') {
-                v = v.map((v) => parseInt(v))
-              }
-            }
-            acc.push({ [field]: { [modifier]: v } })
-            return acc
-          }, [])
-          where.or = parsed
-          continue
-        }
         const [, field, modifier] = key.split('.')
         where[field] ||= {}
         let value = query[key]

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -34,6 +34,19 @@ function generateArgs (entity, ignore) {
     return acc
   }, {})
 
+  // NOTE: probably not the best way to do this but it works for now
+  // TODO: when OpenAPI supports nested objects in querystring this should be changed
+  const whereOrArrayArgs = {
+    'where.or': {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  }
+
+  Object.assign(whereArgs, whereOrArrayArgs)
+
   return { whereArgs, orderByArgs }
 }
 
@@ -73,6 +86,32 @@ function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, ent
       const key = queryKeys[i]
 
       if (key.startsWith('where.')) {
+        if (key.startsWith('where.or')) {
+          const orParam = query[key][0]
+          // NOTE: Remove the first and last character which are the brackets
+          // each or condition is separated by a pipe '|'
+          // the conditions inside the or statement are the same as it would normally be in the where statement
+          // except that the field name is not prefixed with 'where.'
+          // e.g. where.or=(name.eq=foo|name.eq=bar)
+          // e.g. where.or=(name.eq=foo|name.eq=bar|name.eq=baz)
+          //
+          // Also, the or statement supports in and nin operators
+          // e.g. where.or=(name.in=foo,bar|name.eq=baz)
+          const parsed = orParam.substring(1, orParam.length - 1).split('|').map((v) => v.split('=')).reduce((acc, [k, v]) => {
+            const [field, modifier] = k.split('.')
+            if (modifier === 'in' || modifier === 'nin') {
+              // TODO handle escaping of ,
+              v = v.split(',')
+              if (mapSQLTypeToOpenAPIType(entity.fields[field].sqlType) === 'integer') {
+                v = v.map((v) => parseInt(v))
+              }
+            }
+            acc.push({ [field]: { [modifier]: v } })
+            return acc
+          }, [])
+          where.or = parsed
+          continue
+        }
         const [, field, modifier] = key.split('.')
         where[field] ||= {}
         let value = query[key]

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -102,6 +102,7 @@ function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, ent
             if (modifier === 'in' || modifier === 'nin') {
               // TODO handle escaping of ,
               v = v.split(',')
+              /* istanbul ignore next */
               if (mapSQLTypeToOpenAPIType(entity.fields[field].sqlType) === 'integer') {
                 v = v.map((v) => parseInt(v))
               }

--- a/packages/sql-openapi/test/or.test.js
+++ b/packages/sql-openapi/test/or.test.js
@@ -1,0 +1,174 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')
+const sqlOpenAPI = require('..')
+const sqlMapper = require('@platformatic/sql-mapper')
+const { clear, connInfo, isSQLite, isMysql } = require('./helper')
+const { resolve } = require('path')
+const { test } = t
+
+Object.defineProperty(t, 'fullname', {
+  value: 'platformatic/db/openapi/where'
+})
+
+test('list', async (t) => {
+  const { pass, teardown, same, equal, matchSnapshot } = t
+  t.snapshotFile = resolve(__dirname, 'tap-snapshots', 'where-openapi-1.cjs')
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else if (isMysql) {
+        await db.query(sql`CREATE TABLE posts (
+          id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT,
+          counter INTEGER
+        );`)
+      }
+    }
+  })
+  app.register(sqlOpenAPI)
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json'
+    })
+    const openapi = res.json()
+    matchSnapshot(openapi, 'matches expected OpenAPI defs')
+  }
+
+  const posts = [{
+    title: 'Dog',
+    longText: 'Foo',
+    counter: 10
+  }, {
+    title: 'Cat',
+    longText: 'Bar',
+    counter: 20
+  }, {
+    title: 'Mouse',
+    longText: 'Baz',
+    counter: 30
+  }, {
+    title: 'Duck',
+    longText: 'A duck tale',
+    counter: 40
+  }]
+
+  for (const body of posts) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/posts',
+      body
+    })
+    equal(res.statusCode, 200, 'POST /posts status code')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.or=(title.eq=Dog|title.eq=Cat)&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.or=(title.eq=Dog|title.eq=Cat)&fields=id,title,longText status code')
+    same(res.json(), [
+      { id: '1', title: 'Dog', longText: 'Foo' },
+      { id: '2', title: 'Cat', longText: 'Bar' }
+    ], 'GET /posts?where.or=(title.eq=Dog|title.eq=Cat)&fields=id,title,longText response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.or=(title.eq=Dog|title.eq=Cat)&where.id.eq=1&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.or=(title.eq=Dog|title.eq=Cat)&where.id.eq=1&fields=id,title,longText status code')
+    same(res.json(), [
+      { id: '1', title: 'Dog', longText: 'Foo' }
+    ], 'GET /posts?where.or=(title.eq=Dog|title.eq=Cat)&where.id.eq=1&fields=id,title,longText response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.or=(counter.eq=10|counter.gte=30)&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.or=(counter.eq=10|counter.gte=30)&fields=id,title,longText status code')
+    same(res.json(), [
+      { id: '1', title: 'Dog', longText: 'Foo' },
+      { id: '3', title: 'Mouse', longText: 'Baz' },
+      { id: '4', title: 'Duck', longText: 'A duck tale' }
+    ], 'GET /posts?where.or=(counter.eq=10|counter.gte=30)&fields=id,title,longText response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.or=(title.eq=Dog|title.eq=Duck)&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.or=(title.eq=Dog|title.eq=Duck)&fields=id,title,longText status code')
+    same(res.json(), [
+      { id: '1', title: 'Dog', longText: 'Foo' },
+      { id: '4', title: 'Duck', longText: 'A duck tale' }
+    ], 'GET /posts?where.or=(title.eq=Dog|title.eq=Duck)&fields=id,title,longText response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.or=(title.eq=Dog|longText.eq=Baz)&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.or=(title.eq=Dog|longText.eq=Baz)&fields=id,title,longText status code')
+    same(res.json(), [
+      { id: '1', title: 'Dog', longText: 'Foo' },
+      { id: '3', title: 'Mouse', longText: 'Baz' }
+    ], 'GET /posts?where.or=(title.eq=Dog|longText.eq=Baz)&fields=id,title,longText response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.or=(title.eq=Dog|longText.eq=Baz)&where.counter.in=10,20&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.or=(title.eq=Dog|longText.eq=Baz)&where.counter.in=10,20&fields=id,title,longText status code')
+    same(res.json(), [
+      { id: '1', title: 'Dog', longText: 'Foo' }
+    ], 'GET /posts?where.or=(title.eq=Dog|longText.eq=Baz)&where.counter.in=10,20&fields=id,title,longText response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.or=(counter.in=10,20|counter.in=20,30)&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.or=(counter.in=10,20|counter.in=20,30)&fields=id,title,longText status code')
+    same(res.json(), [
+      { id: '1', title: 'Dog', longText: 'Foo' },
+      { id: '2', title: 'Cat', longText: 'Bar' },
+      { id: '3', title: 'Mouse', longText: 'Baz' }
+    ], 'GET /posts?where.or=(counter.in=10,20|counter.in=20,30)&fields=id,title,longText response')
+  }
+})

--- a/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi-recursive.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi-recursive.cjs
@@ -302,6 +302,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.id",
             "required": false,
             "schema": Object {
@@ -624,6 +635,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
@@ -251,6 +251,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.id",
             "required": false,
             "schema": Object {
@@ -482,6 +493,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],
@@ -1189,6 +1211,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.counter",
             "required": false,
             "schema": Object {
@@ -1675,6 +1708,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
@@ -301,6 +301,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.counter",
             "required": false,
             "schema": Object {
@@ -610,6 +621,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
@@ -225,6 +225,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.id",
             "required": false,
             "schema": Object {
@@ -449,6 +460,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
@@ -224,6 +224,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.id",
             "required": false,
             "schema": Object {
@@ -448,6 +459,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
@@ -225,6 +225,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.id",
             "required": false,
             "schema": Object {
@@ -449,6 +460,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-4.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-4.cjs
@@ -225,6 +225,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.id",
             "required": false,
             "schema": Object {
@@ -449,6 +460,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/updateMany-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/updateMany-openapi-1.cjs
@@ -378,6 +378,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.counter",
             "required": false,
             "schema": Object {
@@ -772,6 +783,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
@@ -378,6 +378,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.counter",
             "required": false,
             "schema": Object {
@@ -772,6 +783,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
@@ -251,6 +251,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.id",
             "required": false,
             "schema": Object {
@@ -482,6 +493,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],
@@ -1189,6 +1211,17 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "orderby.counter",
             "required": false,
             "schema": Object {
@@ -1675,6 +1708,17 @@ Object {
             "required": false,
             "schema": Object {
               "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "where.or",
+            "required": false,
+            "schema": Object {
+              "items": Object {
+                "type": "string",
+              },
+              "type": "array",
             },
           },
         ],


### PR DESCRIPTION
Closes #847

## What is added:

Possibility for `OR` conditions in where clause

## Specs:

#### sql-mapper:
Inside the where object we pass the `or` as the key and an array of the conditions as value
```js
const data = await entity.find({
  where: {
    or: [
      {
        counter: {
          eq: 20
        }
      },
      {
        counter: {
          gte: 30
        }
      }
    ]
  }
})
```

#### sql-graphql:
Inside the where object we pass the `or` as the key and an array of the conditions as value
```graphql
query {
  posts(where: { or: [ { counter: { eq: 10 } }, { counter: { gte: 30 } } ] }) {
    id
    title
    longText
    counter
  }
}
```

#### sql-graphql:
In search query params we pass the `where.or` as the key and as a value we pass inside the parenthesis the conditions as we would in normal query but without the `where` prefix. We separate the or parts by `|` (pipe), the reason that I choose pipe as a separator is because we should also support `in` and `nin` operators inside the `or` statement, and `in` and `nin` take comma separated values.
```http
GET /posts?where.or=(counter.eq=10|counter.gte=30)
```

```http
GET /posts?where.or=(counter.in=10,20|counter.in=20,30)
```