### PR TITLE
run utils tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,31 @@ jobs:
     - name: Run start package test suite
       run: cd packages/start && pnpm test
 
+  ci-utils:
+    needs: setup-node_modules
+    runs-on: ${{matrix.os}}
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        node-version: [18]
+        os: [ubuntu-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: pnpm/action-setup@v2.2.4
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - name: pnpm install
+      uses: nick-fields/retry@v2.8.3
+      with:
+        max_attempts: 10
+        timeout_minutes: 15
+        retry_on: error
+        command: pnpm install --frozen-lockfile
+    - name: Run utils package test suite
+      run: cd packages/utils && pnpm test
+
   ci-client:
     needs: setup-node_modules
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The utils package was not being tested in the CI. It was helpful in figuring out some issues with Node 20, plus it should just be tested anyway.