### PR TITLE
runtime: emit errors from API client

### DIFF
--- a/packages/runtime/lib/api-client.js
+++ b/packages/runtime/lib/api-client.js
@@ -65,7 +65,8 @@ class RuntimeApiClient extends EventEmitter {
 
     const { error, data } = message
     if (error !== null) {
-      throw new Error(error)
+      this.emit('error', new Error(error))
+      return
     }
 
     return JSON.parse(data)


### PR DESCRIPTION
The API client is already an event emitter, so emit errors instead of throwing them. If there are no 'error' listeners, the error will still be thrown anyway.