### PR TITLE
fix(client): Properly pass array `querystring`

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -265,9 +265,6 @@ function isArrayQueryParam ({ schema }) {
   return schema?.type === 'array' || schema?.anyOf?.some(({ type }) => type === 'array')
 }
 
-// function handleQueryParameters(urlSearchParamObject, parameter) {
-
-// }
 // TODO: For some unknown reason c8 is not picking up the coverage for this function
 async function graphql (url, log, headers, query, variables, openTelemetry, telemetryContext) {
   const { span, telemetryHeaders } = openTelemetry?.startSpanClient(url.toString(), 'POST', telemetryContext) || { span: null, telemetryHeaders: {} }

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -262,7 +262,7 @@ function capitalize (str) {
 }
 
 function isArrayQueryParam ({ schema }) {
-  return (schema?.type === 'array') || schema?.anyOf?.some(({ type }) => type === 'array')
+  return schema?.type === 'array' || schema?.anyOf?.some(({ type }) => type === 'array')
 }
 
 // function handleQueryParameters(urlSearchParamObject, parameter) {

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -124,7 +124,7 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
       headers = args.headers
       body = args.body
       for (const param of queryParams) {
-        if (param.type === 'array') {
+        if (isArrayQueryParam(param)) {
           args.query[param.name].forEach((p) => query.append(param.name, p))
         } else {
           query.append(param.name, args.query[param.name])
@@ -142,7 +142,7 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
 
       for (const param of queryParams) {
         if (body[param.name] !== undefined) {
-          if (param.type === 'array') {
+          if (isArrayQueryParam(param)) {
             body[param.name].forEach((p) => query.append(param.name, p))
           } else {
             query.append(param.name, body[param.name])
@@ -259,6 +259,10 @@ function getValidateFunction (schema, ajvInstance) {
 }
 function capitalize (str) {
   return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+function isArrayQueryParam ({ schema }) {
+  return (schema?.type === 'array') || schema?.anyOf?.some(({ type }) => type === 'array')
 }
 
 // function handleQueryParameters(urlSearchParamObject, parameter) {

--- a/packages/client/test/fixtures/array-query-params/openapi.json
+++ b/packages/client/test/fixtures/array-query-params/openapi.json
@@ -41,7 +41,7 @@
         "operationId": "getQuery",
         "responses": {
           "200": {
-            "description": "Fantozzi",
+            "description": "This field is required",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/client/test/fixtures/array-query-params/openapi.json
+++ b/packages/client/test/fixtures/array-query-params/openapi.json
@@ -10,16 +10,38 @@
       "get": {
         "parameters": [
           {
-            "name": "ids",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "in": "query",
-            "type": "array",
-            "items": "string"
-
+            "name": "ids"
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                }
+              ]
+            },
+            "in": "query",
+            "name": "stringArrayUnion"
           }
         ],
         "operationId": "getQuery",
         "responses": {
           "200": {
+            "description": "Fantozzi",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/client/test/fixtures/array-query-params/plugins/example.js
+++ b/packages/client/test/fixtures/array-query-params/plugins/example.js
@@ -5,7 +5,8 @@ module.exports = async function (fastify, opts) {
   fastify.get('/query', async (req, res) => {
     return {
       isArray: Array.isArray(req.query.ids),
-      ids: req.query.ids
+      ids: req.query.ids,
+      stringArrayUnion: req.query.stringArrayUnion
     }
   })
 }

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -653,11 +653,13 @@ test('build basic client from file (query array parameter)', async ({ teardown, 
 
     const result = await client.getQuery({
       query: {
-        ids: ['id1', 'id2']
+        ids: ['id1', 'id2'],
+        stringArrayUnion: ['foo', 'bar', 'baz']
       }
     })
     same(result.isArray, true)
     match(result.ids, ['id1', 'id2'])
+    match(result.stringArrayUnion, ['foo', 'bar', 'baz'])
   }
   {
     // without fullRequest
@@ -668,10 +670,12 @@ test('build basic client from file (query array parameter)', async ({ teardown, 
     })
 
     const result = await client.getQuery({
-      ids: ['id1', 'id2']
+      ids: ['id1', 'id2'],
+      stringArrayUnion: ['foo', 'bar', 'baz']
     })
     same(result.isArray, true)
     match(result.ids, ['id1', 'id2'])
+    match(result.stringArrayUnion, ['foo', 'bar', 'baz'])
   }
 })
 


### PR DESCRIPTION
The goal of this PR is to fix the way we pass an array `querystring`:
* fix [this](https://github.com/platformatic/platformatic/blob/main/packages/client/test/fixtures/array-query-params/openapi.json) OpenAPI definition, since it was invalid
* fix [this](https://github.com/platformatic/platformatic/blob/main/packages/client/index.js#L127) code and check `param.schema.type` instead of `param.type`
* consider the case when a `querystring` is defined as a union of `string | string[]` (since for most of the query parser, passing 1 element is considered as a `string`, while multiple ones as `string[]`