### PR TITLE
do not crash if platformatic is not in path when creating a platformatic db

### DIFF
--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -143,7 +143,7 @@ const createPlatformaticDB = async (_args, opts) => {
   }
 
   if (!hasPlatformaticInstalled) {
-    const exe = await which('platformatic', { noThrow: true })
+    const exe = await which('platformatic', { nothrow: true })
     hasPlatformaticInstalled = !!exe
   }
 


### PR DESCRIPTION
Originally reported on Discord https://discord.com/channels/1011258196905689118/1027566961254744084/1113887746965119066.