### PR TITLE
refactor platformatic start to launch apps via the runtime

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -42,7 +42,7 @@ const ensureCommand = async ({ output, help }) => {
 program.register('db', async (args) => ensureCommand(await runDB(args)))
 program.register('runtime', async (args) => ensureCommand(await runRuntime(args)))
 program.register('service', async (args) => ensureCommand(await runService(args)))
-program.register('start', platformaticStart.startCommand)
+program.register('start', platformaticStart.startCommandInRuntime)
 program.register('composer', async (args) => ensureCommand(await runComposer(args)))
 program.register('upgrade', upgrade)
 program.register('client', client)

--- a/packages/cli/test/start.test.js
+++ b/packages/cli/test/start.test.js
@@ -59,6 +59,8 @@ test('starts a runtime application', async ({ teardown }) => {
     timeout: 10_000
   })
 
+  child.stderr.pipe(process.stderr)
+
   teardown(async () => {
     try {
       child.kill('SIGKILL')

--- a/packages/runtime/fixtures/start-command-in-runtime.js
+++ b/packages/runtime/fixtures/start-command-in-runtime.js
@@ -1,0 +1,14 @@
+'use strict'
+const assert = require('node:assert')
+const { request } = require('undici')
+const { startCommandInRuntime } = require('../lib/unified-api')
+
+async function main () {
+  const entrypoint = await startCommandInRuntime(['-c', process.argv[2]])
+  const res = await request(entrypoint)
+
+  assert.strictEqual(res.statusCode, 200)
+  process.exit(42)
+}
+
+main()

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -1,11 +1,12 @@
 'use strict'
 const { once } = require('node:events')
 const { join } = require('node:path')
+const { pathToFileURL } = require('node:url')
 const { Worker } = require('node:worker_threads')
 const closeWithGrace = require('close-with-grace')
 const { loadConfig } = require('@platformatic/service')
 const { platformaticRuntime } = require('./config')
-const kLoaderFile = join(__dirname, 'loader.mjs')
+const kLoaderFile = pathToFileURL(join(__dirname, 'loader.mjs')).href
 const kWorkerFile = join(__dirname, 'worker.js')
 const kWorkerExecArgv = [
   '--no-warnings',

--- a/packages/runtime/test/unified-api.test.js
+++ b/packages/runtime/test/unified-api.test.js
@@ -319,3 +319,36 @@ test('startCommand()', async (t) => {
     assert.strictEqual(exitCode, 42)
   })
 })
+
+test('startCommandInRuntime()', async (t) => {
+  await t.test('can start a non-runtime application', async (t) => {
+    const scriptFile = join(fixturesDir, 'start-command-in-runtime.js')
+    const configFile = join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'platformatic.service.json')
+    const child = spawn(process.execPath, [scriptFile, configFile])
+    child.stdout.pipe(process.stdout)
+    child.stderr.pipe(process.stderr)
+    const [exitCode] = await once(child, 'exit')
+
+    assert.strictEqual(exitCode, 42)
+  })
+
+  await t.test('can start a runtime application', async (t) => {
+    const scriptFile = join(fixturesDir, 'start-command-in-runtime.js')
+    const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+    const child = spawn(process.execPath, [scriptFile, configFile])
+    child.stdout.pipe(process.stdout)
+    child.stderr.pipe(process.stderr)
+    const [exitCode] = await once(child, 'exit')
+
+    assert.strictEqual(exitCode, 42)
+  })
+
+  await t.test('exits on error', async (t) => {
+    const scriptFile = join(fixturesDir, 'start-command-in-runtime.js')
+    const configFile = join(fixturesDir, 'serviceApp', 'platformatic.not-found.json')
+    const child = spawn(process.execPath, [scriptFile, configFile])
+    const [exitCode] = await once(child, 'exit')
+
+    assert.strictEqual(exitCode, 1)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -15084,6 +15084,7 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
     dev: true
 
   /trivial-deferred@1.1.2:


### PR DESCRIPTION
This PR updates `platformatic start` to run things within the runtime.

Unfortunately, the recent c8 update seems to have thrown off some coverage in the runtime's loader so there are some unrelated changes for that in this PR too.