### PR TITLE
Use GraphQLID type for uuid

### DIFF
--- a/packages/sql-graphql/lib/utils.js
+++ b/packages/sql-graphql/lib/utils.js
@@ -53,7 +53,7 @@ function sqlTypeToGraphQL (sqlType) {
     case 'timestamp':
       return scalars.GraphQLDateTime
     case 'uuid':
-      return graphql.GraphQLString
+      return graphql.GraphQLID
     case 'json':
       return GraphQLJSONObject
     case 'jsonb':


### PR DESCRIPTION
Underneath GraphQLID technically is same as a GraphQLString, however, using ID type conveys a bit more meaning that the field value is not meant to be in a human friendly format.