### PR TITLE
support passing explicit client IDs in service clients

### DIFF
--- a/docs/reference/client/introduction.md
+++ b/docs/reference/client/introduction.md
@@ -35,7 +35,7 @@ module.exports = async function (app, opts) {
     const res = await app.myclient.graphql({
       query: 'query { movies { title } }'
     })
-    return res 
+    return res
   })
 }
 ```
@@ -66,6 +66,10 @@ The client configuration in the `platformatic.db.json` and `platformatic.service
 ```
 
 Note that the generator would also have updated the `.env` and `.env.sample` files if they exists.
+
+It is possible to add a `serviceId` property each client object shown above.
+This is not required, but if using the Platformatic Runtime, the `serviceId`
+property will be used to identify the service dependency.
 
 ## Types Generator
 
@@ -224,13 +228,13 @@ fastify.post('/', async (request, reply) => {
   const res = await request.movies.graphql({
     query: 'mutation { saveMovie(input: { title: "foo" }) { id, title } }'
   })
-  return res 
+  return res
 })
 
 // OpenAPI
 fastify.post('/', async (request, reply) => {
   const res = await request.movies.createMovie({ title: 'foo' })
-  return res 
+  return res
 })
 
 fastify.listen({ port: 3000 })
@@ -268,7 +272,7 @@ module.exports = async function (app, opts) {
     const res = await app.myclient.graphql({
       query: 'query { movies { title } }'
     })
-    return res 
+    return res
   })
 }
 ```

--- a/docs/reference/runtime/configuration.md
+++ b/docs/reference/runtime/configuration.md
@@ -72,6 +72,11 @@ these default values.
 runtime. Each service object supports the following settings:
 
 - **`id`** (**required**, `string`) - A unique identifier for the microservice.
+When working with the Platformatic Composer, this value corresponds to the `id`
+property of each object in the `services` section of the config file. When
+working with client objects, this corresponds to the optional `serviceId`
+property or the `name` field in the client's `package.json` file if a
+`serviceId` is not explicitly provided.
 - **`path`** (**required**, `string`) - The path to the directory containing
 the microservice.
 - **`config`** (**required**, `string`) - The configuration file used to start

--- a/packages/runtime/fixtures/configs/monorepo-client-without-id.json
+++ b/packages/runtime/fixtures/configs/monorepo-client-without-id.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.20.0/runtime",
+  "entrypoint": "serviceApp",
+  "allowCycles": true,
+  "hotReload": false,
+  "autoload": {
+    "path": "../monorepo",
+    "exclude": ["docs", "composerApp"],
+    "mappings": {
+      "serviceApp": {
+        "id": "serviceApp",
+        "config": "platformatic.service-client-without-id.json"
+      },
+      "serviceAppWithLogger": {
+        "id": "with-logger",
+        "config": "platformatic.service.json"
+      },
+      "serviceAppWithMultiplePlugins": {
+        "id": "multi-plugin-service",
+        "config": "platformatic.service.json"
+      }
+    }
+  }
+}

--- a/packages/runtime/fixtures/monorepo/serviceApp/platformatic.service-client-without-id.json
+++ b/packages/runtime/fixtures/monorepo/serviceApp/platformatic.service-client-without-id.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.20.0/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      "plugin.js"
+    ]
+  },
+  "clients": [
+    {
+      "path": "./with-logger",
+      "url": "{PLT_WITH_LOGGER_URL}"
+    }
+  ]
+}

--- a/packages/runtime/fixtures/monorepo/serviceApp/platformatic.service.json
+++ b/packages/runtime/fixtures/monorepo/serviceApp/platformatic.service.json
@@ -14,7 +14,7 @@
   },
   "clients": [
     {
-      "id": "with-logger",
+      "serviceId": "with-logger",
       "path": "./with-logger",
       "url": "{PLT_WITH_LOGGER_URL}"
     }

--- a/packages/runtime/fixtures/monorepo/serviceApp/platformatic.service.json
+++ b/packages/runtime/fixtures/monorepo/serviceApp/platformatic.service.json
@@ -14,6 +14,7 @@
   },
   "clients": [
     {
+      "id": "with-logger",
       "path": "./with-logger",
       "url": "{PLT_WITH_LOGGER_URL}"
     }

--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -118,6 +118,7 @@ async function parseClientsAndComposer (configManager) {
       const promises = parsed.clients.map((client) => {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve, reject) => {
+          let clientName = client.id ?? ''
           let clientUrl
           let missingKey
 
@@ -135,11 +136,15 @@ async function parseClientsAndComposer (configManager) {
           }
 
           const isLocal = missingKey && client.url === `{${missingKey}}`
-          const clientAbsolutePath = pathResolve(service.path, client.path)
-          const clientPackageJson = join(clientAbsolutePath, 'package.json')
-          const clientMetadata = JSON.parse(await readFile(clientPackageJson, 'utf8'))
+
           /* c8 ignore next 20 - unclear why c8 is unhappy for nearly 20 lines here */
-          const clientName = clientMetadata.name ?? ''
+          if (!clientName) {
+            const clientAbsolutePath = pathResolve(service.path, client.path)
+            const clientPackageJson = join(clientAbsolutePath, 'package.json')
+            const clientMetadata = JSON.parse(await readFile(clientPackageJson, 'utf8'))
+
+            clientName = clientMetadata.name ?? ''
+          }
 
           if (clientUrl === undefined) {
             // Combine the service name with the client name to avoid collisions

--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -118,7 +118,7 @@ async function parseClientsAndComposer (configManager) {
       const promises = parsed.clients.map((client) => {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve, reject) => {
-          let clientName = client.id ?? ''
+          let clientName = client.serviceId ?? ''
           let clientUrl
           let missingKey
 

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -56,3 +56,12 @@ test('performs a topological sort on services depending on allowCycles', async (
     })
   })
 })
+
+test('can resolve service id from client package.json if not provided', async () => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo-client-without-id.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const entry = config.configManager.current.serviceMap.get('serviceApp')
+
+  assert.strictEqual(entry.dependencies.length, 1)
+  assert.strictEqual(entry.dependencies[0].id, 'with-logger')
+})

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -512,7 +512,7 @@ const clients = {
   items: {
     type: 'object',
     properties: {
-      id: {
+      serviceId: {
         type: 'string'
       },
       path: {

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -512,6 +512,9 @@ const clients = {
   items: {
     type: 'object',
     properties: {
+      id: {
+        type: 'string'
+      },
       path: {
         type: 'string',
         resolvePath: true


### PR DESCRIPTION
This commit allows clients to be given an explicit ID, similar to composer services. The runtime will automatically use this ID if present. Otherwise, the runtime will use its existing behavior.

Fixes: https://github.com/platformatic/platformatic/issues/1095