### PR TITLE
feat: add platformatic start command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
       - name: Run test suite
         run: cd packages/service && pnpm test; cd ../..
 
-  ci-config:
+  ci-start:
     needs: setup-node_modules
     runs-on: ${{matrix.os}}
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,31 @@ jobs:
       - name: Run test suite
         run: cd packages/service && pnpm test; cd ../..
 
+  ci-config:
+    needs: setup-node_modules
+    runs-on: ${{matrix.os}}
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        node-version: [18]
+        os: [ubuntu-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: pnpm/action-setup@v2.2.4
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - name: pnpm install
+      uses: nick-fields/retry@v2.8.3
+      with:
+        max_attempts: 10
+        timeout_minutes: 15
+        retry_on: error
+        command: pnpm install --frozen-lockfile
+    - name: Run start package test suite
+      run: cd packages/start && pnpm test
+
   ci-client:
     needs: setup-node_modules
     runs-on: ${{ matrix.os }}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,6 +89,7 @@ Welcome to Platformatic. Available commands are:
 * upgrade - upgrade the Platformatic configuration to the latest version.
 * gh - creates a new gh action for Platformatic deployments
 * deploy - deploy a Platformatic application to the cloud
+* start - start a Platformatic application
 ```
 
 
@@ -107,7 +108,7 @@ Compile typescript plugins.
 ```
 
 As a result of executing this command, the Platformatic DB will compile typescript
-plugins in the `outDir` directory. 
+plugins in the `outDir` directory.
 
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
@@ -369,7 +370,7 @@ Compile typescript plugins.
 ```
 
 As a result of executing this command, the Platformatic DB will compile typescript
-plugins in the `outDir` directory. 
+plugins in the `outDir` directory.
 
 If not specified, the configuration specified will be loaded from
 `platformatic.service.json`, `platformatic.service.yml`, or `platformatic.service.tml` in the current directory.
@@ -451,7 +452,7 @@ $ platformatic client http://exmaple.com/grapqhl -n myclient
 ```
 
 This will create a Fastify plugin that exposes a client for the remote API in a folder `myclient`
-and a file named myclient.js inside it. 
+and a file named myclient.js inside it.
 
 If platformatic config file is specified, it will be edited and a `clients` section will be added.
 Then, in any part of your Platformatic application you can use the client.
@@ -464,7 +465,7 @@ module.exports = async function (app, opts) {
     const res = await app.myclient.graphql({
       query: 'query { hello }'
     })
-    return res 
+    return res
   })
 }
 ```
@@ -488,3 +489,17 @@ Options:
   * `-c, --config <path>`: Path to the configuration file.
   * `-n, --name <name>`: Name of the client.
 
+### start
+
+```bash
+platformatic start
+```
+
+
+#### help
+
+Start a Platformatic application with the following command:
+
+``` bash
+$ platformatic start
+```

--- a/docs/reference/start/programmatic.md
+++ b/docs/reference/start/programmatic.md
@@ -1,0 +1,97 @@
+# Programmatic API
+
+In many cases it's useful to start Platformatic applications using an API
+instead of the command line. The `@platformatic/start` API makes it simple to
+work with different application types (e.g. `service`, `db`) without needing to
+know the application type a priori.
+
+## `buildServer()`
+
+The `buildServer` function creates a server from a provided configuration
+object.
+
+```js
+import { buildServer } from '@platformatic/start'
+
+// This config can also be obtained via loadConfig().
+const config = {
+  server: {
+    hostname: '127.0.0.1',
+    port: 0
+  }
+}
+const app = await buildServer(config)
+
+await app.start()
+```
+
+## `getConfigType()`
+
+The `getConfigType` function takes an array of command line arguments and a
+directory, and returns a string indicating the application type.
+
+```js
+import { getConfigType } from '@platformatic/start'
+
+// Get the type from command line arguments.
+const type = await getConfigType(['-c', '/path/to/platformatic.config.json'])
+
+// Search a directory for a config file and get the type from that file.
+const type = await getConfigType(undefined, '/directory/of/project')
+
+// Search a the current working directory for a config file and get the type
+// from that file.
+const type = await getConfigType()
+```
+
+## `loadConfig()`
+
+The `loadConfig` function is used to read and parse a configuration file for
+an arbitrary Platformatic application.
+
+```js
+import { loadConfig } from '@platformatic/start'
+
+// Read the config based on command line arguments. loadConfig() will detect
+// the application type.
+const config = await loadConfig({}, ['-c', '/path/to/platformatic.config.json'])
+
+// Read the config based on command line arguments. The application type can
+// be provided explicitly.
+const config = await loadConfig(
+  {},
+  ['-c', '/path/to/platformatic.config.json'],
+  undefined,
+  'service'
+)
+
+// Default config can be specified.
+const config = await loadConfig(
+  {},
+  ['-c', '/path/to/platformatic.config.json'],
+  { key: 'value' }
+)
+```
+
+## `start()`
+
+The `start` function loads a configuration, builds a server, and starts the
+server. However, the server is not returned.
+
+```js
+import { start } from '@platformatic/start'
+
+await start(['-c', '/path/to/platformatic.config.json])
+```
+
+## `startCommand()`
+
+The `startCommand` function is similar to `start`. However, if an exception
+occurs, `startCommand` logs the error and exits the process. This is different
+from `start`, which throws the exception.
+
+```js
+import { start } from '@platformatic/start'
+
+await startCommand(['-c', '/path/to/platformatic.config.json])
+```

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -4,6 +4,7 @@ import commist from 'commist'
 import minimist from 'minimist'
 import { runDB } from '@platformatic/db/db.mjs'
 import { runService } from '@platformatic/service/service.mjs'
+import { startCommand } from '@platformatic/start'
 import { login } from '@platformatic/authenticate/authenticate.js'
 import { command as client } from '@platformatic/client-cli'
 import { readFile } from 'fs/promises'
@@ -38,6 +39,7 @@ const ensureCommand = async ({ output, help }) => {
 
 program.register('db', async (args) => ensureCommand(await runDB(args)))
 program.register('service', async (args) => ensureCommand(await runService(args)))
+program.register('start', startCommand)
 program.register('upgrade', upgrade)
 program.register('client', client)
 program.register('help', help.toStdout)

--- a/packages/cli/help/help.txt
+++ b/packages/cli/help/help.txt
@@ -7,3 +7,4 @@ Welcome to Platformatic. Available commands are:
 * upgrade - upgrade the Platformatic configuration to the latest version.
 * gh - creates a new gh action for Platformatic deployments
 * deploy - deploy a Platformatic application to the cloud
+* start - start a Platformatic application

--- a/packages/cli/help/start.txt
+++ b/packages/cli/help/start.txt
@@ -1,0 +1,5 @@
+Start a Platformatic application with the following command:
+
+``` bash
+$ platformatic start
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "@platformatic/deploy-client": "^0.1.2",
     "@platformatic/metaconfig": "workspace:*",
     "@platformatic/service": "workspace:*",
+    "@platformatic/start": "workspace:*",
     "colorette": "^2.0.20",
     "commist": "^3.2.0",
     "create-platformatic": "workspace:*",

--- a/packages/cli/test/fixtures/platformatic.service.json
+++ b/packages/cli/test/fixtures/platformatic.service.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.22.0/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info",
+      "name": "hello server"
+    }
+  },
+  "metrics": false,
+  "watch": false
+}

--- a/packages/cli/test/start.test.js
+++ b/packages/cli/test/start.test.js
@@ -15,33 +15,26 @@ test('starts a server', async ({ teardown }) => {
 
   await cp(src, dest)
 
-  return new Promise((resolve, reject) => {
-    try {
-      const child = spawn(process.execPath, [cliPath, 'start'], {
-        cwd: destDir,
-        timeout: 10_000
-      })
-
-      teardown(async () => {
-        try {
-          child.kill('SIGINT')
-        } catch {} // Ignore error.
-      })
-
-      let stdout = ''
-
-      child.stdout.setEncoding('utf8')
-      child.stdout.on('data', (chunk) => {
-        stdout += chunk
-
-        if (/server listening at/i.test(stdout)) {
-          resolve()
-        }
-      })
-
-      child.on('error', reject)
-    } catch (err) {
-      reject(err)
-    }
+  const child = spawn(process.execPath, [cliPath, 'start'], {
+    cwd: destDir,
+    timeout: 10_000
   })
+
+  teardown(async () => {
+    try {
+      child.kill('SIGINT')
+    } catch {} // Ignore error.
+  })
+
+  let stdout = ''
+
+  child.stdout.setEncoding('utf8')
+
+  for await (const chunk of child.stdout) {
+    stdout += chunk
+
+    if (/server listening at/i.test(stdout)) {
+      break
+    }
+  }
 })

--- a/packages/cli/test/start.test.js
+++ b/packages/cli/test/start.test.js
@@ -1,0 +1,47 @@
+import { spawn } from 'node:child_process'
+import { cp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'tap'
+import { cliPath } from './helper.js'
+
+let count = 0
+
+test('starts a server', async ({ teardown }) => {
+  const src = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'platformatic.service.json')
+  const destDir = join(tmpdir(), `test-cli-${process.pid}-${count++}`)
+  const dest = join(destDir, 'platformatic.service.json')
+
+  await cp(src, dest)
+
+  return new Promise((resolve, reject) => {
+    try {
+      const child = spawn(process.execPath, [cliPath, 'start'], {
+        cwd: destDir,
+        timeout: 10_000
+      })
+
+      teardown(async () => {
+        try {
+          child.kill('SIGINT')
+        } catch {} // Ignore error.
+      })
+
+      let stdout = ''
+
+      child.stdout.setEncoding('utf8')
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk
+
+        if (/server listening at/i.test(stdout)) {
+          resolve()
+        }
+      })
+
+      child.on('error', reject)
+    } catch (err) {
+      reject(err)
+    }
+  })
+})

--- a/packages/start/LICENSE
+++ b/packages/start/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/start/NOTICE
+++ b/packages/start/NOTICE
@@ -1,0 +1,13 @@
+ Copyright 2023 Platformatic
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.

--- a/packages/start/fixtures/dbApp/platformatic.db.json
+++ b/packages/start/fixtures/dbApp/platformatic.db.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.22.0/db",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "migrations": {
+    "dir": "migrations",
+    "table": "versions"
+  },
+  "types": {
+    "autogenerate": false
+  },
+  "db": {
+    "connectionString": "sqlite://db.sqlite",
+    "graphql": true,
+    "ignore": {
+      "versions": true
+    },
+    "events": false
+  }
+}

