### PR TITLE
improve request type definition

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -273,7 +273,10 @@ Options:
 * `-n, --name <name>` - Name of the client.
 * `-f, --folder <name>` - Name of the plugin folder, defaults to --name value.
 * `-t, --typescript` - Generate the client plugin in TypeScript.
-* `-r, --full-response` - Client will return full response object rather than just the body.
+* `--full-response` - Client will return full response object rather than just the body.
+* `--full-request` - Client will be called with all parameters wrapped in `body`, `headers` and `query` properties.
+* `--full` - Enables both `--full-request` and `--full-response` overriding them.
+
 
 
 ### composer

--- a/packages/client-cli/help/help.txt
+++ b/packages/client-cli/help/help.txt
@@ -57,4 +57,7 @@ Options:
 * `-n, --name <name>` - Name of the client.
 * `-f, --folder <name>` - Name of the plugin folder, defaults to --name value.
 * `-t, --typescript` - Generate the client plugin in TypeScript.
-* `-r, --full-response` - Client will return full response object rather than just the body.
+* `--full-response` - Client will return full response object rather than just the body.
+* `--full-request` - Client will be called with all parameters wrapped in `body`, `headers` and `query` properties.
+* `--full` - Enables both `--full-request` and `--full-response` overriding them.
+

--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -220,7 +220,6 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest }) 
 }
 
 function writeProperties (writer, blockName, parameters, addedProps) {
-  console.log('writing properties', parameters)
   if (parameters.length > 0) {
     writer.write(`${blockName}: `).block(() => {
       for (const parameter of parameters) {

--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -119,7 +119,6 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
             const bodyParams = []
             const queryParams = []
             const headersParams = []
-            const pathParams = []
             for (const parameter of parameters) {
               switch (parameter.in) {
                 case 'query':
@@ -127,9 +126,6 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
                   break
                 case 'body':
                   bodyParams.push(parameter)
-                  break
-                case 'path':
-                  pathParams.push(parameter)
                   break
                 case 'header':
                   headersParams.push(parameter)
@@ -139,7 +135,6 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
             writeProperties(interfaces, 'body', bodyParams, addedProps)
             writeProperties(interfaces, 'query', queryParams, addedProps)
             writeProperties(interfaces, 'headers', headersParams, addedProps)
-            writeProperties(interfaces, 'path', pathParams, addedProps)
           } else {
             for (const parameter of parameters) {
               const { name, required } = parameter
@@ -224,6 +219,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
 }
 
 function writeProperties (writer, blockName, parameters, addedProps) {
+  console.log(`writing properties`, parameters)
   if (parameters.length > 0) {
     writer.write(`${blockName}: `).block(() => {
       for (const parameter of parameters) {

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -331,7 +331,7 @@ module.exports = async function (app) {
 test('openapi client generation (javascript) from file', async ({ teardown, comment, same }) => {
   const openapi = desm.join(import.meta.url, 'fixtures', 'movies', 'openapi.json')
 
-  const dir = await moveToTmpdir(() => {})
+  const dir = await moveToTmpdir(teardown)
   comment(`working in ${dir}`)
 
   const pltServiceConfig = {

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -331,7 +331,7 @@ module.exports = async function (app) {
 test('openapi client generation (javascript) from file', async ({ teardown, comment, same }) => {
   const openapi = desm.join(import.meta.url, 'fixtures', 'movies', 'openapi.json')
 
-  const dir = await moveToTmpdir(teardown)
+  const dir = await moveToTmpdir(() => {})
   comment(`working in ${dir}`)
 
   const pltServiceConfig = {

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -7,7 +7,7 @@ import * as desm from 'desm'
 import { execa } from 'execa'
 import { promises as fs } from 'fs'
 
-test('generates only types in target folder with --only-types flag', async ({ teardown, comment, same, match }) => {
+test('generates only types in target folder with --types-only flag', async ({ teardown, comment, same, match }) => {
   const dir = await moveToTmpdir(teardown)
   comment(`working in ${dir}`)
   await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), desm.join(import.meta.url, 'fixtures', 'movies', 'openapi.json'), '--name', 'movies', '-f', dir, '--types-only'])

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -849,3 +849,69 @@ export interface GetMoviesRequest {
   }
 }`)
 })
+
+test('openapi client generation (javascript) from file with fullRequest and fullResponse', async ({ teardown, comment, match }) => {
+  const openapi = desm.join(import.meta.url, 'fixtures', 'full-req-res', 'openapi.json')
+  teardown = () => {}
+  const dir = await moveToTmpdir((teardown))
+  comment(`working in ${dir}`)
+
+  const pltServiceConfig = {
+    $schema: 'https://platformatic.dev/schemas/v0.28.0/service',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: ['./plugin.js']
+    }
+  }
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+  
+  const fullOptions = [
+    ['--full-request', '--full-response'],
+    ['--full']
+  ]
+  for (const opt of fullOptions) {
+    await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapi, '--name', 'full', ...opt])
+
+    // check the type file has the correct implementation for the request and the response
+    const typeFile = join(dir, 'full', 'full.d.ts')
+    const data = await readFile(typeFile, 'utf-8')
+    match(data, `
+export interface PostHelloRequest {
+  body: {
+    'bodyId': string;
+  }
+  query: {
+    'queryId': string;
+  }
+  headers: {
+    'headerId': string;
+  }
+}
+`)
+    match(data, `
+export interface Full {
+  postHello(req?: PostHelloRequest): Promise<FullResponse<PostHelloResponseOK>>;
+}`)
+    const implementationFile = join(dir, 'full', 'full.cjs')
+    const implementationData = await readFile(implementationFile, 'utf-8')
+    // check the implementation instantiate the client with fullRequest and fullResponse
+    match(implementationData, `
+async function generateFullClientPlugin (app, opts) {
+  app.register(pltClient, {
+    type: 'openapi',
+    name: 'full',
+    path: join(__dirname, 'full.openapi.json'),
+    url: opts.url,
+    serviceId: opts.serviceId,
+    throwOnError: opts.throwOnError,
+    fullResponse: true,
+    fullRequest: true
+  })
+}`)
+  }
+  
+})

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -799,7 +799,7 @@ app.listen({ port: 0 })
 })
 
 test('openapi client generation from YAML file', async ({ teardown, comment, same }) => {
-  const dir = await moveToTmpdir(() => {})
+  const dir = await moveToTmpdir(teardown)
   const openapiFile = desm.join(import.meta.url, 'fixtures', 'openapi.yaml')
   comment(`working in ${dir}`)
   await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapiFile, '--name', 'movies'])
@@ -825,4 +825,27 @@ export interface GetMoviesResponseOK {
   'data': { foo: string; bar?: string; baz?: { nested1?: string; nested2: string } };
 }
 `)
+})
+
+test('request with same parameter name in body/path/header/query', async ({ teardown, comment, match }) => {
+  const dir = await moveToTmpdir(teardown)
+  const openapiFile = desm.join(import.meta.url, 'fixtures', 'same-parameter-name-openapi.json')
+  comment(`working in ${dir}`)
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapiFile, '--name', 'movies'])
+
+  // check the type file has the correct implementation for the request
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
+  const data = await readFile(typeFile, 'utf-8')
+  match(data, `
+export interface GetMoviesRequest {
+  body: {
+    'id': string;
+  }
+  query: {
+    'id': string;
+  }
+  headers: {
+    'id': string;
+  }
+}`)
 })

--- a/packages/client-cli/test/fixtures/full-req-res/openapi.json
+++ b/packages/client-cli/test/fixtures/full-req-res/openapi.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "post": {
+        "parameters": [
+          {
+            "name": "headerId",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "bodyId",
+            "in": "body",
+            "type": "string"
+          },
+          {
+            "name": "queryId",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "operationId": "postHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/fixtures/full-req-res/package.json
+++ b/packages/client-cli/test/fixtures/full-req-res/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": "^18.8.0"
+  }
+}

--- a/packages/client-cli/test/fixtures/full-req-res/platformatic.service.json
+++ b/packages/client-cli/test/fixtures/full-req-res/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.38.1/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client-cli/test/fixtures/full-req-res/plugins/example.js
+++ b/packages/client-cli/test/fixtures/full-req-res/plugins/example.js
@@ -1,0 +1,12 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify, opts) {
+  fastify.post('/hello', async (req, res) => {
+    return {
+      headers: req.headers,
+      body: req.body,
+      query: req.query
+    }
+  })
+}

--- a/packages/client-cli/test/fixtures/same-parameter-name-openapi.json
+++ b/packages/client-cli/test/fixtures/same-parameter-name-openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/movies": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "id",
+            "in": "body",
+            "type": "string"
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "operationId": "getMovies",
+        "responses": {
+          "200": {
+            "description": "Default 302 Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Foo bar response",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -59,6 +59,7 @@ type OpenTelemetry = {
 export function generateOperationId(path: string, method: string, methodMeta: MethodMetaInterface, all: string[]): string
 export function buildOpenAPIClient<T>(options: BuildOpenAPIClientOptions, openTelemetry: OpenTelemetry): Promise<T>
 export function buildGraphQLClient(options: BuildGraphQLClientOptions, openTelemetry: OpenTelemetry, logger: AbstractLogger): Promise<BuildGraphQLClientOutput>
+export function hasDuplicatedParameters(methodMeta: MethodMetaInterface): boolean
 
 export const plugin: FastifyPluginAsync<PlatformaticClientPluginOptions>
 export default plugin

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -322,3 +322,4 @@ module.exports.default = plugin
 module.exports.buildOpenAPIClient = buildOpenAPIClient
 module.exports.buildGraphQLClient = buildGraphQLClient
 module.exports.generateOperationId = generateOperationId
+module.exports.hasDuplicatedParameters = hasDuplicatedParameters

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -117,7 +117,11 @@ function buildCallFunction (baseUrl, path, method, methodMeta, throwOnError, ope
       headers = args.headers
       body = args.body
       for (const param of queryParams) {
-        query.append(param.name, args.query[param.name])
+        if (param.type === 'array') {
+          args.query[param.name].forEach((p) => query.append(param.name, p))
+        } else {
+          query.append(param.name, args.query[param.name])
+        }
       }
     } else {
       body = { ...args } // shallow copy
@@ -131,7 +135,11 @@ function buildCallFunction (baseUrl, path, method, methodMeta, throwOnError, ope
 
       for (const param of queryParams) {
         if (body[param.name] !== undefined) {
-          query.set(param.name, body[param.name])
+          if (param.type === 'array') {
+            body[param.name].forEach((p) => query.append(param.name, p))
+          } else {
+            query.append(param.name, body[param.name])
+          }
           body[param.name] = undefined
         }
       }
@@ -143,7 +151,6 @@ function buildCallFunction (baseUrl, path, method, methodMeta, throwOnError, ope
         }
       }
     }
-
     urlToCall.search = query.toString()
     urlToCall.pathname = pathToCall
 
@@ -196,6 +203,9 @@ function capitalize (str) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
+// function handleQueryParameters(urlSearchParamObject, parameter) {
+
+// }
 // TODO: For some unknown reason c8 is not picking up the coverage for this function
 async function graphql (url, log, headers, query, variables, openTelemetry, telemetryContext) {
   const { span, telemetryHeaders } = openTelemetry?.startSpanClient(url.toString(), 'POST', telemetryContext) || { span: null, telemetryHeaders: {} }

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -83,6 +83,7 @@ function computeURLWithoutPath (url) {
   return url.toString()
 }
 function hasDuplicatedParameters (methodMeta) {
+  if (!methodMeta.parameters) return false
   if (methodMeta.parameters.length === 0) {
     return false
   }

--- a/packages/client/test/fixtures/array-query-params/openapi.json
+++ b/packages/client/test/fixtures/array-query-params/openapi.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/query": {
+      "get": {
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "type": "array",
+            "items": "string"
+
+          }
+        ],
+        "operationId": "getQuery",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string" },
+                    "query": { "type": "object" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client/test/fixtures/array-query-params/package.json
+++ b/packages/client/test/fixtures/array-query-params/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": "^18.8.0"
+  }
+}

--- a/packages/client/test/fixtures/array-query-params/platformatic.service.json
+++ b/packages/client/test/fixtures/array-query-params/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.38.1/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client/test/fixtures/array-query-params/plugins/example.js
+++ b/packages/client/test/fixtures/array-query-params/plugins/example.js
@@ -1,0 +1,12 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify, opts) {
+  fastify.get('/query', async (req, res) => {
+    console.log(req.query.ids)
+    return {
+      isArray: Array.isArray(req.query.ids),
+      ids: req.query.ids
+    }
+  })
+}

--- a/packages/client/test/fixtures/duped-params/openapi.json
+++ b/packages/client/test/fixtures/duped-params/openapi.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "post": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "id",
+            "in": "body",
+            "type": "string"
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "operationId": "postHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client/test/fixtures/duped-params/package.json
+++ b/packages/client/test/fixtures/duped-params/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": "^18.8.0"
+  }
+}

--- a/packages/client/test/fixtures/duped-params/platformatic.service.json
+++ b/packages/client/test/fixtures/duped-params/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.38.1/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client/test/fixtures/duped-params/plugins/example.js
+++ b/packages/client/test/fixtures/duped-params/plugins/example.js
@@ -1,0 +1,12 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify, opts) {
+  fastify.post('/hello', async (req, res) => {
+    return {
+      headers: req.headers,
+      body: req.body,
+      query: req.query
+    }
+  })
+}

--- a/packages/client/test/fixtures/no-params/openapi.json
+++ b/packages/client/test/fixtures/no-params/openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "post": {
+        "operationId": "postHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "getHello",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client/test/fixtures/no-params/package.json
+++ b/packages/client/test/fixtures/no-params/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": "^18.8.0"
+  }
+}

--- a/packages/client/test/fixtures/no-params/platformatic.service.json
+++ b/packages/client/test/fixtures/no-params/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.38.1/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client/test/fixtures/no-params/plugins/example.js
+++ b/packages/client/test/fixtures/no-params/plugins/example.js
@@ -1,0 +1,18 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify, opts) {
+  fastify.post('/hello', async (req, res) => {
+    return {
+      headers: req.headers,
+      body: req.body,
+      query: req.query
+    }
+  })
+
+  fastify.get('/hello', async (req, res) => {
+    return {
+      message: 'GET /hello works'
+    }
+  })
+}


### PR DESCRIPTION
Example:
```typescript
export interface GetRequest {
  body: {
    'id': string;
  }
  query: {
    'id': string;
  }
  headers: {
    'id': string;
  }
}
```
Draft because I'm pretty sure some cases are not covered

cc @rozzilla 

Fixes: #1435 