### PR TITLE
fix: parse querystring fields param

### DIFF
--- a/packages/composer/lib/openapi-generator.js
+++ b/packages/composer/lib/openapi-generator.js
@@ -103,6 +103,12 @@ async function composeOpenAPI (app, opts) {
       }
     }
   })
+
+  app.addHook('preValidation', async (req) => {
+    if (typeof req.query.fields === 'string') {
+      req.query.fields = req.query.fields.split(',')
+    }
+  })
 }
 
 function createPathMapper (originOpenApiPath, renamedOpenApiPath, prefix) {


### PR DESCRIPTION
it does the same parsing for the composer.

https://github.com/platformatic/platformatic/blob/0f89c0d91d019bb29265155bb56c4d6d755f50ce/packages/sql-openapi/lib/entity-to-routes.js#L60

Fix #1310 