--- a/packages/start/fixtures/invalid-schema-type.config.json
+++ b/packages/start/fixtures/invalid-schema-type.config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.22.0/trickortreat",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info",
+      "name": "hello server"
+    }
+  },
+  "plugins": {
+    "paths": ["./plugin.js"],
+    "hotReload": false
+  },
+  "service": {
+    "openapi": true
+  },
+  "metrics": false,
+  "watch": false
+}

--- a/packages/start/fixtures/no-schema.config.json
+++ b/packages/start/fixtures/no-schema.config.json
@@ -1,0 +1,19 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info",
+      "name": "hello server"
+    }
+  },
+  "plugins": {
+    "paths": ["./plugin.js"],
+    "hotReload": false
+  },
+  "service": {
+    "openapi": true
+  },
+  "metrics": false,
+  "watch": false
+}

--- a/packages/start/fixtures/serviceApp/platformatic.service.json
+++ b/packages/start/fixtures/serviceApp/platformatic.service.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.22.0/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info",
+      "name": "hello server"
+    }
+  },
+  "plugins": {
+    "paths": ["./plugin.js"],
+    "hotReload": false
+  },
+  "service": {
+    "openapi": true
+  },
+  "metrics": false,
+  "watch": false
+}

--- a/packages/start/fixtures/serviceApp/plugin.js
+++ b/packages/start/fixtures/serviceApp/plugin.js
@@ -1,0 +1,7 @@
+'use default'
+
+module.exports = async function (app) {
+  app.get('/', async () => {
+    return { hello: 'world' }
+  })
+}

