### PR TITLE
chore(create-platformatic): removed whitespace in gitignore generator

### DIFF
--- a/packages/create-platformatic/src/create-gitignore.mjs
+++ b/packages/create-platformatic/src/create-gitignore.mjs
@@ -3,7 +3,7 @@ import { writeFile } from 'fs/promises'
 import { join } from 'node:path'
 
 const gitignore = `\
-dist 
+dist
 .DS_Store
 
 # dotenv environment variable files


### PR DESCRIPTION
I noticed this whitespace when a new platformatic project is created.

This commit remove the whitespace in gitignore generator.