### PR TITLE
Always call .ready() before calling .swagger()

### DIFF
--- a/packages/runtime/lib/api.js
+++ b/packages/runtime/lib/api.js
@@ -197,6 +197,7 @@ class RuntimeApi {
     }
 
     try {
+      await service.server.ready()
       const openapiSchema = service.server.swagger()
       return openapiSchema
     } catch (err) {


### PR DESCRIPTION
Ref https://github.com/fastify/fastify-swagger/pull/757