### PR TITLE
utils: remove unused fsWatcher property from FileWatcher

### DIFF
--- a/packages/utils/lib/file-watcher.js
+++ b/packages/utils/lib/file-watcher.js
@@ -27,8 +27,6 @@ class FileWatcher extends EventEmitter {
     this.path = opts.path
     this.allowToWatch = opts.allowToWatch?.map(removeDotSlash) || null
     this.watchIgnore = opts.watchIgnore?.map(removeDotSlash) || null
-
-    this.fsWatcher = null
     this.handlePromise = null
     this.abortController = null
 


### PR DESCRIPTION
This property is never used, so remove it.