### PR TITLE
feat(client-cli): export interfaces

### DIFF
--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -97,7 +97,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
   })
   interfaces.blankLine()
 
-  writer.write(`interface ${capitalizedName}`).block(() => {
+  writer.write(`export interface ${capitalizedName}`).block(() => {
     const originalFullResponse = fullResponse
     let currentFullResponse = originalFullResponse
     for (const operation of operations) {
@@ -109,7 +109,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
       }
       const operationRequestName = `${capitalize(operationId)}Request`
       const operationResponseName = `${capitalize(operationId)}Response`
-      interfaces.write(`interface ${operationRequestName}`).block(() => {
+      interfaces.write(`export interface ${operationRequestName}`).block(() => {
         const addedProps = new Set()
         if (parameters) {
           for (const parameter of parameters) {
@@ -133,7 +133,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
         }
         let isResponseArray
         let type = `${operationResponseName}${classCase(STATUS_CODES[statusCode])}`
-        interfaces.write(`interface ${type}`).block(() => {
+        interfaces.write(`export interface ${type}`).block(() => {
           isResponseArray = writeContent(interfaces, response.content, schema, new Set())
         })
         interfaces.blankLine()

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -20,6 +20,9 @@ test('generates only types in target folder with --only-types flag', async ({ te
   match(fileContents, /declare namespace Movies {/)
   match(fileContents, /type MoviesPlugin = FastifyPluginAsync<NonNullable<Movies.MoviesOptions>>/)
   match(fileContents, /export const movies: MoviesPlugin;/)
+  match(fileContents, /export interface GetMoviesRequest {/)
+  match(fileContents, /export interface GetMoviesResponseOK {/)
+  match(fileContents, /export interface Movies {/)
 })
 
 test('openapi client generation (javascript)', async ({ teardown, comment, same }) => {


### PR DESCRIPTION
When generating types, this helps in case you want to select a specific request or response typ