### PR TITLE
fix: modify schema with resolved refs

### DIFF
--- a/packages/composer/lib/openapi-modifier.js
+++ b/packages/composer/lib/openapi-modifier.js
@@ -102,7 +102,6 @@ function modifyOpenApiSchema (app, schema, config) {
     }
 
     for (const method in pathSchema) {
-      const routeSchema = pathSchema[method]
       const routeConfig = pathConfig?.[method.toLowerCase()]
 
       if (routeConfig?.ignore) {
@@ -110,14 +109,16 @@ function modifyOpenApiSchema (app, schema, config) {
         continue
       }
 
-      const responseSchema = routeSchema.responses?.['200']?.content?.['application/json']?.schema
       const modificationResponseSchema = routeConfig?.responses?.['200']
-      if (!responseSchema || !modificationResponseSchema) continue
+      if (!modificationResponseSchema) continue
 
       const modificationRules = getModificationRules(modificationResponseSchema)
-      modifySchema(responseSchema, modificationRules)
 
       app.platformatic.addComposerOnRouteHook(path, [method], routeOptions => {
+        const routeSchema = routeOptions.schema
+        const responseSchema = routeSchema.response?.['200']
+        modifySchema(responseSchema, modificationRules)
+
         async function onComposerResponse (request, reply, body) {
           const payload = await body.json()
           modifyPayload(payload, responseSchema, modificationRules)

--- a/packages/composer/test/cli/fetch-schema.test.js
+++ b/packages/composer/test/cli/fetch-schema.test.js
@@ -59,8 +59,6 @@ test('should fetch the schemas', async (t) => {
   const openApiSchema = JSON.parse(openApiSchemaFile)
   openApiValidator.validate(openApiSchema)
 
-  // console.log(openApiSchema)
-
   const pathToUsersSchema = join(__dirname, '..', 'openapi', 'fixtures', 'schemas', 'users.json')
   const usersOpenApiSchemaFile = await readFile(pathToUsersSchema, 'utf-8')
   const usersOpenApiSchema = JSON.parse(usersOpenApiSchemaFile)

--- a/packages/composer/test/helper.js
+++ b/packages/composer/test/helper.js
@@ -110,20 +110,22 @@ async function createOpenApiService (t, entitiesNames = []) {
     saveEntity({ name: 'test3' })
     saveEntity({ name: 'test4' })
 
-    const entitySchema = {
+    app.addSchema({
+      $id: entity,
+      title: entity,
       type: 'object',
       properties: {
         id: { type: 'number' },
         name: { type: 'string' }
       }
-    }
+    })
 
     app.get(`/${entity}`, {
       schema: {
         response: {
           200: {
             type: 'array',
-            items: entitySchema
+            items: { $ref: entity }
           }
         }
       }
@@ -140,7 +142,7 @@ async function createOpenApiService (t, entitiesNames = []) {
           }
         },
         response: {
-          200: entitySchema
+          200: { $ref: entity }
         }
       }
     }, async (req) => {
@@ -150,9 +152,9 @@ async function createOpenApiService (t, entitiesNames = []) {
 
     app.put(`/${entity}`, {
       schema: {
-        body: entitySchema,
+        body: { $ref: entity },
         response: {
-          200: entitySchema
+          200: { $ref: entity }
         }
       }
     }, async (req) => {
@@ -163,7 +165,7 @@ async function createOpenApiService (t, entitiesNames = []) {
     app.get(`/${entity}/:id`, {
       schema: {
         response: {
-          200: entitySchema
+          200: { $ref: entity }
         }
       }
     }, async (req) => {
@@ -173,7 +175,7 @@ async function createOpenApiService (t, entitiesNames = []) {
     app.post(`/${entity}/:id`, {
       schema: {
         response: {
-          200: entitySchema
+          200: { $ref: entity }
         }
       }
     }, async (req) => {
@@ -185,7 +187,7 @@ async function createOpenApiService (t, entitiesNames = []) {
     app.put(`/${entity}/:id`, {
       schema: {
         response: {
-          200: entitySchema
+          200: { $ref: entity }
         }
       }
     }, async (req) => {
@@ -197,7 +199,7 @@ async function createOpenApiService (t, entitiesNames = []) {
     app.delete(`/${entity}/:id`, {
       schema: {
         response: {
-          200: entitySchema
+          200: { $ref: entity }
         }
       }
     }, async (req) => {

--- a/packages/composer/test/openapi/fields-renaming.test.js
+++ b/packages/composer/test/openapi/fields-renaming.test.js
@@ -70,6 +70,7 @@ test('should rename top level object fields', async (t) => {
 
   t.strictSame(responseSchema, {
     type: 'object',
+    title: 'users',
     properties: {
       user_id: { type: 'number' },
       first_name: { type: 'string' }
@@ -297,6 +298,7 @@ test('should rename top level object fields in array', async (t) => {
   t.strictSame(responseSchema, {
     type: 'array',
     items: {
+      title: 'users',
       type: 'object',
       properties: {
         user_id: { type: 'number' },

--- a/packages/composer/test/openapi/fixtures/schemas/users.json
+++ b/packages/composer/test/openapi/fixtures/schemas/users.json
@@ -5,7 +5,20 @@
     "title": "Test"
   },
   "components": {
-    "schemas": {}
+    "schemas": {
+      "def-0": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "title": "users"
+      }
+    }
   },
   "paths": {
     "/users": {
@@ -18,15 +31,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "number"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
+                    "$ref": "#/components/schemas/def-0"
                   }
                 }
               }
@@ -55,15 +60,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }
@@ -75,15 +72,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "number"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                }
+                "$ref": "#/components/schemas/def-0"
               }
             }
           }
@@ -94,15 +83,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }
@@ -118,15 +99,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }
@@ -140,15 +113,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }
@@ -162,15 +127,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }
@@ -184,15 +141,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }


### PR DESCRIPTION
Ideally, we should resolve schemas on our end, but for now, we can reuse `fastify-openapi-glue` schema resolving.