### PR TITLE
only use recursive file watching on macOS and Windows

### DIFF
--- a/packages/utils/lib/file-watcher.js
+++ b/packages/utils/lib/file-watcher.js
@@ -7,6 +7,12 @@ const minimatch = require('minimatch').default
 
 const ALLOWED_FS_EVENTS = ['change', 'rename']
 
+// Recursive watch is unreliable on platforms besides macOS and Windows.
+// See: https://github.com/nodejs/node/issues/48437
+/* c8 ignore next 2 */
+const useRecursiveWatch = process.platform === 'darwin' ||
+  process.platform === 'win32'
+
 function removeDotSlash (path) {
   return path.replace(/^\.[/\\]/, '')
 }
@@ -36,7 +42,7 @@ class FileWatcher extends EventEmitter {
     this.abortController = new AbortController()
     const signal = this.abortController.signal
 
-    const fsWatcher = watch(this.path, { signal, recursive: true })
+    const fsWatcher = watch(this.path, { signal, recursive: useRecursiveWatch })
 
     let updateTimeout = null
 


### PR DESCRIPTION
Input validation in core is inconsistent, it was only supported on macOS and Windows prior to Node 20, and the recursive watch on Linux seems to have some bugs.