### PR TITLE
 Runtime project: Displayed  default services path changed

### DIFF
--- a/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
+++ b/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
@@ -50,7 +50,7 @@ export async function createPlatformaticRuntime (_args) {
   // Create the project directory
   await mkdir(projectDir, { recursive: true })
 
-  const baseServicesDir = join(relative(process.cwd(), projectDir), 'services')
+  const baseServicesDir = join(relative(process.cwd(), projectDir), 'library-app/services')
   const servicesDir = await askDir(logger, baseServicesDir, 'Where would you like to load your services from?')
 
   const { runPackageManagerInstall } = await inquirer.prompt([

--- a/packages/create-platformatic/test/runtime/create-runtime.test.mjs
+++ b/packages/create-platformatic/test/runtime/create-runtime.test.mjs
@@ -23,7 +23,7 @@ const fakeLogger = {
 }
 
 test('creates runtime', async ({ equal, same, ok }) => {
-  await createRuntime(fakeLogger, tmpDir, undefined, 'services', 'foobar')
+  await createRuntime(fakeLogger, tmpDir, undefined, 'library-app/services', 'foobar')
 
   const pathToRuntimeConfigFile = join(tmpDir, 'platformatic.runtime.json')
   const runtimeConfigFile = readFileSync(pathToRuntimeConfigFile, 'utf8')
@@ -36,7 +36,7 @@ test('creates runtime', async ({ equal, same, ok }) => {
     allowCycles: false,
     hotReload: true,
     autoload: {
-      path: 'services',
+      path: 'library-app/services',
       exclude: ['docs']
     }
   })


### PR DESCRIPTION
Fix: #1228 
The default services path that was displayed is changed from services to library-app/services.
And the respective test file is also changed.