### PR TITLE
use `platformatic start` in create-platformatic

### DIFF
--- a/packages/create-platformatic/src/composer/create-composer-cli.mjs
+++ b/packages/create-platformatic/src/composer/create-composer-cli.mjs
@@ -79,7 +79,7 @@ const createPlatformaticComposer = async (_args, opts) => {
   // Create the package.json, notes that we don't have the option for TS (yet) so we don't generate
   // the package.json with the TS build
   if (!opts.skipPackageJson) {
-    await createPackageJson('composer', version, fastifyVersion, logger, projectDir, false)
+    await createPackageJson(version, fastifyVersion, logger, projectDir, false)
   }
   if (!opts.skipGitignore) {
     await createGitignore(logger, projectDir)

--- a/packages/create-platformatic/src/create-package-json.mjs
+++ b/packages/create-platformatic/src/create-package-json.mjs
@@ -7,10 +7,10 @@ const packageJsonTemplate = (addTSBuild = false) => (`\
 {
   "scripts": {
     ${addTSBuild
-? `"start": "npm run clean && platformatic {type} start",
+? `"start": "npm run clean && platformatic start",
     "clean": "rm -fr ./dist",
     "build": "npx tsc"`
-: '"start": "platformatic {type} start"'}
+: '"start": "platformatic start"'}
   },
   "devDependencies": {
     "fastify": "^{fastifyVersion}"
@@ -23,11 +23,11 @@ const packageJsonTemplate = (addTSBuild = false) => (`\
   }
 }`)
 
-export const createPackageJson = async (type, platVersion, fastifyVersion, logger, dir, addTSBuild = false, scripts = {}) => {
+export const createPackageJson = async (platVersion, fastifyVersion, logger, dir, addTSBuild = false, scripts = {}) => {
   const packageJsonFileName = join(dir, 'package.json')
   const isPackageJsonExists = await isFileAccessible(packageJsonFileName)
   if (!isPackageJsonExists) {
-    const packageJson = pupa(packageJsonTemplate(addTSBuild), { platVersion, fastifyVersion, type })
+    const packageJson = pupa(packageJsonTemplate(addTSBuild), { platVersion, fastifyVersion })
     const parsed = JSON.parse(packageJson)
     Object.assign(parsed.scripts, scripts)
     await writeFile(packageJsonFileName, JSON.stringify(parsed, null, 2))

--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -113,7 +113,7 @@ const createPlatformaticDB = async (_args, opts) => {
   }
 
   // Create the package.json, .gitignore, readme
-  await createPackageJson('db', version, fastifyVersion, logger, projectDir, useTypescript, scripts)
+  await createPackageJson(version, fastifyVersion, logger, projectDir, useTypescript, scripts)
   await createGitignore(logger, projectDir)
   await createReadme(logger, projectDir)
 

--- a/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
+++ b/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
@@ -60,7 +60,7 @@ export async function createPlatformaticRuntime (_args) {
 
   // Create the package.json, notes that we don't have the option for TS (yet) so we don't generate
   // the package.json with the TS build
-  await createPackageJson('runtime', version, fastifyVersion, logger, projectDir, false)
+  await createPackageJson(version, fastifyVersion, logger, projectDir, false)
   await createGitignore(logger, projectDir)
   await createReadme(logger, projectDir)
 

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -80,7 +80,7 @@ const createPlatformaticService = async (_args, opts = {}) => {
   if (!opts.skipPackageJson) {
     // Create the package.json, notes that we don't have the option for TS (yet) so we don't generate
     // the package.json with the TS build
-    await createPackageJson('service', version, fastifyVersion, logger, projectDir, false)
+    await createPackageJson(version, fastifyVersion, logger, projectDir, false)
   }
   if (!opts.skipGitignore) {
     await createGitignore(logger, projectDir)

--- a/packages/create-platformatic/test/create-package-json.test.mjs
+++ b/packages/create-platformatic/test/create-package-json.test.mjs
@@ -23,12 +23,12 @@ afterEach(() => {
 test('creates package.json file for db project', async ({ equal }) => {
   const version = '1.2.3'
   const fastifyVersion = '4.5.6'
-  await createPackageJson('db', version, fastifyVersion, fakeLogger, tmpDir, false)
+  await createPackageJson(version, fastifyVersion, fakeLogger, tmpDir, false)
   equal(log, `${join(tmpDir, 'package.json')} successfully created.`)
   const accessible = await isFileAccessible(join(tmpDir, 'package.json'))
   equal(accessible, true)
   const packageJson = JSON.parse(readFileSync(join(tmpDir, 'package.json')))
-  equal(packageJson.scripts.start, 'platformatic db start')
+  equal(packageJson.scripts.start, 'platformatic start')
   equal(packageJson.scripts.build, undefined)
   equal(packageJson.dependencies.platformatic, `^${version}`)
   equal(packageJson.devDependencies.fastify, `^${fastifyVersion}`)
@@ -37,12 +37,12 @@ test('creates package.json file for db project', async ({ equal }) => {
 test('creates package.json file for service project', async ({ equal }) => {
   const version = '1.2.3'
   const fastifyVersion = '4.5.6'
-  await createPackageJson('service', version, fastifyVersion, fakeLogger, tmpDir, false)
+  await createPackageJson(version, fastifyVersion, fakeLogger, tmpDir, false)
   equal(log, `${join(tmpDir, 'package.json')} successfully created.`)
   const accessible = await isFileAccessible(join(tmpDir, 'package.json'))
   equal(accessible, true)
   const packageJson = JSON.parse(readFileSync(join(tmpDir, 'package.json')))
-  equal(packageJson.scripts.start, 'platformatic service start')
+  equal(packageJson.scripts.start, 'platformatic start')
   equal(packageJson.dependencies.platformatic, `^${version}`)
   equal(packageJson.devDependencies.fastify, `^${fastifyVersion}`)
 })
@@ -52,19 +52,19 @@ test('do not create package.json file because already present', async ({ equal }
   const fastifyVersion = '4.5.6'
   const packagejson = join(tmpDir, 'package.json')
   writeFileSync(packagejson, 'TEST')
-  await createPackageJson('db', version, fastifyVersion, fakeLogger, tmpDir, false)
+  await createPackageJson(version, fastifyVersion, fakeLogger, tmpDir, false)
   equal(log, `${join(tmpDir, 'package.json')} found, skipping creation of package.json file.`)
 })
 
 test('creates package.json file with TS build', async ({ equal }) => {
   const version = '1.2.3'
   const fastifyVersion = '4.5.6'
-  await createPackageJson('db', version, fastifyVersion, fakeLogger, tmpDir, true)
+  await createPackageJson(version, fastifyVersion, fakeLogger, tmpDir, true)
   equal(log, `${join(tmpDir, 'package.json')} successfully created.`)
   const accessible = await isFileAccessible(join(tmpDir, 'package.json'))
   equal(accessible, true)
   const packageJson = JSON.parse(readFileSync(join(tmpDir, 'package.json')))
-  equal(packageJson.scripts.start, 'npm run clean && platformatic db start')
+  equal(packageJson.scripts.start, 'npm run clean && platformatic start')
   equal(packageJson.scripts.clean, 'rm -fr ./dist')
   equal(packageJson.scripts.build, 'npx tsc')
   equal(packageJson.dependencies.platformatic, `^${version}`)


### PR DESCRIPTION
Use `platformatic start` instead of the application specific start commands.