### PR TITLE
Generate unique operation id

### DIFF
--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -58,15 +58,16 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
   const camelcasedName = toJavaScriptName(name)
   const capitalizedName = capitalize(camelcasedName)
   const { paths } = schema
-
+  const generatedOperationIds = []
   const operations = Object.entries(paths).flatMap(([path, methods]) => {
     return Object.entries(methods).map(([method, operation]) => {
+      const opId = generateOperationId(path, method, operation, generatedOperationIds)
       return {
         path,
         method,
         operation: {
           ...operation,
-          operationId: generateOperationId(path, method, operation)
+          operationId: opId
         }
       }
     })

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -56,7 +56,7 @@ type OpenTelemetry = {
   setErrorInSpanClient?: (span: any, err: unknown) => void
 }
 
-export function generateOperationId(path: string, method: string, methodMeta: MethodMetaInterface): string
+export function generateOperationId(path: string, method: string, methodMeta: MethodMetaInterface, all: string[]): string
 export function buildOpenAPIClient<T>(options: BuildOpenAPIClientOptions, openTelemetry: OpenTelemetry): Promise<T>
 export function buildGraphQLClient(options: BuildGraphQLClientOptions, openTelemetry: OpenTelemetry, logger: AbstractLogger): Promise<BuildGraphQLClientOutput>
 

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -18,13 +18,23 @@ function generateOperationId (path, method, methodMeta, all) {
     }
     operationId = method.toLowerCase() + stringToUpdate.split(/[/-]+/).map(capitalize).join('')
   } else {
-    if (all.includes(operationId)) {
-      operationId = `${method}${capitalize(operationId)}`
+    let count = 0
+    let candidate = operationId
+    while (all.includes(candidate)) {
+      if (count === 0) {
+        // first try with method name
+        candidate = `${method}${capitalize(operationId)}`
+      } else {
+        candidate = `${method}${capitalize(operationId)}${count}`
+      }
+      count++
     }
+    operationId = candidate
   }
   all.push(operationId)
   return operationId
 }
+
 
 async function buildOpenAPIClient (options, openTelemetry) {
   const client = {}

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -8,7 +8,7 @@ const kGetHeaders = Symbol('getHeaders')
 const kTelemetryContext = Symbol('telemetry-context')
 const abstractLogging = require('abstract-logging')
 
-function generateOperationId (path, method, methodMeta) {
+function generateOperationId (path, method, methodMeta, all) {
   let operationId = methodMeta.operationId
   if (!operationId) {
     const pathParams = methodMeta.parameters?.filter(p => p.in === 'path') || []
@@ -17,7 +17,12 @@ function generateOperationId (path, method, methodMeta) {
       stringToUpdate = stringToUpdate.replace(`{${param.name}}`, capitalize(param.name))
     }
     operationId = method.toLowerCase() + stringToUpdate.split(/[/-]+/).map(capitalize).join('')
+  } else {
+    if (all.includes(operationId)) {
+      operationId = `${method}${capitalize(operationId)}`
+    }
   }
+  all.push(operationId)
   return operationId
 }
 
@@ -41,13 +46,13 @@ async function buildOpenAPIClient (options, openTelemetry) {
 
   client[kHeaders] = options.headers || {}
   let { fullResponse, throwOnError } = options
-
+  const generatedOperationIds = []
   for (const path of Object.keys(spec.paths)) {
     const pathMeta = spec.paths[path]
 
     for (const method of Object.keys(pathMeta)) {
       const methodMeta = pathMeta[method]
-      const operationId = generateOperationId(path, method, methodMeta)
+      const operationId = generateOperationId(path, method, methodMeta, generatedOperationIds)
       const responses = pathMeta[method].responses
       const successResponses = Object.entries(responses).filter(([s]) => s.startsWith('2'))
       if (successResponses.length !== 1) {

--- a/packages/client/test/generateOperationId.test.js
+++ b/packages/client/test/generateOperationId.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { test } = require('tap')
+const { generateOperationId } = require('..')
+
+test('generates name from different path with same method and opeartionId', async (t) => {
+  const bucket = []
+  const first = generateOperationId('sample-path', 'get', {
+    operationId: 'sampleOperationId'
+  }, bucket)
+
+  const second = generateOperationId('sample-path2', 'get', {
+    operationId: 'sampleOperationId'
+  }, bucket)
+
+  const third = generateOperationId('sample-path3', 'get', {
+    operationId: 'sampleOperationId'
+  }, bucket)
+
+  const fourth = generateOperationId('sample-path4', 'get', {
+    operationId: 'sampleOperationId'
+  }, bucket)
+  t.equal(first, 'sampleOperationId')
+  t.equal(second, 'getSampleOperationId')
+  t.equal(third, 'getSampleOperationId1')
+  t.equal(fourth, 'getSampleOperationId2')
+})

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -370,7 +370,7 @@ test('build basic client from file', async ({ teardown, same, rejects }) => {
     url: `${app.url}/movies-api/`,
     path: join(__dirname, 'fixtures', 'movies', 'openapi.json')
   })
-  console.log(client)
+
   const movie = await client.createMovie({
     title: 'The Matrix'
   })

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -370,7 +370,7 @@ test('build basic client from file', async ({ teardown, same, rejects }) => {
     url: `${app.url}/movies-api/`,
     path: join(__dirname, 'fixtures', 'movies', 'openapi.json')
   })
-
+  console.log(client)
   const movie = await client.createMovie({
     title: 'The Matrix'
   })
@@ -389,7 +389,7 @@ test('build basic client from file', async ({ teardown, same, rejects }) => {
     }
   ])
 
-  const updatedMovie = await client.updateMovie({
+  const updatedMovie = await client.putUpdateMovie({
     id: 1,
     title: 'The Matrix Reloaded'
   })

--- a/packages/frontend-template/index.js
+++ b/packages/frontend-template/index.js
@@ -64,7 +64,7 @@ export async function command (argv) {
     await help.toStdout(['invalid-url'])
     process.exit(1)
   }
-  console.log('@@@@@@ name')
+
   try {
     await frontendTemplate({ url: urlOrLanguage, language, name: 'api' })
   } catch (err) {

--- a/packages/frontend-template/index.js
+++ b/packages/frontend-template/index.js
@@ -43,7 +43,7 @@ async function frontendTemplate ({ url, language, name }) {
 
 export async function command (argv) {
   const {
-    _: [urlOrLanguage, language]
+    _: [urlOrLanguage, language, name]
   } = parseArgs(argv)
 
   const help = helpMe({
@@ -64,7 +64,7 @@ export async function command (argv) {
     await help.toStdout(['invalid-url'])
     process.exit(1)
   }
-
+  console.log('@@@@@@ name')
   try {
     await frontendTemplate({ url: urlOrLanguage, language, name: 'api' })
   } catch (err) {

--- a/packages/frontend-template/lib/gen-openapi.mjs
+++ b/packages/frontend-template/lib/gen-openapi.mjs
@@ -14,15 +14,16 @@ export function processOpenAPI ({ schema, name, url, language }) {
 function generateFrontendImplementationFromOpenAPI ({ schema, name, url, language }) {
   const capitalizedName = capitalize(name)
   const { paths } = schema
-
+  const generatedOperationIds = []
   const operations = Object.entries(paths).flatMap(([path, methods]) => {
     return Object.entries(methods).map(([method, operation]) => {
+      const opId = generateOperationId(path, method, operation, generatedOperationIds)
       return {
         path,
         method,
         operation: {
           ...operation,
-          operationId: generateOperationId(path, method, operation)
+          operationId: opId
         }
       }
     })
@@ -164,15 +165,16 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, url, languag
 function generateTypesFromOpenAPI ({ schema, name }) {
   const capitalizedName = capitalize(name)
   const { paths } = schema
-
+  const generatedOperationIds = []
   const operations = Object.entries(paths).flatMap(([path, methods]) => {
     return Object.entries(methods).map(([method, operation]) => {
+      const opId = generateOperationId(path, method, operation, generatedOperationIds)
       return {
         path,
         method,
         operation: {
           ...operation,
-          operationId: generateOperationId(path, method, operation)
+          operationId: opId
         }
       }
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -12368,3 +12364,7 @@ packages:
   /zenscroll@4.0.2:
     resolution: {integrity: sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg==}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
Instead of having a progressive number I used the method name before the operation Id.

One of our test was failing , and after the fix with progressive number, I had to change the test to

```
client.updateMovies1(...)
``` 

Which didn't look good to me.

There is still an edge case

```json
{
  "openapi": "3.0.3",
  "paths": {
    "/sample-path": {
      "get": {
        "operationId": "sampleOperationId"
      }
    },
    "/sample-path2": {
      "get": {
        "operationId": "sampleOperationId"
      }
    }
  }
}

```
Same operationId, same method (but different path). 
I think it's very uncommon, should we support also this? 
Maybe using this [code](https://github.com/platformatic/platformatic/blob/1396-duplicated-exports/packages/client/index.js#L13-L19) we already have? 

Fixes: #1396 