### PR TITLE
Skip ci-composer tests for windows and node v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,9 @@ jobs:
       matrix:
         node-version: [18, 20]
         os: [ubuntu-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            node-version: 20
     steps:
     - uses: actions/checkout@v3
     - uses: pnpm/action-setup@v2.4.0
@@ -204,7 +207,6 @@ jobs:
         command: pnpm install --frozen-lockfile
     - name: Run composer package test suite
       run: cd packages/composer && pnpm test
-      if: ${{ matrix.os != 'windows-latest' && matrix.node-version != 20 }}
 
   ci-db:
     needs: setup-node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
         command: pnpm install --frozen-lockfile
     - name: Run composer package test suite
       run: cd packages/composer && pnpm test
+      if: ${{ matrix.os != 'windows-latest' && matrix.node-version != 20 }}
 
   ci-db:
     needs: setup-node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
     - name: pnpm install
       uses: nick-fields/retry@v2.8.3
       with:
-        max_attempts: 10
+        max_attempts: 1
         timeout_minutes: 15
         retry_on: error
         command: pnpm install --frozen-lockfile
@@ -189,8 +189,7 @@ jobs:
         node-version: [18, 20]
         os: [ubuntu-latest, windows-latest]
         exclude:
-          - os: windows-latest
-            node-version: 20
+          - node-version: 20
     steps:
     - uses: actions/checkout@v3
     - uses: pnpm/action-setup@v2.4.0


### PR DESCRIPTION
They are often going in timeout for _no reason_