### PR TITLE
Correct telemetry span types and Semantic HTTP attributes

### DIFF
--- a/packages/client/test/telemetry.test.js
+++ b/packages/client/test/telemetry.test.js
@@ -62,8 +62,8 @@ test('telemetry correctly propagates from a service client to a server for an Op
   equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
   equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
   equal(clientSpan.name, `POST ${targetAppUrl}/movies/`)
-  equal(clientSpan.attributes['server.url'], `${targetAppUrl}/movies/`)
-  equal(clientSpan.attributes['response.statusCode'], 200)
+  equal(clientSpan.attributes['url.full'], `${targetAppUrl}/movies/`)
+  equal(clientSpan.attributes['http.response.status_code'], 200)
   const clientTraceId = clientSpan.spanContext().traceId
   const clientSpanId = clientSpan.spanContext().spanId
 
@@ -139,8 +139,8 @@ test('telemetry correctly propagates from a generic client through a service cli
   equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
   equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
   equal(clientSpan.name, `POST ${targetAppUrl}/movies/`)
-  equal(clientSpan.attributes['server.url'], `${targetAppUrl}/movies/`)
-  equal(clientSpan.attributes['response.statusCode'], 200)
+  equal(clientSpan.attributes['url.full'], `${targetAppUrl}/movies/`)
+  equal(clientSpan.attributes['http.response.status_code'], 200)
   const clientTraceId = clientSpan.spanContext().traceId
   const clientSpanId = clientSpan.spanContext().spanId
   same(clientTraceId, traceId)
@@ -218,8 +218,8 @@ test('telemetry correctly propagates from a service client to a server for an Gr
   equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
   equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
   equal(clientSpan.name, `POST ${targetAppUrl}/graphql`)
-  equal(clientSpan.attributes['server.url'], `${targetAppUrl}/graphql`)
-  equal(clientSpan.attributes['response.statusCode'], 200)
+  equal(clientSpan.attributes['url.full'], `${targetAppUrl}/graphql`)
+  equal(clientSpan.attributes['http.response.status_code'], 200)
   const clientTraceId = clientSpan.spanContext().traceId
   const clientSpanId = clientSpan.spanContext().spanId
 

--- a/packages/composer/test/telemetry/proxy.test.js
+++ b/packages/composer/test/telemetry/proxy.test.js
@@ -56,8 +56,8 @@ test('should proxy openapi requests with telemetry span', async (t) => {
     const proxyCallSpan = finishedSpans[0]
     const composerCallSpan = finishedSpans[1]
     t.equal(proxyCallSpan.name, `GET ${origin1}/internal/service1/users`)
-    t.equal(proxyCallSpan.attributes['server.url'], `${origin1}/internal/service1/users`)
-    t.equal(proxyCallSpan.attributes['response.statusCode'], 200)
+    t.equal(proxyCallSpan.attributes['url.full'], `${origin1}/internal/service1/users`)
+    t.equal(proxyCallSpan.attributes['http.response.status_code'], 200)
     t.equal(proxyCallSpan.parentSpanId, composerCallSpan.spanContext().spanId)
     t.equal(proxyCallSpan.traceId, composerCallSpan.traceId)
   }
@@ -108,7 +108,7 @@ test('should proxy openapi requests with telemetry, managing errors', async (t) 
     const finishedSpans = exporter.getFinishedSpans()
     const span = finishedSpans[0]
     t.equal(span.name, `GET ${origin1}/internal/service1/error`)
-    t.equal(span.attributes['server.url'], `${origin1}/internal/service1/error`)
-    t.equal(span.attributes['response.statusCode'], 500)
+    t.equal(span.attributes['url.full'], `${origin1}/internal/service1/error`)
+    t.equal(span.attributes['http.response.status_code'], 500)
   }
 })

--- a/packages/composer/test/telemetry/routes-composition-telemetry.test.js
+++ b/packages/composer/test/telemetry/routes-composition-telemetry.test.js
@@ -52,8 +52,8 @@ test('should compose openapi with prefixes', async (t) => {
   const proxyCallSpan = finishedSpans[0]
   const composerCallSpan = finishedSpans[1]
   t.equal(proxyCallSpan.name, `GET ${api1Origin}/api1/users`)
-  t.equal(proxyCallSpan.attributes['server.url'], `${api1Origin}/api1/users`)
-  t.equal(proxyCallSpan.attributes['response.statusCode'], 200)
+  t.equal(proxyCallSpan.attributes['url.full'], `${api1Origin}/api1/users`)
+  t.equal(proxyCallSpan.attributes['http.response.status_code'], 200)
   t.equal(proxyCallSpan.parentSpanId, composerCallSpan.spanContext().spanId)
   t.equal(proxyCallSpan.traceId, composerCallSpan.traceId)
 })

--- a/packages/db/test/telemetry.test.js
+++ b/packages/db/test/telemetry.test.js
@@ -73,7 +73,7 @@ test('should setup telemetry if configured', async ({ teardown, equal, pass, sam
   equal(finishedSpans.length, 1)
   const span = finishedSpans[0]
   equal(span.name, 'POST /graphql')
-  equal(span.attributes['req.method'], 'POST')
-  equal(span.attributes['req.url'], '/graphql')
-  equal(span.attributes['reply.statusCode'], 200)
+  equal(span.attributes['http.request.method'], 'POST')
+  equal(span.attributes['url.path'], '/graphql')
+  equal(span.attributes['http.response.status_code'], 200)
 })

--- a/packages/service/test/telemetry.test.js
+++ b/packages/service/test/telemetry.test.js
@@ -81,7 +81,7 @@ test('should setup telemetry if configured', async ({ teardown, equal, pass, sam
   equal(finishedSpans.length, 1)
   const span = finishedSpans[0]
   equal(span.name, 'GET /')
-  equal(span.attributes['req.method'], 'GET')
-  equal(span.attributes['req.url'], '/')
-  equal(span.attributes['reply.statusCode'], 200)
+  equal(span.attributes['http.request.method'], 'GET')
+  equal(span.attributes['url.path'], '/')
+  equal(span.attributes['http.response.status_code'], 200)
 })

--- a/packages/telemetry/lib/telemetry.js
+++ b/packages/telemetry/lib/telemetry.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const { SpanStatusCode } = require('@opentelemetry/api')
+const { SpanStatusCode, SpanKind } = require('@opentelemetry/api')
 const { ConsoleSpanExporter, BatchSpanProcessor, SimpleSpanProcessor, InMemorySpanExporter } = require('@opentelemetry/sdk-trace-base')
 const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions')
 const { Resource } = require('@opentelemetry/resources')
 const { PlatformaticTracerProvider } = require('./platformatic-trace-provider')
 const { PlatformaticContext } = require('./platformatic-context')
 const { fastifyTextMapGetter, fastifyTextMapSetter } = require('./fastify-text-map')
+const fastUri = require('fast-uri')
 
 // Platformatic telemetry plugin.
 // Supported Exporters:
@@ -34,14 +35,19 @@ function formatSpanName (request) {
 
 const defaultFormatSpanAttributes = {
   request (request) {
+    const { hostname, method, url, protocol } = request
+    const urlData = fastUri.parse(`${protocol}://${hostname})`)
     return {
-      'req.method': request.raw.method,
-      'req.url': request.raw.url
+      'server.address': hostname,
+      'server.port': urlData.port,
+      'http.request.method': method,
+      'url.path': url,
+      'url.scheme': protocol
     }
   },
   reply (reply) {
     return {
-      'reply.statusCode': reply.statusCode
+      'http.response.status_code': reply.statusCode
     }
   },
   error (error) {
@@ -60,7 +66,7 @@ const setupProvider = (app, opts) => {
     app.log.warn('No exporter configured, defaulting to console.')
     exporter = { type: 'console' }
   }
-  app.log.info(`Setting up telemetry for service: ${serviceName} version: ${version} and exporter of type ${exporter.type}`)
+  app.log.info(`Setting up telemetry for service: ${serviceName}${version ? ' version: ' + version : ''} with exporter of type ${exporter.type}`)
   const provider = new PlatformaticTracerProvider({
     resource: new Resource({
       [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
@@ -119,6 +125,7 @@ async function setupTelemetry (app, opts) {
       {},
       context
     )
+    span.kind = SpanKind.SERVER
     // Next 2 lines are needed by W3CTraceContextPropagator
     context = context.setSpan(span)
     span.setAttributes(formatSpanAttributes.request(request))
@@ -177,8 +184,19 @@ async function setupTelemetry (app, opts) {
     /* istanbul ignore next */
     method = method || ''
     const span = tracer.startSpan(`${method} ${url}`, {}, context)
+    span.kind = SpanKind.CLIENT
+
+    const urlObj = fastUri.parse(url)
     /* istanbul ignore next */
-    const attributes = url ? { 'server.url': url } : {}
+    const attributes = url
+      ? {
+          'server.address': urlObj.host,
+          'server.port': urlObj.port,
+          'http.request.method': method,
+          'url.full': url,
+          'url.path': urlObj.pathname
+        }
+      : {}
     span.setAttributes(attributes)
 
     // Next 2 lines are needed by W3CTraceContextPropagator
@@ -200,7 +218,7 @@ async function setupTelemetry (app, opts) {
         spanStatus.code = SpanStatusCode.ERROR
       }
       span.setAttributes({
-        'response.statusCode': response.statusCode
+        'http.response.status_code': response.statusCode
       })
       span.setStatus(spanStatus)
     } else {

--- a/packages/telemetry/lib/telemetry.js
+++ b/packages/telemetry/lib/telemetry.js
@@ -194,7 +194,7 @@ async function setupTelemetry (app, opts) {
           'server.port': urlObj.port,
           'http.request.method': method,
           'url.full': url,
-          'url.path': urlObj.pathname
+          'url.path': urlObj.path
         }
       : {}
     span.setAttributes(attributes)

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -27,6 +27,7 @@
     "@opentelemetry/resources": "^1.15.0",
     "@opentelemetry/sdk-trace-base": "^1.15.0",
     "@opentelemetry/semantic-conventions": "^1.15.0",
+    "fast-uri": "^2.2.0",
     "fastify-plugin": "^4.5.0"
   }
 }

--- a/packages/telemetry/test/client.test.js
+++ b/packages/telemetry/test/client.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const fastify = require('fastify')
-const { SpanStatusCode } = require('@opentelemetry/api')
+const { SpanStatusCode, SpanKind } = require('@opentelemetry/api')
 const telemetryPlugin = require('../lib/telemetry')
 const { PlatformaticContext } = require('../lib/platformatic-context')
 const { fastifyTextMapGetter } = require('../lib/fastify-text-map')
@@ -29,7 +29,6 @@ test('should add the propagation headers correctly, new propagation started', as
 
   const app = await setupApp({
     serviceName: 'test-service',
-    version: '1.0.0',
     exporter: {
       type: 'memory'
     }
@@ -126,16 +125,20 @@ test('should trace a client request', async ({ equal, same, teardown }) => {
   // We have two one for the client and one for the server
   const spanServer = finishedSpans[0]
   equal(spanServer.name, 'GET /test')
+  equal(spanServer.kind, SpanKind.SERVER)
   equal(spanServer.status.code, SpanStatusCode.OK)
-  equal(spanServer.attributes['req.method'], 'GET')
-  equal(spanServer.attributes['req.url'], '/test')
-  equal(spanServer.attributes['reply.statusCode'], 200)
+  equal(spanServer.attributes['http.request.method'], 'GET')
+  equal(spanServer.attributes['url.path'], '/test')
+  equal(spanServer.attributes['http.response.status_code'], 200)
 
   const spanClient = finishedSpans[1]
   equal(spanClient.name, 'GET http://localhost:3000/test')
+  equal(spanClient.kind, SpanKind.CLIENT)
   equal(spanClient.status.code, SpanStatusCode.OK)
-  equal(spanClient.attributes['server.url'], 'http://localhost:3000/test')
-  equal(spanClient.attributes['response.statusCode'], 200)
+  equal(spanClient.attributes['url.full'], 'http://localhost:3000/test')
+  equal(spanClient.attributes['http.response.status_code'], 200)
+  equal(spanClient.attributes['server.port'], 3000)
+  equal(spanClient.attributes['server.address'], 'localhost')
 
   // The traceparent header is added to the request and propagated to the server
   equal(receivedHeaders.traceparent, telemetryHeaders.traceparent)
@@ -175,16 +178,18 @@ test('should trace a client request failing', async ({ equal, same, teardown }) 
   // We have two one for the client and one for the server
   const spanServer = finishedSpans[0]
   equal(spanServer.name, 'GET')
+  equal(spanServer.kind, SpanKind.SERVER)
   equal(spanServer.status.code, SpanStatusCode.ERROR)
-  equal(spanServer.attributes['req.method'], 'GET')
-  equal(spanServer.attributes['req.url'], '/wrong')
-  equal(spanServer.attributes['reply.statusCode'], 404)
+  equal(spanServer.attributes['http.request.method'], 'GET')
+  equal(spanServer.attributes['url.path'], '/wrong')
+  equal(spanServer.attributes['http.response.status_code'], 404)
 
   const spanClient = finishedSpans[1]
   equal(spanClient.name, 'GET http://localhost:3000/test')
+  equal(spanClient.kind, SpanKind.CLIENT)
   equal(spanClient.status.code, SpanStatusCode.ERROR)
-  equal(spanClient.attributes['server.url'], 'http://localhost:3000/test')
-  equal(spanClient.attributes['response.statusCode'], 404)
+  equal(spanClient.attributes['url.full'], 'http://localhost:3000/test')
+  equal(spanClient.attributes['http.response.status_code'], 404)
 })
 
 test('should trace a client request failing (no HTTP error)', async ({ equal, same, teardown }) => {
@@ -219,7 +224,7 @@ test('should trace a client request failing (no HTTP error)', async ({ equal, sa
   const spanClient = finishedSpans[0]
   equal(spanClient.name, 'GET http://localhost:3000/test')
   equal(spanClient.status.code, SpanStatusCode.ERROR)
-  equal(spanClient.attributes['server.url'], 'http://localhost:3000/test')
+  equal(spanClient.attributes['url.full'], 'http://localhost:3000/test')
   equal(spanClient.attributes['error.name'], 'Error')
   equal(spanClient.attributes['error.message'], 'KABOOM!!!')
   equal(spanClient.attributes['error.stack'].includes('Error: KABOOM!!!'), true)

--- a/packages/telemetry/test/client.test.js
+++ b/packages/telemetry/test/client.test.js
@@ -139,6 +139,7 @@ test('should trace a client request', async ({ equal, same, teardown }) => {
   equal(spanClient.attributes['http.response.status_code'], 200)
   equal(spanClient.attributes['server.port'], 3000)
   equal(spanClient.attributes['server.address'], 'localhost')
+  equal(spanClient.attributes['url.path'], '/test')
 
   // The traceparent header is added to the request and propagated to the server
   equal(receivedHeaders.traceparent, telemetryHeaders.traceparent)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1612,6 +1612,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.15.0
         version: 1.15.1
+      fast-uri:
+        specifier: ^2.2.0
+        version: 2.2.0
       fastify-plugin:
         specifier: ^4.5.0
         version: 4.5.0


### PR DESCRIPTION
Two telemetry fixes here:
- Set the correct `SpanType` for client and server.
- Set the correct standard required attributes, following the [Semantic conventions for HTTP spans](https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/#http-client)
 