### PR TITLE
[DRAFT]: Updated graphql schema object to selectively ignore entity fields

### DIFF
--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -149,7 +149,11 @@ export interface PlatformaticDB {
       | {
           graphiql?: boolean;
           ignore?: {
-            [k: string]: boolean;
+            [k: string]:
+              | boolean
+              | {
+                  [k: string]: boolean;
+                };
           };
           subscriptionIgnore?: string[];
           schema?: string;

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -62,9 +62,15 @@ const db = {
           },
           ignore: {
             type: 'object',
-            // TODO add support for column-level ignore
             additionalProperties: {
-              type: 'boolean'
+              anyOf: [{
+                type: 'boolean'
+              }, {
+                type: 'object',
+                additionalProperties: {
+                  type: 'boolean'
+                }
+              }]
             }
           },
           subscriptionIgnore: {


### PR DESCRIPTION
Updated graphql schema object to selectively ignore entity fields as per the [Platformatic reference configuration](https://docs.platformatic.dev/docs/reference/db/configuration) found under section `db` graphql.

Updated from only ignoring entities,

```
{
  "db": {
    ...
    "graphql": {
      "ignore": {
        "categories": true
      }
    }
  }
}
```

to been able to selectively ignore entity fields as well.

```
{
  "db": {
    ...
    "graphql": {
      "ignore": {
        "categories": {
          "name": true
        }
      }
    }
  }
}
```

Tests pass: 

Platformatic: 0.32.0
Nodejs: 18.16.1