### PR TITLE
metaconfig: remove hotReload from plugins object

### DIFF
--- a/packages/metaconfig/test/from-eighteen-to-will-see.test.js
+++ b/packages/metaconfig/test/from-eighteen-to-will-see.test.js
@@ -77,3 +77,37 @@ test('does not add watch if it is set to false', async (t) => {
   const upped = meta.up()
   t.equal(upped.config.watch, false)
 })
+
+test('removes plugins.hotReload if it exists', async (t) => {
+  const version = '0.26.0'
+
+  {
+    const meta = new FromZeroEighteenToWillSee({
+      version,
+      config: { plugins: { hotReload: true } }
+    })
+    t.equal('hotReload' in meta.config.plugins, true)
+    const upped = meta.up()
+    t.equal('hotReload' in upped.config.plugins, false)
+  }
+
+  {
+    const meta = new FromZeroEighteenToWillSee({
+      version,
+      config: { plugins: { hotReload: false } }
+    })
+    t.equal('hotReload' in meta.config.plugins, true)
+    const upped = meta.up()
+    t.equal('hotReload' in upped.config.plugins, false)
+  }
+
+  {
+    const meta = new FromZeroEighteenToWillSee({
+      version,
+      config: { plugins: {} }
+    })
+    t.equal('hotReload' in meta.config.plugins, false)
+    const upped = meta.up()
+    t.equal('hotReload' in upped.config.plugins, false)
+  }
+})

--- a/packages/metaconfig/versions/from-zero-eighteen-to-will-see.js
+++ b/packages/metaconfig/versions/from-zero-eighteen-to-will-see.js
@@ -28,6 +28,8 @@ class FromZeroEighteenToWillSee extends SimpleZeroConfig {
         }
       }
 
+      delete config.plugins?.hotReload
+
       return new FromZeroEighteenToWillSee({ config, path: this.path, format: this.format, version })
     }
   }


### PR DESCRIPTION
This property was removed in #1103.

Fixes: https://github.com/platformatic/platformatic/issues/1104