### PR TITLE
runtime: ignore test/tmp directory for linting

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -52,7 +52,8 @@
   },
   "standard": {
     "ignore": [
-      "**/dist/*"
+      "**/dist/*",
+      "**/test/tmp"
     ]
   }
 }


### PR DESCRIPTION
Since dbd19c851d87db32548b3a8bfa057af93cc99e14, the linter fails due to the contents of the test/tmp directory. This commit ignores that directory for linting purposes.