### PR TITLE
fix(client-cli): Make TS block optional when all params are optional

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -100,11 +100,11 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
 export function writeProperties (writer, blockName, parameters, addedProps) {
   if (parameters.length > 0) {
     let allOptionalParams = true
-    parameters.forEach(({ required }) => {
+    for (const { required } of parameters) {
       if (required !== false) {
         allOptionalParams = false
       }
-    })
+    }
     const nameToWrite = allOptionalParams ? `${blockName}?: ` : `${blockName}: `
     writer.write(nameToWrite).block(() => {
       for (const parameter of parameters) {

--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -99,7 +99,14 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
 
 export function writeProperties (writer, blockName, parameters, addedProps) {
   if (parameters.length > 0) {
-    writer.write(`${blockName}: `).block(() => {
+    let allOptionalParams = true
+    parameters.forEach(({ required }) => {
+      if (required !== false) {
+        allOptionalParams = false
+      }
+    })
+    const nameToWrite = allOptionalParams ? `${blockName}?: ` : `${blockName}: `
+    writer.write(nameToWrite).block(() => {
       for (const parameter of parameters) {
         const { name, required } = parameter
         // We do not check for addedProps here because it's the first

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -889,7 +889,7 @@ test('openapi client generation (javascript) from file with fullRequest, fullRes
     query: {
       'queryId': string;
     }
-    headers: {
+    headers?: {
       'headerId'?: string;
     }
   }


### PR DESCRIPTION
The result of this PR is that if a block (like `headers`) has all optional parameters, the entire block will be optional (f.e. it will not be required to pass an empty object to make TypeScript compile).