### PR TITLE
fix(client-cli): Enum with single quote

### DIFF
--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -281,7 +281,7 @@ export function getType (typeDef) {
   if (typeDef.enum) {
     return typeDef.enum.map((en) => {
       if (typeDef.type === 'string') {
-        return `'${en}'`
+        return `'${en.replace(/'/g, "\\'")}'`
       } else {
         return en
       }

--- a/packages/client-cli/test/get-type.test.mjs
+++ b/packages/client-cli/test/get-type.test.mjs
@@ -149,7 +149,8 @@ test('support enum', async (t) => {
       prop1: {
         enum: [
           'foo',
-          'bar'
+          'bar',
+          "pippo'Giuseppe_Raimondo_Vittorio'baudo"
         ],
         type: 'string'
       },
@@ -160,7 +161,7 @@ test('support enum', async (t) => {
     type: 'object'
   }
 
-  t.equal(getType(enumDef), '{ prop1: \'foo\' | \'bar\'; prop2: string }')
+  t.equal(getType(enumDef), '{ prop1: \'foo\' | \'bar\' | \'pippo\\\'Giuseppe_Raimondo_Vittorio\\\'baudo\'; prop2: string }')
 })
 
 test('support enum with numbers', async (t) => {


### PR DESCRIPTION
Fix the following issue, in case you have an enum containing the single quote char `'`
![image](https://github.com/platformatic/platformatic/assets/3996291/376e42a8-c8f1-41dd-8639-4cdae42fe0d5)
