### PR TITLE
fix: send header parameters from platformatic/client (#875)

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -62,6 +62,7 @@ function buildCallFunction (baseUrl, path, method, methodMeta, operationId) {
 
   const pathParams = methodMeta.parameters?.filter(p => p.in === 'path') || []
   const queryParams = methodMeta.parameters?.filter(p => p.in === 'query') || []
+  const headerParams = methodMeta.parameters?.filter(p => p.in === 'header') || []
 
   return async function (args) {
     let headers = this[kHeaders]
@@ -83,6 +84,13 @@ function buildCallFunction (baseUrl, path, method, methodMeta, operationId) {
     for (const param of queryParams) {
       if (body[param.name] !== undefined) {
         query.set(param.name, body[param.name])
+        body[param.name] = undefined
+      }
+    }
+
+    for (const param of headerParams) {
+      if (body[param.name] !== undefined) {
+        headers[param.name] = body[param.name]
         body[param.name] = undefined
       }
     }

--- a/packages/client/test/fixtures/auth/openapi.json
+++ b/packages/client/test/fixtures/auth/openapi.json
@@ -681,6 +681,25 @@
           }
         }
       }
+    },
+    "/hello/header/name": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "name": "name",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
     }
   }
 }

--- a/packages/client/test/fixtures/auth/plugin.js
+++ b/packages/client/test/fixtures/auth/plugin.js
@@ -19,4 +19,18 @@ module.exports = async function (app) {
   }, async (request, reply) => {
     return { hello: request.params.name }
   })
+
+  app.get('/hello/header/name', {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' }
+        },
+        required: ['name']
+      }
+    }
+  }, async (request, reply) => {
+    return { hello: request.headers.name }
+  })
 }

--- a/packages/client/test/fixtures/movies/openapi.json
+++ b/packages/client/test/fixtures/movies/openapi.json
@@ -681,6 +681,33 @@
           }
         }
       }
+    },
+    "/hello/header/name": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "name": "name",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "name": "id",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
     }
   }
 }

--- a/packages/client/test/fixtures/movies/plugin.js
+++ b/packages/client/test/fixtures/movies/plugin.js
@@ -20,6 +20,21 @@ module.exports = async function (app) {
     return { hello: request.params.name }
   })
 
+  app.get('/hello/header/name', {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          id: { type: 'string' }
+        },
+        required: ['name']
+      }
+    }
+  }, async (request, reply) => {
+    return { hello: request.headers.name }
+  })
+
   app.post('/weird/:name', {
     schema: {
       params: {

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -79,6 +79,11 @@ test('build basic client from url', async ({ teardown, same, rejects }) => {
     const hello = await client.getHelloName({ name: 'Matteo' })
     same(hello, { hello: 'Matteo' })
   }
+
+  {
+    const hello = await client.getHelloHeaderName({ name: 'Matteo' })
+    same(hello, { hello: 'Matteo' })
+  }
 })
 
 test('build basic client from file', async ({ teardown, same, rejects }) => {
@@ -147,6 +152,11 @@ test('build basic client from file', async ({ teardown, same, rejects }) => {
 
   {
     const hello = await client.getHelloName({ name: 'Matteo' })
+    same(hello, { hello: 'Matteo' })
+  }
+
+  {
+    const hello = await client.getHelloHeaderName({ name: 'Matteo' })
     same(hello, { hello: 'Matteo' })
   }
 })
@@ -219,6 +229,11 @@ test('build basic client from url with custom headers', async ({ teardown, same,
 
   {
     const hello = await client.getHelloName({ name: 'Matteo' })
+    same(hello, { hello: 'Matteo' })
+  }
+
+  {
+    const hello = await client.getHelloHeaderName({ name: 'Matteo' })
     same(hello, { hello: 'Matteo' })
   }
 })


### PR DESCRIPTION
Closes #875

Ensures client inputs which map to header paramters are actually sent with request. Thanks!