### PR TITLE
runtime: add regression test for db app crashes

### DIFF
--- a/packages/runtime/fixtures/dbApp/platformatic.db.json
+++ b/packages/runtime/fixtures/dbApp/platformatic.db.json
@@ -18,5 +18,10 @@
       "versions": true
     },
     "events": false
+  },
+  "plugins": {
+    "paths": [
+      "plugin.js"
+    ]
   }
 }

--- a/packages/runtime/fixtures/dbApp/plugin.js
+++ b/packages/runtime/fixtures/dbApp/plugin.js
@@ -1,0 +1,12 @@
+'use strict'
+
+/** @param {import('fastify').FastifyInstance} app */
+module.exports = async function (app) {
+  app.get('/async_crash', async () => {
+    setImmediate(() => {
+      throw new Error('boom')
+    })
+
+    return 'ok'
+  })
+}

--- a/packages/runtime/fixtures/start-command-in-runtime.js
+++ b/packages/runtime/fixtures/start-command-in-runtime.js
@@ -5,7 +5,8 @@ const { startCommandInRuntime } = require('../lib/unified-api')
 
 async function main () {
   const entrypoint = await startCommandInRuntime(['-c', process.argv[2]])
-  const res = await request(entrypoint)
+  const endpoint = process.argv[3] ?? '/'
+  const res = await request(entrypoint + endpoint)
 
   assert.strictEqual(res.statusCode, 200)
   process.exit(42)

--- a/packages/runtime/test/start.test.js
+++ b/packages/runtime/test/start.test.js
@@ -1,5 +1,6 @@
 'use strict'
 const assert = require('node:assert')
+const { spawn } = require('node:child_process')
 const { once } = require('node:events')
 const { join } = require('node:path')
 const { test } = require('node:test')
@@ -142,4 +143,16 @@ test('can start with a custom environment', async (t) => {
 
   assert.strictEqual(res.statusCode, 200)
   assert.deepStrictEqual(await res.body.json(), { A_CUSTOM_ENV_VAR: 'foobar' })
+})
+
+test('handles uncaught exceptions with db app', async (t) => {
+  // Test for https://github.com/platformatic/platformatic/issues/1193
+  const scriptFile = join(fixturesDir, 'start-command-in-runtime.js')
+  const configFile = join(fixturesDir, 'dbApp', 'platformatic.db.json')
+  const child = spawn(process.execPath, [scriptFile, configFile, '/async_crash'])
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+  const [exitCode] = await once(child, 'exit')
+
+  assert.strictEqual(exitCode, 42)
 })


### PR DESCRIPTION
Regression test for https://github.com/platformatic/platformatic/issues/1193

Opening as a draft because the test causes a segfault until #1193 is fixed.