### PR TITLE
Move duplicated cli option in single place

### DIFF
--- a/packages/create-platformatic/src/cli-options.mjs
+++ b/packages/create-platformatic/src/cli-options.mjs
@@ -19,6 +19,16 @@ export const getUseTypescript = typescript => {
   }
 }
 
+export const getOverwriteReadme = () => {
+  return {
+    type: 'list',
+    name: 'shouldReplace',
+    message: 'Do you want to overwrite the existing README.md?',
+    default: true,
+    choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
+  }
+}
+
 let port = 3042
 export const getPort = (nextPort) => {
   if (nextPort === undefined) {

--- a/packages/create-platformatic/src/composer/create-composer-cli.mjs
+++ b/packages/create-platformatic/src/composer/create-composer-cli.mjs
@@ -13,20 +13,14 @@ import ora from 'ora'
 import createComposer from './create-composer.mjs'
 import askDir from '../ask-dir.mjs'
 import { askDynamicWorkspaceCreateGHAction, askStaticWorkspaceGHAction } from '../ghaction.mjs'
-import { getRunPackageManagerInstall, getPort } from '../cli-options.mjs'
+import { getRunPackageManagerInstall, getPort, getOverwriteReadme } from '../cli-options.mjs'
 
 export const createReadme = async (logger, dir = '.') => {
   const readmeFileName = join(dir, 'README.md')
   let isReadmeExists = await isFileAccessible(readmeFileName)
   if (isReadmeExists) {
     logger.debug(`${readmeFileName} found, asking to overwrite it.`)
-    const { shouldReplace } = await inquirer.prompt([{
-      type: 'list',
-      name: 'shouldReplace',
-      message: 'Do you want to overwrite the existing README.md?',
-      default: true,
-      choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-    }])
+    const { shouldReplace } = await inquirer.prompt([getOverwriteReadme()])
     isReadmeExists = !shouldReplace
   }
 

--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -14,20 +14,14 @@ import ora from 'ora'
 import createDB from './create-db.mjs'
 import askDir from '../ask-dir.mjs'
 import { askDynamicWorkspaceCreateGHAction, askStaticWorkspaceGHAction } from '../ghaction.mjs'
-import { getRunPackageManagerInstall, getUseTypescript, getPort } from '../cli-options.mjs'
+import { getRunPackageManagerInstall, getUseTypescript, getPort, getOverwriteReadme } from '../cli-options.mjs'
 
 export const createReadme = async (logger, dir = '.') => {
   const readmeFileName = join(dir, 'README.md')
   let isReadmeExists = await isFileAccessible(readmeFileName)
   if (isReadmeExists) {
     logger.debug(`${readmeFileName} found, asking to overwrite it.`)
-    const { shouldReplace } = await inquirer.prompt([{
-      type: 'list',
-      name: 'shouldReplace',
-      message: 'Do you want to overwrite the existing README.md?',
-      default: true,
-      choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-    }])
+    const { shouldReplace } = await inquirer.prompt([getOverwriteReadme()])
     isReadmeExists = !shouldReplace
   }
 

--- a/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
+++ b/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
@@ -12,7 +12,7 @@ import ora from 'ora'
 import createRuntime from './create-runtime.mjs'
 import askDir from '../ask-dir.mjs'
 import { askDynamicWorkspaceCreateGHAction, askStaticWorkspaceGHAction } from '../ghaction.mjs'
-import { getRunPackageManagerInstall } from '../cli-options.mjs'
+import { getOverwriteReadme, getRunPackageManagerInstall } from '../cli-options.mjs'
 import generateName from 'boring-name-generator'
 import { chooseKind } from '../index.mjs'
 
@@ -21,13 +21,7 @@ export const createReadme = async (logger, dir = '.') => {
   let isReadmeExists = await isFileAccessible(readmeFileName)
   if (isReadmeExists) {
     logger.debug(`${readmeFileName} found, asking to overwrite it.`)
-    const { shouldReplace } = await inquirer.prompt([{
-      type: 'list',
-      name: 'shouldReplace',
-      message: 'Do you want to overwrite the existing README.md?',
-      default: true,
-      choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-    }])
+    const { shouldReplace } = await inquirer.prompt([getOverwriteReadme()])
     isReadmeExists = !shouldReplace
   }
 

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -13,20 +13,14 @@ import ora from 'ora'
 import createService from './create-service.mjs'
 import askDir from '../ask-dir.mjs'
 import { askDynamicWorkspaceCreateGHAction, askStaticWorkspaceGHAction } from '../ghaction.mjs'
-import { getRunPackageManagerInstall, getUseTypescript, getPort } from '../cli-options.mjs'
+import { getRunPackageManagerInstall, getUseTypescript, getPort, getOverwriteReadme } from '../cli-options.mjs'
 
 export const createReadme = async (logger, dir = '.') => {
   const readmeFileName = join(dir, 'README.md')
   let isReadmeExists = await isFileAccessible(readmeFileName)
   if (isReadmeExists) {
     logger.debug(`${readmeFileName} found, asking to overwrite it.`)
-    const { shouldReplace } = await inquirer.prompt([{
-      type: 'list',
-      name: 'shouldReplace',
-      message: 'Do you want to overwrite the existing README.md?',
-      default: true,
-      choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
-    }])
+    const { shouldReplace } = await inquirer.prompt([getOverwriteReadme()])
     isReadmeExists = !shouldReplace
   }
 

--- a/packages/create-platformatic/test/cli-options.test.mjs
+++ b/packages/create-platformatic/test/cli-options.test.mjs
@@ -1,5 +1,5 @@
 import { test } from 'tap'
-import { getRunPackageManagerInstall, getUseTypescript, getPort } from '../src/cli-options.mjs'
+import { getRunPackageManagerInstall, getUseTypescript, getPort, getOverwriteReadme } from '../src/cli-options.mjs'
 
 test('getRunPackageManagerInstall', async ({ same }) => {
   same(
@@ -22,6 +22,19 @@ test('getUseTypescript', async ({ same }) => {
       when: false,
       name: 'useTypescript',
       message: 'Do you want to use TypeScript?',
+      default: true,
+      choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
+    }
+  )
+})
+
+test('getOverwriteReadme', async ({ same }) => {
+  same(
+    getOverwriteReadme(),
+    {
+      type: 'list',
+      name: 'shouldReplace',
+      message: 'Do you want to overwrite the existing README.md?',
       default: true,
       choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
     }


### PR DESCRIPTION
It is a chore PR to extract duplicated cli option into the single place for improving consistency and maintainability. Also, the configuration of cli option is covered by unit test to let someone know when the configuration is slightly changed.