### PR TITLE
Fixing #1299 Composer: Namespace schema operation id's that are not pascal case

### DIFF
--- a/packages/composer/lib/openapi-composer.js
+++ b/packages/composer/lib/openapi-composer.js
@@ -9,7 +9,7 @@ function composeOpenApi (apis, options = {}) {
   for (const { id, prefix, schema } of apis) {
     const { paths, components } = clone(schema)
 
-    const apiPrefix = id + '_'
+    const apiPrefix = generateOperationIdApiPrefix(id)
     for (const [path, pathSchema] of Object.entries(paths)) {
       namespaceSchemaRefs(apiPrefix, pathSchema)
       namespaceSchemaOperationIds(apiPrefix, pathSchema)
@@ -44,6 +44,12 @@ function composeOpenApi (apis, options = {}) {
     },
     paths: mergedPaths
   }
+}
+
+function generateOperationIdApiPrefix (operationId) {
+  return operationId.trim()
+    .replace(/[^A-Z0-9]+/ig, '_')
+    .replace(/^_+|_+$/g, '') + '_'
 }
 
 function namespaceSchemaRefs (apiPrefix, schema) {

--- a/packages/composer/test/openapi/schemas-composition.test.js
+++ b/packages/composer/test/openapi/schemas-composition.test.js
@@ -253,9 +253,52 @@ test('should merge two basic apis with path prefixes', async (t) => {
     }
   }
 
+  const schema3 = {
+    openapi: '3.0.0',
+    info: {
+      title: 'API 3',
+      version: '1.0.0'
+    },
+    paths: {
+      '/actors': {
+        get: {
+          operationId: 'getActors',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Actors'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    components: {
+      schemas: {
+        Actors: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string'
+            },
+            name: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  }
+
   const composedSchema = composeOpenApi([
     { id: 'api1', prefix: '/api1', schema: schema1 },
-    { id: 'api2', prefix: '/api2', schema: schema2 }
+    { id: 'api-2', prefix: '/api2', schema: schema2 },
+    { id: '-api-3_', prefix: '/api3', schema: schema3 }
   ])
 
   openApiValidator.validate(composedSchema)
@@ -278,7 +321,7 @@ test('should merge two basic apis with path prefixes', async (t) => {
         }
       }
     },
-    api2_Films: {
+    api_2_Films: {
       type: 'object',
       title: 'Films',
       properties: {
@@ -286,6 +329,18 @@ test('should merge two basic apis with path prefixes', async (t) => {
           type: 'string'
         },
         title: {
+          type: 'string'
+        }
+      }
+    },
+    api_3_Actors: {
+      type: 'object',
+      title: 'Actors',
+      properties: {
+        id: {
+          type: 'string'
+        },
+        name: {
           type: 'string'
         }
       }
@@ -312,14 +367,32 @@ test('should merge two basic apis with path prefixes', async (t) => {
 
   t.same(composedSchema.paths['/api2/films'], {
     get: {
-      operationId: 'api2_getFilms',
+      operationId: 'api_2_getFilms',
       responses: {
         200: {
           description: 'OK',
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/schemas/api2_Films'
+                $ref: '#/components/schemas/api_2_Films'
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  t.same(composedSchema.paths['/api3/actors'], {
+    get: {
+      operationId: 'api_3_getActors',
+      responses: {
+        200: {
+          description: 'OK',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/api_3_Actors'
               }
             }
           }

--- a/packages/composer/test/openapi/schemas-composition.test.js
+++ b/packages/composer/test/openapi/schemas-composition.test.js
@@ -564,7 +564,7 @@ test('should not overwrite a schema title if exists', async (t) => {
   })
 })
 
-test('should trow an error if there are duplicates paths', async (t) => {
+test('should throw an error if there are duplicates paths', async (t) => {
   const schema1 = {
     openapi: '3.0.0',
     info: {
@@ -608,7 +608,7 @@ test('should trow an error if there are duplicates paths', async (t) => {
   }
 })
 
-test('should trow an error if there are duplicates paths with prefixes', async (t) => {
+test('should throw an error if there are duplicates paths with prefixes', async (t) => {
   const schema1 = {
     openapi: '3.0.0',
     info: {


### PR DESCRIPTION
This PR is fixing https://github.com/platformatic/platformatic/issues/1299. The issue was that the openapi composer schema composition test, did not take into account namespace schema operation id's that are not pascal case. 

Currently namespaced schemas are composed using the operationID directly from `platformatic.composer.json`.  This had unexpected consequences when creating a frontend client. 

For example the composer service id:

`"id": "website-service"`

becomes

`export async function website-service_getPages(request) {...}`

When using the `api.js or api.ts` downloaded frontend code, type errors makes the file unusable due to the `hypen` in the function names.

The solution now generates an api prefix for the operationId using regex to remove undesired characters. For example:

1.  'website-service'  becomes `website_service`
2.  'website__service-'  becomes `website_service`
3. 'website__service-'  becomes `website_service`
4. '_website_&service-'  becomes `website_service`

I have update the existing tests which pass.