### PR TITLE
runtime: support logging over message ports

### DIFF
--- a/packages/runtime/lib/message-port-writable.js
+++ b/packages/runtime/lib/message-port-writable.js
@@ -1,0 +1,42 @@
+'use strict'
+const assert = require('node:assert')
+const { Writable } = require('node:stream')
+
+class MessagePortWritable extends Writable {
+  constructor (options) {
+    const opts = { ...options, objectMode: true }
+
+    super(opts)
+    this.port = opts.port
+    this.metadata = opts.metadata
+  }
+
+  _writev (chunks, callback) {
+    // Process the logs here before trying to send them across the thread
+    // boundary. Sometimes the chunks have an undocumented method on them
+    // which will prevent sending the chunk itself across threads.
+    const logs = chunks.map((chunk) => {
+      // pino should always produce a string here.
+      assert(typeof chunk.chunk === 'string')
+      return chunk.chunk.trim()
+    })
+
+    this.port.postMessage({
+      metadata: this.metadata,
+      logs
+    })
+    setImmediate(callback)
+  }
+
+  _final (callback) {
+    this.port.close()
+    callback()
+  }
+
+  _destroy (err, callback) {
+    this.port.close()
+    callback(err)
+  }
+}
+
+module.exports = { MessagePortWritable }

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -41,6 +41,7 @@ async function startWithConfig (configManager) {
   const worker = new Worker(kWorkerFile, {
     /* c8 ignore next */
     execArgv: config.hotReload ? kWorkerExecArgv : [],
+    transferList: config.loggingPort ? [config.loggingPort] : [],
     workerData: { config }
   })
 

--- a/packages/runtime/lib/worker.js
+++ b/packages/runtime/lib/worker.js
@@ -1,25 +1,31 @@
 'use strict'
 
 const inspector = require('node:inspector')
+const { isatty } = require('node:tty')
 const { parentPort, workerData } = require('node:worker_threads')
-const RuntimeApi = require('./api')
-
-const loaderPort = globalThis.LOADER_PORT // Added by loader.mjs.
 const pino = require('pino')
-const { isatty } = require('tty')
+const RuntimeApi = require('./api')
+const { MessagePortWritable } = require('./message-port-writable')
+const loaderPort = globalThis.LOADER_PORT // Added by loader.mjs.
 
 delete globalThis.LOADER_PORT
 
 let transport
+let destination
 
-/* c8 ignore next 5 */
-if (isatty(1)) {
+/* c8 ignore next 10 */
+if (workerData.config.loggingPort) {
+  destination = new MessagePortWritable({
+    metadata: workerData.config.loggingMetadata,
+    port: workerData.config.loggingPort
+  })
+} else if (isatty(1)) {
   transport = pino.transport({
     target: 'pino-pretty'
   })
 }
 
-const logger = pino(transport)
+const logger = pino(transport, destination)
 
 /* c8 ignore next 4 */
 process.once('uncaughtException', (err) => {


### PR DESCRIPTION
This commit allows runtime applications to use a message port as a destination so that logs can be sent to another thread.