### PR TITLE
feat(#877): add support to receive full response objects from client

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -25,7 +25,7 @@ async function isFileAccessible (filename) {
 
 const configFileNames = ConfigManager.listConfigFiles()
 
-async function downloadAndProcess ({ url, name, folder, config, fullResponse }) {
+async function downloadAndProcess ({ url, name, folder, config, r: fullResponse }) {
   // try OpenAPI first
   let res = await request(url)
   if (res.statusCode === 200) {
@@ -106,7 +106,7 @@ export async function command (argv) {
     // the default
     ext: '.txt'
   })
-  const { _: [url], 'full-response': fullResponse, ...options } = parseArgs(argv, {
+  const { _: [url], ...options } = parseArgs(argv, {
     string: ['name', 'folder'],
     boolean: ['typescript', 'full-response'],
     default: {
@@ -127,7 +127,7 @@ export async function command (argv) {
     process.exit(1)
   }
   try {
-    await downloadAndProcess({ url, fullResponse, ...options })
+    await downloadAndProcess({ url, ...options })
   } catch (err) {
     console.error(err)
     console.log('')

--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -25,7 +25,7 @@ async function isFileAccessible (filename) {
 
 const configFileNames = ConfigManager.listConfigFiles()
 
-async function downloadAndProcess ({ url, name, folder, config }) {
+async function downloadAndProcess ({ url, name, folder, config, fullResponse }) {
   // try OpenAPI first
   let res = await request(url)
   if (res.statusCode === 200) {
@@ -36,7 +36,7 @@ async function downloadAndProcess ({ url, name, folder, config }) {
     // TODO deal with yaml
     const schema = JSON.parse(text)
     await writeFile(join(folder, `${name}.openapi.json`), JSON.stringify(schema, null, 2))
-    const { types, implementation } = processOpenAPI({ schema, name })
+    const { types, implementation } = processOpenAPI({ schema, name, fullResponse })
     await writeFile(join(folder, `${name}.d.ts`), types)
     await writeFile(join(folder, `${name}.cjs`), implementation)
     await writeFile(join(folder, 'package.json'), getPackageJSON({ name }))
@@ -106,9 +106,9 @@ export async function command (argv) {
     // the default
     ext: '.txt'
   })
-  const { _: [url], ...options } = parseArgs(argv, {
+  const { _: [url], 'full-response': fullResponse, ...options } = parseArgs(argv, {
     string: ['name', 'folder'],
-    boolean: ['typescript'],
+    boolean: ['typescript', 'full-response'],
     default: {
       name: 'client',
       typescript: false
@@ -117,7 +117,8 @@ export async function command (argv) {
       n: 'name',
       f: 'folder',
       t: 'typescript',
-      c: 'config'
+      c: 'config',
+      r: 'full-response'
     }
   })
   options.folder = options.folder || join(process.cwd(), options.name)
@@ -126,7 +127,7 @@ export async function command (argv) {
     process.exit(1)
   }
   try {
-    await downloadAndProcess({ url, ...options })
+    await downloadAndProcess({ url, fullResponse, ...options })
   } catch (err) {
     console.error(err)
     console.log('')

--- a/packages/client-cli/help/help.txt
+++ b/packages/client-cli/help/help.txt
@@ -13,7 +13,7 @@ $ platformatic client http://exmaple.com/grapqhl -n myclient
 ```
 
 This will create a Fastify plugin that exposes a client for the remote API in a folder `myclient`
-and a file named myclient.js inside it. 
+and a file named myclient.js inside it.
 
 If platformatic config file is specified, it will be edited and a `clients` section will be added.
 Then, in any part of your Platformatic application you can use the client.
@@ -26,7 +26,7 @@ module.exports = async function (app, opts) {
     const res = await app.myclient.graphql({
       query: 'query { hello }'
     })
-    return res 
+    return res
   })
 }
 ```
@@ -49,3 +49,6 @@ Options:
 
   * `-c, --config <path>`: Path to the configuration file.
   * `-n, --name <name>`: Name of the client.
+  * `-f, --folder <name>`: Name of the plugin folder, defaults to --name value.
+  * `-t, --typescript`: Generate the client plugin in TypeScript.
+  * `-r, --full-response`: Client will return full response object rather than just the body.


### PR DESCRIPTION
Closes #877

Adds support to get full HTTP response by passing `fullResponse: true`:

```javascript
app.register(pltClient, {
  type: 'openapi',
  name: 'cats',
  path: join(__dirname, 'cats.openapi.json'),
  url: 'https://cats/',
  fullResponse: true,
})

// { statusCode: 200, headers: { 'content-type': 'application/json' }, body: { type: 'Norwegian forest' } }
await app.cats.getCat(10)
```