### PR TITLE
feat(#1019): support throwOnError option in platformatic/client

### DIFF
--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -38,6 +38,7 @@ function generateImplementationFromOpenAPI ({ schema, name, fullResponse }) {
       writer.writeLine(`path: join(__dirname, '${name}.openapi.json'),`)
       writer.writeLine('url: opts.url,')
       writer.writeLine('serviceId: opts.serviceId,')
+      writer.writeLine('throwOnError: opts.throwOnError,')
       writer.writeLine(`fullResponse: ${fullResponse}`)
     })
     writer.write(')')

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -38,6 +38,7 @@ async function buildOpenAPIClient (options) {
   }
 
   client[kHeaders] = options.headers || {}
+  const { fullResponse, throwOnError } = options
 
   for (const path of Object.keys(spec.paths)) {
     const pathMeta = spec.paths[path]
@@ -46,7 +47,7 @@ async function buildOpenAPIClient (options) {
       const methodMeta = pathMeta[method]
       const operationId = generateOperationId(path, method, methodMeta)
 
-      client[operationId] = buildCallFunction(baseUrl, path, method, methodMeta, options.fullResponse)
+      client[operationId] = buildCallFunction(baseUrl, path, method, methodMeta, fullResponse, throwOnError)
     }
   }
 
@@ -59,7 +60,7 @@ function computeURLWithoutPath (url) {
   return url.toString()
 }
 
-function buildCallFunction (baseUrl, path, method, methodMeta, fullResponse) {
+function buildCallFunction (baseUrl, path, method, methodMeta, fullResponse, throwOnError) {
   const url = new URL(baseUrl)
   method = method.toUpperCase()
   path = join(url.pathname, path)
@@ -108,7 +109,8 @@ function buildCallFunction (baseUrl, path, method, methodMeta, fullResponse) {
         ...headers,
         'content-type': 'application/json; charset=utf-8'
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      throwOnError
     })
 
     const responseBody = res.statusCode === 204


### PR DESCRIPTION
Resolves #1019

Can set `throwOnError` option in the platform/client plugin which is passed down the undici request options.