### PR TITLE
Runtime config hotReload: string type added

### DIFF
--- a/packages/runtime/lib/schema.js
+++ b/packages/runtime/lib/schema.js
@@ -67,7 +67,14 @@ const platformaticRuntimeSchema = {
       type: 'string'
     },
     hotReload: {
-      type: 'boolean'
+      anyOf: [
+        {
+          type: 'boolean'
+        },
+        {
+          type: 'string'
+        }
+      ]
     },
     allowCycles: {
       type: 'boolean'


### PR DESCRIPTION
Fix: #1277 

To control the hotReload property via environment variable string type is added.