### PR TITLE
Restore watch: true by default in service

### DIFF
--- a/packages/client-cli/test/cli-graphql.test.mjs
+++ b/packages/client-cli/test/cli-graphql.test.mjs
@@ -351,7 +351,8 @@ test('adds clients to platformatic service', async ({ teardown, comment, same, m
     },
     plugins: {
       paths: ['./plugin.js']
-    }
+    },
+    watch: false
   }
 
   await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
@@ -375,7 +376,8 @@ test('adds clients to platformatic service', async ({ teardown, comment, same, m
       clients: [{
         path: './movies',
         url: '{PLT_MOVIES_URL}'
-      }]
+      }],
+      watch: false
     })
   }
 

--- a/packages/client-cli/test/fixtures/auth/platformatic.db.json
+++ b/packages/client-cli/test/fixtures/auth/platformatic.db.json
@@ -21,5 +21,6 @@
   },
   "plugins": {
     "paths": ["./plugin.js"]
-  }
+  },
+  "watch": false
 }

--- a/packages/client-cli/test/fixtures/movies-quotes/platformatic.db.json
+++ b/packages/client-cli/test/fixtures/movies-quotes/platformatic.db.json
@@ -18,5 +18,6 @@
   },
   "plugins": {
     "paths": ["./plugin.js"]
-  }
+  },
+  "watch": false
 }

--- a/packages/client-cli/test/fixtures/movies/platformatic.db.json
+++ b/packages/client-cli/test/fixtures/movies/platformatic.db.json
@@ -18,5 +18,6 @@
   },
   "plugins": {
     "paths": ["./plugin.js"]
-  }
+  },
+  "watch": false
 }

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -112,6 +112,13 @@ platformaticService.configManagerConfig = {
     coerceTypes: true,
     allErrors: true,
     strict: false
+  },
+  transformConfig () {
+    // Set watch to true by default. This is not possible
+    // to do in the schema, because it is uses an anyOf.
+    if (this.current.watch === undefined) {
+      this.current.watch = true
+    }
   }
 }
 

--- a/packages/service/test/watch.test.js
+++ b/packages/service/test/watch.test.js
@@ -180,3 +180,69 @@ test('should stop watching typescript files after disabling watch option', async
     same(await res.body.json(), { res: 'plugin, version 1' }, 'get rest plugin')
   }
 })
+
+test('should watch files by default', async ({ teardown, equal, pass, same }) => {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic.service.test-'))
+  const pathToPlugin = join(tmpDir, 'plugin.js')
+  const pathToConfig = join(tmpDir, 'platformatic.service.json')
+
+  teardown(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  await writeFile(pathToPlugin, `
+    module.exports = async function plugin (app) {
+      app.get('/test', {}, async function (request, response) {
+        return { res: "plugin, version 1"}
+      })
+    }`)
+
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: [pathToPlugin],
+      stopTimeout: 1000,
+      hotReload: true
+    },
+    metrics: false
+  }
+
+  await writeFile(pathToConfig, JSON.stringify(config, null, 2))
+  const app = await buildServer(pathToConfig)
+
+  teardown(async () => {
+    await app.close()
+  })
+  await app.start()
+
+  {
+    const res = await request(`${app.url}/test`, {
+      method: 'GET'
+    })
+    same(await res.body.json(), { res: 'plugin, version 1' }, 'get rest plugin')
+  }
+
+  equal(app.fileWatcher.isWatching, true)
+
+  await writeFile(pathToPlugin, `
+    module.exports = async function plugin (app) {
+      app.get('/test', {}, async function (request, response) {
+        return { res: "plugin, version 2"}
+      })
+    }`)
+
+  // wait to be sure that app is not watching files anymore
+  await new Promise((resolve) => setTimeout(resolve, 5000))
+
+  {
+    const res = await request(`${app.url}/test`, {
+      method: 'GET'
+    })
+    equal(res.statusCode, 200)
+    // must be unchanged
+    same(await res.body.json(), { res: 'plugin, version 2' })
+  }
+})


### PR DESCRIPTION
This fixes a regression we introduced from v0.23 onwards.