### PR TITLE
config,utils: refactor tmpdir access

### DIFF
--- a/packages/config/test/helper.js
+++ b/packages/config/test/helper.js
@@ -1,18 +1,15 @@
 'use strict'
 const os = require('os')
 const { join } = require('path')
-const { writeFile } = require('fs/promises')
-function getTempFile (filename = 'platformatic.json') {
-  return join(os.tmpdir(), filename)
-}
+const { mkdtemp, writeFile } = require('fs/promises')
 
-async function saveConfigToFile (config, filename, serializer = JSON) {
-  const targetFile = getTempFile(filename)
+async function saveConfigToFile (config, filename = 'platformatic.json', serializer = JSON) {
+  const tempDir = await mkdtemp(join(os.tmpdir(), 'plt-config-test-'))
+  const targetFile = join(tempDir, filename)
   await writeFile(targetFile, serializer.stringify(config))
   return targetFile
 }
 
 module.exports = {
-  getTempFile,
   saveConfigToFile
 }

--- a/packages/utils/test/file-watcher.test.js
+++ b/packages/utils/test/file-watcher.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const os = require('os')
-const { writeFile } = require('fs/promises')
+const { mkdtemp, writeFile } = require('fs/promises')
 const { join } = require('path')
 const { test } = require('tap')
 const { FileWatcher } = require('..')
@@ -53,8 +53,8 @@ test('should not watch not allowed files', async ({ equal, plan }) => {
   equal(false, fileWatcher.shouldFileBeWatched('another.file'))
 })
 
-test('should emit event if file is updated', ({ end }) => {
-  const tmpDir = os.tmpdir()
+test('should emit event if file is updated', async ({ end }) => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
   const filename = join(tmpDir, 'test.file')
   const fileWatcher = new FileWatcher({ path: tmpDir })
 
@@ -67,8 +67,8 @@ test('should emit event if file is updated', ({ end }) => {
   writeFile(filename, 'foobar')
 })
 
-test('should not call fs watch twice', ({ pass, plan, end }) => {
-  const tmpDir = os.tmpdir()
+test('should not call fs watch twice', async ({ pass, plan, end }) => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
   const filename = join(tmpDir, 'test.file')
   const fileWatcher = new FileWatcher({ path: tmpDir })
 


### PR DESCRIPTION
When trying to get the tests running on Node 20, the way these modules use the temp directory in tests was causing problems. This commit refactors the temp directory logic.