### PR TITLE
feat(#876): allow for URL context paths when suppling openapi JSON path

### DIFF
--- a/packages/client/test/fixtures/movies/platformatic-prefix.db.json
+++ b/packages/client/test/fixtures/movies/platformatic-prefix.db.json
@@ -1,0 +1,28 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "db": {
+    "connectionString": "sqlite://./db.sqlite",
+    "graphql": true,
+    "openapi": {
+      "prefix": "/movies-api"
+    }
+  },
+  "migrations": {
+    "dir": "./migrations",
+    "autoApply": true
+  },
+  "plugins": {
+    "paths": [{
+      "path": "./plugin.js",
+      "options": {
+        "prefix": "/movies-api"
+      }
+    }]
+  }
+}

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -99,7 +99,7 @@ test('build basic client from url', async ({ teardown, same, rejects }) => {
   }
 })
 
-test('build basic client from file', { only: true }, async ({ teardown, same, rejects }) => {
+test('build basic client from file', async ({ teardown, same, rejects }) => {
   try {
     await fs.unlink(join(__dirname, 'fixtures', 'movies', 'db.sqlite'))
   } catch {

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -99,18 +99,18 @@ test('build basic client from url', async ({ teardown, same, rejects }) => {
   }
 })
 
-test('build basic client from file', async ({ teardown, same, rejects }) => {
+test('build basic client from file', { only: true }, async ({ teardown, same, rejects }) => {
   try {
     await fs.unlink(join(__dirname, 'fixtures', 'movies', 'db.sqlite'))
   } catch {
     // noop
   }
-  const server = await buildServer(join(__dirname, 'fixtures', 'movies', 'platformatic.db.json'))
+  const server = await buildServer(join(__dirname, 'fixtures', 'movies', 'platformatic-prefix.db.json'))
   teardown(server.stop)
   await server.listen()
 
   const client = await buildOpenAPIClient({
-    url: server.url,
+    url: `${server.url}/movies-api/`,
     path: join(__dirname, 'fixtures', 'movies', 'openapi.json')
   })
 


### PR DESCRIPTION
Closes #876

Hi, my apporach to this problem is as follows:
* If only a URL is provided, strip paths and use root as basePath - I didn't know if it would be safe to always assume the first path in the openapi JSON URL will be required by the endpoints, as there is probably mulitple standards?
* If a URL and JSON path are provided, use the full provided URL and append paths from the spec

```javascript
// baseUrl === 'https://test-server'
app.register(pltClient, {
  type: 'openapi',
  name: 'dogs',
  url: 'https://test-server/documentation/json'
})

// baseUrl === 'https://test-server/cats'
app.register(pltClient, {
  type: 'openapi',
  name: 'cats',
  path: join(__dirname, 'cats.openapi.json'),
  url: 'https://test-server/cats'
})
```

Lemme know what you think, thanks!