### PR TITLE
Telemetry: multiple exporters support

### DIFF
--- a/docs/reference/composer/configuration.md
+++ b/docs/reference/composer/configuration.md
@@ -274,7 +274,7 @@ _Examples_
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry.
 - **`version`** (`string`) — Optional version (free form)
 - **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
-- **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
+- **`exporter`** (`object` or `array`) — Exporter configuration. If not defined, the exporter defaults to `console`. If an array of objects is configured, every object must be a valid exporter object. The exporter object has the following properties:
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:
         - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -520,7 +520,7 @@ operations are allowed unless `adminSecret` is passed.
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry.
 - **`version`** (`string`) — Optional version (free form)
 - **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
-- **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
+- **`exporter`** (`object` or `array`) — Exporter configuration. If not defined, the exporter defaults to `console`. If an array of objects is configured, every object must be a valid exporter object. The exporter object has the following properties:
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:
         - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.

--- a/docs/reference/runtime/configuration.md
+++ b/docs/reference/runtime/configuration.md
@@ -121,8 +121,8 @@ microservices are started in the order specified in the configuration file.
 
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry. In the `runtime` case, the name of the services as reported in traces is `${serviceName}-${serviceId}`, where `serviceId` is the id of the service in the runtime.
 - **`version`** (`string`) — Optional version (free form)
-- **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
 - **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
+- **`exporter`** (`object` or `array`) — Exporter configuration. If not defined, the exporter defaults to `console`. If an array of objects is configured, every object must be a valid exporter object. The exporter object has the following properties:
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:
         - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -242,8 +242,8 @@ Configure `@platformatic/service` specific settings such as `graphql` or `openap
 
 - **`serviceName`** (**required**, `string`) — Name of the service as will be reported in open telemetry.
 - **`version`** (`string`) — Optional version (free form)
-- **`exporter`** (`object`) — Exporter configuration object. If not defined, the exporter defaults to `console`. This object has the following properties:
 - **`skip`** (`array`). Optional list of operations to skip when exporting telemetry in the form of `${method}/${path}`. e.g.: `GET/documentation/json` 
+- **`exporter`** (`object` or `array`) — Exporter configuration. If not defined, the exporter defaults to `console`. If an array of objects is configured, every object must be a valid exporter object. The exporter object has the following properties:
     - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes. 
     - **`options`** (`object`) — These options are supported:
         - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.

--- a/packages/client/test/telemetry.test.js
+++ b/packages/client/test/telemetry.test.js
@@ -51,8 +51,8 @@ test('telemetry correctly propagates from a service client to a server for an Op
     url: '/'
   })
 
-  const { exporter } = app.openTelemetry
-  const finishedSpans = exporter.getFinishedSpans()
+  const { exporters } = app.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
   // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
   equal(finishedSpans.length, 2)
   const clientSpan = finishedSpans[0]
@@ -68,9 +68,9 @@ test('telemetry correctly propagates from a service client to a server for an Op
   const clientSpanId = clientSpan.spanContext().spanId
 
   // Target app, we check that propagation works
-  same(targetApp.openTelemetry.exporter.getFinishedSpans().length, 2)
+  same(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
   // The first span is the client call to `/documentation/json`, the second is the server call to `/movies/
-  const serverSpan = targetApp.openTelemetry.exporter.getFinishedSpans()[1]
+  const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
   same(serverSpan.name, 'POST /movies/')
   const serverTraceId = serverSpan.spanContext().traceId
   const serverParentSpanId = serverSpan.parentSpanId
@@ -127,8 +127,8 @@ test('telemetry correctly propagates from a generic client through a service cli
     }
   })
 
-  const { exporter } = app.openTelemetry
-  const finishedSpans = exporter.getFinishedSpans()
+  const { exporters } = app.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
 
   // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
   equal(finishedSpans.length, 2)
