### PR TITLE
fix(client): Add validateResponse param

### DIFF
--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -9,8 +9,9 @@ export type PlatformaticClientPluginOptions = {
   path?: string;
   headers?: Headers;
   throwOnError: boolean;
-  fullRequest: boolean;
-  fullResponse: boolean;
+  fullRequest?: boolean;
+  fullResponse?: boolean;
+  validateResponse?: boolean;
   type: 'openapi' | 'graphql';
   name?: string;
   serviceId?: string;

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -9,8 +9,8 @@ export type PlatformaticClientPluginOptions = {
   path?: string;
   headers?: Headers;
   throwOnError: boolean;
-  fullRequest?: boolean;
-  fullResponse?: boolean;
+  fullRequest: boolean;
+  fullResponse: boolean;
   validateResponse?: boolean;
   type: 'openapi' | 'graphql';
   name?: string;

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -7,23 +7,17 @@ const server = await fastify()
 expectError<PlatformaticClientPluginOptions>({})
 
 expectError<PlatformaticClientPluginOptions>({
-  fullRequest: true,
-  fullResponse: true,
   throwOnError: true,
   url: 'localhost'
 })
 
 expectError<PlatformaticClientPluginOptions>({
-  fullRequest: true,
-  fullResponse: true,
   throwOnError: true,
   type: 'WRONG',
   url: 'localhost'
 })
 
 server.register(pltClient, {
-  fullRequest: true,
-  fullResponse: true,
   throwOnError: true,
   type: 'graphql',
   url: 'localhost'
@@ -32,6 +26,7 @@ server.register(pltClient, {
 server.register(pltClient, {
   fullRequest: false,
   fullResponse: false,
+  validateResponse: false,
   throwOnError: false,
   type: 'openapi',
   url: 'http://127.0.0.1/path/42',

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -7,17 +7,23 @@ const server = await fastify()
 expectError<PlatformaticClientPluginOptions>({})
 
 expectError<PlatformaticClientPluginOptions>({
+  fullRequest: true,
+  fullResponse: true,
   throwOnError: true,
   url: 'localhost'
 })
 
 expectError<PlatformaticClientPluginOptions>({
+  fullRequest: true,
+  fullResponse: true,
   throwOnError: true,
   type: 'WRONG',
   url: 'localhost'
 })
 
 server.register(pltClient, {
+  fullRequest: true,
+  fullResponse: true,
   throwOnError: true,
   type: 'graphql',
   url: 'localhost'


### PR DESCRIPTION
As by title, this PR adds the `validateResponse` to the type definition of the client.