--- a/packages/start/fixtures/start-command.js
+++ b/packages/start/fixtures/start-command.js
@@ -1,0 +1,9 @@
+'use strict'
+const { startCommand } = require('..')
+
+async function main () {
+  await startCommand(['-c', process.argv[2]])
+  process.exit(42)
+}
+
+main()

--- a/packages/start/fixtures/starter.js
+++ b/packages/start/fixtures/starter.js
@@ -1,0 +1,9 @@
+'use strict'
+const { start } = require('..')
+
+async function main () {
+  await start(['-c', process.argv[2]])
+  process.exit(42)
+}
+
+main()

--- a/packages/start/index.js
+++ b/packages/start/index.js
@@ -27,7 +27,7 @@ function tryGetConfigTypeFromSchema (config) {
   return configType
 }
 
-async function getConfigType (args, directory) {
+async function getConfigType (args = [], directory) {
   try {
     // The config type was not specified, so we need to figure it out.
     // Try to get the config file from the provided arguments.

--- a/packages/start/index.js
+++ b/packages/start/index.js
@@ -1,0 +1,134 @@
+'use strict'
+const { resolve } = require('node:path')
+const parseArgs = require('minimist')
+const ConfigManager = require('@platformatic/config')
+const {
+  buildServer: dbBuildServer
+} = require('@platformatic/db')
+const {
+  buildServer: serviceBuildServer,
+  loadConfig: serviceLoadConfig
+} = require('@platformatic/service')
+const kSupportedAppTypes = new Set(['service', 'db'])
+
+function tryGetConfigTypeFromSchema (config) {
+  const schema = config?.$schema
+
+  if (typeof schema !== 'string') {
+    throw new Error('configuration is missing a schema')
+  }
+
+  const configType = schema.split('/').pop()
+
+  if (!kSupportedAppTypes.has(configType)) {
+    throw new Error(`unknown configuration type: '${configType}'`)
+  }
+
+  return configType
+}
+
+async function getConfigType (args, directory) {
+  try {
+    // The config type was not specified, so we need to figure it out.
+    // Try to get the config file from the provided arguments.
+    let { config } = parseArgs(args, { alias: { c: 'config' } })
+
+    if (!config) {
+      // Couldn't get the config file from the arguments, so look in the
+      // provided directory (or current directory) for any recognized
+      // config files.
+      const searchDir = directory ?? process.cwd()
+      const configFile = await ConfigManager.findConfigFile(searchDir)
+
+      config = resolve(searchDir, configFile)
+    }
+
+    // At this point, we have the config file. However, several different
+    // file formats are supported, so use the config manager to parse the
+    // file (without worrying about the validity of the file). We can then
+    // use the $schema field to determine the config type.
+    const configManager = new ConfigManager({ source: config })
+    const configString = await configManager.load()
+    const parsedConfig = configManager._parser(configString)
+
+    return tryGetConfigTypeFromSchema(parsedConfig)
+  } catch (err) {
+    const configFiles = ConfigManager.listConfigFiles()
+    const msg = `
+Missing config file!
+Be sure to have a config file with one of the following names: ${configFiles.join('\n')}
+Alternatively run "npm create platformatic@latest" to generate a basic plt service config.
+`
+
+    throw new Error(msg, { cause: err })
+  }
+}
+
+async function buildServer (options) {
+  const configType = tryGetConfigTypeFromSchema(options)
+  let buildServerFn
+
+  if (configType === 'service') {
+    buildServerFn = serviceBuildServer
+  } else if (configType === 'db') {
+    buildServerFn = dbBuildServer
+  }
+
+  return buildServerFn(options)
+}
+
+async function loadConfig (minimistConfig, args, defaultConfig, configType) {
+  // If the config type was specified, then use that. Otherwise, compute it.
+  if (typeof configType !== 'string') {
+    configType = await getConfigType(args)
+  }
+
+  let configLoader
+
+  if (configType === 'service') {
+    configLoader = serviceLoadConfig
+  } else if (configType === 'db') {
+    const { loadConfig: dbLoadConfig } = await import('@platformatic/db/lib/load-config.mjs')
+    configLoader = dbLoadConfig
+  }
+
+  return configLoader(minimistConfig, args, defaultConfig)
+}
+
+async function start (args) {
+  const configType = await getConfigType(args)
+  let startFn
+
+  if (configType === 'service') {
+    const start = await import('@platformatic/service/lib/start.mjs')
+    startFn = start.default
+  } else if (configType === 'db') {
+    const { start } = await import('@platformatic/db/lib/start.mjs')
+    startFn = start
+  }
+
+  return startFn(args)
+}
+
+async function startCommand (...args) {
+  try {
+    await start(...args)
+  } catch (err) {
+    delete err?.stack
+    console.error(err?.message)
+
+    if (err?.cause) {
+      console.error(`${err.cause}`)
+    }
+
+    process.exit(1)
+  }
+}
+
+module.exports = {
+  buildServer,
+  getConfigType,
+  loadConfig,
+  start,
+  startCommand
+}

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@platformatic/start",
+  "version": "0.22.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run lint && c8 --100 -x fixtures -x test node --test",
+    "lint": "standard | snazzy"
+  },
+  "author": "Matteo Collina <hello@matteocollina.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/platformatic/platformatic.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/platformatic/platformatic/issues"
+  },
+  "homepage": "https://github.com/platformatic/platformatic#readme",
+  "dependencies": {
+    "@platformatic/config": "workspace:*",
+    "@platformatic/db": "workspace:*",
+    "@platformatic/service": "workspace:*",
+    "minimist": "^1.2.8"
+  },
+  "devDependencies": {
+    "c8": "^7.13.0",
+    "snazzy": "^9.0.0",
+    "split2": "^4.1.0",
+    "standard": "^17.0.0"
+  },
+  "standard": {
+    "ignore": [
+      "**/dist/*"
+    ]
+  }
+}

