### PR TITLE
Store & Reload the schema metadata on disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ tags
 packages/service/test/tmp
 packages/cli/fixtures/sqlite/db
 packages/client-cli/test/tmp
+packages/db/test/fixtures/schema.lock

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -275,6 +275,24 @@ A **required** object with the following settings:
   }
   ```
 
+- **`schemalock`** (`boolean` or `object`, default: `false`) — Controls the caching of the database schema on disk;
+  if set to `true` it would store the database schema metadata inside a `schema.lock` file.
+  It's also possible to configure the location of that file by specifying a path, like so:
+
+  _Examples_
+
+  ```json
+  {
+    "db": {
+      ...
+      "schemalock": {
+        "path": "./dbmetadata"
+      }
+    }
+  }
+  ```
+
+
 ### `dashboard`
 
 This setting can be a `boolean` or an `object`. If set to `true` the dashboard will be served at the root path (`/`).

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -275,8 +275,8 @@ A **required** object with the following settings:
   }
   ```
 
-- **`schemalock`** (`boolean` or `object`, default: `false`) — Controls the caching of the database schema on disk;
-  if set to `true` it would store the database schema metadata inside a `schema.lock` file.
+- **`schemalock`** (`boolean` or `object`, default: `false`) — Controls the caching of the database schema on disk.
+  If set to `true` the database schema metadata is stored inside a `schema.lock` file.
   It's also possible to configure the location of that file by specifying a path, like so:
 
   _Examples_

--- a/packages/db/lib/migrate.mjs
+++ b/packages/db/lib/migrate.mjs
@@ -8,13 +8,13 @@ import { MigrateError } from './errors.mjs'
 import { loadConfig } from './load-config.mjs'
 import { execute as generateTypes, checkForDependencies } from './gen-types.mjs'
 import { utimesSync } from 'fs'
+import { updateSchemaLock } from './utils.js'
 
 async function execute (logger, args, config) {
   const migrationsConfig = config.migrations
   if (migrationsConfig === undefined) {
     throw new MigrateError('Missing "migrations" section in config file')
   }
-
   const migrator = new Migrator(migrationsConfig, config.db, logger)
 
   try {
@@ -51,6 +51,8 @@ async function applyMigrations (_args) {
       await generateTypes(logger, args, config)
       await checkForDependencies(logger, args, config)
     }
+
+    await updateSchemaLock(logger, configManager)
 
     // touch the platformatic db config to trigger a restart
     const now = new Date()

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -17,6 +17,20 @@ const db = {
         type: 'string'
       }
     },
+    schemaLock: {
+      oneOf: [{
+        type: 'boolean',
+        default: false
+      }, {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            resolvePath: true
+          }
+        }
+      }]
+    },
     poolSize: {
       type: 'integer'
     },

--- a/packages/db/test/fixtures/no-auto-apply.json
+++ b/packages/db/test/fixtures/no-auto-apply.json
@@ -7,7 +7,8 @@
         }
     },
     "db": {
-        "connectionString": "postgres://postgres:postgres@127.0.0.1/postgres"
+        "connectionString": "postgres://postgres:postgres@127.0.0.1/postgres",
+        "schemalock": false
     },
     "migrations": {
         "dir": "./migrations",

--- a/packages/db/test/fixtures/schemalock.json
+++ b/packages/db/test/fixtures/schemalock.json
@@ -1,0 +1,19 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "trace"
+    }
+  },
+  "db": {
+    "connectionString": "postgres://postgres:postgres@127.0.0.1/postgres",
+    "schemalock": true
+  },
+  "migrations": {
+    "dir": "./migrations",
+    "table": "versions",
+    "autoApply": true
+  },
+  "authorization": {}
+}

--- a/packages/db/test/fixtures/schemalock2.json
+++ b/packages/db/test/fixtures/schemalock2.json
@@ -1,0 +1,21 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    }
+  },
+  "db": {
+    "connectionString": "postgres://postgres:postgres@127.0.0.1/postgres",
+    "schemalock": {
+      "path": "./another-schema.lock"
+    }
+  },
+  "migrations": {
+    "dir": "./migrations",
+    "table": "versions",
+    "autoApply": true
+  },
+  "authorization": {}
+}


### PR DESCRIPTION
Retrieving the database schema metadata via SQL at every startup of the database adds quite a bit of latency and it increase cold start time. This change allows us to store it on disk so that it can be skipped at startup time.