### PR TITLE
Return numeric and decimal db types as string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ playwright-report
 
 # IDE folders
 .vscode
+.idea
 
 *.sqlite
 
@@ -127,6 +128,6 @@ tags
 
 # tmp filees for packages
 
-packages/service/test/tmp 
+packages/service/test/tmp
 packages/cli/fixtures/sqlite/db
-packages/client-cli/test/tmp 
+packages/client-cli/test/tmp

--- a/packages/sql-graphql/lib/utils.js
+++ b/packages/sql-graphql/lib/utils.js
@@ -19,7 +19,7 @@ function sqlTypeToGraphQL (sqlType) {
     case 'smallint':
       return graphql.GraphQLInt
     case 'decimal':
-      return graphql.GraphQLInt
+      return graphql.GraphQLString
     case 'bigint':
       return graphql.GraphQLString
     case 'int2':
@@ -43,7 +43,7 @@ function sqlTypeToGraphQL (sqlType) {
     case 'double precision':
       return graphql.GraphQLFloat
     case 'numeric':
-      return graphql.GraphQLFloat
+      return graphql.GraphQLString
     case 'float4':
       return graphql.GraphQLFloat
     case 'date':

--- a/packages/sql-graphql/test/datatypes.test.js
+++ b/packages/sql-graphql/test/datatypes.test.js
@@ -58,7 +58,7 @@ test('[PG] simple db simple graphql schema', { skip: !isPg }, async ({ pass, tea
                               uuid: "12345678-1234-1234-1234-123456789012",
                               aReal: 1.2,
                               aSmallint: 42,
-                              aDecimal: 42,
+                              aDecimal: "42",
                               anEnum: value1
                             }) {
               id
@@ -92,7 +92,7 @@ test('[PG] simple db simple graphql schema', { skip: !isPg }, async ({ pass, tea
           uuid: '12345678-1234-1234-1234-123456789012',
           aReal: 1.2,
           aSmallint: 42,
-          aDecimal: 42,
+          aDecimal: '42',
           anEnum: 'value1'
         }
       }
@@ -303,7 +303,7 @@ test('[MySQL] simple db simple graphql schema', { skip: !isMysql }, async ({ pas
                               uuid: "12345678-1234-1234-1234-123456789012",
                               aReal: 1.2,
                               aSmallint: 42,
-                              aDecimal: 42,
+                              aDecimal: "42",
                               anEnum: value1
                             }) {
               id
@@ -337,7 +337,7 @@ test('[MySQL] simple db simple graphql schema', { skip: !isMysql }, async ({ pas
           uuid: '12345678-1234-1234-1234-123456789012',
           aReal: 1.2,
           aSmallint: 42,
-          aDecimal: 42,
+          aDecimal: '42',
           anEnum: 'value1'
         }
       }
@@ -383,7 +383,7 @@ test('[MySQL] simple db simple graphql schema', { skip: !isMysql }, async ({ pas
           uuid: '12345678-1234-1234-1234-123456789012',
           aReal: 1.2,
           aSmallint: 42,
-          aDecimal: 42,
+          aDecimal: '42',
           anEnum: 'value1'
         }
       }
@@ -546,7 +546,7 @@ test('[SQLite] simple db simple graphql schema', { skip: !isSQLite }, async ({ p
                               uuid: "12345678-1234-1234-1234-123456789012",
                               aReal: 1.2,
                               aSmallint: 42,
-                              aDecimal: 42 }) {
+                              aDecimal: "42" }) {
               id
               published
               current
@@ -573,7 +573,7 @@ test('[SQLite] simple db simple graphql schema', { skip: !isSQLite }, async ({ p
           uuid: '12345678-1234-1234-1234-123456789012',
           aReal: 1.2,
           aSmallint: 42,
-          aDecimal: 42
+          aDecimal: '42'
         }
       }
     }, 'saveSimpleType response')
@@ -613,7 +613,7 @@ test('[SQLite] simple db simple graphql schema', { skip: !isSQLite }, async ({ p
           uuid: '12345678-1234-1234-1234-123456789012',
           aReal: 1.2,
           aSmallint: 42,
-          aDecimal: 42
+          aDecimal: '42'
         }
       }
     }, 'getSimpleTypeById response')

--- a/packages/sql-json-schema-mapper/index.js
+++ b/packages/sql-json-schema-mapper/index.js
@@ -16,7 +16,7 @@ function mapSQLTypeToOpenAPIType (sqlType) {
     case 'smallint':
       return 'integer'
     case 'decimal':
-      return 'number'
+      return 'string'
     case 'bigint':
       return 'string'
     case 'int2':
@@ -42,7 +42,7 @@ function mapSQLTypeToOpenAPIType (sqlType) {
     case 'double precision':
       return 'number'
     case 'numeric':
-      return 'number'
+      return 'string'
     case 'bigint unsigned':
       return 'integer'
     case 'float4':

--- a/packages/sql-json-schema-mapper/test/simple.test.js
+++ b/packages/sql-json-schema-mapper/test/simple.test.js
@@ -91,7 +91,7 @@ test('simple db, simple rest API', async (t) => {
     t.same(pageJsonSchema.properties.id, { type: 'integer' })
     t.same(pageJsonSchema.properties.title, { type: 'string' })
     t.same(pageJsonSchema.properties.description, { type: 'string', nullable: true })
-    t.same(pageJsonSchema.properties.section, { type: 'number', nullable: true })
+    t.same(pageJsonSchema.properties.section, { type: 'string', nullable: true })
     if (isMariaDB) {
       t.same(pageJsonSchema.properties.metadata, { type: 'string', nullable: true })
     } else {


### PR DESCRIPTION
Most node.js database clients return numeric and decimal as string because 64 bit float (number) cannot always represent the value without potential loss of accuracy.