### PR TITLE
Configurable skip for tracing

### DIFF
--- a/docs/reference/composer/configuration.md
+++ b/docs/reference/composer/configuration.md
@@ -273,6 +273,7 @@ _Examples_
 
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry.
 - **`version`** (`string`) — Optional version (free form)
+- **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
 - **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -519,6 +519,7 @@ operations are allowed unless `adminSecret` is passed.
 
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry.
 - **`version`** (`string`) — Optional version (free form)
+- **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
 - **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:

--- a/docs/reference/runtime/configuration.md
+++ b/docs/reference/runtime/configuration.md
@@ -122,6 +122,7 @@ microservices are started in the order specified in the configuration file.
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry. In the `runtime` case, the name of the services as reported in traces is `${serviceName}-${serviceId}`, where `serviceId` is the id of the service in the runtime.
 - **`version`** (`string`) — Optional version (free form)
 - **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
+- **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:
         - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -243,6 +243,7 @@ Configure `@platformatic/service` specific settings such as `graphql` or `openap
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry.
 - **`version`** (`string`) — Optional version (free form)
 - **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
+- **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:
         - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.

--- a/packages/composer/test/telemetry/proxy.test.js
+++ b/packages/composer/test/telemetry/proxy.test.js
@@ -10,7 +10,7 @@ const {
 
 test('should proxy openapi requests with telemetry span', async (t) => {
   const service1 = await createOpenApiService(t, ['users'])
-  const origin1 = await service1.listen({ port: 0 })
+  const origin1 = await service1.listen({ host: '127.0.0.1', port: 0 })
 
   const config = {
     composer: {
@@ -65,7 +65,7 @@ test('should proxy openapi requests with telemetry span', async (t) => {
 
 test('should proxy openapi requests with telemetry, managing errors', async (t) => {
   const service1 = await createBasicService(t)
-  const origin1 = await service1.listen({ port: 0 })
+  const origin1 = await service1.listen({ host: '127.0.0.1', port: 0 })
 
   const config = {
     composer: {

--- a/packages/composer/test/telemetry/routes-composition-telemetry.test.js
+++ b/packages/composer/test/telemetry/routes-composition-telemetry.test.js
@@ -9,7 +9,7 @@ const {
 
 test('should compose openapi with prefixes', async (t) => {
   const api1 = await createOpenApiService(t, ['users'])
-  const api1Origin = await api1.listen({ port: 0 })
+  const api1Origin = await api1.listen({ host: '127.0.0.1', port: 0 })
 
   const composer = await createComposer(t, {
     composer: {

--- a/packages/telemetry/lib/schema.js
+++ b/packages/telemetry/lib/schema.js
@@ -12,6 +12,13 @@ const TelemetrySchema = {
       type: 'string',
       description: 'The version of the service (optional)'
     },
+    skip: {
+      type: 'array',
+      description: 'An array of paths to skip when creating spans. Useful for health checks and other endpoints that do not need to be traced.',
+      items: {
+        type: 'string'
+      }
+    },
     exporter: {
       type: 'object',
       properties: {

--- a/packages/telemetry/test/telemetry.test.js
+++ b/packages/telemetry/test/telemetry.test.js
@@ -59,6 +59,45 @@ test('should trace a request not failing', async ({ equal, same, teardown }) => 
   same(resource.attributes['service.version'], '1.0.0')
 })
 
+test('should not put query in `url.path', async ({ equal, same, teardown }) => {
+  const handler = async (request, reply) => {
+    return { foo: 'bar' }
+  }
+
+  const injectArgs = {
+    method: 'GET',
+    url: '/test?foo=bar',
+    headers: {
+      host: 'test'
+    }
+  }
+
+  const app = await setupApp({
+    serviceName: 'test-service',
+    version: '1.0.0',
+    exporter: {
+      type: 'memory'
+    }
+  }, handler, teardown)
+
+  await app.inject(injectArgs)
+  const { exporter } = app.openTelemetry
+  const finishedSpans = exporter.getFinishedSpans()
+  equal(finishedSpans.length, 1)
+  const span = finishedSpans[0]
+  equal(span.kind, SpanKind.SERVER)
+  equal(span.name, 'GET /test')
+  equal(span.status.code, SpanStatusCode.OK)
+  equal(span.attributes['http.request.method'], 'GET')
+  equal(span.attributes['url.path'], '/test')
+  equal(span.attributes['http.response.status_code'], 200)
+  equal(span.attributes['url.scheme'], 'http')
+  equal(span.attributes['server.address'], 'test')
+  const resource = span.resource
+  same(resource.attributes['service.name'], 'test-service')
+  same(resource.attributes['service.version'], '1.0.0')
+})
+
 test('request should add attribute to a span', async ({ equal, same, teardown }) => {
   const handler = async (request, reply) => {
     request.span.setAttribute('foo', 'bar')
@@ -218,6 +257,9 @@ test('should not trace if the operation is skipped', async ({ equal, same, teard
   const app = await setupApp({
     serviceName: 'test-service',
     version: '1.0.0',
+    skip: [
+      'GET/documentation/json'
+    ],
     exporter: {
       type: 'memory'
     }


### PR DESCRIPTION
Added the new config `skip` property: 
```
    serviceName: 'test-service',
    skip: ['POST/skipme'],
    exporter: {
      type: 'memory'
    }
```
This is useful to skip calls that are not intereseting on traces (like ` GET/documentation/json` from the composer and health checks).
Also some other minor fixes:
- Added some missing guards
-  Avoid to put querystring on `url.path` in spans.
