### PR TITLE
runtime: allow overriding missing config keys

### DIFF
--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -167,13 +167,14 @@ class PlatformaticApp {
             const parts = key.split('.')
             let next = configManager.current
             let obj
+            let i
 
-            for (let i = 0; next !== undefined && i < parts.length; ++i) {
+            for (i = 0; next !== undefined && i < parts.length; ++i) {
               obj = next
               next = obj[parts[i]]
             }
 
-            if (next !== undefined) {
+            if (i === parts.length) {
               obj[parts.at(-1)] = value
             }
           })

--- a/packages/runtime/test/app.test.js
+++ b/packages/runtime/test/app.test.js
@@ -251,7 +251,8 @@ test('supports configuration overrides', async (t) => {
     const { logger } = getLoggerAndStream()
     config._configOverrides = new Map([
       ['server.keepAliveTimeout', 1],
-      ['server.port', 0]
+      ['server.port', 0],
+      ['server.pluginTimeout', 99]
     ])
     const app = new PlatformaticApp(config, null, logger)
 
@@ -265,6 +266,7 @@ test('supports configuration overrides', async (t) => {
 
     await app.start()
     assert.strictEqual(app.config.configManager.current.server.keepAliveTimeout, 1)
+    assert.strictEqual(app.config.configManager.current.server.pluginTimeout, 99)
   })
 })
 


### PR DESCRIPTION
This commit updates the runtime config override logic to support missing config fields. Technically, there is already a test for this, but the behavior depends on whether or not the config manager populates a default value.