### PR TITLE
fix: client-ci url parsing on windows

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -82,10 +82,13 @@ async function downloadAndProcess ({ url, name, folder, config, r: fullResponse 
       await writeGraphQLClient(folder, name, schema, url)
     }
   } catch (err) {
-    if (err.code !== 'ERR_INVALID_URL') {
+    if (
+      err.code !== 'ERR_INVALID_URL' &&
+      err.code !== 'UND_ERR_INVALID_ARG'
+    ) {
       throw err
     }
-    
+
     const text = await readFile(url, 'utf8')
 
     // try OpenAPI first


### PR DESCRIPTION
On windows it fails with:

```bash
InvalidArgumentError: Invalid URL protocol: the URL must start with `http:` or `https:`.
  at Object.parseURL (D:\a\platformatic\platformatic\node_modules\.pnpm\undici@5.22.1\node_modules\undici\lib\core\util.js:51:13)
  at D:\a\platformatic\platformatic\node_modules\.pnpm\undici@5.22.1\node_modules\undici\index.js:78:18
  at downloadAndProcess (file:///D:/a/platformatic/platformatic/packages/client-cli/cli.mjs:54:21)
  at command (file:///D:/a/platformatic/platformatic/packages/client-cli/cli.mjs:164:11)
  at file:///D:/a/platformatic/platformatic/packages/client-cli/cli.mjs:174:3
  at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
code: 'UND_ERR_INVALID_ARG'
```