### PR TITLE
fix: better error when querying an unknown field

### DIFF
--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -223,6 +223,9 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKeys, relation
       }
       const value = where[key]
       const field = inputToFieldMap[key]
+      if (!field) {
+        throw new Error(`Unknown field ${key}`)
+      }
       for (const key of Object.keys(value)) {
         const operator = whereMap[key]
         /* istanbul ignore next */
@@ -231,11 +234,6 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKeys, relation
           throw new Error(`Unsupported where clause ${JSON.stringify(where[key])}`)
         }
         const fieldWrap = fields[field]
-        
-        if (!fieldWrap) {
-          throw new Error(`Unknown field ${field}`)
-        }
-
         /* istanbul ignore next */
         if (fieldWrap.isArray) {
           if (operator === 'ANY') {

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -231,6 +231,10 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKeys, relation
           throw new Error(`Unsupported where clause ${JSON.stringify(where[key])}`)
         }
         const fieldWrap = fields[field]
+        
+        if(!fieldWrap) {
+          throw new Error(`Unknown field ${field}`)
+        }
 
         /* istanbul ignore next */
         if (fieldWrap.isArray) {

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -232,7 +232,7 @@ function createMapper (defaultDb, sql, log, table, fields, primaryKeys, relation
         }
         const fieldWrap = fields[field]
         
-        if(!fieldWrap) {
+        if (!fieldWrap) {
           throw new Error(`Unknown field ${field}`)
         }
 

--- a/packages/sql-mapper/test/updateMany.test.js
+++ b/packages/sql-mapper/test/updateMany.test.js
@@ -4,6 +4,7 @@ const { test } = require('tap')
 const { connect } = require('..')
 const { clear, connInfo, isSQLite, isMysql } = require('./helper')
 const { setTimeout } = require('timers/promises')
+
 const fakeLogger = {
   trace: () => {},
   error: () => {}

--- a/packages/sql-mapper/test/where.test.js
+++ b/packages/sql-mapper/test/where.test.js
@@ -8,7 +8,7 @@ const fakeLogger = {
   error: () => {}
 }
 
-test('list', async ({ pass, teardown, same, equal }) => {
+test('list', async ({ pass, teardown, same, rejects }) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,
@@ -59,6 +59,8 @@ test('list', async ({ pass, teardown, same, equal }) => {
   await entity.insert({
     inputs: posts
   })
+
+  rejects(entity.find.bind(entity, { where: { invalidField: { eq: 'Dog' } } }), 'Unknown field invalidField')
 
   same(await entity.find({ where: { title: { eq: 'Dog' } }, fields: ['id', 'title', 'longText'] }), [{
     id: '1',

--- a/packages/sql-mapper/test/where.test.js
+++ b/packages/sql-mapper/test/where.test.js
@@ -3,6 +3,7 @@
 const { test } = require('tap')
 const { connect } = require('..')
 const { clear, connInfo, isMysql, isSQLite } = require('./helper')
+
 const fakeLogger = {
   trace: () => {},
   error: () => {}


### PR DESCRIPTION
### Context

When querying for an unknown field inside the mapper an error like this get thrown: `TypeError: Cannot read properties of undefined (reading 'isArray')`

### Proposal

Check the existance of the field before computing criteria.