### PR TITLE
fixes #1354: Page not found authorization

### DIFF
--- a/docs/guides/securing-platformatic-db.md
+++ b/docs/guides/securing-platformatic-db.md
@@ -4,7 +4,7 @@
 
 Authorization in Platformatic DB is **role-based**. User authentication and the
 assignment of roles must be handled by an external authentication service.
-Take a look to at the reference documentation for [Authorization](/docs/reference/db/authorization).
+Take a look to at the reference documentation for [Authorization](/docs/reference/db/authorization/introduction).
 
 The goal of this simple guide is to protect an API built with Platformatic DB
 with the use of a shared secret, that we call `adminSecret`. We want to prevent


### PR DESCRIPTION
Fix the link to point the reference documentation for [Authorization Introduction](https://docs.platformatic.dev/docs/reference/db/authorization/introduction).