### PR TITLE
Feat/more consistent type ordering

### DIFF
--- a/packages/db/lib/gen-types.mjs
+++ b/packages/db/lib/gen-types.mjs
@@ -39,7 +39,8 @@ function getTypesFolderPath (config) {
 
 async function generateEntityType (entity) {
   const jsonSchema = mapSQLEntityToJSONSchema(entity)
-  const tsCode = mapOpenAPItoTypes(jsonSchema)
+  const fieldDefinitions = Object.fromEntries(Object.entries(entity.fields).map(([, value]) => [value.camelcase, value]))
+  const tsCode = mapOpenAPItoTypes(jsonSchema, fieldDefinitions)
   entity.name = camelcase(entity.name).replace(/^\w/, c => c.toUpperCase())
   return tsCode + `\nexport { ${entity.name} };\n`
 }

--- a/packages/db/lib/gen-types.mjs
+++ b/packages/db/lib/gen-types.mjs
@@ -204,7 +204,7 @@ async function execute ({ logger, config }) {
 
   let count = 0
   const entitiesValues = Object.values(entities)
-  const entitiesNames = entitiesValues.map(({ name }) => name)
+  const entitiesNames = entitiesValues.map(({ name }) => name).sort()
   for (const entity of entitiesValues) {
     count++
     const types = await generateEntityType(entity)

--- a/packages/db/test/fixtures/auto-gen-types/index.test-d.ts
+++ b/packages/db/test/fixtures/auto-gen-types/index.test-d.ts
@@ -1,14 +1,31 @@
 /// <reference path="./global.d.ts" />
 
 import { expectType } from 'tsd'
-import { Graph } from './types/Graph'
+import { AggregateRating } from './types/AggregateRating'
+import { Movie } from './types/Movie'
 import { FastifyInstance, fastify } from 'fastify'
 
 const app: FastifyInstance = fastify()
 
-const graphs = await app.platformatic.entities.graph.find()
-expectType<Graph[]>(graphs)
+const aggregateRatings = await app.platformatic.entities.aggregateRating.find()
+expectType<Partial<AggregateRating>[]>(aggregateRatings)
 
-const graph = graphs[0]
-expectType<number | undefined>(graph.id)
-expectType<string | null | undefined>(graph.name)
+const aggregateRating = aggregateRatings[0] as AggregateRating
+expectType<{
+	id?: number;
+	movieId: number;
+	rating: number;
+	ratingType: string;
+}>(aggregateRating)
+
+
+const movies = await app.platformatic.entities.movie.find()
+expectType<Partial<Movie>[]>(movies)
+
+const movie = movies[0] as Movie
+expectType<{
+	id?: number;
+	title: string;
+	boxOffice?: number | null;
+	year: number;
+}>(movie)

--- a/packages/db/test/fixtures/auto-gen-types/migrations/001.do.sql
+++ b/packages/db/test/fixtures/auto-gen-types/migrations/001.do.sql
@@ -1,4 +1,14 @@
-CREATE TABLE graphs (
+CREATE TABLE movies (
+  year INTEGER NOT NULL,
   id INTEGER PRIMARY KEY,
-  name TEXT
+  box_office INTEGER,
+  title VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE aggregate_ratings (
+  movie_id INTEGER NOT NULL,
+  rating INTEGER NOT NULL,
+  rating_type VARCHAR(255) NOT NULL,
+  id INTEGER PRIMARY KEY,
+  FOREIGN KEY (movie_id) REFERENCES movies (id)
 );

--- a/packages/sql-json-schema-mapper/test/types.test.js
+++ b/packages/sql-json-schema-mapper/test/types.test.js
@@ -14,7 +14,7 @@ function referenceTest (name, obj, opts = {}) {
   test(name, { only }, async t => {
     const reference = await dtsgenerator.default({ contents: [dtsgenerator.parseSchema(structuredClone(obj))] })
     const cloned = structuredClone(obj)
-    const ours = mapOpenAPItoTypes(cloned)
+    const ours = mapOpenAPItoTypes(cloned, [])
     t.not(cloned, obj)
     t.same(cloned, obj)
     t.same(ours.trim(), reference.trim())

--- a/packages/sql-json-schema-mapper/test/types.test.js
+++ b/packages/sql-json-schema-mapper/test/types.test.js
@@ -14,7 +14,7 @@ function referenceTest (name, obj, opts = {}) {
   test(name, { only }, async t => {
     const reference = await dtsgenerator.default({ contents: [dtsgenerator.parseSchema(structuredClone(obj))] })
     const cloned = structuredClone(obj)
-    const ours = mapOpenAPItoTypes(cloned, [])
+    const ours = mapOpenAPItoTypes(cloned, { id: { primaryKey: true } })
     t.not(cloned, obj)
     t.same(cloned, obj)
     t.same(ours.trim(), reference.trim())
@@ -30,8 +30,9 @@ referenceTest('p1', {
     id: {
       type: 'integer'
     },
-    title: {
-      type: 'string'
+    description: {
+      type: 'string',
+      nullable: true
     },
     metadata: {
       type: 'object',
@@ -42,9 +43,8 @@ referenceTest('p1', {
       type: 'number',
       nullable: true
     },
-    description: {
-      type: 'string',
-      nullable: true
+    title: {
+      type: 'string'
     }
   },
   required: [
@@ -61,6 +61,10 @@ referenceTest('p2', {
     id: {
       type: 'integer'
     },
+    description: {
+      type: 'string',
+      nullable: true
+    },
     metadata: {
       type: 'object',
       additionalProperties: true,
@@ -68,10 +72,6 @@ referenceTest('p2', {
     },
     section: {
       type: 'number',
-      nullable: true
-    },
-    description: {
-      type: 'string',
       nullable: true
     }
   },
@@ -114,8 +114,9 @@ referenceTest('multiple types', {
     id: {
       type: ['integer', 'string']
     },
-    title: {
-      type: 'string'
+    description: {
+      type: 'string',
+      nullable: true
     },
     metadata: {
       type: 'object',
@@ -125,9 +126,8 @@ referenceTest('multiple types', {
     section: {
       type: ['number', 'null']
     },
-    description: {
-      type: 'string',
-      nullable: true
+    title: {
+      type: 'string'
     }
   },
   required: [
@@ -144,14 +144,14 @@ referenceTest('arrays', {
     id: {
       type: 'integer'
     },
-    title: {
-      type: 'string'
-    },
     tags: {
       type: 'array',
       items: {
         type: 'string'
       }
+    },
+    title: {
+      type: 'string'
     }
   },
   required: [
@@ -168,9 +168,6 @@ referenceTest('objects in arrays', {
     id: {
       type: 'integer'
     },
-    title: {
-      type: 'string'
-    },
     tags: {
       type: 'array',
       items: {
@@ -181,6 +178,9 @@ referenceTest('objects in arrays', {
           }
         }
       }
+    },
+    title: {
+      type: 'string'
     }
   },
   required: [
@@ -197,12 +197,12 @@ referenceTest('enums', {
     id: {
       type: 'integer'
     },
-    title: {
-      type: 'string'
-    },
     color: {
       type: 'string',
       enum: ['amber', 'green', 'red']
+    },
+    title: {
+      type: 'string'
     }
   },
   required: [


### PR DESCRIPTION
Fixes two issues:

* entities in generated `index.d.ts` were not sorted, only those in `global.d.ts`
* fields inside generated typings for entities could have inconsistent order (if the column order in the DB is inconsistent between instances)

The second issue mostly arise when two devs are each working at a migration adding columns to the same table, thus the migrations are not applied in the same order for both devs. I think it’s good to have consistent ordering there, but I’ll concede that having the typings be consistent with the columns in the db is also nice. As a concession, I’ve ensured primary keys get ordered first.

closes #869