### PR TITLE
runtime: add _write() to MessagePortWritable

### DIFF
--- a/packages/runtime/fixtures/dbAppWithMigrationError/migrations/001.do.sql
+++ b/packages/runtime/fixtures/dbAppWithMigrationError/migrations/001.do.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS movies (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL fiddlesticks
+);

--- a/packages/runtime/fixtures/dbAppWithMigrationError/migrations/001.undo.sql
+++ b/packages/runtime/fixtures/dbAppWithMigrationError/migrations/001.undo.sql
@@ -1,0 +1,1 @@
+DROP TABLE movies;

--- a/packages/runtime/fixtures/dbAppWithMigrationError/platformatic.db.json
+++ b/packages/runtime/fixtures/dbAppWithMigrationError/platformatic.db.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.30.0/db",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 3042
+  },
+  "migrations": {
+    "autoApply": true,
+    "dir": "migrations",
+    "table": "versions"
+  },
+  "types": {
+    "autogenerate": false
+  },
+  "plugins": {
+    "paths": [
+      "plugin.js"
+    ]
+  },
+  "db": {
+    "connectionString": "sqlite://db.sqlite",
+    "graphql": true,
+    "ignore": {
+      "versions": true
+    },
+    "events": false
+  }
+}

--- a/packages/runtime/fixtures/dbAppWithMigrationError/plugin.js
+++ b/packages/runtime/fixtures/dbAppWithMigrationError/plugin.js
@@ -1,0 +1,5 @@
+/// <reference path="./global.d.ts" />
+'use strict'
+
+/** @param {import('fastify').FastifyInstance} app */
+module.exports = async function (app) {}

--- a/packages/runtime/lib/message-port-writable.js
+++ b/packages/runtime/lib/message-port-writable.js
@@ -11,6 +11,14 @@ class MessagePortWritable extends Writable {
     this.metadata = opts.metadata
   }
 
+  _write (chunk, encoding, callback) {
+    this.port.postMessage({
+      metadata: this.metadata,
+      logs: [chunk.toString().trim()]
+    })
+    process.nextTick(callback)
+  }
+
   _writev (chunks, callback) {
     // Process the logs here before trying to send them across the thread
     // boundary. Sometimes the chunks have an undocumented method on them

--- a/packages/runtime/test/start.test.js
+++ b/packages/runtime/test/start.test.js
@@ -8,6 +8,7 @@ const { MessageChannel } = require('node:worker_threads')
 const { request } = require('undici')
 const { loadConfig } = require('@platformatic/service')
 const { buildServer, platformaticRuntime } = require('..')
+const { wrapConfigInRuntimeConfig } = require('../lib/config')
 const { startWithConfig } = require('../lib/start')
 const fixturesDir = join(__dirname, '..', 'fixtures')
 
@@ -155,4 +156,31 @@ test('handles uncaught exceptions with db app', async (t) => {
   const [exitCode] = await once(child, 'exit')
 
   assert.strictEqual(exitCode, 42)
+})
+
+test('logs errors during db migrations', async (t) => {
+  const configFile = join(fixturesDir, 'dbAppWithMigrationError', 'platformatic.db.json')
+  const config = await loadConfig({}, ['-c', configFile], 'db')
+  const runtimeConfig = await wrapConfigInRuntimeConfig(config)
+  const { port1, port2 } = new MessageChannel()
+  runtimeConfig.current.loggingPort = port2
+  runtimeConfig.current.loggingMetadata = { foo: 1, bar: 2 }
+  const runtime = await startWithConfig(runtimeConfig)
+  const messages = []
+
+  port1.on('message', (msg) => {
+    messages.push(msg)
+  })
+
+  await assert.rejects(async () => {
+    await runtime.start()
+  }, /The runtime exited before the operation completed/)
+
+  assert.strictEqual(messages.length, 2)
+  assert.deepStrictEqual(messages[0].metadata, runtimeConfig.current.loggingMetadata)
+  assert.strictEqual(messages[0].logs.length, 1)
+  assert.match(messages[0].logs[0], /running 001.do.sql/)
+  assert.deepStrictEqual(messages[1].metadata, runtimeConfig.current.loggingMetadata)
+  assert.strictEqual(messages[1].logs.length, 1)
+  assert.match(messages[1].logs[0], /near \\"fiddlesticks\\": syntax error/)
 })


### PR DESCRIPTION
In some situations, such as when DB migrations fail during startup, the error logs were not being handled properly. According to the Node.js docs, custom writables such as `MessagePortWritable` need to implement one or both of `_write()` and `_writev()`. The runtime only implemented `_writev()`, and this seemed to be the cause of the missing logs. This commit adds `_write()`, and seems to resolve the missing logs issue.

Fixes: https://github.com/platformatic/dashformatic/issues/648