### PR TITLE
feat: add ConfigManager methods for finding configs

### DIFF
--- a/packages/cli/lib/gh.js
+++ b/packages/cli/lib/gh.js
@@ -7,6 +7,7 @@ import parseArgs from 'minimist'
 import { access } from 'fs/promises'
 import pino from 'pino'
 import pretty from 'pino-pretty'
+import ConfigManager from '@platformatic/config'
 
 export const createGHAction = async (logger, workspaceId, env, config, buildTS, type, projectDir = process.cwd()) => {
   if (type === 'static') {
@@ -21,20 +22,7 @@ const logger = pino(pretty({
   ignore: 'hostname,pid'
 }))
 
-const configFileNames = [
-  './platformatic.db.json',
-  './platformatic.db.json5',
-  './platformatic.db.yaml',
-  './platformatic.db.yml',
-  './platformatic.db.toml',
-  './platformatic.db.tml',
-  './platformatic.service.json',
-  './platformatic.service.json5',
-  './platformatic.service.yaml',
-  './platformatic.service.yml',
-  './platformatic.service.toml',
-  './platformatic.service.tml'
-]
+const configFileNames = ConfigManager.listConfigFiles()
 
 async function isFileAccessible (filename) {
   try {

--- a/packages/cli/lib/upgrade.js
+++ b/packages/cli/lib/upgrade.js
@@ -1,22 +1,10 @@
+import ConfigManager from '@platformatic/config'
 import { analyze, write, upgrade as upgradeConfig } from '@platformatic/metaconfig'
 import parseArgs from 'minimist'
 import { access } from 'fs/promises'
 import { resolve } from 'path'
 
-const configFileNames = [
-  './platformatic.db.json',
-  './platformatic.db.json5',
-  './platformatic.db.yaml',
-  './platformatic.db.yml',
-  './platformatic.db.toml',
-  './platformatic.db.tml',
-  './platformatic.service.json',
-  './platformatic.service.json5',
-  './platformatic.service.yaml',
-  './platformatic.service.yml',
-  './platformatic.service.toml',
-  './platformatic.service.tml'
-]
+const configFileNames = ConfigManager.listConfigFiles()
 
 async function isFileAccessible (filename) {
   try {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@platformatic/authenticate": "workspace:*",
     "@platformatic/db": "workspace:*",
+    "@platformatic/config": "workspace:*",
     "@platformatic/metaconfig": "workspace:*",
     "@platformatic/service": "workspace:*",
     "@platformatic/client-cli": "workspace:*",

--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -9,6 +9,7 @@ import * as desm from 'desm'
 import { request } from 'undici'
 import { processOpenAPI } from './lib/gen-openapi.mjs'
 import { processGraphQL } from './lib/gen-graphql.mjs'
+import ConfigManager from '@platformatic/config'
 import { analyze, write } from '@platformatic/metaconfig'
 import graphql from 'graphql'
 import { appendToBothEnvs } from './lib/utils.mjs'
@@ -22,20 +23,7 @@ async function isFileAccessible (filename) {
   }
 }
 
-const configFileNames = [
-  './platformatic.db.json',
-  './platformatic.db.json5',
-  './platformatic.db.yaml',
-  './platformatic.db.yml',
-  './platformatic.db.toml',
-  './platformatic.db.tml',
-  './platformatic.service.json',
-  './platformatic.service.json5',
-  './platformatic.service.yaml',
-  './platformatic.service.yml',
-  './platformatic.service.toml',
-  './platformatic.service.tml'
-]
+const configFileNames = ConfigManager.listConfigFiles()
 
 async function downloadAndProcess ({ url, name, folder, config }) {
   // try OpenAPI first

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@platformatic/client": "workspace:*",
+    "@platformatic/config": "workspace:*",
     "@platformatic/metaconfig": "workspace:*",
     "abstract-logging": "^2.0.1",
     "code-block-writer": "^12.0.0",

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -238,18 +238,8 @@ class ConfigManager extends EventEmitter {
       // formats. Unfortunately, this means the ConfigManager needs to be
       // aware of the different application types (but that should be small).
       return [
-        'platformatic.service.json',
-        'platformatic.service.json5',
-        'platformatic.service.yaml',
-        'platformatic.service.yml',
-        'platformatic.service.toml',
-        'platformatic.service.tml',
-        'platformatic.db.json',
-        'platformatic.db.json5',
-        'platformatic.db.yaml',
-        'platformatic.db.yml',
-        'platformatic.db.toml',
-        'platformatic.db.tml'
+        ...this.listConfigFiles('service'),
+        ...this.listConfigFiles('db')
       ]
     }
   }

--- a/packages/config/test/fixtures/platformatic.db.json
+++ b/packages/config/test/fixtures/platformatic.db.json
@@ -1,0 +1,15 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "db": {
+    "connectionString": "postgres://postgres:postgres@127.0.0.1/postgres"
+  },
+  "migrations": {
+    "dir": "./migrations",
+    "table": "versions",
+    "autoApply": false,
+    "validateChecksums": true
+  }
+}

--- a/packages/config/test/fixtures/platformatic.service.json
+++ b/packages/config/test/fixtures/platformatic.service.json
@@ -1,0 +1,10 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "plugins": {
+    "paths": ["./plugin.js"],
+    "hotReload": false
+  }
+}

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const { resolve } = require('path')
+const { join, resolve } = require('path')
 const ConfigManager = require('..')
 const path = require('path')
 const { unlink, writeFile, mkdir } = require('fs/promises')
@@ -251,4 +251,72 @@ test('should look for a .env file in process.cwd() too', async ({ same, fail, pl
   same(cm.current, expectedConfig)
   await unlink(file)
   await unlink(envFile)
+})
+
+test('ConfigManager.listConfigFiles() lists possible configs by type', async ({ plan, same }) => {
+  plan(2)
+  same(ConfigManager.listConfigFiles('db'), [
+    'platformatic.db.json',
+    'platformatic.db.json5',
+    'platformatic.db.yaml',
+    'platformatic.db.yml',
+    'platformatic.db.toml',
+    'platformatic.db.tml'
+  ])
+  same(ConfigManager.listConfigFiles('service'), [
+    'platformatic.service.json',
+    'platformatic.service.json5',
+    'platformatic.service.yaml',
+    'platformatic.service.yml',
+    'platformatic.service.toml',
+    'platformatic.service.tml'
+  ])
+})
+
+test('ConfigManager.listConfigFiles() lists all possible configs', async ({ plan, same }) => {
+  plan(1)
+  same(ConfigManager.listConfigFiles(), [
+    'platformatic.service.json',
+    'platformatic.service.json5',
+    'platformatic.service.yaml',
+    'platformatic.service.yml',
+    'platformatic.service.toml',
+    'platformatic.service.tml',
+    'platformatic.db.json',
+    'platformatic.db.json5',
+    'platformatic.db.yaml',
+    'platformatic.db.yml',
+    'platformatic.db.toml',
+    'platformatic.db.tml'
+  ])
+})
+
+test('ConfigManager.findConfigFile() finds configs by type', async ({ plan, same }) => {
+  plan(2)
+  const fixturesDir = join(__dirname, 'fixtures')
+  same(
+    await ConfigManager.findConfigFile(fixturesDir, 'db'),
+    'platformatic.db.json'
+  )
+  same(
+    await ConfigManager.findConfigFile(fixturesDir, 'service'),
+    'platformatic.service.json'
+  )
+})
+
+test('ConfigManager.findConfigFile() finds configs without type', async ({ plan, same }) => {
+  plan(1)
+  const fixturesDir = join(__dirname, 'fixtures')
+  same(
+    await ConfigManager.findConfigFile(fixturesDir),
+    'platformatic.service.json'
+  )
+})
+
+test('ConfigManager.findConfigFile() searches cwd by default', async ({ plan, same }) => {
+  plan(1)
+  same(
+    await ConfigManager.findConfigFile(),
+    undefined
+  )
 })

--- a/packages/create-platformatic/package.json
+++ b/packages/create-platformatic/package.json
@@ -19,6 +19,7 @@
   "license": "Apache-2.0",
   "author": "Marco Piraccini <marco.piraccini@gmail.com>",
   "dependencies": {
+    "@platformatic/config": "workspace:*",
     "chalk": "^5.2.0",
     "commist": "^3.2.0",
     "desm": "^1.3.0",

--- a/packages/create-platformatic/src/utils.mjs
+++ b/packages/create-platformatic/src/utils.mjs
@@ -4,6 +4,7 @@ import { resolve, join, dirname } from 'path'
 import { createRequire } from 'module'
 import semver from 'semver'
 import * as desm from 'desm'
+import ConfigManager from '@platformatic/config'
 
 export const sleep = ms => new Promise((resolve) => setTimeout(resolve, ms))
 export const randomBetween = (min, max) => Math.floor(Math.random() * (max - min + 1) + min)
@@ -67,22 +68,8 @@ export const validatePath = async projectPath => {
   return canAccessParent
 }
 
-const findConfigFile = async (directory, type) => {
-  const configFileNames = [
-    `platformatic.${type}.json`,
-    `platformatic.${type}.json5`,
-    `platformatic.${type}.yaml`,
-    `platformatic.${type}.yml`,
-    `platformatic.${type}.toml`,
-    `platformatic.${type}.tml`
-  ]
-  const configFilesAccessibility = await Promise.all(configFileNames.map((fileName) => isFileAccessible(fileName, directory)))
-  const accessibleConfigFilename = configFileNames.find((value, index) => configFilesAccessibility[index])
-  return accessibleConfigFilename
-}
-
-export const findDBConfigFile = async (directory) => (findConfigFile(directory, 'db'))
-export const findServiceConfigFile = async (directory) => (findConfigFile(directory, 'service'))
+export const findDBConfigFile = async (directory) => (ConfigManager.findConfigFile(directory, 'db'))
+export const findServiceConfigFile = async (directory) => (ConfigManager.findConfigFile(directory, 'service'))
 
 export const getDependencyVersion = async (dependencyName) => {
   const require = createRequire(import.meta.url)

--- a/packages/db-dashboard/package.json
+++ b/packages/db-dashboard/package.json
@@ -23,7 +23,8 @@
     "lint": "standard | snazzy"
   },
   "dependencies": {
-    "@fastify/static": "^6.9.0"
+    "@fastify/static": "^6.9.0",
+    "@platformatic/config": "workspace:*"
   },
   "devDependencies": {
     "@graphiql/toolkit": "0.8.3",

--- a/packages/db-dashboard/scripts/fix-dashboard-env.js
+++ b/packages/db-dashboard/scripts/fix-dashboard-env.js
@@ -3,19 +3,10 @@
 const { join } = require('path')
 const { readFile, writeFile } = require('fs/promises')
 const { ConfigManager } = require('@platformatic/service')
-const { findConfigFile } = require('@platformatic/service/lib/utils')
 
 async function main () {
-  const ourConfigFiles = [
-    'platformatic.db.json',
-    'platformatic.db.json5',
-    'platformatic.db.yaml',
-    'platformatic.db.yml',
-    'platformatic.db.toml',
-    'platformatic.db.tml'
-  ]
   const rootDirectory = join(__dirname, '..', '..', '..')
-  const configFileName = await findConfigFile(rootDirectory, ourConfigFiles)
+  const configFileName = await ConfigManager.findConfigFile(rootDirectory, 'db')
   if (!configFileName) {
     console.log('No config file found, skipping other checks.')
     return

--- a/packages/db-dashboard/scripts/fix-dashboard-env.js
+++ b/packages/db-dashboard/scripts/fix-dashboard-env.js
@@ -2,7 +2,7 @@
 
 const { join } = require('path')
 const { readFile, writeFile } = require('fs/promises')
-const { ConfigManager } = require('@platformatic/service')
+const ConfigManager = require('@platformatic/config')
 
 async function main () {
   const rootDirectory = join(__dirname, '..', '..', '..')

--- a/packages/db/lib/load-config.mjs
+++ b/packages/db/lib/load-config.mjs
@@ -3,15 +3,6 @@ import { schema } from './schema.js'
 import { platformaticDB } from '../index.js'
 import adjustConfig from './adjust-config.js'
 
-const ourConfigFiles = [
-  'platformatic.db.json',
-  'platformatic.db.json5',
-  'platformatic.db.yaml',
-  'platformatic.db.yml',
-  'platformatic.db.toml',
-  'platformatic.db.tml'
-]
-
 export function generateConfigManagerConfig () {
   return {
     ...service.generateConfigManagerConfig(),
@@ -22,7 +13,7 @@ export function generateConfigManagerConfig () {
 }
 
 export async function loadConfig (a, b) {
-  const res = await service.loadConfig(a, b, generateConfigManagerConfig(), ourConfigFiles)
+  const res = await service.loadConfig(a, b, generateConfigManagerConfig(), 'db')
   await adjustConfig(res.configManager)
   return res
 }

--- a/packages/service/lib/utils.js
+++ b/packages/service/lib/utils.js
@@ -3,12 +3,6 @@
 const { access } = require('fs/promises')
 const { resolve, join, relative, dirname, basename } = require('path')
 
-async function findConfigFile (directory, configFileNames) {
-  const configFilesAccessibility = await Promise.all(configFileNames.map((fileName) => isFileAccessible(fileName, directory)))
-  const accessibleConfigFilename = configFileNames.find((value, index) => configFilesAccessibility[index])
-  return accessibleConfigFilename
-}
-
 async function isFileAccessible (filename, directory) {
   try {
     const filePath = directory ? resolve(directory, filename) : filename
@@ -64,7 +58,6 @@ function getJSPluginPath (configPath, tsPluginPath, compileDir) {
 }
 
 module.exports = {
-  findConfigFile,
   isFileAccessible,
   getJSPluginPath,
   addLoggerToTheConfig

--- a/packages/service/test/utils.test.js
+++ b/packages/service/test/utils.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const { getJSPluginPath, findConfigFile, isFileAccessible } = require('../lib/utils')
+const { getJSPluginPath, isFileAccessible } = require('../lib/utils')
 const { join, resolve } = require('path')
 
 test('should get the path of a TS plugin', (t) => {
@@ -17,20 +17,6 @@ test('should get the path of a JS plugin', (t) => {
 
   const result = getJSPluginPath('/something/platformatic.service.json', '/something/plugin.js', '/something/dist')
   t.equal(result, '/something/plugin.js')
-})
-
-test('findConfigFile', async (t) => {
-  const result = await findConfigFile(join(__dirname, '..', 'fixtures', 'hello'), [
-    'platformatic.service.json'
-  ])
-  t.equal(result, 'platformatic.service.json')
-})
-
-test('findConfigFile / failure', async (t) => {
-  const result = await findConfigFile(join(__dirname, '..', 'fixtures', 'hello'), [
-    'foobar'
-  ])
-  t.equal(result, undefined)
 })
 
 test('isFileAccessible no dir', async (t) => {

--- a/packages/service/test/utils.test.js
+++ b/packages/service/test/utils.test.js
@@ -19,6 +19,11 @@ test('should get the path of a JS plugin', (t) => {
   t.equal(result, '/something/plugin.js')
 })
 
+test('isFileAccessible with dir', async (t) => {
+  const dir = resolve(join(__dirname, '..', 'fixtures', 'hello'))
+  t.equal(await isFileAccessible('platformatic.service.json', dir), true)
+})
+
 test('isFileAccessible no dir', async (t) => {
   const file = resolve(join(__dirname, '..', 'fixtures', 'hello', 'platformatic.service.json'))
   t.equal(await isFileAccessible(file), true)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@platformatic/client-cli':
         specifier: workspace:*
         version: link:../client-cli
+      '@platformatic/config':
+        specifier: workspace:*
+        version: link:../config
       '@platformatic/db':
         specifier: workspace:*
         version: link:../db
@@ -169,6 +172,9 @@ importers:
       '@platformatic/client':
         specifier: workspace:*
         version: link:../client
+      '@platformatic/config':
+        specifier: workspace:*
+        version: link:../config
       '@platformatic/metaconfig':
         specifier: workspace:*
         version: link:../metaconfig
@@ -285,6 +291,9 @@ importers:
 
   packages/create-platformatic:
     dependencies:
+      '@platformatic/config':
+        specifier: workspace:*
+        version: link:../config
       chalk:
         specifier: ^5.2.0
         version: 5.2.0
@@ -622,6 +631,9 @@ importers:
       '@fastify/static':
         specifier: ^6.9.0
         version: 6.9.0
+      '@platformatic/config':
+        specifier: workspace:*
+        version: link:../config
     devDependencies:
       '@graphiql/toolkit':
         specifier: 0.8.3
@@ -14659,6 +14671,7 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
     dev: true
 
   /trivial-deferred@1.1.2:


### PR DESCRIPTION
This commit adds two static methods to the `ConfigManager` class:

- `listConfigFiles()` - this lists well known config files with or without a project type filter. It does not touch the file system at all.
- `findConfigFile()` - this looks for a well known config file (with or without a project type filter) in a specific directory.

The goal of these methods is to reduce code duplication in the codebase and make it simpler to discover config files before creating a `ConfigManager` instance.