--- a/packages/start/test/start.test.js
+++ b/packages/start/test/start.test.js
@@ -1,6 +1,7 @@
 'use strict'
 const assert = require('node:assert')
 const { spawn } = require('node:child_process')
+const { once } = require('node:events')
 const { join } = require('node:path')
 const { test } = require('node:test')
 const {
@@ -142,73 +143,41 @@ test('buildServer()', async (t) => {
 })
 
 test('start()', async (t) => {
-  await t.test('can start a service server', (t) => {
-    return new Promise((resolve, reject) => {
-      const scriptFile = join(fixturesDir, 'starter.js')
-      const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
-      const child = spawn(process.execPath, [scriptFile, configFile])
+  await t.test('can start a service server', async (t) => {
+    const scriptFile = join(fixturesDir, 'starter.js')
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+    const child = spawn(process.execPath, [scriptFile, configFile])
+    const [exitCode] = await once(child, 'exit')
 
-      child.on('error', reject)
-      child.on('exit', (exitCode) => {
-        if (exitCode === 42) {
-          resolve()
-        } else {
-          reject(new Error(`unexpected exit code: ${exitCode}`))
-        }
-      })
-    })
+    assert.strictEqual(exitCode, 42)
   })
 
-  await t.test('can start a db server', (t) => {
-    return new Promise((resolve, reject) => {
-      const scriptFile = join(fixturesDir, 'starter.js')
-      const configFile = join(fixturesDir, 'dbApp', 'platformatic.db.json')
-      const child = spawn(process.execPath, [scriptFile, configFile])
+  await t.test('can start a db server', async (t) => {
+    const scriptFile = join(fixturesDir, 'starter.js')
+    const configFile = join(fixturesDir, 'dbApp', 'platformatic.db.json')
+    const child = spawn(process.execPath, [scriptFile, configFile])
+    const [exitCode] = await once(child, 'exit')
 
-      child.on('error', reject)
-      child.on('exit', (exitCode) => {
-        if (exitCode === 42) {
-          resolve()
-        } else {
-          reject(new Error(`unexpected exit code: ${exitCode}`))
-        }
-      })
-    })
+    assert.strictEqual(exitCode, 42)
   })
 })
 
 test('startCommand()', async (t) => {
-  await t.test('can start a server', (t) => {
-    return new Promise((resolve, reject) => {
-      const scriptFile = join(fixturesDir, 'start-command.js')
-      const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
-      const child = spawn(process.execPath, [scriptFile, configFile])
+  await t.test('can start a server', async (t) => {
+    const scriptFile = join(fixturesDir, 'start-command.js')
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+    const child = spawn(process.execPath, [scriptFile, configFile])
+    const [exitCode] = await once(child, 'exit')
 
-      child.on('error', reject)
-      child.on('exit', (exitCode) => {
-        if (exitCode === 42) {
-          resolve()
-        } else {
-          reject(new Error(`unexpected exit code: ${exitCode}`))
-        }
-      })
-    })
+    assert.strictEqual(exitCode, 42)
   })
 
-  await t.test('exits on error', (t) => {
-    return new Promise((resolve, reject) => {
-      const scriptFile = join(fixturesDir, 'start-command.js')
-      const configFile = join(fixturesDir, 'serviceApp', 'platformatic.not-found.json')
-      const child = spawn(process.execPath, [scriptFile, configFile])
+  await t.test('exits on error', async (t) => {
+    const scriptFile = join(fixturesDir, 'start-command.js')
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.not-found.json')
+    const child = spawn(process.execPath, [scriptFile, configFile])
+    const [exitCode] = await once(child, 'exit')
 
-      child.on('error', reject)
-      child.on('exit', (exitCode) => {
-        if (exitCode === 1) {
-          resolve()
-        } else {
-          reject(new Error(`unexpected exit code: ${exitCode}`))
-        }
-      })
-    })
+    assert.strictEqual(exitCode, 1)
   })
 })

--- a/packages/start/test/start.test.js
+++ b/packages/start/test/start.test.js
@@ -1,0 +1,214 @@
+'use strict'
+const assert = require('node:assert')
+const { spawn } = require('node:child_process')
+const { join } = require('node:path')
+const { test } = require('node:test')
+const {
+  buildServer,
+  getConfigType,
+  loadConfig
+} = require('..')
+const fixturesDir = join(__dirname, '..', 'fixtures')
+
+test('getConfigType()', async (t) => {
+  await t.test('throws if there is no $schema', async () => {
+    const configFile = join(fixturesDir, 'no-schema.config.json')
+    let err
+
+    try {
+      await getConfigType(['-c', configFile])
+    } catch (error) {
+      err = error
+    }
+
+    assert(err)
+    assert.strictEqual(err.cause.message, 'configuration is missing a schema')
+  })
+
+  await t.test('throws if the schema type is unsupported', async () => {
+    const configFile = join(fixturesDir, 'invalid-schema-type.config.json')
+    let err
+
+    try {
+      await getConfigType(['-c', configFile])
+    } catch (error) {
+      err = error
+    }
+
+    assert(err)
+    assert.strictEqual(err.cause.message, 'unknown configuration type: \'trickortreat\'')
+  })
+
+  await t.test('gets type from config via args', async () => {
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+    const type = await getConfigType(['-c', configFile])
+
+    assert.strictEqual(type, 'service')
+  })
+
+  await t.test('gets type from config in provided directory', async () => {
+    const configDir = join(fixturesDir, 'serviceApp')
+    const type = await getConfigType([], configDir)
+
+    assert.strictEqual(type, 'service')
+  })
+
+  await t.test('gets type from config in cwd', async (t) => {
+    const cwd = process.cwd()
+
+    t.after(() => {
+      process.chdir(cwd)
+    })
+
+    const configDir = join(fixturesDir, 'dbApp')
+    process.chdir(configDir)
+    const type = await getConfigType([])
+
+    assert.strictEqual(type, 'db')
+  })
+})
+
+test('loadConfig()', async (t) => {
+  await t.test('can explicitly provide config type', async () => {
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+    const config = await loadConfig({}, ['-c', configFile], undefined, 'service')
+
+    assert.strictEqual(config.args.config, configFile)
+    assert.strictEqual(config.configManager.fullPath, configFile)
+    assert.strictEqual(config.configManager.current.server.logger.name, 'hello server')
+    assert.strictEqual(config.configManager.schemaOptions.useDefaults, true)
+  })
+
+  await t.test('throws if explicit type is wrong', async () => {
+    // Prevent the failed validation from logging and exiting the process.
+    t.mock.method(process, 'exit', () => {})
+    t.mock.method(console, 'table', () => {})
+
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+
+    await assert.rejects(async () => {
+      await loadConfig({}, ['-c', configFile], undefined, 'db')
+    })
+  })
+
+  await t.test('can load a platformatic service project', async () => {
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+    const config = await loadConfig({}, ['-c', configFile])
+
+    assert.strictEqual(config.args.config, configFile)
+    assert.strictEqual(config.configManager.fullPath, configFile)
+    assert.strictEqual(config.configManager.current.server.logger.name, 'hello server')
+    assert.strictEqual(config.configManager.schemaOptions.useDefaults, true)
+  })
+
+  await t.test('can load a platformatic db project', async () => {
+    const configFile = join(fixturesDir, 'dbApp', 'platformatic.db.json')
+    const config = await loadConfig({}, ['-c', configFile])
+
+    assert.strictEqual(config.args.config, configFile)
+    assert.strictEqual(config.configManager.fullPath, configFile)
+    assert.strictEqual(config.configManager.current.db.graphql, true)
+  })
+})
+
+test('buildServer()', async (t) => {
+  await t.test('can build a service server', async (t) => {
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+    const config = await loadConfig({}, ['-c', configFile])
+    const server = await buildServer(config.configManager.current)
+
+    t.after(async () => {
+      await server.close()
+    })
+
+    const address = await server.start()
+    // The address should be a valid URL.
+    new URL(address) // eslint-disable-line no-new
+  })
+
+  await t.test('can build a db server', async (t) => {
+    const configFile = join(fixturesDir, 'dbApp', 'platformatic.db.json')
+    const config = await loadConfig({}, ['-c', configFile])
+    const server = await buildServer(config.configManager.current)
+
+    t.after(async () => {
+      await server.close()
+    })
+
+    const address = await server.start()
+    // The address should be a valid URL.
+    new URL(address) // eslint-disable-line no-new
+  })
+})
+
+test('start()', async (t) => {
+  await t.test('can start a service server', (t) => {
+    return new Promise((resolve, reject) => {
+      const scriptFile = join(fixturesDir, 'starter.js')
+      const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+      const child = spawn(process.execPath, [scriptFile, configFile])
+
+      child.on('error', reject)
+      child.on('exit', (exitCode) => {
+        if (exitCode === 42) {
+          resolve()
+        } else {
+          reject(new Error(`unexpected exit code: ${exitCode}`))
+        }
+      })
+    })
+  })
+
+  await t.test('can start a db server', (t) => {
+    return new Promise((resolve, reject) => {
+      const scriptFile = join(fixturesDir, 'starter.js')
+      const configFile = join(fixturesDir, 'dbApp', 'platformatic.db.json')
+      const child = spawn(process.execPath, [scriptFile, configFile])
+
+      child.on('error', reject)
+      child.on('exit', (exitCode) => {
+        if (exitCode === 42) {
+          resolve()
+        } else {
+          reject(new Error(`unexpected exit code: ${exitCode}`))
+        }
+      })
+    })
+  })
+})
+
+test('startCommand()', async (t) => {
+  await t.test('can start a server', (t) => {
+    return new Promise((resolve, reject) => {
+      const scriptFile = join(fixturesDir, 'start-command.js')
+      const configFile = join(fixturesDir, 'serviceApp', 'platformatic.service.json')
+      const child = spawn(process.execPath, [scriptFile, configFile])
+
+      child.on('error', reject)
+      child.on('exit', (exitCode) => {
+        if (exitCode === 42) {
+          resolve()
+        } else {
+          reject(new Error(`unexpected exit code: ${exitCode}`))
+        }
+      })
+    })
+  })
+
+  await t.test('exits on error', (t) => {
+    return new Promise((resolve, reject) => {
+      const scriptFile = join(fixturesDir, 'start-command.js')
+      const configFile = join(fixturesDir, 'serviceApp', 'platformatic.not-found.json')
+      const child = spawn(process.execPath, [scriptFile, configFile])
+
+      child.on('error', reject)
+      child.on('exit', (exitCode) => {
+        if (exitCode === 1) {
+          resolve()
+        } else {
+          reject(new Error(`unexpected exit code: ${exitCode}`))
+        }
+      })
+    })
+  })
+})

--- a/packages/start/test/start.test.js
+++ b/packages/start/test/start.test.js
@@ -48,7 +48,7 @@ test('getConfigType()', async (t) => {
 
   await t.test('gets type from config in provided directory', async () => {
     const configDir = join(fixturesDir, 'serviceApp')
-    const type = await getConfigType([], configDir)
+    const type = await getConfigType(undefined, configDir)
 
     assert.strictEqual(type, 'service')
   })
@@ -62,7 +62,7 @@ test('getConfigType()', async (t) => {
 
     const configDir = join(fixturesDir, 'dbApp')
     process.chdir(configDir)
-    const type = await getConfigType([])
+    const type = await getConfigType()
 
     assert.strictEqual(type, 'db')
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@platformatic/service':
         specifier: workspace:*
         version: link:../service
+      '@platformatic/start':
+        specifier: workspace:*
+        version: link:../start
       colorette:
         specifier: ^2.0.20
         version: 2.0.20
@@ -1160,6 +1163,49 @@ importers:
       tsd:
         specifier: ^0.28.1
         version: 0.28.1
+
+  packages/start:
+    dependencies:
+      '@platformatic/config':
+        specifier: workspace:*
+        version: link:../config
+      '@platformatic/db':
+        specifier: workspace:*
+        version: link:../db
+      '@platformatic/service':
+        specifier: workspace:*
+        version: link:../service
+      commist:
+        specifier: ^3.2.0
+        version: 3.2.0
+      desm:
+        specifier: ^1.3.0
+        version: 1.3.0
+      es-main:
+        specifier: ^1.2.0
+        version: 1.2.0
+      help-me:
+        specifier: ^4.2.0
+        version: 4.2.0
+      minimist:
+        specifier: ^1.2.8
+        version: 1.2.8
+    devDependencies:
+      c8:
+        specifier: ^7.13.0
+        version: 7.13.0
+      execa:
+        specifier: ^7.0.0
+        version: 7.1.1
+      snazzy:
+        specifier: ^9.0.0
+        version: 9.0.0
+      split2:
+        specifier: ^4.1.0
+        version: 4.2.0
+      standard:
+        specifier: ^17.0.0
+        version: 17.0.0
 
   packages/utils:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1175,18 +1175,6 @@ importers:
       '@platformatic/service':
         specifier: workspace:*
         version: link:../service
-      commist:
-        specifier: ^3.2.0
-        version: 3.2.0
-      desm:
-        specifier: ^1.3.0
-        version: 1.3.0
-      es-main:
-        specifier: ^1.2.0
-        version: 1.2.0
-      help-me:
-        specifier: ^4.2.0
-        version: 4.2.0
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
@@ -1194,9 +1182,6 @@ importers:
       c8:
         specifier: ^7.13.0
         version: 7.13.0
-      execa:
-        specifier: ^7.0.0
-        version: 7.1.1
       snazzy:
         specifier: ^9.0.0
         version: 9.0.0


### PR DESCRIPTION
This commit adds a `platformatic start` command for starting any supported type of Platformatic app. It also adds programmatic APIs for loading arbitrary types of configs, building servers, and starting them.