### PR TITLE
Trigger runtime update after docker image pushed

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,3 +27,7 @@ jobs:
             platformatic/platformatic:latest
             platformatic/platformatic:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
+
+  update-cloud-runtime:
+    needs: buildx
+    uses: platformatic/platformatic/.github/workflows/update-platformatic-runtime.yml@main

--- a/.github/workflows/update-platformatic-runtime.yml
+++ b/.github/workflows/update-platformatic-runtime.yml
@@ -2,8 +2,7 @@ name: Update Platformatic Cloud runtime
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
+  workflow_call:
 
 jobs:
   update-cloud-runtime:


### PR DESCRIPTION
This changes the way that the Platformatic Cloud runtime is updated. Currently, the update process would start when a new version of `platformatic` is released on Github. This is no longer the case, the update is now triggered if a new Docker image is successfully built and pushed to Docker Hub.