### PR TITLE
uses global runtime server for entrypoint if defined

### DIFF
--- a/docs/reference/runtime/configuration.md
+++ b/docs/reference/runtime/configuration.md
@@ -151,61 +151,9 @@ Note that OTLP traces can be consumed by different solutions, like [Jaeger](http
 
 ### `server`
 
-A object with the following settings:
+This configures the Platformatic Runtime entrypoint `server`. If the entrypoint has also a `server` configured, when the runtime is started, this is the one used to configure the entrypoint `server`. 
 
-- **`hostname`** (**required**, `string`) — Hostname where Platformatic Runtime entrypoint server will listen for connections.
-- **`port`** (**required**, `number` or `string`) — Port where Platformatic Runtime etnrypoint server will listen for connections.
-- **`healthCheck`** (`boolean` or `object`) — Enables the health check endpoint.
-  - Powered by [`@fastify/under-pressure`](https://github.com/fastify/under-pressure).
-  - The value can be an object, used to specify the interval between checks in milliseconds (default: `5000`)
-
-  _Example_
-
-  ```json
-  {
-    "server": {
-      ...
-      "healthCheck": {
-        "interval": 2000
-      }
-    }
-  }
-  ```
-- **`cors`** (`object`) — Configuration for Cross-Origin Resource Sharing (CORS) headers.
-  - All options will be passed to the [`@fastify/cors`](https://github.com/fastify/fastify-cors) plugin. In order to specify a `RegExp` object, you can pass `{ regexp: 'yourregexp' }`,
-    it will be automatically converted
-- **`https`** (`object`) - Configuration for HTTPS supporting the following options.
-  - `key` (**required**, `string`, `object`, or `array`) - If `key` is a string, it specifies the private key to be used. If `key` is an object, it must have a `path` property specifying the private key file. Multiple keys are supported by passing an array of keys.
-  - `cert` (**required**, `string`, `object`, or `array`) - If `cert` is a string, it specifies the certificate to be used. If `cert` is an object, it must have a `path` property specifying the certificate file. Multiple certificates are supported by passing an array of keys.
-
-- **`logger`** (`object`) -- the [logger configuration](https://www.fastify.io/docs/latest/Reference/Server/#logger).
-- **`pluginTimeout`** (`integer`) -- the number of milliseconds to wait for a Fastify plugin to load
-- **`bodyLimit`** (`integer`) -- the maximum request body size in bytes
-- **`maxParamLength`** (`integer`) -- the maximum length of a request parameter
-- **`caseSensitive`** (`boolean`) -- if `true`, the router will be case sensitive
-- **`ignoreTrailingSlash`** (`boolean`) -- if `true`, the router will ignore the trailing slash
-- **`ignoreTrailingSlash`** (`boolean`) -- if `true`, the router will ignore the trailing slash
-- **`connectionTimeout`** (`integer`) -- the milliseconds to wait for a new HTTP request
-- **`keepAliveTimeout`** (`integer`) -- the milliseconds to wait for a keep-alive HTTP request
-- **`maxRequestsPerSocket`** (`integer`) -- the maximum number of requests per socket
-- **`forceCloseConnections`** (`boolean` or `"idle"`) -- if `true`, the server will close all connections when it is closed
-- **`requestTimeout`** (`integer`) -- the milliseconds to wait for a request to be completed
-- **`disableRequestLogging`** (`boolean`) -- if `true`, the request logger will be disabled
-- **`exposeHeadRoutes`** (`boolean`) -- if `true`, the router will expose HEAD routes
-- **`serializerOpts`** (`object`) -- the [serializer options](https://www.fastify.io/docs/latest/Reference/Server/#serializeropts)
-- **`requestIdHeader`** (`string` or `false`) -- the name of the header that will contain the request id
-- **`requestIdLogLabel`** (`string`) -- Defines the label used for the request identifier when logging the request. default: `'reqId'`
-- **`jsonShorthand`** (`boolean`) -- default: `true` -- visit [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#jsonshorthand) for more details
-- **`trustProxy`** (`boolean` or `integer` or `string` or `String[]`) -- default: `false` -- visit [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#trustproxy) for more details
-
-:::tip
-
-See the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server) for more details.
-
-:::
-
-
-
+See [Platformatic Service server](/docs/reference/service/configuration.md#server) for more details.
 
 ## Environment variable placeholders
 

--- a/docs/reference/runtime/configuration.md
+++ b/docs/reference/runtime/configuration.md
@@ -39,6 +39,7 @@ Configuration settings are organized into the following groups:
 - [`hotReload`](#hotReload)
 - [`allowCycles`](#allowCycles)
 - [`telemetry`](#telemetry)
+- [`server`](#server)
 
 Configuration settings containing sensitive data should be set using
 [configuration placeholders](#configuration-placeholders).
@@ -147,6 +148,62 @@ Note that OTLP traces can be consumed by different solutions, like [Jaeger](http
     }
   }
   ```
+
+### `server`
+
+A object with the following settings:
+
+- **`hostname`** (**required**, `string`) — Hostname where Platformatic Runtime entrypoint server will listen for connections.
+- **`port`** (**required**, `number` or `string`) — Port where Platformatic Runtime etnrypoint server will listen for connections.
+- **`healthCheck`** (`boolean` or `object`) — Enables the health check endpoint.
+  - Powered by [`@fastify/under-pressure`](https://github.com/fastify/under-pressure).
+  - The value can be an object, used to specify the interval between checks in milliseconds (default: `5000`)
+
+  _Example_
+
+  ```json
+  {
+    "server": {
+      ...
+      "healthCheck": {
+        "interval": 2000
+      }
+    }
+  }
+  ```
+- **`cors`** (`object`) — Configuration for Cross-Origin Resource Sharing (CORS) headers.
+  - All options will be passed to the [`@fastify/cors`](https://github.com/fastify/fastify-cors) plugin. In order to specify a `RegExp` object, you can pass `{ regexp: 'yourregexp' }`,
+    it will be automatically converted
+- **`https`** (`object`) - Configuration for HTTPS supporting the following options.
+  - `key` (**required**, `string`, `object`, or `array`) - If `key` is a string, it specifies the private key to be used. If `key` is an object, it must have a `path` property specifying the private key file. Multiple keys are supported by passing an array of keys.
+  - `cert` (**required**, `string`, `object`, or `array`) - If `cert` is a string, it specifies the certificate to be used. If `cert` is an object, it must have a `path` property specifying the certificate file. Multiple certificates are supported by passing an array of keys.
+
+- **`logger`** (`object`) -- the [logger configuration](https://www.fastify.io/docs/latest/Reference/Server/#logger).
+- **`pluginTimeout`** (`integer`) -- the number of milliseconds to wait for a Fastify plugin to load
+- **`bodyLimit`** (`integer`) -- the maximum request body size in bytes
+- **`maxParamLength`** (`integer`) -- the maximum length of a request parameter
+- **`caseSensitive`** (`boolean`) -- if `true`, the router will be case sensitive
+- **`ignoreTrailingSlash`** (`boolean`) -- if `true`, the router will ignore the trailing slash
+- **`ignoreTrailingSlash`** (`boolean`) -- if `true`, the router will ignore the trailing slash
+- **`connectionTimeout`** (`integer`) -- the milliseconds to wait for a new HTTP request
+- **`keepAliveTimeout`** (`integer`) -- the milliseconds to wait for a keep-alive HTTP request
+- **`maxRequestsPerSocket`** (`integer`) -- the maximum number of requests per socket
+- **`forceCloseConnections`** (`boolean` or `"idle"`) -- if `true`, the server will close all connections when it is closed
+- **`requestTimeout`** (`integer`) -- the milliseconds to wait for a request to be completed
+- **`disableRequestLogging`** (`boolean`) -- if `true`, the request logger will be disabled
+- **`exposeHeadRoutes`** (`boolean`) -- if `true`, the router will expose HEAD routes
+- **`serializerOpts`** (`object`) -- the [serializer options](https://www.fastify.io/docs/latest/Reference/Server/#serializeropts)
+- **`requestIdHeader`** (`string` or `false`) -- the name of the header that will contain the request id
+- **`requestIdLogLabel`** (`string`) -- Defines the label used for the request identifier when logging the request. default: `'reqId'`
+- **`jsonShorthand`** (`boolean`) -- default: `true` -- visit [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#jsonshorthand) for more details
+- **`trustProxy`** (`boolean` or `integer` or `string` or `String[]`) -- default: `false` -- visit [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#trustproxy) for more details
+
+:::tip
+
+See the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server) for more details.
+
+:::
+
 
 
 

--- a/docs/reference/runtime/configuration.md
+++ b/docs/reference/runtime/configuration.md
@@ -151,7 +151,7 @@ Note that OTLP traces can be consumed by different solutions, like [Jaeger](http
 
 ### `server`
 
-This configures the Platformatic Runtime entrypoint `server`. If the entrypoint has also a `server` configured, when the runtime is started, this is the one used to configure the entrypoint `server`. 
+This configures the Platformatic Runtime entrypoint `server`. If the entrypoint has also a `server` configured, when the runtime is started, this configuration is used. 
 
 See [Platformatic Service server](/docs/reference/service/configuration.md#server) for more details.
 

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -46,7 +46,7 @@ a password, should be set using [configuration placeholders](#configuration-plac
 
 ### `server`
 
-A **required** object with the following settings:
+A object with the following settings:
 
 - **`hostname`** (**required**, `string`) — Hostname where Platformatic Service server will listen for connections.
 - **`port`** (**required**, `number` or `string`) — Port where Platformatic Service server will listen for connections.

--- a/packages/runtime/fixtures/server/overrides-service/platformatic.runtime.json
+++ b/packages/runtime/fixtures/server/overrides-service/platformatic.runtime.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.31.0/runtime",
+  "entrypoint": "echo",
+  "allowCycles": false,
+  "hotReload": true,
+  "autoload": {
+    "path": "services",
+    "exclude": [
+      "docs"
+    ]
+  },
+   "server": {
+    "hostname": "127.0.0.1",
+    "port": "14242",
+    "logger": {
+      "level": "info"
+    }
+  }
+}

--- a/packages/runtime/fixtures/server/overrides-service/services/echo/platformatic.service.json
+++ b/packages/runtime/fixtures/server/overrides-service/services/echo/platformatic.service.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.28.1/service", 
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      "./routes"
+    ],
+    "typescript": false
+  },
+   "server": {
+    "hostname": "127.0.0.1",
+    "port": "14343",
+    "logger": {
+      "level": "info"
+    }
+  }
+}

--- a/packages/runtime/fixtures/server/overrides-service/services/echo/routes/span.js
+++ b/packages/runtime/fixtures/server/overrides-service/services/echo/routes/span.js
@@ -1,0 +1,8 @@
+'use strict'
+module.exports = async function (fastify, opts) {
+  // This returns the traceId set on the span by the service
+  fastify.get('/', async (request, reply) => {
+    const traceId = request.span.spanContext().traceId
+    return { traceId }
+  })
+}

--- a/packages/runtime/fixtures/server/runtime-server/platformatic.runtime.json
+++ b/packages/runtime/fixtures/server/runtime-server/platformatic.runtime.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.31.0/runtime",
+  "entrypoint": "echo",
+  "allowCycles": false,
+  "hotReload": true,
+  "autoload": {
+    "path": "services",
+    "exclude": [
+      "docs"
+    ]
+  },
+   "server": {
+    "hostname": "127.0.0.1",
+    "port": "14242",
+    "logger": {
+      "level": "info"
+    }
+  }
+}

--- a/packages/runtime/fixtures/server/runtime-server/services/echo/platformatic.service.json
+++ b/packages/runtime/fixtures/server/runtime-server/services/echo/platformatic.service.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.28.1/service", 
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      "./routes"
+    ],
+    "typescript": false
+  }
+}

--- a/packages/runtime/fixtures/server/runtime-server/services/echo/routes/span.js
+++ b/packages/runtime/fixtures/server/runtime-server/services/echo/routes/span.js
@@ -1,0 +1,8 @@
+'use strict'
+module.exports = async function (fastify, opts) {
+  // This returns the traceId set on the span by the service
+  fastify.get('/', async (request, reply) => {
+    const traceId = request.span.spanContext().traceId
+    return { traceId }
+  })
+}

--- a/packages/runtime/lib/api.js
+++ b/packages/runtime/lib/api.js
@@ -16,7 +16,13 @@ class RuntimeApi {
     for (let i = 0; i < config.services.length; ++i) {
       const service = config.services[i]
       const serviceTelemetryConfig = telemetryConfig ? { ...telemetryConfig, serviceName: `${telemetryConfig.serviceName}-${service.id}` } : null
-      const app = new PlatformaticApp(service, loaderPort, logger, serviceTelemetryConfig)
+
+      // If the service is an entrypoint and runtime server config is defined, use it.
+      let serverConfig = null
+      if (config.server && service.entrypoint) {
+        serverConfig = config.server
+      }
+      const app = new PlatformaticApp(service, loaderPort, logger, serviceTelemetryConfig, serverConfig)
 
       this.#services.set(service.id, app)
     }

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -17,9 +17,10 @@ class PlatformaticApp {
   #fileWatcher
   #logger
   #telemetryConfig
+  #serverConfig
   #debouncedRestart
 
-  constructor (appConfig, loaderPort, logger, telemetryConfig) {
+  constructor (appConfig, loaderPort, logger, telemetryConfig, serverConfig) {
     this.appConfig = appConfig
     this.config = null
     this.#hotReload = false
@@ -33,6 +34,7 @@ class PlatformaticApp {
       name: this.appConfig.id
     })
     this.#telemetryConfig = telemetryConfig
+    this.#serverConfig = serverConfig
 
     /* c8 ignore next 4 */
     this.#debouncedRestart = debounce(() => {
@@ -93,6 +95,15 @@ class PlatformaticApp {
       ...configManager.current,
       telemetry: this.#telemetryConfig
     })
+
+    /* istanbul ignore else */
+    if (this.#serverConfig) {
+      configManager.update({
+        ...configManager.current,
+        server: this.#serverConfig
+      })
+    }
+
     const config = configManager.current
 
     this.#setuplogger(configManager)

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -96,7 +96,6 @@ class PlatformaticApp {
       telemetry: this.#telemetryConfig
     })
 
-    /* istanbul ignore else */
     if (this.#serverConfig) {
       configManager.update({
         ...configManager.current,

--- a/packages/runtime/lib/schema.js
+++ b/packages/runtime/lib/schema.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const telemetry = require('@platformatic/telemetry').schema
+const { server } = require('@platformatic/service').schema
 const pkg = require('../package.json')
 const version = 'v' + pkg.version
 const platformaticRuntimeSchema = {
@@ -44,6 +45,7 @@ const platformaticRuntimeSchema = {
       }
     },
     telemetry,
+    server,
     services: {
       type: 'array',
       default: [],

--- a/packages/runtime/test/cli/server.test.mjs
+++ b/packages/runtime/test/cli/server.test.mjs
@@ -129,17 +129,3 @@ test('stackable', async () => {
   assert.deepStrictEqual(await res.body.text(), 'Hello World')
   child.kill('SIGINT')
 })
-
-test('use runtime server', async ({ equal, same, match, teardown }) => {
-  const config = join(import.meta.url, '..', '..', 'fixtures', 'server', 'runtime-server', 'platformatic.runtime.json')
-  const { child, url } = await start('start', '-c', config)
-  assert.strictEqual(url, 'http://127.0.0.1:14242')
-  child.kill('SIGINT')
-})
-
-test('the runtime server overrides the entrypoint server', async ({ equal, same, match, teardown }) => {
-  const config = join(import.meta.url, '..', '..', 'fixtures', 'server', 'overrides-service', 'platformatic.runtime.json')
-  const { child, url } = await start('start', '-c', config)
-  assert.strictEqual(url, 'http://127.0.0.1:14242')
-  child.kill('SIGINT')
-})


### PR DESCRIPTION
If a `server` is defined on runtime, it's used for the entrypoint `server`  (and in case, overrides the `server` config)

Fixes: https://github.com/platformatic/platformatic/issues/1611
