### PR TITLE
client-cli: set response types to undefined for 204 responses, support 201 and empty objects

### DIFF
--- a/packages/client-cli/lib/utils.mjs
+++ b/packages/client-cli/lib/utils.mjs
@@ -5,6 +5,10 @@ export function capitalize (str) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
+export function classCase (str) {
+  return str.split(/[^a-z]+/i).map(s => capitalize(s)).join('')
+}
+
 export async function appendToEnv (file, key, value) {
   const str = `\n${key}=${value}\n`
   try {

--- a/packages/client-cli/test/cli-graphql.test.mjs
+++ b/packages/client-cli/test/cli-graphql.test.mjs
@@ -297,7 +297,7 @@ app.post('/', async (request, reply) => {
   const res = await app.movies.graphql({
     query: 'mutation { saveMovie(input: { title: "foo" }) { id, title } }'
   })
-  return res 
+  return res
 })
 app.listen({ port: 0 })
 `

--- a/packages/client-cli/test/fixtures/movies/plugin.js
+++ b/packages/client-cli/test/fixtures/movies/plugin.js
@@ -45,11 +45,26 @@ module.exports = async function (app) {
               schema: {}
             }
           }
+        },
+        400: {
+          description: 'Validation error',
+          content: {
+            'application/json': {
+              schema: {
+                statusCode: { type: 'number', const: 400 },
+                error: { type: 'string' },
+                message: { type: 'string' }
+              }
+            }
+          }
         }
       }
     }
   },
   async (request, reply) => {
+    await app.platformatic.entities.movie.save({
+      input: request.body
+    })
     reply.status(201)
     return {}
   })

--- a/packages/client-cli/test/fixtures/movies/plugin.js
+++ b/packages/client-cli/test/fixtures/movies/plugin.js
@@ -2,6 +2,58 @@
 
 /** @param {import('fastify').FastifyInstance} app */
 module.exports = async function (app) {
+  app.put('/movies/:id/:title', {
+    schema: {
+      operationId: 'updateMovieTitle',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' }
+        },
+        required: ['id', 'title']
+      },
+      response: {
+        204: {
+          type: 'null',
+          description: 'No Content'
+        }
+      }
+    }
+  }, async (request, reply) => {
+    await app.platformatic.entities.movie.save({
+      fields: ['id', 'title'],
+      input: {
+        id: request.params.id,
+        title: request.params.title
+      }
+    })
+    reply.status(204)
+  })
+
+  app.post('/movies-201', {
+    schema: {
+      operationId: 'createMovie201',
+      body: {
+        $ref: 'Movie'
+      },
+      response: {
+        201: {
+          description: 'Movie created successfully',
+          content: {
+            'application/json': {
+              schema: {}
+            }
+          }
+        }
+      }
+    }
+  },
+  async (request, reply) => {
+    reply.status(201)
+    return {}
+  })
+
   app.get('/hello', async (request, reply) => {
     return { hello: 'world' }
   })

--- a/packages/client/test/fixtures/movies/plugin.js
+++ b/packages/client/test/fixtures/movies/plugin.js
@@ -13,9 +13,10 @@ module.exports = async function (app) {
         },
         required: ['id', 'title']
       },
-      responses: {
+      response: {
         204: {
-          description: 'Successuly updated title'
+          type: 'null',
+          description: 'No Content'
         }
       }
     }


### PR DESCRIPTION
Hi,

In https://github.com/platformatic/platformatic/pull/884 I added support for 204 responses with no body to the client plugin, the changes in this PR allow the client-cli to generate `undefined` types for those responses rather than throw because of a lack of a 200 response.

Example:

```json
{
  "responses": {
    "204": {
      "description": "Delete an task template",
      "content": {
        "*/*": {
          "schema": {
            "type": "object"
          }
        }
      }
    }
  }
}
```

Gives:

```typescript
interface Tasks {
  deleteTaskTemplate(req: DeleteTaskTemplateRequest): Promise<undefined>;
}
```

I've also allowed 201 responses and skip attempting to add interface properties if there's no schema defined for the respone (again to prevent client-cli throwing in this case). This is due to having a bunch of Java/Spring APIs in my organisation that return 201 respones with empty object bodies, example openapi schema I'm dealing with:

```json
{
  "201": {
    "description": "Agent created successfully",
    "headers": {
      "Location": {
        "description": "Location URL of the newly created agent.",
        "style": "simple"
      }
    },
    "content": {
      "application/json": {}
    }
  }
}
```

Gives:
```typescript
interface CreateAgentResponse {
}
```
