### PR TITLE
fix(sql-mapper): add types for tx option on all entity hooks

### DIFF
--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -32,7 +32,11 @@ export interface Database {
   /**
    * Dispose the connection. Once this is called, any subsequent queries will fail.
    */
-  dispose(): Promise<void>
+  dispose(): Promise<void>,
+  /**
+   * Begin new transaction
+   */
+  tx<T = any>(fn: (tx: Database) => Promise<T>, options?: any): Promise<T>
 }
 
 export interface DBEntityField {
@@ -150,8 +154,8 @@ interface Find<EntityFields> {
      */
     offset?: number,
     /**
-     * If present, the entity partecipates in transaction
-    */
+     * If present, the entity participates in transaction
+     */
     tx?: Database
   }): Promise<Partial<EntityFields>[]>
 }
@@ -162,6 +166,10 @@ interface Count {
      * SQL where condition.
      */
     where?: WhereCondition,
+    /**
+     * If present, the entity participates in transaction
+     */
+    tx?: Database
   }): Promise<number>
 }
 
@@ -174,7 +182,11 @@ interface Insert<EntityFields> {
     /**
      * List of fields to be returned for each object
      */
-    fields?: string[]
+    fields?: string[],
+    /**
+     * If present, the entity participates in transaction
+     */
+    tx?: Database
   }): Promise<Partial<EntityFields>[]>
 }
 
@@ -187,7 +199,11 @@ interface Save<EntityFields> {
     /**
      * List of fields to be returned for each object
      */
-    fields?: string[]
+    fields?: string[],
+    /**
+     * If present, the entity participates in transaction
+     */
+    tx?: Database
   }): Promise<Partial<EntityFields>>
 }
 
@@ -196,11 +212,15 @@ interface Delete<EntityFields> {
     /**
      * SQL where condition.
      */
-    where: WhereCondition,
+    where?: WhereCondition,
     /**
      * List of fields to be returned for each object
      */
-    fields: string[]
+    fields?: string[],
+    /**
+     * If present, the entity participates in transaction
+     */
+    tx?: Database
   }): Promise<Partial<EntityFields>[]>,
 }
 

--- a/packages/sql-mapper/test/types/mapper.test-d.ts
+++ b/packages/sql-mapper/test/types/mapper.test-d.ts
@@ -56,6 +56,11 @@ expectType<Partial<EntityFields>[]>(await entity.insert({ inputs: [{ id: 1, name
 expectType<Partial<EntityFields>>(await entity.save({ input: { id: 1, name: 'test' } }))
 expectType<Partial<EntityFields>[]>(await entity.delete())
 expectType<number>(await entity.count())
+expectType<Partial<EntityFields>[]>(await entity.find({ tx: pluginOptions.db }))
+expectType<Partial<EntityFields>[]>(await entity.insert({ inputs: [{ id: 1, name: 'test' }], tx: pluginOptions.db }))
+expectType<Partial<EntityFields>>(await entity.save({ input: { id: 1, name: 'test' }, tx: pluginOptions.db }))
+expectType<Partial<EntityFields>[]>(await entity.delete({ tx: pluginOptions.db }))
+expectType<number>(await entity.count({ tx: pluginOptions.db }))
 
 const entityHooks: EntityHooks = {
   async find(originalFind: typeof entity.find, ...options: Parameters<typeof entity.find>): ReturnType<typeof entity.find> { return [] },
@@ -79,6 +84,7 @@ expectType<SQLMapperPluginInterface<Entities>>(await connect<Entities>({
   connectionString: '', log, onDatabaseLoad(db: Database, sql: SQL) {
     expectType<(query: SQLQuery) => Promise<any[]>>(db.query)
     expectType<() => Promise<void>>(db.dispose)
+    expectType<(fn: (tx: Database) => Promise<EntityFields>, options?: any) => Promise<EntityFields>>(db.tx<EntityFields>)
     expectType<boolean | undefined>(pluginOptions.db.isMySql)
     expectType<boolean | undefined>(pluginOptions.db.isMariaDB)
     expectType<boolean | undefined>(pluginOptions.db.isSQLite)


### PR DESCRIPTION
I have also made `fields` and `where` options on delete hook optional, I believe they are not required. let me know if I should revert it.

Example usecase:

```ts
/// <reference path="./global.d.ts" />
import { FastifyInstance } from "fastify";

export default async function (app: FastifyInstance) {
  app.platformatic.addEntityHooks("entity", {
    save: async (originalSave, opts) => {
      return app.platformatic.db.tx(async (tx) => {
        // Do other things atomically

        return originalSave({
          ...opts,
          tx,
        });
      });
    },
  });
}

```