### PR TITLE
Make server config not required in runtime

### DIFF
--- a/packages/create-platformatic/src/composer/create-composer-cli.mjs
+++ b/packages/create-platformatic/src/composer/create-composer-cli.mjs
@@ -91,7 +91,8 @@ const createPlatformaticComposer = async (_args, opts) => {
 
   const params = {
     hostname: args.hostname,
-    port
+    port,
+    isRuntime: opts.isRuntime
   }
 
   const env = await createComposer(

--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -158,7 +158,8 @@ const createPlatformaticDB = async (_args, opts) => {
     migrations: wizardOptions.defaultMigrations ? args.migrations : '',
     plugin: generatePlugin,
     types: useTypes,
-    typescript: useTypescript
+    typescript: useTypescript,
+    isRuntime: opts.isRuntime
   }
 
   const env = await createDB(params, logger, projectDir, version)

--- a/packages/create-platformatic/src/db/create-db.mjs
+++ b/packages/create-platformatic/src/db/create-db.mjs
@@ -324,28 +324,23 @@ export function getConnectionString (database) {
   return connectionStrings[database]
 }
 
-export async function createDB ({ hostname, database = 'sqlite', port, migrations = 'migrations', plugin = true, types = true, typescript = false, connectionString, isRuntime = false }, logger, currentDir, version) {
+export async function createDB ({ hostname, database = 'sqlite', port, migrations = 'migrations', plugin = true, types = true, typescript = false, connectionString }, logger, currentDir, version) {
   connectionString = connectionString || getConnectionString(database)
   const createMigrations = !!migrations // If we don't define a migrations folder, we don't create it
   const accessibleConfigFilename = await findDBConfigFile(currentDir)
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(migrations, plugin, types, typescript, version)
-    if (isRuntime) {
-      delete config.server
-    }
     await writeFile(join(currentDir, 'platformatic.db.json'), JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.db.json successfully created.')
-    if (!isRuntime) {
-      const env = generateEnv(hostname, port, connectionString, typescript)
-      const envFileExists = await isFileAccessible('.env', currentDir)
-      await appendFile(join(currentDir, '.env'), env)
-      await writeFile(join(currentDir, '.env.sample'), generateEnv(hostname, port, getConnectionString(database), typescript))
-      /* c8 ignore next 5 */
-      if (envFileExists) {
-        logger.info('Environment file .env found, appending new environment variables to existing .env file.')
-      } else {
-        logger.info('Environment file .env successfully created.')
-      }
+    const env = generateEnv(hostname, port, connectionString, typescript)
+    const envFileExists = await isFileAccessible('.env', currentDir)
+    await appendFile(join(currentDir, '.env'), env)
+    await writeFile(join(currentDir, '.env.sample'), generateEnv(hostname, port, getConnectionString(database), typescript))
+    /* c8 ignore next 5 */
+    if (envFileExists) {
+      logger.info('Environment file .env found, appending new environment variables to existing .env file.')
+    } else {
+      logger.info('Environment file .env successfully created.')
     }
   } else {
     logger.info(`Configuration file ${accessibleConfigFilename} found, skipping creation of configuration file.`)

--- a/packages/create-platformatic/src/runtime/create-runtime.mjs
+++ b/packages/create-platformatic/src/runtime/create-runtime.mjs
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'fs/promises'
+import { readFile, readdir, unlink, writeFile } from 'fs/promises'
 import { findRuntimeConfigFile } from '../utils.mjs'
 import { join, relative, isAbsolute } from 'path'
 import * as desm from 'desm'
@@ -34,7 +34,77 @@ async function createRuntime (logger, currentDir = process.cwd(), version, servi
     logger.info(`Configuration file ${accessibleConfigFilename} found, skipping creation of configuration file.`)
   }
 
+  await cleanServicesConfig(logger, servicesDir, entrypoint)
+
+  await manageServicesEnvFiles(servicesDir, currentDir, entrypoint)
   return {}
+}
+/**
+ *
+ * @param {string} servicesDir the services dir
+ * @param {string | null} entrypoint the entrypoint. If specified the function will filter it out
+ * @returns {Promise}
+ */
+async function getAllServices (servicesDir, entrypoint = null) {
+  const services = (await readdir(servicesDir))
+  if (entrypoint) {
+    return services.filter(dir => dir !== entrypoint)
+  }
+  return services
+}
+async function cleanServicesConfig (logger, servicesDir, entrypoint) {
+  const services = await getAllServices(servicesDir, entrypoint)
+  for (const svc of services) {
+    const serviceDir = join(servicesDir, svc)
+    const configFile = await findConfigFile(serviceDir)
+    if (!configFile) {
+      logger.warn(`Cannot find config file in ${serviceDir}`)
+    } else {
+      console.log(`Found config file ${configFile}`)
+      const configFilePath = join(serviceDir, configFile)
+      const config = JSON.parse(await readFile(configFilePath, 'utf8'))
+      delete config.server
+      await writeFile(configFilePath, JSON.stringify(config, null, 2))
+    }
+  }
+}
+
+async function manageServicesEnvFiles (servicesDir, runtimeDir, entrypoint) {
+  // read main env file
+
+  // let mainEnvFile = await readFile(join(runtimeDir, '.env'), 'utf8')
+  let mainEnvFile = ''
+  const services = await getAllServices(servicesDir)
+  for (const svc of services) {
+    const envFile = await readFile(join(servicesDir, svc, '.env'), 'utf8')
+    if (svc === entrypoint) {
+      // copy the whole file
+      mainEnvFile += `\n${envFile}`
+    } else {
+      // read .env file
+      const lines = envFile.split('\n')
+      lines.forEach((line) => {
+        // copy to main env file only if line _doesn't_ match
+        // i.e any other config or comments
+        if (!line.match(/(PLT_LOGGER_LEVEL|PORT|PLT_SERVER_HOSTNAME)=/)) {
+          mainEnvFile += `\n${line}`
+        }
+      })
+    }
+    try {
+      await unlink(join(servicesDir, svc, '.env.sample'))
+    } catch (err) {
+      // do nothing
+    }
+  }
+  await writeFile(join(runtimeDir, '.env'), mainEnvFile)
+}
+
+async function findConfigFile (dir) {
+  const allFiles = await readdir(dir)
+  return allFiles.find((file) => {
+    return file.match(/platformatic\.(.*)\.json/)
+  })
 }
 
 export default createRuntime

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -70,7 +70,8 @@ const createPlatformaticService = async (_args, opts = {}) => {
   const params = {
     hostname: args.hostname,
     port,
-    typescript: useTypescript
+    typescript: useTypescript,
+    isRuntime: opts.isRuntime
   }
 
   const env = await createService(params, logger, projectDir, version)

--- a/packages/create-platformatic/src/service/create-service.mjs
+++ b/packages/create-platformatic/src/service/create-service.mjs
@@ -65,23 +65,18 @@ async function createService ({ hostname, port, typescript = false }, logger, cu
 
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(version, typescript)
-    if (isRuntime) {
-      delete config.server
-    }
     await writeFile(join(currentDir, 'platformatic.service.json'), JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.service.json successfully created.')
 
-    if (!isRuntime) {
-      const env = generateEnv(hostname, port, typescript)
-      const envFileExists = await isFileAccessible('.env', currentDir)
-      await appendFile(join(currentDir, '.env'), env)
-      await writeFile(join(currentDir, '.env.sample'), env)
-      /* c8 ignore next 5 */
-      if (envFileExists) {
-        logger.info('Environment file .env found, appending new environment variables to existing .env file.')
-      } else {
-        logger.info('Environment file .env successfully created.')
-      }
+    const env = generateEnv(hostname, port, typescript)
+    const envFileExists = await isFileAccessible('.env', currentDir)
+    await appendFile(join(currentDir, '.env'), env)
+    await writeFile(join(currentDir, '.env.sample'), env)
+    /* c8 ignore next 5 */
+    if (envFileExists) {
+      logger.info('Environment file .env found, appending new environment variables to existing .env file.')
+    } else {
+      logger.info('Environment file .env successfully created.')
     }
   } else {
     logger.info(`Configuration file ${accessibleConfigFilename} found, skipping creation of configuration file.`)

--- a/packages/create-platformatic/src/service/create-service.mjs
+++ b/packages/create-platformatic/src/service/create-service.mjs
@@ -65,18 +65,23 @@ async function createService ({ hostname, port, typescript = false }, logger, cu
 
   if (accessibleConfigFilename === undefined) {
     const config = generateConfig(version, typescript)
+    if (isRuntime) {
+      delete config.server
+    }
     await writeFile(join(currentDir, 'platformatic.service.json'), JSON.stringify(config, null, 2))
     logger.info('Configuration file platformatic.service.json successfully created.')
 
-    const env = generateEnv(hostname, port, typescript)
-    const envFileExists = await isFileAccessible('.env', currentDir)
-    await appendFile(join(currentDir, '.env'), env)
-    await writeFile(join(currentDir, '.env.sample'), env)
-    /* c8 ignore next 5 */
-    if (envFileExists) {
-      logger.info('Environment file .env found, appending new environment variables to existing .env file.')
-    } else {
-      logger.info('Environment file .env successfully created.')
+    if (!isRuntime) {
+      const env = generateEnv(hostname, port, typescript)
+      const envFileExists = await isFileAccessible('.env', currentDir)
+      await appendFile(join(currentDir, '.env'), env)
+      await writeFile(join(currentDir, '.env.sample'), env)
+      /* c8 ignore next 5 */
+      if (envFileExists) {
+        logger.info('Environment file .env found, appending new environment variables to existing .env file.')
+      } else {
+        logger.info('Environment file .env successfully created.')
+      }
     }
   } else {
     logger.info(`Configuration file ${accessibleConfigFilename} found, skipping creation of configuration file.`)

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -66,7 +66,7 @@ async function platformaticService (app, opts, toLoad = []) {
     await app.register(loadPlugins)
   }
 
-  if (config.server.cors) {
+  if (isKeyEnabled('cors', config.server)) {
     app.register(setupCors, config.server.cors)
   }
 

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -638,7 +638,6 @@ const platformaticServiceSchema = {
     clients
   },
   additionalProperties: false,
-  required: ['server'],
   $defs: openApiDefs
 }
 

--- a/packages/service/lib/start.js
+++ b/packages/service/lib/start.js
@@ -61,7 +61,6 @@ async function buildServer (options, app) {
 
     return root
   }
-  const handler = await restartable(createRestartable)
 
   if (options.server) {
     const { port, hostname, ...serverOptions } = options.server
@@ -70,19 +69,20 @@ async function buildServer (options, app) {
       serverOptions.https.key = await adjustHttpsKeyAndCert(serverOptions.https.key)
       serverOptions.https.cert = await adjustHttpsKeyAndCert(serverOptions.https.cert)
     }
+    const handler = await restartable(createRestartable)
+
+    configManager.on('error', function (err) {
+      /* c8 ignore next 1 */
+      handler.log.error({ err }, 'error reloading the configuration')
+    })
 
     handler.decorate('start', async () => {
       url = await handler.listen({ host: hostname, port })
       return url
     })
+    return handler
   }
-
-  configManager.on('error', function (err) {
-    /* c8 ignore next 1 */
-    handler.log.error({ err }, 'error reloading the configuration')
-  })
-
-  return handler
+  return null
 }
 
 /* c8 ignore next 12 */

--- a/packages/service/lib/start.js
+++ b/packages/service/lib/start.js
@@ -83,6 +83,7 @@ async function buildServer (options, app) {
     /* c8 ignore next 1 */
     handler.log.error({ err }, 'error reloading the configuration')
   })
+
   return handler
 }
 

--- a/packages/service/test/cli/gen-schema.test.mjs
+++ b/packages/service/test/cli/gen-schema.test.mjs
@@ -16,7 +16,7 @@ test('generateJsonSchemaConfig generates the file', async (t) => {
   const configSchema = await fs.readFile('platformatic.service.schema.json', 'utf8')
   const schema = JSON.parse(configSchema)
   const { required } = schema
-  t.has(required, ['server'])
+  t.has(required, undefined, 'There is no required fields in service schema')
   const { $id, type } = schema
   t.equal($id, `https://platformatic.dev/schemas/v${pkg.version}/service`)
   t.equal(type, 'object')

--- a/packages/service/test/cli/validations.test.mjs
+++ b/packages/service/test/cli/validations.test.mjs
@@ -16,7 +16,8 @@ test('missing config', async (t) => {
   await t.rejects(execa('node', [cliPath, 'start']))
 })
 
-test('print validation errors', async ({ equal, plan }) => {
+// Skipping because now we don't have any required property in service schema
+test('print validation errors', { skip: true }, async ({ equal, plan }) => {
   plan(2)
   try {
     await execa('node', [cliPath, 'start', '--config', join(import.meta.url, '..', 'fixtures', 'missing-property.config.json')])

--- a/packages/service/test/config.test.js
+++ b/packages/service/test/config.test.js
@@ -315,10 +315,11 @@ test('do not watch typescript outDir', async ({ teardown, equal, pass, same }) =
   })
 })
 
-test('returns null if no server field is provided', async ({ equal }) => {
+test('returns not null if no server field is provided', async ({ equal, not }) => {
   const app = await buildServer({
     watch: false,
     metrics: false
   })
-  equal(app, null)
+  equal(app.start, undefined) // does not have server-specific method
+  not(app, null)
 })

--- a/packages/service/test/config.test.js
+++ b/packages/service/test/config.test.js
@@ -314,3 +314,11 @@ test('do not watch typescript outDir', async ({ teardown, equal, pass, same }) =
     ignore: ['dist/**/*']
   })
 })
+
+test('returns null if no server field is provided', async ({ equal }) => {
+  const app = await buildServer({
+    watch: false,
+    metrics: false
+  })
+  equal(app, null)
+})

--- a/packages/utils/lib/is-key-enabled.js
+++ b/packages/utils/lib/is-key-enabled.js
@@ -1,6 +1,7 @@
 'use strict'
 
 function isKeyEnabled (key, config) {
+  if (config === undefined) return false
   if (typeof config[key] === 'boolean') {
     return config[key]
   }

--- a/packages/utils/test/is-key-enabled.test.js
+++ b/packages/utils/test/is-key-enabled.test.js
@@ -15,4 +15,5 @@ test('isKeyEnabled', async (t) => {
   t.equal(isKeyEnabled('bar', a), true)
   t.equal(isKeyEnabled('baz', a), false)
   t.equal(isKeyEnabled('nope', a), false)
+  t.equal(isKeyEnabled('something', undefined), false)
 })


### PR DESCRIPTION
Opening early to check CI, since this PR may affect other packages.

This PR aims to remove the `server` block from the services inside the runtime. 
It will keep it for the service entrypoint, though.

It also manages services `.env` files: it will copy the contents into the main `.env` file, purging the `PORT`, `PLT_LOGGER_LEVEL` and `PLT_SERVER_HOSTNAME` if the service is _not_ the entrypoint.

This will probably affect #1424 

Fixes: #1372
Fixes: https://github.com/platformatic/platformatic/issues/1575