### PR TITLE
fix: create-platformatic ask dir input

### DIFF
--- a/packages/create-platformatic/src/ask-dir.mjs
+++ b/packages/create-platformatic/src/ask-dir.mjs
@@ -1,4 +1,3 @@
-import { validatePath } from './utils.mjs'
 import inquirer from 'inquirer'
 import { resolve } from 'path'
 
@@ -7,8 +6,7 @@ const askProjectDir = async (logger, defaultName, message = 'Where would you lik
     type: 'input',
     name: 'dir',
     message,
-    default: defaultName,
-    validate: validatePath
+    default: defaultName
   })
 
   const projectDir = resolve(process.cwd(), options.dir)

--- a/packages/create-platformatic/src/db/create-db.mjs
+++ b/packages/create-platformatic/src/db/create-db.mjs
@@ -351,7 +351,7 @@ export async function createDB ({ hostname, database = 'sqlite', port, migration
   if (createMigrations) {
     const isMigrationFolderExists = await isFileAccessible(migrationsFolderName, currentDir)
     if (!isMigrationFolderExists) {
-      await mkdir(join(currentDir, migrationsFolderName))
+      await mkdir(join(currentDir, migrationsFolderName), { recursive: true })
       logger.info(`Migrations folder ${migrationsFolderName} successfully created.`)
     } else {
       logger.info(`Migrations folder ${migrationsFolderName} found, skipping creation of migrations folder.`)

--- a/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
+++ b/packages/create-platformatic/src/runtime/create-runtime-cli.mjs
@@ -50,7 +50,7 @@ export async function createPlatformaticRuntime (_args) {
   // Create the project directory
   await mkdir(projectDir, { recursive: true })
 
-  const baseServicesDir = join(relative(process.cwd(), projectDir), 'library-app/services')
+  const baseServicesDir = join(relative(process.cwd(), projectDir), 'services')
   const servicesDir = await askDir(logger, baseServicesDir, 'Where would you like to load your services from?')
 
   const { runPackageManagerInstall } = await inquirer.prompt([

--- a/packages/create-platformatic/src/utils.mjs
+++ b/packages/create-platformatic/src/utils.mjs
@@ -61,19 +61,6 @@ export async function isDirectoryWriteable (directory) {
   }
 }
 
-export const validatePath = async projectPath => {
-  // if the folder exists, is OK:
-  const projectDir = resolve(projectPath)
-  const canAccess = await isDirectoryWriteable(projectDir)
-  if (canAccess) {
-    return true
-  }
-  // if the folder does not exist, check if the parent folder exists:
-  const parentDir = dirname(projectDir)
-  const canAccessParent = await isDirectoryWriteable(parentDir)
-  return canAccessParent
-}
-
 export const findDBConfigFile = async (directory) => (ConfigManager.findConfigFile(directory, 'db'))
 export const findServiceConfigFile = async (directory) => (ConfigManager.findConfigFile(directory, 'service'))
 export const findComposerConfigFile = async (directory) => (ConfigManager.findConfigFile(directory, 'composer'))

--- a/packages/create-platformatic/test/runtime/create-runtime.test.mjs
+++ b/packages/create-platformatic/test/runtime/create-runtime.test.mjs
@@ -23,7 +23,7 @@ const fakeLogger = {
 }
 
 test('creates runtime', async ({ equal, same, ok }) => {
-  await createRuntime(fakeLogger, tmpDir, undefined, 'library-app/services', 'foobar')
+  await createRuntime(fakeLogger, tmpDir, undefined, 'services', 'foobar')
 
   const pathToRuntimeConfigFile = join(tmpDir, 'platformatic.runtime.json')
   const runtimeConfigFile = readFileSync(pathToRuntimeConfigFile, 'utf8')
@@ -36,7 +36,7 @@ test('creates runtime', async ({ equal, same, ok }) => {
     allowCycles: false,
     hotReload: true,
     autoload: {
-      path: 'library-app/services',
+      path: 'services',
       exclude: ['docs']
     }
   })

--- a/packages/create-platformatic/test/utils.test.mjs
+++ b/packages/create-platformatic/test/utils.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'tap'
-import { randomBetween, sleep, validatePath, getDependencyVersion, findDBConfigFile, findServiceConfigFile, isFileAccessible, isCurrentVersionSupported, minimumSupportedNodeVersions, findRuntimeConfigFile, findComposerConfigFile } from '../src/utils.mjs'
+import { randomBetween, sleep, getDependencyVersion, findDBConfigFile, findServiceConfigFile, isFileAccessible, isCurrentVersionSupported, minimumSupportedNodeVersions, findRuntimeConfigFile, findComposerConfigFile } from '../src/utils.mjs'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir, platform } from 'os'
+import { tmpdir } from 'os'
 import { join } from 'path'
 import esmock from 'esmock'
 import semver from 'semver'
@@ -106,32 +106,6 @@ test('sleep', async ({ equal }) => {
   await sleep(100)
   const end = Date.now()
   equal(end - start >= 100, true)
-})
-
-test('validatePath', async ({ end, equal, rejects, ok }) => {
-  {
-    // new folder
-    const valid = await validatePath('new-project')
-    ok(valid)
-  }
-
-  {
-    // existing folder
-    const valid = await validatePath('test')
-    ok(valid)
-  }
-
-  {
-    // current folder
-    const valid = await validatePath('.')
-    ok(valid)
-  }
-
-  if (platform().indexOf('win') < 0) {
-    // not writeable folder
-    const valid = await validatePath('/')
-    ok(!valid)
-  }
 })
 
 test('getDependencyVersion', async ({ equal }) => {


### PR DESCRIPTION
This PR does two things:
- Changes the default dir for runtime services from `library-app/services` to `services`.
- Drops the input dir validation. 


Problems with current dir validation are:
- It doesn't allow to generate the nested folders.
- Inquirer doesn't show a user the error. Instead of it just doesn't accept an input which is confusing for a user.