### PR TITLE
runtime: support node inspector flags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -136,7 +136,7 @@ Compile typescript plugins.
 ```
 
 As a result of executing this command, the Platformatic DB will compile typescript
-plugins in the `outDir` directory. 
+plugins in the `outDir` directory.
 
 If not specified, the configuration specified will be loaded from
 `platformatic.db.json`, `platformatic.db.yml`, or `platformatic.db.tml` in the current directory.
@@ -422,7 +422,7 @@ Compile typescript plugins.
 ```
 
 As a result of executing this command, the Platformatic DB will compile typescript
-plugins in the `outDir` directory. 
+plugins in the `outDir` directory.
 
 If not specified, the configuration specified will be loaded from
 `platformatic.service.json`, `platformatic.service.yml`, or `platformatic.service.tml` in the current directory.
@@ -553,6 +553,11 @@ Start a Platformatic application with the following command:
 $ platformatic start
 ```
 
+Options:
+
+  * `-c, --config <path>`: Path to the configuration file.
+  * `--inspect[=[host:]port]`: Start the Node.js debugger. `host` defaults to `'127.0.0.1'`. `port` defaults to 9229. Use caution when binding to a public host:port combination.
+  * `--inspect-brk[=[host:]port]`: Start the Node.js debugger and block until a client has attached. `host` defaults to `'127.0.0.1'`. `port` defaults to 9229. Use caution when binding to a public host:port combination.
 
 ### frontend
 

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -1,11 +1,12 @@
 'use strict'
 const { once } = require('node:events')
+const inspector = require('node:inspector')
 const { join } = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { Worker } = require('node:worker_threads')
 const closeWithGrace = require('close-with-grace')
 const { loadConfig } = require('@platformatic/service')
-const { platformaticRuntime } = require('./config')
+const { parseInspectorOptions, platformaticRuntime } = require('./config')
 const RuntimeApiClient = require('./api-client.js')
 const kLoaderFile = pathToFileURL(join(__dirname, 'loader.mjs')).href
 const kWorkerFile = join(__dirname, 'worker.js')
@@ -16,17 +17,27 @@ const kWorkerExecArgv = [
 ]
 
 async function start (argv) {
-  const { configManager } = await loadConfig({}, argv, platformaticRuntime, {
+  const config = await loadConfig({}, argv, platformaticRuntime, {
     watch: true
   })
-  const app = await startWithConfig(configManager)
 
+  config.configManager.args = config.args
+  const app = await startWithConfig(config.configManager)
   await app.start()
   return app
 }
 
 async function startWithConfig (configManager) {
   const config = configManager.current
+
+  if (inspector.url()) {
+    throw new Error('The Node.js inspector flags are not supported. Please use \'platformatic start --inspect\' instead.')
+  }
+
+  if (configManager.args) {
+    parseInspectorOptions(configManager)
+  }
+
   const worker = new Worker(kWorkerFile, {
     /* c8 ignore next */
     execArgv: config.hotReload ? kWorkerExecArgv : [],

--- a/packages/runtime/lib/unified-api.js
+++ b/packages/runtime/lib/unified-api.js
@@ -163,9 +163,11 @@ async function startCommandInRuntime (args) {
     let runtime
 
     if (configType === 'runtime') {
+      config.configManager.args = config.args
       runtime = await runtimeStartWithConfig(config.configManager)
     } else {
       const wrappedConfig = await wrapConfigInRuntimeConfig(config)
+      wrappedConfig.args = config.args
       runtime = await runtimeStartWithConfig(wrappedConfig)
     }
 

--- a/packages/runtime/lib/worker.js
+++ b/packages/runtime/lib/worker.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const inspector = require('node:inspector')
 const { parentPort, workerData } = require('node:worker_threads')
 const RuntimeApi = require('./api')
 
@@ -34,6 +35,17 @@ process.once('unhandledRejection', (err) => {
 })
 
 function main () {
+  const { inspectorOptions } = workerData.config
+
+  if (inspectorOptions) {
+    /* c8 ignore next 3 */
+    if (inspectorOptions.hotReloadDisabled) {
+      logger.info('debugging flags were detected. hot reloading has been disabled')
+    }
+
+    inspector.open(inspectorOptions.port, inspectorOptions.host, inspectorOptions.breakFirstLine)
+  }
+
   const runtime = new RuntimeApi(workerData.config, logger, loaderPort)
   runtime.startListening(parentPort)
 

--- a/packages/runtime/test/cli/start.test.mjs
+++ b/packages/runtime/test/cli/start.test.mjs
@@ -59,3 +59,59 @@ test('exits on error', async () => {
   assert.strictEqual(res.statusCode, 200)
   assert.strictEqual(exitCode, 1)
 })
+
+test('does not start if node inspector flags are provided', async (t) => {
+  const { execa } = await import('execa')
+  const config = join(import.meta.url, '..', '..', 'fixtures', 'configs', 'monorepo.json')
+  const child = execa(process.execPath, [cliPath, 'start', '-c', config], {
+    env: { NODE_OPTIONS: '--inspect' },
+    encoding: 'utf8'
+  })
+  let stderr = ''
+  let found = false
+
+  for await (const messages of on(child.stderr, 'data')) {
+    for (const message of messages) {
+      stderr += message
+
+      if (/Error: The Node.js inspector flags are not supported/.test(stderr)) {
+        found = true
+        break
+      }
+    }
+
+    if (found) {
+      break
+    }
+  }
+
+  assert(found)
+})
+
+test('starts the inspector', async (t) => {
+  const { execa } = await import('execa')
+  const config = join(import.meta.url, '..', '..', 'fixtures', 'configs', 'monorepo.json')
+  const child = execa(process.execPath, [cliPath, 'start', '-c', config, '--inspect'], {
+    encoding: 'utf8'
+  })
+  let stderr = ''
+  let found = false
+
+  for await (const messages of on(child.stderr, 'data')) {
+    for (const message of messages) {
+      stderr += message
+
+      if (/Debugger listening on ws:\/\/127\.0\.0\.1:9229/.test(stderr)) {
+        found = true
+        break
+      }
+    }
+
+    if (found) {
+      break
+    }
+  }
+
+  assert(found)
+  child.kill('SIGINT')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
Fixes: https://github.com/platformatic/platformatic/issues/835

Opening as a draft until we know if we want to do this and tests are added.

@mcollina please take a look (and possibly pull this down locally to try it out). It seems to work well enough. The two biggest hiccups are:

1. Printing the "Debugger listening" message twice - once on the main thread and a second time in the worker thread.
2. The debug port can currently be customized, but the host cannot.