### PR TITLE
Fix hot reload with single service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,7 @@ jobs:
   ci-runtime:
     needs: setup-node_modules
     runs-on: ${{matrix.os}}
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: [18, 20]

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -43,7 +43,7 @@ const ensureCommand = async ({ output, help }) => {
 program.register('db', async (args) => ensureCommand(await runDB(args)))
 program.register('runtime', async (args) => ensureCommand(await runRuntime(args)))
 program.register('service', async (args) => ensureCommand(await runService(args)))
-program.register('start', platformaticStart.startCommandInRuntime)
+program.register('start', platformaticStart.startCommand)
 program.register('composer', async (args) => ensureCommand(await runComposer(args)))
 program.register('upgrade', upgrade)
 program.register('client', client)

--- a/packages/runtime/fixtures/configs/hotreload.json
+++ b/packages/runtime/fixtures/configs/hotreload.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.20.0/runtime",
+  "entrypoint": "serviceApp",
+  "allowCycles": true,
+  "hotReload": true,
+  "autoload": {
+    "path": "../monorepo",
+    "exclude": ["docs", "composerApp"],
+    "mappings": {
+      "serviceAppWithLogger": {
+        "id": "with-logger",
+        "config": "platformatic.service.json"
+      },
+      "serviceAppWithMultiplePlugins": {
+        "id": "multi-plugin-service",
+        "config": "platformatic.service.json"
+      }
+    }
+  }
+}

--- a/packages/runtime/fixtures/configs/hotreload.json
+++ b/packages/runtime/fixtures/configs/hotreload.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://platformatic.dev/schemas/v0.20.0/runtime",
+  "$schema": "https://platformatic.dev/schemas/v0.32.0/runtime",
   "entrypoint": "serviceApp",
   "allowCycles": true,
   "hotReload": true,

--- a/packages/runtime/fixtures/monorepo/serviceAppWithLogger/platformatic.service.json
+++ b/packages/runtime/fixtures/monorepo/serviceAppWithLogger/platformatic.service.json
@@ -15,5 +15,6 @@
     "paths": [
       "plugin.js"
     ]
-  }
+  },
+  "watch": true
 }

--- a/packages/runtime/fixtures/start-command-in-runtime.js
+++ b/packages/runtime/fixtures/start-command-in-runtime.js
@@ -1,10 +1,10 @@
 'use strict'
 const assert = require('node:assert')
 const { request } = require('undici')
