### PR TITLE
Fixes typo in schemalock schema definition

### DIFF
--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -17,7 +17,7 @@ const db = {
         type: 'string'
       }
     },
-    schemaLock: {
+    schemalock: {
       oneOf: [{
         type: 'boolean',
         default: false


### PR DESCRIPTION
This might confuse users when autocomplete is on for config file