### PR TITLE
runtime: set global fetch to be undici fetch

### DIFF
--- a/packages/runtime/lib/worker.js
+++ b/packages/runtime/lib/worker.js
@@ -2,12 +2,13 @@
 
 const inspector = require('node:inspector')
 const { parentPort, workerData } = require('node:worker_threads')
+const undici = require('undici')
 const RuntimeApi = require('./api')
-
 const loaderPort = globalThis.LOADER_PORT // Added by loader.mjs.
 const pino = require('pino')
 const { isatty } = require('tty')
 
+globalThis.fetch = undici.fetch
 delete globalThis.LOADER_PORT
 
 let transport


### PR DESCRIPTION
This will let us pick up fetch fixes more quickly and match the behavior of the cloud.