### PR TITLE
Custom GraphQL resolver test and removed Error Handler to wrap errors from sandbox

### DIFF
--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -26,17 +26,6 @@ async function platformaticService (app, opts, toLoad = []) {
     app.register(setupMetrics, config.metrics)
   }
 
-  app.setErrorHandler(async (err, req, reply) => {
-    if (!(err instanceof Error)) {
-      req.log.debug({ err }, 'error encountered within the sandbox, wrapping it')
-      const newError = new Error(err.message)
-      newError.cause = err
-      newError.statusCode = err.statusCode || 500
-      err = newError
-    }
-    throw err
-  })
-
   if (Array.isArray(toLoad)) {
     for (const plugin of toLoad) {
       await app.register(plugin)

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -63,7 +63,7 @@
     "fastify": "^4.17.0",
     "fastify-metrics": "^10.3.0",
     "fastify-plugin": "^4.5.0",
-    "fastify-sandbox": "^0.13.0",
+    "fastify-sandbox": "^0.13.1",
     "graphql": "^16.6.0",
     "help-me": "^4.2.0",
     "mercurius": "^13.0.0",

--- a/packages/service/test/fixtures/throw-resolver.js
+++ b/packages/service/test/fixtures/throw-resolver.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = async function (app) {
+  app.graphql.extendSchema(`
+    extend type Query {
+      hello: String
+    }
+  `)
+  app.graphql.defineResolvers({
+    Query: {
+      hello: async function (root, args, context) {
+        throw new Error('Kaboooooom!!!')
+      }
+    }
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1086,8 +1086,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       fastify-sandbox:
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.13.1
+        version: 0.13.1
       graphql:
         specifier: ^16.6.0
         version: 16.6.0
@@ -8391,8 +8391,8 @@ packages:
       table: 6.8.1
     dev: false
 
-  /fastify-sandbox@0.13.0:
-    resolution: {integrity: sha512-rc3q3luI1U/dXxJzF8JlTBPkI9uW/PnnWlOtc7vgfcqZDEg7RA+ueelnA3pe1TTaAEloUzg026Bcimsn+5NOdQ==}
+  /fastify-sandbox@0.13.1:
+    resolution: {integrity: sha512-0nufHO/MdzKCnS4oUu/tM8gOC+VmOxMutobLnWaU4wJirzBYS9oJyPJVD0YYVZkqXSxsW7dDFGEXvgRdliuGRA==}
     dependencies:
       import-fresh: 3.3.0
     optionalDependencies:
@@ -15015,7 +15015,6 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
-    deprecated: Use String.prototype.trim() instead
     dev: true
 
   /trivial-deferred@1.1.2:


### PR DESCRIPTION
This is a test that is missing (throwing an error in a custom GraphQL resolver). 
If we had this, we would have spot [this problem in fastify-sandbox ](https://github.com/mcollina/fastify-sandbox/pull/29) earlier. 