### PR TITLE
fix(client-cli): Generate path types on full-request

### DIFF
--- a/packages/client-cli/lib/gen-openapi.mjs
+++ b/packages/client-cli/lib/gen-openapi.mjs
@@ -123,12 +123,16 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
           if (parameters) {
             if (forceFullRequest) {
               const bodyParams = []
+              const pathParams = []
               const queryParams = []
               const headersParams = []
               for (const parameter of parameters) {
                 switch (parameter.in) {
                   case 'query':
                     queryParams.push(parameter)
+                    break
+                  case 'path':
+                    pathParams.push(parameter)
                     break
                   case 'body':
                     bodyParams.push(parameter)
@@ -139,6 +143,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
                 }
               }
               writeProperties(interfaces, 'body', bodyParams, addedProps)
+              writeProperties(interfaces, 'path', pathParams, addedProps)
               writeProperties(interfaces, 'query', queryParams, addedProps)
               writeProperties(interfaces, 'headers', headersParams, addedProps)
             } else {

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -841,6 +841,9 @@ test('request with same parameter name in body/path/header/query', async ({ tear
     body: {
       'id': string;
     }
+    path: {
+      'id': string;
+    }
     query: {
       'id': string;
     }

--- a/packages/client-cli/test/fixtures/same-parameter-name-openapi.json
+++ b/packages/client-cli/test/fixtures/same-parameter-name-openapi.json
@@ -24,6 +24,12 @@
             "in": "query",
             "type": "string"
           }
+          ,
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string"
+          }
         ],
         "operationId": "getMovies",
         "responses": {


### PR DESCRIPTION
As by title, `path` is currently not generated on types when `--full` option is specified.