### PR TITLE
feat(docker): secure `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,6 @@ RUN pnpm install --prod --offline --node-linker=hoisted
 # Add platformatic to path
 RUN cd packages/cli && pnpm link --global
 
-# Move to the app directory
-WORKDIR $APP_HOME
-
-# Reduce our permissions from root to a normal user
-RUN chown node:node . 
-USER node
-
 # No pnpm/build tools install here, we just copy the files from the previous stage
 FROM node:18-alpine 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN pnpm install --prod --offline --node-linker=hoisted
 RUN cd packages/cli && pnpm link --global
 
 # No pnpm/build tools install here, we just copy the files from the previous stage
-FROM node:18-alpine 
+FROM node:18-alpine
 
 # We don't need the build tools anymore
 RUN apk update && apk add --no-cache dumb-init
@@ -46,8 +46,8 @@ ENV PLT_HOME=$HOME/platformatic/
 
 COPY --from=base $PLT_HOME $PLT_HOME
 
-# Add platformatic to path 
-RUN cd $PLT_HOME/packages/cli && npm link 
+# Add platformatic to path
+RUN cd $PLT_HOME/packages/cli && npm link
 
 # Move to the app directory
 WORKDIR $APP_HOME
@@ -58,5 +58,3 @@ USER node
 
 ENTRYPOINT ["dumb-init"]
 CMD ["platformatic"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN cd $PLT_HOME/packages/cli && npm link
 WORKDIR $APP_HOME
 
 # Reduce our permissions from root to a normal user
-RUN chown node:node . 
+RUN chown node:node .
 USER node
 
 ENTRYPOINT ["dumb-init"]


### PR DESCRIPTION
This PR tries to make the `Dockerfile` _slightly_ more secure by preventing the running user from changing sources (by not `chown`ing files `node:node` in the first place.