### PR TITLE
fixes #1309 Updated openapi schema object to selectively ignore entity fields

### DIFF
--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -175,7 +175,11 @@ export interface PlatformaticDB {
            */
           prefix?: string;
           ignore?: {
-            [k: string]: boolean;
+            [k: string]:
+              | boolean
+              | {
+                  [k: string]: boolean;
+                };
           };
         };
     ignore?: {

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -92,9 +92,15 @@ const db = {
           ...(openApiBase.properties),
           ignore: {
             type: 'object',
-            // TODO add support for column-level ignore
             additionalProperties: {
-              type: 'boolean'
+              anyOf: [{
+                type: 'boolean'
+              }, {
+                type: 'object',
+                additionalProperties: {
+                  type: 'boolean'
+                }
+              }]
             }
           }
         },


### PR DESCRIPTION
Updated openapi schema object to selectively ignore entity fields as per the [Platformatic reference configuration](https://docs.platformatic.dev/docs/reference/db/configuration) found under section `db` openapi.

Updated from only ignoring entities,

```
{
  "db": {
    ...
    "openapi": {
      "ignore": {
        "categories": true
      }
    }
  }
}
```

to been able to selectively ignore entity  fields as well.

```
{
  "db": {
    ...
    "openapi": {
      "ignore": {
        "categories": {
          "name": true
        }
      }
    }
  }
}
```

Tests pass: 

Platformatic: 0.32.0
Nodejs: 18.16.1