@@ -146,9 +146,9 @@ test('telemetry correctly propagates from a generic client through a service cli
   same(clientTraceId, traceId)
 
   // Target app
-  same(targetApp.openTelemetry.exporter.getFinishedSpans().length, 2)
+  same(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
   // The first span is the client call to `/documentation/json`, the second is the server call to `/movies/
-  const serverSpan = targetApp.openTelemetry.exporter.getFinishedSpans()[1]
+  const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
   same(serverSpan.name, 'POST /movies/')
   const serverTraceId = serverSpan.spanContext().traceId
   const serverParentSpanId = serverSpan.parentSpanId
@@ -207,8 +207,8 @@ test('telemetry correctly propagates from a service client to a server for an Gr
     url: '/'
   })
 
-  const { exporter } = app.openTelemetry
-  const finishedSpans = exporter.getFinishedSpans()
+  const { exporters } = app.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
   // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
   equal(finishedSpans.length, 2)
   const clientSpan = finishedSpans[0]
@@ -224,8 +224,8 @@ test('telemetry correctly propagates from a service client to a server for an Gr
   const clientSpanId = clientSpan.spanContext().spanId
 
   // Target app, we check that propagation works
-  same(targetApp.openTelemetry.exporter.getFinishedSpans().length, 1)
-  const serverSpan = targetApp.openTelemetry.exporter.getFinishedSpans()[0]
+  same(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 1)
+  const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[0]
   same(serverSpan.name, 'POST /graphql')
   const serverTraceId = serverSpan.spanContext().traceId
   const serverParentSpanId = serverSpan.parentSpanId

--- a/packages/composer/test/telemetry/proxy.test.js
+++ b/packages/composer/test/telemetry/proxy.test.js
@@ -49,8 +49,8 @@ test('should proxy openapi requests with telemetry span', async (t) => {
     t.equal(statusCode, 200)
 
     // Check that the client span is correctly set
-    const { exporter } = composer.openTelemetry
-    const finishedSpans = exporter.getFinishedSpans()
+    const { exporters } = composer.openTelemetry
+    const finishedSpans = exporters[0].getFinishedSpans()
     t.equal(finishedSpans.length, 2)
 
     const proxyCallSpan = finishedSpans[0]
@@ -104,8 +104,8 @@ test('should proxy openapi requests with telemetry, managing errors', async (t) 
     t.equal(statusCode, 500)
 
     // Check that the client span is correctly set
-    const { exporter } = composer.openTelemetry
-    const finishedSpans = exporter.getFinishedSpans()
+    const { exporters } = composer.openTelemetry
+    const finishedSpans = exporters[0].getFinishedSpans()
     const span = finishedSpans[0]
     t.equal(span.name, `GET ${origin1}/internal/service1/error`)
     t.equal(span.attributes['url.full'], `${origin1}/internal/service1/error`)

--- a/packages/composer/test/telemetry/routes-composition-telemetry.test.js
+++ b/packages/composer/test/telemetry/routes-composition-telemetry.test.js
@@ -46,8 +46,8 @@ test('should compose openapi with prefixes', async (t) => {
   t.equal(statusCode, 200)
 
   // Check that the client span is correctly set
-  const { exporter } = composer.openTelemetry
-  const finishedSpans = exporter.getFinishedSpans()
+  const { exporters } = composer.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
   t.equal(finishedSpans.length, 2)
   const proxyCallSpan = finishedSpans[0]
   const composerCallSpan = finishedSpans[1]

--- a/packages/db/test/telemetry.test.js
+++ b/packages/db/test/telemetry.test.js
@@ -68,8 +68,8 @@ test('should setup telemetry if configured', async ({ teardown, equal, pass, sam
     })
   })
   equal(res.statusCode, 200, 'savePage status code')
-  const { exporter } = app.openTelemetry
-  const finishedSpans = exporter.getFinishedSpans()
+  const { exporters } = app.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
   equal(finishedSpans.length, 1)
   const span = finishedSpans[0]
   equal(span.name, 'POST /graphql')

--- a/packages/service/test/telemetry.test.js
+++ b/packages/service/test/telemetry.test.js
@@ -76,8 +76,8 @@ test('should setup telemetry if configured', async ({ teardown, equal, pass, sam
     })
   })
   equal(res.statusCode, 200, 'savePage status code')
-  const { exporter } = app.openTelemetry
-  const finishedSpans = exporter.getFinishedSpans()
+  const { exporters } = app.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
   equal(finishedSpans.length, 1)
   const span = finishedSpans[0]
   equal(span.name, 'GET /')

--- a/packages/telemetry/lib/platformatic-trace-provider.js
+++ b/packages/telemetry/lib/platformatic-trace-provider.js
@@ -32,7 +32,11 @@ class PlatformaticTracerProvider {
   }
 
   addSpanProcessor (spanProcessor) {
-    this._registeredSpanProcessors.push(spanProcessor)
+    if (Array.isArray(spanProcessor)) {
+      this._registeredSpanProcessors.push(...spanProcessor)
+    } else {
+      this._registeredSpanProcessors.push(spanProcessor)
+    }
     this.activeSpanProcessor = new MultiSpanProcessor(
       this._registeredSpanProcessors
     )

--- a/packages/telemetry/lib/schema.js
+++ b/packages/telemetry/lib/schema.js
@@ -1,5 +1,31 @@
 'use strict'
 
+const ExporterSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['console', 'otlp', 'zipkin', 'memory'],
+      default: 'console'
+    },
+    options: {
+      type: 'object',
+      description: 'Options for the exporter. These are passed directly to the exporter.',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The URL to send the traces to. Not used for console or memory exporters.'
+        },
+        headers: {
+          type: 'object',
+          description: 'Headers to send to the exporter. Not used for console or memory exporters.'
+        }
+      }
+    },
+    additionalProperties: false
+  }
+}
+
 const TelemetrySchema = {
   $id: '/OpenTelemetry',
   type: 'object',
@@ -20,29 +46,13 @@ const TelemetrySchema = {
       }
     },
     exporter: {
-      type: 'object',
-      properties: {
-        type: {
-          type: 'string',
-          enum: ['console', 'otlp', 'zipkin', 'memory'],
-          default: 'console'
+      anyOf: [
+        {
+          type: 'array',
+          items: ExporterSchema
         },
-        options: {
-          type: 'object',
-          description: 'Options for the exporter. These are passed directly to the exporter.',
-          properties: {
-            url: {
-              type: 'string',
-              description: 'The URL to send the traces to. Not used for console or memory exporters.'
-            },
-            headers: {
-              type: 'object',
-              description: 'Headers to send to the exporter. Not used for console or memory exporters.'
-            }
-          }
-        },
-        additionalProperties: false
-      }
+        ExporterSchema
+      ]
     }
   },
   required: ['serviceName'],


### PR DESCRIPTION
With this  PR, `exporter` can also be an array, so multiple exporters can be setup for telemetry. 