### PR TITLE
fix two runtime test issues

### DIFF
--- a/packages/runtime/test/app.test.js
+++ b/packages/runtime/test/app.test.js
@@ -268,7 +268,7 @@ test('supports configuration overrides', async (t) => {
   })
 })
 
-test('restarts on config change without overriding the configManager', { only: true }, async (t) => {
+test('restarts on config change without overriding the configManager', async (t) => {
   const { logger, stream } = getLoggerAndStream()
   const appPath = join(fixturesDir, 'monorepo', 'serviceApp')
   const configFile = join(appPath, 'platformatic.service.json')

--- a/packages/runtime/test/cli/validations.test.mjs
+++ b/packages/runtime/test/cli/validations.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { test } from 'node:test'
+import { stripVTControlCharacters } from 'node:util'
 import { join } from 'desm'
 import { execa } from 'execa'
 import { cliPath } from './helper.mjs'
@@ -42,7 +43,7 @@ test('print validation errors', async () => {
 
   assert(error)
   assert.strictEqual(error.exitCode, 1)
-  assert.strictEqual(error.stdout, `
+  assert.strictEqual(stripVTControlCharacters(error.stdout), `
 ┌─────────┬─────────────┬─────────────────────────────────────────────────────────────────┐
 │ (index) │    path     │                             message                             │
 ├─────────┼─────────────┼─────────────────────────────────────────────────────────────────┤


### PR DESCRIPTION
- One test had a leftover 'only' flag.
- One test recently started failing due to ANSI characters.

(FYI - we can use `stripVTControlCharacters()` from core instead of depending on an npm package that only supports ESM)