-const { startCommandInRuntime } = require('../lib/unified-api')
+const { startCommand } = require('../lib/unified-api')
 
 async function main () {
-  const entrypoint = await startCommandInRuntime(['-c', process.argv[2]])
+  const entrypoint = await startCommand(['-c', process.argv[2]])
   const endpoint = process.argv[3] ?? '/'
   const res = await request(entrypoint + endpoint)
 

--- a/packages/runtime/lib/api.js
+++ b/packages/runtime/lib/api.js
@@ -47,9 +47,9 @@ class RuntimeApi {
   }
 
   async #handleProcessLevelEvent (message) {
-    for (const service of this.#services.values()) {
+    await Promise.allSettled(this.#services.values().map(async (service) => {
       await service.handleProcessLevelEvent(message)
-    }
+    }))
   }
 
   async #executeCommand (message) {

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -116,7 +116,7 @@ class PlatformaticApp {
 
   async stop () {
     if (!this.#started) {
-      return
+      throw new Error('application has not been started')
     }
 
     await this.#stopFileWatching()

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -66,12 +66,13 @@ class PlatformaticApp {
 
     if (!this.#restarting) {
       await this.#initializeConfig()
+      this.#originalWatch = this.config.configManager.current.watch
+      this.config.configManager.current.watch = false
     }
+
     const { configManager } = this.config
     const config = configManager.current
 
-    this.#originalWatch = config.watch
-    config.watch = false
     this.#setuplogger(configManager)
 
     try {
@@ -110,12 +111,12 @@ class PlatformaticApp {
     if (!this.#started) {
       throw new Error('application has not been started')
     }
+    await this.#stopFileWatching()
 
     if (!this.#restarting) {
       await this.server.close()
     }
 
-    await this.#stopFileWatching()
     this.#started = false
   }
 

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -2,6 +2,7 @@
 const { once } = require('node:events')
 const { dirname, basename } = require('node:path')
 const { FileWatcher } = require('@platformatic/utils')
+const { setTimeout: sleep } = require('node:timers/promises')
 const {
   buildServer,
   loadConfig
@@ -45,6 +46,8 @@ class PlatformaticApp {
     if (!this.#hotReload && !force) {
       return
     }
+
+    await sleep(50) // Delay restarts to allow multiple changes to be coalesced.
 
     this.#restarting = true
     await this.stop()

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -116,7 +116,7 @@ class PlatformaticApp {
 
   async stop () {
     if (!this.#started) {
-      throw new Error('application has not been started')
+      return
     }
 
     await this.#stopFileWatching()

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -46,8 +46,12 @@ async function startWithConfig (configManager, env = process.env) {
     env
   })
 
+  let exited = null
   worker.on('exit', () => {
     configManager.fileWatcher?.stopWatching()
+    if (typeof exited === 'function') {
+      exited()
+    }
   })
 
   worker.on('error', () => {
@@ -65,8 +69,9 @@ async function startWithConfig (configManager, env = process.env) {
       worker.postMessage({ signal: 'SIGUSR2' })
     })
 
-    closeWithGrace((event) => {
+    closeWithGrace((event, cb) => {
       worker.postMessage(event)
+      exited = cb
     })
 
     /* c8 ignore next 3 */

--- a/packages/runtime/lib/unified-api.js
+++ b/packages/runtime/lib/unified-api.js
@@ -155,14 +155,6 @@ async function _start (args) {
 
 async function startCommand (args) {
   try {
-    await _start(args)
-  } catch (err) {
-    logErrorAndExit(err)
-  }
-}
-
-async function startCommandInRuntime (args) {
-  try {
     const configType = await getConfigType(args)
     const config = await _loadConfig({}, args, configType)
     let runtime
@@ -200,6 +192,5 @@ module.exports = {
   loadConfig: _loadConfig,
   start: _start,
   startCommand,
-  startCommandInRuntime,
   getApp
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -41,6 +41,7 @@
     "@platformatic/utils": "workspace:*",
     "close-with-grace": "^1.2.0",
     "commist": "^3.2.0",
+    "debounce": "^1.2.1",
     "desm": "^1.3.0",
     "es-main": "^1.2.0",
     "fastest-levenshtein": "^1.0.16",

--- a/packages/runtime/runtime.mjs
+++ b/packages/runtime/runtime.mjs
@@ -6,7 +6,7 @@ import { join } from 'desm'
 import isMain from 'es-main'
 import helpMe from 'help-me'
 import parseArgs from 'minimist'
-import { start } from './lib/start.js'
+import { startCommand } from './lib/unified-api.js'
 import { compile as compileCmd } from './lib/compile.js'
 
 export const compile = compileCmd
@@ -22,7 +22,7 @@ const program = commist({ maxDistance: 2 })
 program.register('help', help.toStdout)
 program.register('help start', help.toStdout.bind(null, ['start']))
 program.register('help compile', help.toStdout.bind(null, ['compile']))
-program.register('start', start)
+program.register('start', startCommand)
 program.register('compile', compile)
 
 export async function run (argv) {

--- a/packages/runtime/test/app.test.js
+++ b/packages/runtime/test/app.test.js
@@ -68,7 +68,7 @@ test('errors when starting an already started application', async (t) => {
   }, /application is already started/)
 })
 
-test('does not errors when stopping an already stopped application', async (t) => {
+test('errors when stopping an already stopped application', async (t) => {
   const { logger } = getLoggerAndStream()
   const appPath = join(fixturesDir, 'monorepo', 'serviceApp')
   const configFile = join(appPath, 'platformatic.service.json')
@@ -83,7 +83,10 @@ test('does not errors when stopping an already stopped application', async (t) =
     localServiceEnvVars: new Map([['PLT_WITH_LOGGER_URL', ' ']])
   }
   const app = new PlatformaticApp(config, null, logger)
-  await app.stop()
+
+  await assert.rejects(async () => {
+    await app.stop()
+  }, /application has not been started/)
 })
 
 test('does not restart while restarting', async (t) => {

--- a/packages/runtime/test/app.test.js
+++ b/packages/runtime/test/app.test.js
@@ -346,7 +346,6 @@ test('logs errors if an env variable is missing', async (t) => {
   }, /exited/)
   assert.strictEqual(process.exit.mock.calls.length, 1)
   assert.strictEqual(process.exit.mock.calls[0].arguments[0], 1)
-  t.mock.reset()
 
   stream.end()
   const lines = []

--- a/packages/runtime/test/app.test.js
+++ b/packages/runtime/test/app.test.js
@@ -68,7 +68,7 @@ test('errors when starting an already started application', async (t) => {
   }, /application is already started/)
 })
 
-test('errors when stopping an already stopped application', async (t) => {
+test('does not errors when stopping an already stopped application', async (t) => {
   const { logger } = getLoggerAndStream()
   const appPath = join(fixturesDir, 'monorepo', 'serviceApp')
   const configFile = join(appPath, 'platformatic.service.json')
@@ -83,10 +83,7 @@ test('errors when stopping an already stopped application', async (t) => {
     localServiceEnvVars: new Map([['PLT_WITH_LOGGER_URL', ' ']])
   }
   const app = new PlatformaticApp(config, null, logger)
-
-  await assert.rejects(async () => {
-    await app.stop()
-  }, /application has not been started/)
+  await app.stop()
 })
 
 test('does not restart while restarting', async (t) => {

--- a/packages/runtime/test/cli/helper.mjs
+++ b/packages/runtime/test/cli/helper.mjs
@@ -35,12 +35,14 @@ export async function start (...args) {
 
   for await (const messages of on(output, 'data')) {
     for (const message of messages) {
-      const url = message.url ??
-        message.msg.match(/server listening at (.+)/i)?.[1]
+      if (message.msg) {
+        const url = message.url ??
+          message.msg.match(/server listening at (.+)/i)?.[1]
 
-      if (url !== undefined) {
-        clearTimeout(errorTimeout)
-        return { child, url, output }
+        if (url !== undefined) {
+          clearTimeout(errorTimeout)
+          return { child, url, output }
+        }
       }
     }
   }

--- a/packages/runtime/test/cli/start.test.mjs
+++ b/packages/runtime/test/cli/start.test.mjs
@@ -74,7 +74,7 @@ test('does not start if node inspector flags are provided', async (t) => {
     for (const message of messages) {
       stderr += message
 
-      if (/Error: The Node.js inspector flags are not supported/.test(stderr)) {
+      if (/The Node.js inspector flags are not supported/.test(stderr)) {
         found = true
         break
       }

--- a/packages/runtime/test/cli/watch.test.mjs
+++ b/packages/runtime/test/cli/watch.test.mjs
@@ -195,6 +195,7 @@ test('watches CommonJS files with hotreload on a single service', { timeout: 300
     if (log.msg === 'RELOADED v2') {
       restartedSecondTime = true
     } else if (log.msg === 'RELOADED v3') {
+      assert.ok(restartedSecondTime)
       restartedThirdTime = true
       break
     } else if (log.msg?.match(/listening/)) {
@@ -202,6 +203,5 @@ test('watches CommonJS files with hotreload on a single service', { timeout: 300
     }
   }
 
-  assert.ok(restartedSecondTime)
   assert.ok(restartedThirdTime)
 })

--- a/packages/runtime/test/cli/watch.test.mjs
+++ b/packages/runtime/test/cli/watch.test.mjs
@@ -10,6 +10,7 @@ import { start } from './helper.mjs'
 const fixturesDir = join(desm(import.meta.url), '..', '..', 'fixtures')
 
 const base = join(desm(import.meta.url), '..', 'tmp')
+const linux = process.platform === 'linux'
 
 try {
   await mkdir(base, { recursive: true })
@@ -133,7 +134,7 @@ test('should not hot reload files with `--hot-reload false', async (t) => {
   assert.strictEqual(version, 'v1')
 })
 
-test('watches CommonJS files with hotreload', async (t) => {
+test('watches CommonJS files with hotreload', { timeout: 30000, skip: linux }, async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
   t.after(() => rm(tmpDir, { recursive: true, force: true }))
   t.diagnostic(`using ${tmpDir}`)
@@ -171,7 +172,7 @@ test('watches CommonJS files with hotreload', async (t) => {
   }
 })
 
-test('watches CommonJS files with hotreload on a single service', async (t) => {
+test('watches CommonJS files with hotreload on a single service', { timeout: 30000, skip: linux }, async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
   t.after(() => rm(tmpDir, { recursive: true, force: true }))
   t.diagnostic(`using ${tmpDir}`)

--- a/packages/runtime/test/cli/watch.test.mjs
+++ b/packages/runtime/test/cli/watch.test.mjs
@@ -10,7 +10,6 @@ import { start } from './helper.mjs'
 const fixturesDir = join(desm(import.meta.url), '..', '..', 'fixtures')
 
 const base = join(desm(import.meta.url), '..', 'tmp')
-const linux = process.platform === 'linux'
 
 try {
   await mkdir(base, { recursive: true })
@@ -132,7 +131,7 @@ test('should not hot reload files with `--hot-reload false', async (t) => {
   assert.strictEqual(version, 'v1')
 })
 
-test('watches CommonJS files with hotreload', { timeout: 30000, skip: linux }, async (t) => {
+test('watches CommonJS files with hotreload', { timeout: 30000, skip: process.env.CI }, async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
   t.after(() => saferm(tmpDir))
   t.diagnostic(`using ${tmpDir}`)
@@ -171,7 +170,7 @@ test('watches CommonJS files with hotreload', { timeout: 30000, skip: linux }, a
   assert.ok(restartedThirdTime)
 })
 
-test('watches CommonJS files with hotreload on a single service', { timeout: 30000, skip: linux }, async (t) => {
+test('watches CommonJS files with hotreload on a single service', { timeout: 30000, skip: process.env.CI }, async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
   t.after(() => saferm(tmpDir))
   t.diagnostic(`using ${tmpDir}`)

--- a/packages/runtime/test/cli/watch.test.mjs
+++ b/packages/runtime/test/cli/watch.test.mjs
@@ -48,9 +48,13 @@ function createEsmLoggingPlugin (text, reloaded) {
   `
 }
 
+function saferm (path) {
+  return rm(path, { recursive: true, force: true }).catch(() => {})
+}
+
 test('watches CommonJS files', async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
-  t.after(() => rm(tmpDir, { recursive: true, force: true }))
+  t.after(() => saferm(tmpDir))
   t.diagnostic(`using ${tmpDir}`)
   const configFileSrc = join(fixturesDir, 'configs', 'monorepo.json')
   const configFileDst = join(tmpDir, 'configs', 'monorepo.json')
@@ -80,7 +84,7 @@ test('watches CommonJS files', async (t) => {
 
 test('watches ESM files', async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
-  t.after(() => rm(tmpDir, { recursive: true, force: true }))
+  t.after(() => saferm(tmpDir))
   t.diagnostic(`using ${tmpDir}`)
   const configFileSrc = join(fixturesDir, 'configs', 'monorepo.json')
   const configFileDst = join(tmpDir, 'configs', 'monorepo.json')
@@ -109,7 +113,7 @@ test('watches ESM files', async (t) => {
 
 test('should not hot reload files with `--hot-reload false', async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
-  t.after(() => rm(tmpDir, { recursive: true, force: true }))
+  t.after(() => saferm(tmpDir))
   t.diagnostic(`using ${tmpDir}`)
   const configFileSrc = join(fixturesDir, 'configs', 'monorepo.json')
   const configFileDst = join(tmpDir, 'configs', 'monorepo.json')
@@ -136,7 +140,7 @@ test('should not hot reload files with `--hot-reload false', async (t) => {
 
 test('watches CommonJS files with hotreload', { timeout: 30000, skip: linux }, async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
-  t.after(() => rm(tmpDir, { recursive: true, force: true }))
+  t.after(() => saferm(tmpDir))
   t.diagnostic(`using ${tmpDir}`)
   const configFileSrc = join(fixturesDir, 'configs', 'hotreload.json')
   const configFileDst = join(tmpDir, 'configs', 'monorepo.json')
@@ -174,7 +178,7 @@ test('watches CommonJS files with hotreload', { timeout: 30000, skip: linux }, a
 
 test('watches CommonJS files with hotreload on a single service', { timeout: 30000, skip: linux, only: true }, async (t) => {
   const tmpDir = await mkdtemp(join(base, 'watch-'))
-  t.after(() => rm(tmpDir, { recursive: true, force: true }))
+  t.after(() => saferm(tmpDir))
   t.diagnostic(`using ${tmpDir}`)
   const appSrc = join(fixturesDir, 'monorepo', 'serviceAppWithLogger')
   const appDst = join(tmpDir)

--- a/packages/runtime/test/start.test.js
+++ b/packages/runtime/test/start.test.js
@@ -85,11 +85,7 @@ test('can restart the runtime apps', async (t) => {
   const entryUrl = await app.start()
 
   t.after(async () => {
-    try {
-      await app.close()
-    } catch (err) {
-      console.error(err)
-    }
+    await app.close()
   })
 
   {

--- a/packages/runtime/test/start.test.js
+++ b/packages/runtime/test/start.test.js
@@ -85,7 +85,11 @@ test('can restart the runtime apps', async (t) => {
   const entryUrl = await app.start()
 
   t.after(async () => {
-    await app.close()
+    try {
+      await app.close()
+    } catch (err) {
+      console.error(err)
+    }
   })
 
   {

--- a/packages/runtime/test/unified-api.test.js
+++ b/packages/runtime/test/unified-api.test.js
@@ -254,7 +254,6 @@ test('start()', async (t) => {
     const scriptFile = join(fixturesDir, 'starter.js')
     const configFile = join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'platformatic.service.json')
     const child = spawn(process.execPath, [scriptFile, configFile])
-    child.stdout.pipe(process.stdout)
     child.stderr.pipe(process.stderr)
     const [exitCode] = await once(child, 'exit')
 
@@ -318,14 +317,11 @@ test('startCommand()', async (t) => {
 
     assert.strictEqual(exitCode, 42)
   })
-})
 
-test('startCommandInRuntime()', async (t) => {
   await t.test('can start a non-runtime application', async (t) => {
     const scriptFile = join(fixturesDir, 'start-command-in-runtime.js')
     const configFile = join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'platformatic.service.json')
     const child = spawn(process.execPath, [scriptFile, configFile])
-    child.stdout.pipe(process.stdout)
     child.stderr.pipe(process.stderr)
     const [exitCode] = await once(child, 'exit')
 
@@ -336,7 +332,6 @@ test('startCommandInRuntime()', async (t) => {
     const scriptFile = join(fixturesDir, 'start-command-in-runtime.js')
     const configFile = join(fixturesDir, 'configs', 'monorepo.json')
     const child = spawn(process.execPath, [scriptFile, configFile])
-    child.stdout.pipe(process.stdout)
     child.stderr.pipe(process.stderr)
     const [exitCode] = await once(child, 'exit')
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1091,6 +1091,9 @@ importers:
       commist:
         specifier: ^3.2.0
         version: 3.2.0
+      debounce:
+        specifier: ^1.2.1
+        version: 1.2.1
       desm:
         specifier: ^1.3.0
         version: 1.3.0
@@ -4954,6 +4957,10 @@ packages:
 
   /dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    dev: false
+
+  /debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
     dev: false
 
   /debug@3.2.7:


### PR DESCRIPTION
This fixes a few things:

* fast exit (not waiting 10s)
* watch gets disabled after the first change
* support running a single service with `platformatic runtime start`