### PR TITLE
support bodyless 204 responses (#883)

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -96,8 +96,13 @@ function buildCallFunction (baseUrl, path, method, methodMeta, operationId) {
         ...headers,
         'content-type': 'application/json; charset=utf-8'
       },
-      body: JSON.stringify(args)
+      body: JSON.stringify(body)
     })
+
+    if (res.statusCode === 204) {
+      return await res.body.dump()
+    }
+
     return await res.body.json()
   }
 }

--- a/packages/client/test/fixtures/movies/plugin.js
+++ b/packages/client/test/fixtures/movies/plugin.js
@@ -2,6 +2,34 @@
 
 /** @param {import('fastify').FastifyInstance} app */
 module.exports = async function (app) {
+  app.put('/movies/:id/:title', {
+    schema: {
+      operationId: 'updateMovieTitle',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' }
+        },
+        required: ['id', 'title']
+      },
+      responses: {
+        204: {
+          description: 'Successuly updated title'
+        }
+      }
+    }
+  }, async (request, reply) => {
+    await app.platformatic.entities.movie.save({
+      fields: ['id', 'title'],
+      input: {
+        id: request.params.id,
+        title: request.params.title
+      }
+    })
+    reply.status(204)
+  })
+
   app.get('/hello', async (request, reply) => {
     return { hello: 'world' }
   })

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -63,6 +63,19 @@ test('build basic client from url', async ({ teardown, same, rejects }) => {
     title: 'The Matrix Reloaded'
   })
 
+  const updatedTitle = await client.updateMovieTitle({ id: 1, title: 'The Matrix Revolutions' })
+
+  same(updatedTitle, undefined)
+
+  const movie3 = await client.getMovieById({
+    id: 1
+  })
+
+  same(movie3, {
+    id: 1,
+    title: 'The Matrix Revolutions'
+  })
+
   await rejects(client.getMovieById())
 
   {


### PR DESCRIPTION
Closes #883

Adds support for 204 level responses by dumping the empty body.

Also, I changed the `JSON.Stringify()` to be on `body` rather than `args`, I think this was is a mistake? By setting the properties to undefined withing the params loops I assume you're building a payload without data duplicated from the path params and query, so body should be sent?

Thanks!