### PR TITLE
Add dedupe cache

### DIFF
--- a/packages/sql-mapper/lib/cache.js
+++ b/packages/sql-mapper/lib/cache.js
@@ -1,0 +1,34 @@
+'use strict'
+const { createCache } = require('async-cache-dedupe')
+
+function setupCache (res, opts) {
+  const { entities, addEntityHooks } = res
+  const cache = createCache(opts)
+  for (const entity of Object.values(entities)) {
+    const fnName = `${entity.name}Find`
+    const originalFn = entity.find
+    cache.define(fnName, {
+      serialize (query) {
+        const serialized = {
+          ...query,
+          ctx: undefined
+        }
+        return serialized
+      }
+    }, async function (query) {
+      const res = await originalFn.call(entity, query)
+      return res
+    })
+
+    addEntityHooks(entity.singularName, {
+      find (originalFn, query) {
+        if (query.tx) {
+          return originalFn(query)
+        }
+        return cache[fnName](query)
+      }
+    })
+  }
+}
+
+module.exports = setupCache

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -1,6 +1,9 @@
 import { FastifyPluginAsync, FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { SQL, SQLQuery } from '@databases/sql'
 import { FastifyError } from '@fastify/error'
+import { createCache } from 'async-cache-dedupe'
+
+type cacheOptions = (Parameters<typeof createCache>[0]) | boolean
 
 interface ILogger {
   trace(): any,
@@ -347,6 +350,11 @@ export interface SQLMapperPluginOptions extends BasePoolOptions {
    * An async function that is called after the connection is established.
    */
   onDatabaseLoad?(db: Database, sql: SQL): any,
+  /**
+   * Query caching Configuration
+   * @default false
+   */
+  cache?: cacheOptions
 }
 
 export interface Entities {

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -1,12 +1,13 @@
 'use strict'
 
+const fp = require('fastify-plugin')
 const { findNearestString } = require('@platformatic/utils')
 const buildEntity = require('./lib/entity')
 const buildCleanUp = require('./lib/clean-up')
 const queriesFactory = require('./lib/queries')
-const fp = require('fastify-plugin')
 const { areSchemasSupported } = require('./lib/utils')
 const errors = require('./lib/errors')
+const setupCache = require('./lib/cache')
 
 // Ignore the function as it is only used only for MySQL and PostgreSQL
 /* istanbul ignore next */
@@ -97,7 +98,7 @@ async function createConnectionPool ({ log, connectionString, poolSize }) {
   return { db, sql }
 }
 
-async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignore = {}, autoTimestamp = true, hooks = {}, schema, limit = {}, dbschema }) {
+async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignore = {}, autoTimestamp = true, hooks = {}, schema, limit = {}, dbschema, cache }) {
   if (typeof autoTimestamp === 'boolean' && autoTimestamp === true) {
     autoTimestamp = defaultAutoTimestampFields
   }
@@ -197,7 +198,7 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignor
       }
     }
 
-    return {
+    const res = {
       db,
       sql,
       entities,
@@ -205,6 +206,12 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignor
       addEntityHooks,
       dbschema
     }
+
+    if (cache) {
+      setupCache(res, cache)
+    }
+
+    return res
   } catch (err) /* istanbul ignore next */ {
     db.dispose()
     throw err

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -32,13 +32,14 @@
     "tsd": "^0.29.0"
   },
   "dependencies": {
-    "@platformatic/utils": "workspace:*",
     "@databases/mysql": "^6.0.0",
     "@databases/pg": "^5.4.1",
     "@databases/sql": "^3.3.0",
     "@fastify/error": "^3.2.1",
     "@hapi/topo": "^6.0.2",
     "@matteo.collina/sqlite-pool": "^0.3.0",
+    "@platformatic/utils": "workspace:*",
+    "async-cache-dedupe": "^1.12.0",
     "camelcase": "^6.3.0",
     "fastify-plugin": "^4.5.0",
     "inflected": "^2.1.0"

--- a/packages/sql-mapper/test/types/mapper.test-d.ts
+++ b/packages/sql-mapper/test/types/mapper.test-d.ts
@@ -35,6 +35,30 @@ expectType<{ [entityName: string]: Entity }>(pluginOptions.entities)
 
 expectType<Promise<void>>(pluginOptions.cleanUpAllEntities())
 
+{
+  const pluginOptions2: SQLMapperPluginInterface<Entities> = await connect<Entities>({
+    connectionString: '',
+    cache: false
+  })
+}
+
+{
+  const pluginOptions2: SQLMapperPluginInterface<Entities> = await connect<Entities>({
+    connectionString: '',
+    cache: true
+  })
+}
+
+{
+  const pluginOptions2: SQLMapperPluginInterface<Entities> = await connect<Entities>({
+    connectionString: '',
+    cache: {
+      ttl: 1000,
+      stale: 10
+    }
+  })
+}
+
 interface EntityFields {
   id: number,
   name: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1475,6 +1475,9 @@ importers:
       '@platformatic/utils':
         specifier: workspace:*
         version: link:../utils
+      async-cache-dedupe:
+        specifier: ^1.12.0
+        version: 1.12.0
       camelcase:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3379,6 +3382,13 @@ packages:
   /astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+    dev: false
+
+  /async-cache-dedupe@1.12.0:
+    resolution: {integrity: sha512-LKumaBNhzvZrbrRi3DtIf0ETgjqcGOa/M2U+0DpTp8f+RzIiWubiQmBjuYUaihxetR3cWWC6hQj/uDVBuYajRA==}
+    dependencies:
+      mnemonist: 0.39.5
+      safe-stable-stringify: 2.4.3
     dev: false
 
   /async-hook-domain@2.0.4:


### PR DESCRIPTION
This adds `async-cache-dedupe` to Platformatic DB so that queries can be deduplicated before sending them down, saving quite a bit of DB latency.
On my local tests, enabling it gives around 6x more throughput (with just deduping).

Todo:

* [ ] Add cache to sql-mapper
* [ ] Add tests for redis
* [ ] Add options in the schema of Platformatic DB