### PR TITLE
runtime: make runtime worker accessible to embedders

### DIFF
--- a/packages/runtime/lib/api-client.js
+++ b/packages/runtime/lib/api-client.js
@@ -6,14 +6,12 @@ const { randomUUID } = require('node:crypto')
 const MAX_LISTENERS_COUNT = 100
 
 class RuntimeApiClient extends EventEmitter {
-  #worker
-
   constructor (worker) {
     super()
     this.setMaxListeners(MAX_LISTENERS_COUNT)
 
-    this.#worker = worker
-    this.#worker.on('message', (message) => {
+    this.worker = worker
+    this.worker.on('message', (message) => {
       if (message.operationId) {
         this.emit(message.operationId, message)
       }
@@ -26,7 +24,7 @@ class RuntimeApiClient extends EventEmitter {
 
   async close () {
     await this.#sendCommand('plt:stop-services')
-    await once(this.#worker, 'exit')
+    await once(this.worker, 'exit')
   }
 
   async restart () {
@@ -60,7 +58,7 @@ class RuntimeApiClient extends EventEmitter {
   async #sendCommand (command, params = {}) {
     const operationId = randomUUID()
 
-    this.#worker.postMessage({ operationId, command, params })
+    this.worker.postMessage({ operationId, command, params })
     const [message] = await once(this, operationId)
 
     const { error, data } = message

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -51,8 +51,12 @@ async function startWithConfig (configManager, env = process.env) {
   })
 
   worker.on('error', () => {
-    // the error is logged in the worker
-    process.exit(1)
+    // If this is the only 'error' handler, then exit the process as the default
+    // behavior. If anything else is listening for errors, then don't exit.
+    if (worker.listenerCount('error') === 1) {
+      // The error is logged in the worker.
+      process.exit(1)
+    }
   })
 
   if (config.hotReload) {


### PR DESCRIPTION
This commit does two things:

- Make the runtime worker available to embedders. This is done to listen for worker events without needing to proxy them all through the runtime API.
- Make the runtime only exit the process on error if there are no other error event listeners. This is done so that embedders can handle errors without the process terminating.