### PR TITLE
fix: generated operation IDs included dashes from URL

### DIFF
--- a/packages/client-cli/test/fixtures/movies/openapi.json
+++ b/packages/client-cli/test/fixtures/movies/openapi.json
@@ -654,7 +654,7 @@
         }
       }
     },
-    "/hello": {
+    "/hello-world": {
       "get": {
         "responses": {
           "200": {

--- a/packages/client-cli/test/fixtures/movies/plugin.js
+++ b/packages/client-cli/test/fixtures/movies/plugin.js
@@ -69,7 +69,7 @@ module.exports = async function (app) {
     return {}
   })
 
-  app.get('/hello', async (request, reply) => {
+  app.get('/hello-world', async (request, reply) => {
     return { hello: 'world' }
   })
 

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -15,7 +15,7 @@ function generateOperationId (path, method, methodMeta) {
     for (const param of pathParams) {
       stringToUpdate = stringToUpdate.replace(`{${param.name}}`, capitalize(param.name))
     }
-    operationId = method.toLowerCase() + stringToUpdate.split('/').map(capitalize).join('')
+    operationId = method.toLowerCase() + stringToUpdate.split(/[/-]+/).map(capitalize).join('')
   }
   return operationId
 }

--- a/packages/client/test/fixtures/movies/openapi.json
+++ b/packages/client/test/fixtures/movies/openapi.json
@@ -654,7 +654,7 @@
         }
       }
     },
-    "/hello": {
+    "/hello-world": {
       "get": {
         "responses": {
           "200": {

--- a/packages/client/test/fixtures/movies/plugin.js
+++ b/packages/client/test/fixtures/movies/plugin.js
@@ -31,7 +31,7 @@ module.exports = async function (app) {
     reply.status(204)
   })
 
-  app.get('/hello', async (request, reply) => {
+  app.get('/hello-world', async (request, reply) => {
     return { hello: 'world' }
   })
 

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -95,7 +95,7 @@ test('build basic client from url', async ({ teardown, same, rejects }) => {
   }
 
   {
-    const hello = await client.getHello()
+    const hello = await client.getHelloWorld()
     same(hello, { hello: 'world' })
   }
 
@@ -275,7 +275,7 @@ test('build full response client from url', async ({ teardown, same, match, reje
   }
 
   {
-    const hello = await client.getHello()
+    const hello = await client.getHelloWorld()
     match(hello, {
       statusCode: 200,
       headers: {
@@ -420,7 +420,7 @@ test('build basic client from file', async ({ teardown, same, rejects }) => {
   }
 
   {
-    const hello = await client.getHello()
+    const hello = await client.getHelloWorld()
     same(hello, { hello: 'world' })
   }
 


### PR DESCRIPTION
The `generateOperationId()` function in the client package was not accounting for hyphens in URLs which meant that for:

```javascript
app.get('/hello-world', async (request, reply) => {
  return { hello: 'world' }
})
```

You would get the following client method:

```javascript
client['getHello-world']()
```

And broken types:

```typescript
interface GetHello-worldRequest {
}

interface GetHello-worldResponseOK {
}
```

This fix will treat hyphens as slashes when determining case: `GET: /hello-world -> getHelloWorld`