### PR TITLE
Do not generate clients when not needed

### DIFF
--- a/docs/reference/client/introduction.md
+++ b/docs/reference/client/introduction.md
@@ -59,7 +59,9 @@ The client configuration in the `platformatic.db.json` and `platformatic.service
 ```json
 {
   "clients": [{
-    "path": "./myclient",
+    "schema": "./myclient/myclient.openapi.json" // or ./myclient/myclient.schema.graphl
+    "name": "myclient",
+    "type": "openapi" // or graphql
     "url": "{ PLT_MYCLIENT_URL }"
   }]
 }
@@ -253,7 +255,8 @@ it accordingly.
 
 ## Usage with standalone Fastify
 
-You can know use the client in your Fastify application:
+If a platformatic configuration file is not found, a complete Fastify plugin is generated to be 
+used in your Fastify application like so:
 
 ```js
 const fastify = require('fastify')()

--- a/packages/client-cli/lib/utils.mjs
+++ b/packages/client-cli/lib/utils.mjs
@@ -1,4 +1,4 @@
-import { writeFile, access } from 'fs/promises'
+import { writeFile } from 'fs/promises'
 import camelcase from 'camelcase'
 import { join } from 'path'
 
@@ -13,7 +13,6 @@ export function classCase (str) {
 export async function appendToEnv (file, key, value) {
   const str = `\n${key}=${value}\n`
   try {
-    await access(file)
     await writeFile(file, str, { flag: 'a' })
     /* c8 ignore next 1 */
   } catch {}

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -33,7 +33,8 @@
     "split2": "^4.2.0",
     "standard": "^17.1.0",
     "tap": "^16.3.6",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "why-is-node-running": "^2.2.2"
   },
   "dependencies": {
     "@platformatic/client": "workspace:*",

--- a/packages/client-cli/test/cli-graphql-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-graphql-no-implementation.test.mjs
@@ -1,0 +1,191 @@
+import { request, moveToTmpdir } from './helper.js'
+import { test } from 'tap'
+import { buildServer } from '@platformatic/db'
+import { join } from 'path'
+import * as desm from 'desm'
+import { execa } from 'execa'
+import { promises as fs } from 'fs'
+import split from 'split2'
+import graphql from 'graphql'
+import dotenv from 'dotenv'
+
+test('graphql client generation (javascript)', async ({ teardown, comment, same, equal, match }) => {
+  try {
+    await fs.unlink(desm.join(import.meta.url, 'fixtures', 'movies', 'db.sqlite'))
+  } catch {
+    // noop
+  }
+  const app = await buildServer(desm.join(import.meta.url, 'fixtures', 'movies', 'zero.db.json'))
+
+  await app.start()
+
+  const dir = await moveToTmpdir(teardown)
+
+  comment(`working in ${dir}`)
+
+  const pltServiceConfig = {
+    $schema: 'https://platformatic.dev/schemas/v0.18.0/service',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: ['./plugin.js']
+    }
+  }
+
+  const plugin = `
+module.exports = async function (app) {
+  app.post('/', async (request, reply) => {
+    const res = await app.movies.graphql({
+      query: 'mutation { saveMovie(input: { title: "foo" }) { id, title } }'
+    })
+    return res
+  })
+}
+  `
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+  await fs.writeFile('./plugin.js', plugin)
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), app.url + '/graphql', '--name', 'movies'])
+
+  const readSDL = await fs.readFile(join(dir, 'movies', 'movies.schema.graphql'), 'utf8')
+  {
+    const schema = graphql.buildSchema(readSDL)
+    const sdl = graphql.printSchema(schema)
+    equal(sdl, readSDL)
+  }
+
+  const server2 = execa(desm.join(import.meta.url, '..', 'node_modules', '.bin', 'plt-service'), ['start'])
+
+  teardown(() => server2.kill())
+  teardown(async () => { await app.close() })
+
+  const stream = server2.stdout.pipe(split(JSON.parse))
+
+  // this is unfortuate :(
+  const base = 'Server listening at '
+  let url
+  for await (const line of stream) {
+    const msg = line.msg
+    if (msg.indexOf(base) !== 0) {
+      continue
+    }
+    url = msg.slice(base.length)
+    break
+  }
+  if (!url) {
+    throw new Error('no url was found')
+  }
+  const res = await request(url, {
+    method: 'POST'
+  })
+  const body = await res.body.json()
+  match(body, {
+    title: 'foo'
+  })
+
+  {
+    const envs = dotenv.parse(await fs.readFile(join(dir, '.env')))
+    same(envs, {
+      PLT_MOVIES_URL: app.url + '/graphql'
+    })
+  }
+
+  {
+    const envs = dotenv.parse(await fs.readFile(join(dir, '.env.sample')))
+    same(envs, {
+      PLT_MOVIES_URL: app.url + '/graphql'
+    })
+  }
+})
+
+test('graphql client generation (typescript)', async ({ teardown, comment, same, match }) => {
+  try {
+    await fs.unlink(desm.join(import.meta.url, 'fixtures', 'movies', 'db.sqlite'))
+  } catch {
+    // noop
+  }
+  const app = await buildServer(desm.join(import.meta.url, 'fixtures', 'movies', 'zero.db.json'))
+
+  await app.start()
+
+  const dir = await moveToTmpdir(teardown)
+
+  comment(`working in ${dir}`)
+
+  const pltServiceConfig = {
+    $schema: 'https://platformatic.dev/schemas/v0.18.0/service',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: ['./plugin.ts'],
+      typescript: true
+    }
+  }
+
+  const plugin = `
+/// <reference types="./movies" />
+import { FastifyPluginAsync } from 'fastify'
+
+const myPlugin: FastifyPluginAsync<{}> = async (app, options) => {
+  app.post('/', async (request, reply) => {
+    const res = await app.movies.graphql({
+      query: 'mutation { saveMovie(input: { title: "foo" }) { id, title } }'
+    })
+    return res
+  })
+}
+
+export default myPlugin
+  `
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+  await fs.writeFile('./plugin.ts', plugin)
+
+  const tsconfig = JSON.stringify({
+    extends: 'fastify-tsconfig',
+    compilerOptions: {
+      outDir: 'build',
+      target: 'es2018',
+      moduleResolution: 'node',
+      lib: ['es2018']
+    }
+  }, null, 2)
+
+  await fs.writeFile(join(dir, 'tsconfig.json'), tsconfig)
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), app.url + '/graphql', '--name', 'movies'])
+
+  comment(`upstream URL is ${app.url}`)
+
+  const server2 = execa(desm.join(import.meta.url, '..', 'node_modules', '.bin', 'plt-service'), ['start'])
+
+  teardown(() => server2.kill())
+  teardown(async () => { await app.close() })
+
+  const stream = server2.stdout.pipe(split(JSON.parse))
+
+  // this is unfortuate :(
+  const base = 'Server listening at '
+  let url
+  for await (const line of stream) {
+    const msg = line.msg
+    if (msg.indexOf(base) !== 0) {
+      continue
+    }
+    url = msg.slice(base.length)
+    break
+  }
+  comment(`client URL is ${url}`)
+  const res = await request(url, {
+    method: 'POST'
+  })
+  const body = await res.body.json()
+  match(body, {
+    title: 'foo'
+  })
+})

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -1,11 +1,11 @@
 import { request, moveToTmpdir } from './helper.js'
 import { test } from 'tap'
 import { buildServer } from '@platformatic/db'
+import { buildServer as buildService } from '@platformatic/service'
 import { join } from 'path'
 import * as desm from 'desm'
 import { execa } from 'execa'
 import { promises as fs } from 'fs'
-import split from 'split2'
 
 test('openapi client generation (javascript)', async ({ teardown, comment, same }) => {
   try {
@@ -14,6 +14,7 @@ test('openapi client generation (javascript)', async ({ teardown, comment, same 
     // noop
   }
   const app = await buildServer(desm.join(import.meta.url, 'fixtures', 'movies', 'zero.db.json'))
+  teardown(async () => { await app.close() })
 
   await app.start()
 
@@ -21,7 +22,7 @@ test('openapi client generation (javascript)', async ({ teardown, comment, same 
   comment(`working in ${dir}`)
 
   const pltServiceConfig = {
-    $schema: 'https://platformatic.dev/schemas/v0.18.0/service',
+    $schema: 'https://platformatic.dev/schemas/v0.28.0/service',
     server: {
       hostname: '127.0.0.1',
       port: 0
@@ -45,29 +46,15 @@ module.exports = async function (app) {
 
   await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), app.url + '/documentation/json', '--name', 'movies'])
 
-  const app2 = execa(desm.join(import.meta.url, '..', 'node_modules', '.bin', 'plt-service'), ['start'], {
-    env: {
-      PLT_MOVIES_URL: app.url
-    }
+  process.env.PLT_MOVIES_URL = app.url
+
+  const app2 = await buildService('./platformatic.service.json')
+  await app2.start()
+  teardown(async () => {
+    await app2.close()
   })
-  teardown(() => app2.kill())
-  teardown(async () => { await app.close() })
 
-  const stream = app2.stdout.pipe(split(JSON.parse))
-  app2.stderr.pipe(process.stderr)
-
-  // this is unfortuate :(
-  const base = 'Server listening at '
-  let url
-  for await (const line of stream) {
-    const msg = line.msg
-    if (msg.indexOf(base) !== 0) {
-      continue
-    }
-    url = msg.slice(base.length)
-    break
-  }
-  const res = await request(url, {
+  const res = await request(app2.url, {
     method: 'POST'
   })
   const body = await res.body.json()
@@ -133,28 +120,14 @@ export default myPlugin
 
   await fs.writeFile(join(dir, 'tsconfig.json'), tsconfig)
 
-  const server2 = execa(desm.join(import.meta.url, '..', 'node_modules', '.bin', 'plt-service'), ['start'], {
-    env: {
-      PLT_MOVIES_URL: app.url
-    }
-  })
+  process.env.PLT_MOVIES_URL = app.url
+
+  const app2 = await buildService('./platformatic.service.json')
+  await app2.start()
   teardown(async () => { await app.close() })
-  teardown(async () => { await server2.kill() })
+  teardown(async () => { await app2.close() })
 
-  const stream = server2.stdout.pipe(split(JSON.parse))
-
-  // this is unfortuate :(
-  const base = 'Server listening at '
-  let url
-  for await (const line of stream) {
-    const msg = line.msg
-    if (msg.indexOf(base) !== 0) {
-      continue
-    }
-    url = msg.slice(base.length)
-    break
-  }
-  const res = await request(url, {
+  const res = await request(app2.url, {
     method: 'POST'
   })
   const body = await res.body.json()

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -1,0 +1,209 @@
+import { request, moveToTmpdir } from './helper.js'
+import { test } from 'tap'
+import { buildServer } from '@platformatic/db'
+import { join } from 'path'
+import * as desm from 'desm'
+import { execa } from 'execa'
+import { promises as fs } from 'fs'
+import split from 'split2'
+
+test('openapi client generation (javascript)', async ({ teardown, comment, same }) => {
+  try {
+    await fs.unlink(desm.join(import.meta.url, 'fixtures', 'movies', 'db.sqlite'))
+  } catch {
+    // noop
+  }
+  const app = await buildServer(desm.join(import.meta.url, 'fixtures', 'movies', 'zero.db.json'))
+
+  await app.start()
+
+  const dir = await moveToTmpdir(teardown)
+  comment(`working in ${dir}`)
+
+  const pltServiceConfig = {
+    $schema: 'https://platformatic.dev/schemas/v0.18.0/service',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: ['./plugin.js']
+    }
+  }
+
+  const plugin = `
+module.exports = async function (app) {
+  app.post('/', async (request, reply) => {
+    const res = await app.movies.createMovie({ title: 'foo' })
+    return res
+  })
+}
+  `
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+  await fs.writeFile('./plugin.js', plugin)
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), app.url + '/documentation/json', '--name', 'movies'])
+
+  const app2 = execa(desm.join(import.meta.url, '..', 'node_modules', '.bin', 'plt-service'), ['start'], {
+    env: {
+      PLT_MOVIES_URL: app.url
+    }
+  })
+  teardown(() => app2.kill())
+  teardown(async () => { await app.close() })
+
+  const stream = app2.stdout.pipe(split(JSON.parse))
+  app2.stderr.pipe(process.stderr)
+
+  // this is unfortuate :(
+  const base = 'Server listening at '
+  let url
+  for await (const line of stream) {
+    const msg = line.msg
+    if (msg.indexOf(base) !== 0) {
+      continue
+    }
+    url = msg.slice(base.length)
+    break
+  }
+  const res = await request(url, {
+    method: 'POST'
+  })
+  const body = await res.body.json()
+  same(body, {
+    id: 1,
+    title: 'foo'
+  })
+})
+
+test('openapi client generation (typescript)', async ({ teardown, comment, same }) => {
+  try {
+    await fs.unlink(desm.join(import.meta.url, 'fixtures', 'movies', 'db.sqlite'))
+  } catch {
+    // noop
+  }
+  const app = await buildServer(desm.join(import.meta.url, 'fixtures', 'movies', 'zero.db.json'))
+
+  await app.start()
+
+  const dir = await moveToTmpdir(teardown)
+
+  comment(`working in ${dir}`)
+  const pltServiceConfig = {
+    $schema: 'https://platformatic.dev/schemas/v0.18.0/service',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: ['./plugin.ts'],
+      typescript: true
+    }
+  }
+
+  const plugin = `
+/// <reference types="./movies" />
+import { FastifyPluginAsync } from 'fastify'
+
+const myPlugin: FastifyPluginAsync<{}> = async (app, options) => {
+  app.post('/', async (request, reply) => {
+    const res = await app.movies.createMovie({ title: 'foo' })
+    return res
+  })
+}
+
+export default myPlugin
+  `
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+  await fs.writeFile('./plugin.ts', plugin)
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), app.url + '/documentation/json', '--name', 'movies'])
+
+  const tsconfig = JSON.stringify({
+    extends: 'fastify-tsconfig',
+    compilerOptions: {
+      outDir: 'build',
+      target: 'es2018',
+      moduleResolution: 'node',
+      lib: ['es2018']
+    }
+  }, null, 2)
+
+  await fs.writeFile(join(dir, 'tsconfig.json'), tsconfig)
+
+  const server2 = execa(desm.join(import.meta.url, '..', 'node_modules', '.bin', 'plt-service'), ['start'], {
+    env: {
+      PLT_MOVIES_URL: app.url
+    }
+  })
+  teardown(async () => { await app.close() })
+  teardown(async () => { await server2.kill() })
+
+  const stream = server2.stdout.pipe(split(JSON.parse))
+
+  // this is unfortuate :(
+  const base = 'Server listening at '
+  let url
+  for await (const line of stream) {
+    const msg = line.msg
+    if (msg.indexOf(base) !== 0) {
+      continue
+    }
+    url = msg.slice(base.length)
+    break
+  }
+  const res = await request(url, {
+    method: 'POST'
+  })
+  const body = await res.body.json()
+  same(body, {
+    id: 1,
+    title: 'foo'
+  })
+})
+
+test('config support with folder', async ({ teardown, comment, match }) => {
+  try {
+    await fs.unlink(desm.join(import.meta.url, 'fixtures', 'movies', 'db.sqlite'))
+  } catch {
+    // noop
+  }
+  const app = await buildServer(desm.join(import.meta.url, 'fixtures', 'movies', 'zero.db.json'))
+
+  await app.start()
+  teardown(async () => {
+    await app.close()
+  })
+
+  const dir = await moveToTmpdir(teardown)
+  comment(`working in ${dir}`)
+
+  const pltServiceConfig = {
+    $schema: 'https://platformatic.dev/schemas/v0.18.0/service',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: ['./plugin.js']
+    }
+  }
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), app.url + '/documentation/json', '--name', 'movies', '--folder', 'uncanny'])
+
+  {
+    const config = JSON.parse(await fs.readFile('./platformatic.service.json'))
+    match(config, {
+      clients: [{
+        schema: 'uncanny/movies.openapi.json',
+        name: 'movies',
+        type: 'openapi',
+        url: '{PLT_MOVIES_URL}'
+      }]
+    })
+  }
+})

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -199,7 +199,7 @@ test('config support with folder', async ({ teardown, comment, match }) => {
     const config = JSON.parse(await fs.readFile('./platformatic.service.json'))
     match(config, {
       clients: [{
-        schema: 'uncanny/movies.openapi.json',
+        schema: join('uncanny', 'movies.openapi.json'),
         name: 'movies',
         type: 'openapi',
         url: '{PLT_MOVIES_URL}'

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -710,50 +710,6 @@ app.listen({ port: 0 });
   })
 })
 
-test('config support with folder', async ({ teardown, comment, match }) => {
-  try {
-    await fs.unlink(desm.join(import.meta.url, 'fixtures', 'movies', 'db.sqlite'))
-  } catch {
-    // noop
-  }
-  const app = await buildServer(desm.join(import.meta.url, 'fixtures', 'movies', 'zero.db.json'))
-
-  await app.start()
-  teardown(async () => {
-    await app.close()
-  })
-
-  const dir = await moveToTmpdir(teardown)
-  comment(`working in ${dir}`)
-
-  const pltServiceConfig = {
-    $schema: 'https://platformatic.dev/schemas/v0.18.0/service',
-    server: {
-      hostname: '127.0.0.1',
-      port: 0
-    },
-    plugins: {
-      paths: ['./plugin.js']
-    }
-  }
-
-  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
-
-  await fs.writeFile(join(dir, '.env'), 'FOO=bar')
-  await fs.writeFile(join(dir, '.env.sample'), 'FOO=bar')
-  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), app.url + '/documentation/json', '--name', 'movies', '--folder', 'uncanny'])
-
-  {
-    const config = JSON.parse(await fs.readFile('./platformatic.service.json'))
-    match(config, {
-      clients: [{
-        path: 'uncanny',
-        url: '{PLT_MOVIES_URL}'
-      }]
-    })
-  }
-})
-
 test('name with tilde', async ({ teardown, comment, same }) => {
   try {
     await fs.unlink(desm.join(import.meta.url, 'fixtures', 'movies', 'db.sqlite'))

--- a/packages/client-cli/test/helper.js
+++ b/packages/client-cli/test/helper.js
@@ -18,7 +18,8 @@ async function moveToTmpdir (teardown) {
   const tmp = join(__dirname, 'tmp')
   try {
     await fs.mkdir(tmp)
-  } catch {}
+  } catch {
+  }
   const dir = join(tmp, `platformatic-client-${process.pid}-${Date.now()}-${counter++}`)
   await fs.mkdir(dir)
   process.chdir(dir)

--- a/packages/client-cli/test/runtime.test.mjs
+++ b/packages/client-cli/test/runtime.test.mjs
@@ -40,7 +40,8 @@ PLT_SERVER_LOGGER_LEVEL=info
   match(read, {
     clients: [{
       serviceId: 'somber-chariot',
-      path: 'movies'
+      type: 'openapi',
+      schema: 'movies/movies.openapi.json'
     }]
   })
 

--- a/packages/client-cli/test/runtime.test.mjs
+++ b/packages/client-cli/test/runtime.test.mjs
@@ -41,7 +41,7 @@ PLT_SERVER_LOGGER_LEVEL=info
     clients: [{
       serviceId: 'somber-chariot',
       type: 'openapi',
-      schema: 'movies/movies.openapi.json'
+      schema: join('movies', 'movies.openapi.json')
     }]
   })
 

--- a/packages/service/fixtures/hello-client-ts-without-deps/hello.d.ts
+++ b/packages/service/fixtures/hello-client-ts-without-deps/hello.d.ts
@@ -1,0 +1,34 @@
+import { FastifyPluginAsync } from 'fastify'
+
+interface GetRequest {
+}
+
+interface GetResponse {
+}
+
+interface Hello {
+  get(req: GetRequest): Promise<GetResponse>;
+}
+
+type HelloPlugin = FastifyPluginAsync<NonNullable<hello.HelloOptions>>
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    'hello': Hello;
+  }
+
+  interface FastifyRequest {
+    'hello': Hello;
+  }
+}
+
+declare namespace hello {
+  export interface HelloOptions {
+    url: string
+  }
+  export const hello: HelloPlugin;
+  export { hello as default };
+}
+
+declare function hello(...params: Parameters<HelloPlugin>): ReturnType<HelloPlugin>;
+export = hello;

--- a/packages/service/fixtures/hello-client-ts-without-deps/hello.openapi.json
+++ b/packages/service/fixtures/hello-client-ts-without-deps/hello.openapi.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic",
+    "description": "This is a service built on top of Platformatic",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/service/fixtures/hello-client-ts-without-deps/platformatic.service.json
+++ b/packages/service/fixtures/hello-client-ts-without-deps/platformatic.service.json
@@ -1,0 +1,23 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "warn",
+      "name": "hello client ts"
+    },
+    "pluginTimeout": 30000
+  },
+  "plugins": {
+    "paths": ["./plugin.ts"],
+    "typescript": true
+  },
+  "clients": [{
+    "schema": "./hello.openapi.json",
+    "name": "hello",
+    "type": "openapi",
+    "url": "{PLT_CLIENT_URL}"
+  }],
+  "metrics": false,
+  "watch": false
+}

--- a/packages/service/fixtures/hello-client-ts-without-deps/plugin.ts
+++ b/packages/service/fixtures/hello-client-ts-without-deps/plugin.ts
@@ -1,0 +1,8 @@
+import { FastifyInstance } from 'fastify'
+/// <reference path="./hello" />
+
+export default async function (app: FastifyInstance) {
+  app.get('/', async () => {
+    return app.hello.get({})
+  })
+}

--- a/packages/service/fixtures/hello-client-ts-without-deps/tsconfig.json
+++ b/packages/service/fixtures/hello-client-ts-without-deps/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "target": "es6",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "pretty": true,
+    "noEmitOnError": true,
+    "outDir": "dist"
+  },
+  "watchOptions": {
+    "watchFile": "fixedPollingInterval",
+    "watchDirectory": "fixedPollingInterval",
+    "fallbackPolling": "dynamicPriority",
+    "synchronousWatchDirectory": true,
+    "excludeDirectories": [
+      "**/node_modules",
+      "dist"
+    ]
+  }
+}

--- a/packages/service/fixtures/hello-client-without-deps/hello.d.ts
+++ b/packages/service/fixtures/hello-client-without-deps/hello.d.ts
@@ -1,0 +1,34 @@
+import { FastifyPluginAsync } from 'fastify'
+
+interface GetRequest {
+}
+
+interface GetResponse {
+}
+
+interface Hello {
+  get(req: GetRequest): Promise<GetResponse>;
+}
+
+type HelloPlugin = FastifyPluginAsync<NonNullable<hello.HelloOptions>>
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    'hello': Hello;
+  }
+
+  interface FastifyRequest {
+    'hello': Hello;
+  }
+}
+
+declare namespace hello {
+  export interface HelloOptions {
+    url: string
+  }
+  export const hello: HelloPlugin;
+  export { hello as default };
+}
+
+declare function hello(...params: Parameters<HelloPlugin>): ReturnType<HelloPlugin>;
+export = hello;

--- a/packages/service/fixtures/hello-client-without-deps/hello.openapi.json
+++ b/packages/service/fixtures/hello-client-without-deps/hello.openapi.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic",
+    "description": "This is a service built on top of Platformatic",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/service/fixtures/hello-client-without-deps/platformatic.service.json
+++ b/packages/service/fixtures/hello-client-without-deps/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "warn",
+      "name": "hello client"
+    }
+  },
+  "plugins": {
+    "paths": ["./plugin.js"]
+  },
+  "clients": [{
+    "schema": "./hello.openapi.json",
+    "name": "hello",
+    "type": "openapi",
+    "url": "{PLT_CLIENT_URL}"
+  }],
+  "metrics": false,
+  "watch": false
+}

--- a/packages/service/fixtures/hello-client-without-deps/plugin.js
+++ b/packages/service/fixtures/hello-client-without-deps/plugin.js
@@ -1,0 +1,8 @@
+'use default'
+
+/**  @type {import('fastify').FastifyPluginAsync<{ optionA: boolean, optionB: string }>} */
+module.exports = async function (app) {
+  app.get('/', async () => {
+    return app.hello.get()
+  })
+}

--- a/packages/service/lib/plugins/clients.js
+++ b/packages/service/lib/plugins/clients.js
@@ -1,10 +1,15 @@
 'use strict'
 
 const fp = require('fastify-plugin')
+const client = require('@platformatic/client')
 
 async function setupClients (app, opts) {
-  for (const { path, url, serviceId } of opts) {
-    app.register(require(path), { url, serviceId })
+  for (const { path, url, serviceId, name, schema, type } of opts) {
+    if (path) {
+      app.register(require(path), { url, serviceId })
+    } else {
+      app.register(client, { url, serviceId, name, path: schema, type })
+    }
   }
 }
 

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -515,7 +515,18 @@ const clients = {
       serviceId: {
         type: 'string'
       },
+      name: {
+        type: 'string'
+      },
+      type: {
+        type: 'string',
+        enum: ['openapi', 'graphql']
+      },
       path: {
+        type: 'string',
+        resolvePath: true
+      },
+      schema: {
         type: 'string',
         resolvePath: true
       },
@@ -523,8 +534,7 @@ const clients = {
         type: 'string'
       }
     },
-    additionalProperties: false,
-    required: ['path']
+    additionalProperties: false
   }
 }
 

--- a/packages/service/test/clients.test.js
+++ b/packages/service/test/clients.test.js
@@ -60,3 +60,56 @@ test('client is loaded (ts)', async ({ teardown, equal, pass, same }) => {
   const data = await res.body.json()
   same(data, { hello: 'world' })
 })
+
+test('client is loaded dependencyless', async ({ teardown, equal, same }) => {
+  const app1 = await buildServer(join(__dirname, '..', 'fixtures', 'hello', 'warn-log.service.json'))
+
+  teardown(async () => {
+    await app1.close()
+  })
+  await app1.start()
+
+  process.env.PLT_CLIENT_URL = app1.url
+
+  const app2 = await buildServer(join(__dirname, '..', 'fixtures', 'hello-client-without-deps', 'platformatic.service.json'))
+
+  teardown(async () => {
+    await app2.close()
+  })
+  await app2.start()
+
+  const res = await request(`${app2.url}/`)
+  equal(res.statusCode, 200, 'status code')
+  const data = await res.body.json()
+  same(data, { hello: 'world' })
+})
+
+test('client is loaded (ts) depencyless', async ({ teardown, equal, pass, same }) => {
+  const app1 = await buildServer(join(__dirname, '..', 'fixtures', 'hello', 'warn-log.service.json'))
+
+  teardown(async () => {
+    await app1.close()
+  })
+  await app1.start()
+
+  process.env.PLT_CLIENT_URL = app1.url
+
+  const targetDir = join(__dirname, '..', 'fixtures', 'hello-client-ts-without-deps')
+
+  try {
+    await rmdir(join(targetDir, 'dist'))
+  } catch {}
+
+  await compile(targetDir, { server: { logger: { level: 'warn' } } })
+
+  const app2 = await buildServer(join(targetDir, 'platformatic.service.json'))
+  teardown(async () => {
+    await app2.close()
+  })
+  await app2.start()
+
+  const res = await request(`${app2.url}/`)
+  equal(res.statusCode, 200, 'status code')
+  const data = await res.body.json()
+  same(data, { hello: 'world' })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -279,6 +279,9 @@ importers:
       typescript:
         specifier: ^5.1.3
         version: 5.1.3
+      why-is-node-running:
+        specifier: ^2.2.2
+        version: 2.2.2
 
   packages/composer:
     dependencies:
@@ -15402,6 +15405,7 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
     dev: true
 
   /trivial-deferred@1.1.2:


### PR DESCRIPTION
I noticed that we could save quite a bit of codegen and typescript issues by not generating the clients Fastify plugins at all.