### PR TITLE
Allow metrics.port to be a string

### DIFF
--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -403,7 +403,12 @@ const metrics = {
     {
       type: 'object',
       properties: {
-        port: { type: 'integer' },
+        port: {
+          anyOf: [
+            { type: 'integer' },
+            { type: 'string' }
+          ]
+        },
         hostname: { type: 'string' },
         auth: {
           type: 'object',


### PR DESCRIPTION
Fixes https://github.com/platformatic/platformatic/issues/1177