### PR TITLE
feat(client-cli): Import as type

### DIFF
--- a/packages/client-cli/lib/gen-graphql.mjs
+++ b/packages/client-cli/lib/gen-graphql.mjs
@@ -28,7 +28,7 @@ function generateTypesFromGraphQL ({ schema, name }) {
   })
   /* eslint-enable new-cap */
 
-  writer.writeLine('import { FastifyPluginAsync } from \'fastify\'')
+  writer.writeLine('import { type FastifyPluginAsync } from \'fastify\'')
   writer.blankLine()
 
   const pluginname = `${capitalizedName}plugin`

--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -85,7 +85,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
   })
   /* eslint-enable new-cap */
 
-  interfaces.writeLine('import { FastifyPluginAsync } from \'fastify\'')
+  interfaces.writeLine('import { type FastifyPluginAsync } from \'fastify\'')
   interfaces.blankLine()
 
   // Add always FullResponse interface because we don't know yet

--- a/packages/client-cli/test/cli-graphql-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-graphql-no-implementation.test.mjs
@@ -116,7 +116,7 @@ test('graphql client generation (typescript)', async ({ teardown, comment, same,
 
   const plugin = `
 /// <reference types="./movies" />
-import { FastifyPluginAsync } from 'fastify'
+import { type FastifyPluginAsync } from 'fastify'
 
 const myPlugin: FastifyPluginAsync<{}> = async (app, options) => {
   app.post('/', async (request, reply) => {

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -91,7 +91,7 @@ test('openapi client generation (typescript)', async ({ teardown, comment, same 
 
   const plugin = `
 /// <reference types="./movies" />
-import { FastifyPluginAsync } from 'fastify'
+import { type FastifyPluginAsync } from 'fastify'
 
 const myPlugin: FastifyPluginAsync<{}> = async (app, options) => {
   app.post('/', async (request, reply) => {


### PR DESCRIPTION
So that, as mentioned on [ts website](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html):
> `import type` only imports declarations to be used for type annotations and declarations. It always gets fully erased, so there’s no remnant of it at runtime. Similarly, `export type` only provides an export that can be used for type contexts, and is also erased from TypeScript’s output.

and to avoid issues, f.e. when using `elint` plugins, like:
```
All imports in the declaration are only used as types. Use `import type`.eslint[@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports)
```