### PR TITLE
update fastify dependency in composer

### DIFF
--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -40,7 +40,7 @@
     "desm": "^1.3.0",
     "es-main": "^1.2.0",
     "fast-deep-equal": "^3.1.3",
-    "fastify": "^4.15.0",
+    "fastify": "^4.18.0",
     "fastify-openapi-glue": "^4.1.4",
     "fastify-plugin": "^4.5.0",
     "help-me": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,8 +301,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       fastify:
-        specifier: ^4.15.0
-        version: 4.17.0
+        specifier: ^4.18.0
+        version: 4.18.0
       fastify-openapi-glue:
         specifier: ^4.1.4
         version: 4.1.4
@@ -3531,7 +3531,7 @@ packages:
   /@fastify/restartable@2.1.0:
     resolution: {integrity: sha512-zq0g0s0r87b0gUOv+11Mi3D9B2NdkTjKX+QM8s5WK3IhmTKLJ5UfMkJXfqYbqeDOgoGfXfSjyxtfkHbTFlDk/Q==}
     dependencies:
-      fastify: 4.17.0
+      fastify: 4.18.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8413,7 +8413,7 @@ packages:
     dependencies:
       '@fastify/error': 3.2.0
       '@fastify/jwt': 6.7.1
-      fastify: 4.17.0
+      fastify: 4.18.0
       fastify-plugin: 4.5.0
       get-jwks: 8.0.6
     transitivePeerDependencies:
@@ -8442,6 +8442,29 @@ packages:
       tiny-lru: 11.0.1
     transitivePeerDependencies:
       - supports-color
+
+  /fastify@4.18.0:
+    resolution: {integrity: sha512-L5o/2GEkBastQ3HV0dtKo7SUZ497Z1+q4fcqAoPyq6JCQ/8zdk1JQEoTQwnBWCp+EmA7AQa6mxNqSAEhzP0RwQ==}
+    dependencies:
+      '@fastify/ajv-compiler': 3.5.0
+      '@fastify/error': 3.2.0
+      '@fastify/fast-json-stringify-compiler': 4.3.0
+      abstract-logging: 2.0.1
+      avvio: 8.2.1
+      fast-content-type-parse: 1.0.0
+      fast-json-stringify: 5.7.0
+      find-my-way: 7.6.0
+      light-my-request: 5.9.1
+      pino: 8.14.1
+      process-warning: 2.2.0
+      proxy-addr: 2.0.7
+      rfdc: 1.3.0
+      secure-json-parse: 2.7.0
+      semver: 7.5.1
+      tiny-lru: 11.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /fastparallel@2.4.1:
     resolution: {integrity: sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==}
@@ -12435,6 +12458,10 @@ packages:
 
   /process-warning@2.1.0:
     resolution: {integrity: sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg==}
+
+  /process-warning@2.2.0:
+    resolution: {integrity: sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==}
+    dev: false
 
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}


### PR DESCRIPTION
The composer test suite was failing on Node 20. fastify@4.18.0 includes a fix (fastify #4810) that gets the composer test suite passing on Node 20.