### PR TITLE
runtime: abort API operations if worker exits

### DIFF
--- a/packages/runtime/lib/api-client.js
+++ b/packages/runtime/lib/api-client.js
@@ -6,11 +6,15 @@ const { randomUUID } = require('node:crypto')
 const MAX_LISTENERS_COUNT = 100
 
 class RuntimeApiClient extends EventEmitter {
+  #exitCode
+  #exitPromise
+
   constructor (worker) {
     super()
     this.setMaxListeners(MAX_LISTENERS_COUNT)
 
     this.worker = worker
+    this.#exitPromise = this.#exitHandler()
     this.worker.on('message', (message) => {
       if (message.operationId) {
         this.emit(message.operationId, message)
@@ -24,7 +28,7 @@ class RuntimeApiClient extends EventEmitter {
 
   async close () {
     await this.#sendCommand('plt:stop-services')
-    await once(this.worker, 'exit')
+    await this.#exitPromise
   }
 
   async restart () {
@@ -59,15 +63,28 @@ class RuntimeApiClient extends EventEmitter {
     const operationId = randomUUID()
 
     this.worker.postMessage({ operationId, command, params })
-    const [message] = await once(this, operationId)
+    const [message] = await Promise.race(
+      [once(this, operationId), this.#exitPromise]
+    )
+
+    if (this.#exitCode !== undefined) {
+      throw new Error('The runtime exited before the operation completed')
+    }
 
     const { error, data } = message
     if (error !== null) {
-      this.emit('error', new Error(error))
-      return
+      throw new Error(error)
     }
 
     return JSON.parse(data)
+  }
+
+  async #exitHandler () {
+    this.#exitCode = undefined
+    return once(this.worker, 'exit').then((msg) => {
+      this.#exitCode = msg[0]
+      return msg
+    })
   }
 }
 

--- a/packages/runtime/test/api.test.js
+++ b/packages/runtime/test/api.test.js
@@ -275,6 +275,16 @@ test('should fail inject request is service is not started', async (t) => {
   }
 })
 
+test('does not wait forever if worker exits during api operation', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'service-throws-on-start.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await assert.rejects(async () => {
+    await app.start()
+  }, /The runtime exited before the operation completed/)
+})
+
 test('should handle a lot of runtime api requests', async (t) => {
   const configFile = join(fixturesDir, 'configs', 'monorepo.json')
   const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)


### PR DESCRIPTION
This commit uses `Promise.race()` to abort API client operations if the worker thread exits. Prior to this commit, the client could hang indefinitely while awaiting a response that would never come because the worker had already exited.

Fixes: https://github.com/platformatic/platformatic/issues/1191