### PR TITLE
Add dedupe cache

### DIFF
--- a/docs/reference/sql-mapper/introduction.md
+++ b/docs/reference/sql-mapper/introduction.md
@@ -32,6 +32,7 @@ The valid options are:
 - `ignore` — Object used to ignore some tables from building entities. (i.e. `{ 'versions': true }` will ignore `versions` table)
 - `autoTimestamp` — Generate timestamp automatically when inserting/updating records.
 - `hooks` — For each entity name (like `Page`) you can customize any of the entity API function. Your custom function will receive the original function as first parameter, and then all the other parameters passed to it.
+- `cache` — enable cache and dedupe features - currently supported `dedupe` on entities `find` method only. Boolean, default is disabled.
 
 ### `createConnectionPool(opts) : Promise`
 
@@ -77,7 +78,8 @@ const mapper = await connect({
         return await _find(opts)
       }
     }
-  }
+  },
+  cache: true
 })
 const pageEntity = mapper.entities.page
 

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -23,9 +23,9 @@ export type CrudOperationAuth =
   | boolean;
 
 export interface PlatformaticDB {
-  server: {
-    hostname: string;
-    port: number | string;
+  server?: {
+    hostname?: string;
+    port?: number | string;
     pluginTimeout?: number;
     healthCheck?:
       | boolean
@@ -198,6 +198,7 @@ export interface PlatformaticDB {
       | {
           connectionString?: string;
         };
+    cache?: boolean;
     [k: string]: unknown;
   };
   authorization?: {

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -146,6 +146,9 @@ const db = {
         },
         additionalProperties: false
       }]
+    },
+    cache: {
+      type: 'boolean'
     }
   },
   required: ['connectionString']

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -6,9 +6,9 @@
  */
 
 export interface PlatformaticService {
-  server: {
-    hostname: string;
-    port: number | string;
+  server?: {
+    hostname?: string;
+    port?: number | string;
     pluginTimeout?: number;
     healthCheck?:
       | boolean

--- a/packages/sql-mapper/lib/cache.js
+++ b/packages/sql-mapper/lib/cache.js
@@ -2,7 +2,16 @@
 const { createCache } = require('async-cache-dedupe')
 
 function setupCache (res, opts) {
+  // TODO validate opts
+  if (opts === true) {
+    opts = { ttl: 0 }
+  } else {
+    // ttl=0 means dedupe only
+    // TODO remove it to implement full cache features
+    opts.ttl = 0
+  }
   const { entities, addEntityHooks } = res
+
   const cache = createCache(opts)
   for (const entity of Object.values(entities)) {
     const fnName = `${entity.name}Find`

--- a/packages/sql-mapper/lib/cache.js
+++ b/packages/sql-mapper/lib/cache.js
@@ -7,6 +7,7 @@ function setupCache (res, opts) {
   for (const entity of Object.values(entities)) {
     const fnName = `${entity.name}Find`
     const originalFn = entity.find
+
     cache.define(fnName, {
       serialize (query) {
         const serialized = {

--- a/packages/sql-mapper/lib/cache.js
+++ b/packages/sql-mapper/lib/cache.js
@@ -1,0 +1,34 @@
+'use strict'
+const { createCache } = require('async-cache-dedupe')
+
+function setupCache (res, opts) {
+  const { entities, addEntityHooks } = res
+  const cache = createCache(opts)
+  for (const entity of Object.values(entities)) {
+    const fnName = `${entity.name}Find`
+    const originalFn = entity.find
+    cache.define(fnName, {
+      serialize (query) {
+        const serialized = {
+          ...query,
+          ctx: undefined
+        }
+        return serialized
+      }
+    }, async function (query) {
+      const res = await originalFn.call(entity, query)
+      return res
+    })
+
+    addEntityHooks(entity.singularName, {
+      find (originalFn, query) {
+        if (query.tx) {
+          return originalFn(query)
+        }
+        return cache[fnName](query)
+      }
+    })
+  }
+}
+
+module.exports = setupCache

--- a/packages/sql-mapper/lib/cache.js
+++ b/packages/sql-mapper/lib/cache.js
@@ -39,6 +39,8 @@ function setupCache (res, opts) {
       }
     })
   }
+
+  return cache
 }
 
 module.exports = setupCache

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -1,6 +1,9 @@
 import { FastifyPluginAsync, FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { SQL, SQLQuery } from '@databases/sql'
 import { FastifyError } from '@fastify/error'
+import { createCache } from 'async-cache-dedupe'
+
+type cacheOptions = (Parameters<typeof createCache>[0]) | boolean
 
 interface ILogger {
   trace(): any,
@@ -347,6 +350,11 @@ export interface SQLMapperPluginOptions extends BasePoolOptions {
    * An async function that is called after the connection is established.
    */
   onDatabaseLoad?(db: Database, sql: SQL): any,
+  /**
+   * Query caching Configuration
+   * @default false
+   */
+  cache?: cacheOptions
 }
 
 export interface Entities {

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -1,12 +1,13 @@
 'use strict'
 
+const fp = require('fastify-plugin')
 const { findNearestString } = require('@platformatic/utils')
 const buildEntity = require('./lib/entity')
 const buildCleanUp = require('./lib/clean-up')
 const queriesFactory = require('./lib/queries')
-const fp = require('fastify-plugin')
 const { areSchemasSupported } = require('./lib/utils')
 const errors = require('./lib/errors')
+const setupCache = require('./lib/cache')
 
 // Ignore the function as it is only used only for MySQL and PostgreSQL
 /* istanbul ignore next */
@@ -97,7 +98,7 @@ async function createConnectionPool ({ log, connectionString, poolSize }) {
   return { db, sql }
 }
 
-async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignore = {}, autoTimestamp = true, hooks = {}, schema, limit = {}, dbschema }) {
+async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignore = {}, autoTimestamp = true, hooks = {}, schema, limit = {}, dbschema, cache }) {
   if (typeof autoTimestamp === 'boolean' && autoTimestamp === true) {
     autoTimestamp = defaultAutoTimestampFields
   }
@@ -197,7 +198,7 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignor
       }
     }
 
-    return {
+    const res = {
       db,
       sql,
       entities,
@@ -205,6 +206,12 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignor
       addEntityHooks,
       dbschema
     }
+
+    if (cache) {
+      setupCache(res, cache)
+    }
+
+    return res
   } catch (err) /* istanbul ignore next */ {
     db.dispose()
     throw err

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -208,7 +208,7 @@ async function connect ({ connectionString, log, onDatabaseLoad, poolSize, ignor
     }
 
     if (cache) {
-      setupCache(res, cache)
+      res.cache = setupCache(res, cache)
     }
 
     return res

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -39,7 +39,7 @@
     "@hapi/topo": "^6.0.2",
     "@matteo.collina/sqlite-pool": "^0.3.0",
     "@platformatic/utils": "workspace:*",
-    "async-cache-dedupe": "^1.12.0",
+    "async-cache-dedupe": "^2.0.0",
     "camelcase": "^6.3.0",
     "fastify-plugin": "^4.5.1",
     "inflected": "^2.1.0"

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -39,6 +39,7 @@
     "@hapi/topo": "^6.0.2",
     "@matteo.collina/sqlite-pool": "^0.3.0",
     "@platformatic/utils": "workspace:*",
+    "async-cache-dedupe": "^1.12.0",
     "camelcase": "^6.3.0",
     "fastify-plugin": "^4.5.1",
     "inflected": "^2.1.0"

--- a/packages/sql-mapper/test/cache.test.js
+++ b/packages/sql-mapper/test/cache.test.js
@@ -18,7 +18,7 @@ const seed = [
 ]
 
 t.test('dedupe', async t => {
-  t.test('should not dedupe find method', async t => {
+  t.test('should dedupe find method', async t => {
     let dedupes = 0
     let hits = 0
     let misses = 0

--- a/packages/sql-mapper/test/cache.test.js
+++ b/packages/sql-mapper/test/cache.test.js
@@ -17,32 +17,15 @@ const seed = [
   'INSERT INTO movies (title) VALUES (\'Jurassic Park\'), (\'The Dark Knight\'), (\'Memento\')'
 ]
 
-t.test('dedupe', async t => {
-  t.test('should dedupe with default settings', async t => {
-    let dedupes = 0
-    let hits = 0
-    let misses = 0
-    let errors = 0
-    const cache = {
-      onDedupe: () => { dedupes++ },
-      onHit: () => { hits++ },
-      onMiss: () => { misses++ },
-      onError: () => { errors++ }
-    }
-    const mapper = await setupDatabase({ seed, cache, t })
-    const concurrency = 10
+t.test('setup', async t => {
+  t.test('should setup cache with default settings', async t => {
+    const mapper = await setupDatabase({ seed, cache: true, t })
 
-    const tasks = new Array(concurrency).fill().map(_ => mapper.entities.movie.find({ fields: ['title'] }))
-    const results = await Promise.allSettled(tasks)
-
-    t.equal(results.length, concurrency)
-    results.forEach(r => t.same(r.value, [{ title: 'Jurassic Park' }, { title: 'The Dark Knight' }, { title: 'Memento' }]))
-    t.equal(dedupes, concurrency - 1)
-    t.equal(hits, 0)
-    t.equal(misses, 0)
-    t.equal(errors, 0)
+    t.type(mapper.cache.MovieFind, 'function')
   })
+})
 
+t.test('dedupe', async t => {
   t.test('should dedupe find method', async t => {
     let dedupes = 0
     let hits = 0

--- a/packages/sql-mapper/test/cache.test.js
+++ b/packages/sql-mapper/test/cache.test.js
@@ -1,0 +1,75 @@
+const t = require('tap')
+const { setupDatabase, isSQLite } = require('./helper')
+
+const seed = [
+  'DROP TABLE IF EXISTS movies',
+  isSQLite
+    ? `CREATE TABLE movies (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    title VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )`
+    : `CREATE TABLE movies (
+    id SERIAL NOT NULL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+  )`,
+  'INSERT INTO movies (title) VALUES (\'Jurassic Park\'), (\'The Dark Knight\'), (\'Memento\')'
+]
+
+t.test('dedupe', async t => {
+  t.test('should not dedupe find method', async t => {
+    let dedupes = 0
+    let hits = 0
+    let misses = 0
+    let errors = 0
+    const cache = {
+      ttl: 0,
+      onDedupe: () => { dedupes++ },
+      onHit: () => { hits++ },
+      onMiss: () => { misses++ },
+      onError: () => { errors++ }
+    }
+    const mapper = await setupDatabase({ seed, cache, t })
+    const concurrency = 10
+
+    const tasks = new Array(concurrency).fill().map(_ => mapper.entities.movie.find({ fields: ['title'] }))
+    const results = await Promise.allSettled(tasks)
+
+    t.equal(results.length, concurrency)
+    results.forEach(r => t.same(r.value, [{ title: 'Jurassic Park' }, { title: 'The Dark Knight' }, { title: 'Memento' }]))
+    t.equal(dedupes, concurrency - 1)
+    t.equal(hits, 0)
+    t.equal(misses, 0)
+    t.equal(errors, 0)
+  })
+
+  t.test('should not dedupe find method under transaction', async t => {
+    let dedupes = 0
+    let hits = 0
+    let misses = 0
+    let errors = 0
+    const cache = {
+      ttl: 0,
+      onDedupe: () => { dedupes++ },
+      onHit: () => { hits++ },
+      onMiss: () => { misses++ },
+      onError: () => { errors++ }
+    }
+    const mapper = await setupDatabase({ seed, cache, t })
+    const concurrency = 10
+
+    await mapper.db.tx(async tx => {
+      const tasks = new Array(concurrency).fill().map(_ => mapper.entities.movie.find({ fields: ['title'], tx }))
+      const results = await Promise.allSettled(tasks)
+
+      t.equal(results.length, concurrency)
+      results.forEach(r => t.same(r.value, [{ title: 'Jurassic Park' }, { title: 'The Dark Knight' }, { title: 'Memento' }]))
+    })
+
+    t.equal(dedupes, 0)
+    t.equal(hits, 0)
+    t.equal(misses, 0)
+    t.equal(errors, 0)
+  })
+})

--- a/packages/sql-mapper/test/helper.js
+++ b/packages/sql-mapper/test/helper.js
@@ -111,11 +111,20 @@ module.exports.clear = async function (db, sql) {
     await db.query(sql`DROP TABLE generated_test`)
   } catch (err) {
   }
+
+  try {
+    await db.query(sql`DROP TABLE movies`)
+  } catch (err) {
+  }
 }
 
 const fakeLogger = {
   trace: () => { },
-  error: () => { }
+  debug: () => { },
+  info: () => { },
+  warn: () => { },
+  error: () => { },
+  fatal: () => { }
 }
 
 module.exports.fakeLogger = fakeLogger

--- a/packages/sql-mapper/test/helper.js
+++ b/packages/sql-mapper/test/helper.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { connect } = require('..')
+
 // Needed to work with dates & postgresql
 // See https://node-postgres.com/features/types/
 process.env.TZ = 'UTC'
@@ -109,4 +111,28 @@ module.exports.clear = async function (db, sql) {
     await db.query(sql`DROP TABLE generated_test`)
   } catch (err) {
   }
+}
+
+const fakeLogger = {
+  trace: () => { },
+  error: () => { }
+}
+
+module.exports.fakeLogger = fakeLogger
+
+module.exports.setupDatabase = async function ({ seed, cache, t }) {
+  return connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad: async (db, sql) => {
+      t.teardown(() => db.dispose())
+
+      for (const query of seed) {
+        await db.query(sql(query))
+      }
+    },
+    ignore: {},
+    hooks: {},
+    cache
+  })
 }

--- a/packages/sql-mapper/test/types/mapper.test-d.ts
+++ b/packages/sql-mapper/test/types/mapper.test-d.ts
@@ -35,6 +35,30 @@ expectType<{ [entityName: string]: Entity }>(pluginOptions.entities)
 
 expectType<Promise<void>>(pluginOptions.cleanUpAllEntities())
 
+{
+  const pluginOptions2: SQLMapperPluginInterface<Entities> = await connect<Entities>({
+    connectionString: '',
+    cache: false
+  })
+}
+
+{
+  const pluginOptions2: SQLMapperPluginInterface<Entities> = await connect<Entities>({
+    connectionString: '',
+    cache: true
+  })
+}
+
+{
+  const pluginOptions2: SQLMapperPluginInterface<Entities> = await connect<Entities>({
+    connectionString: '',
+    cache: {
+      ttl: 1000,
+      stale: 10
+    }
+  })
+}
+
 interface EntityFields {
   id: number,
   name: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1488,8 +1488,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       async-cache-dedupe:
-        specifier: ^1.12.0
-        version: 1.12.0
+        specifier: ^2.0.0
+        version: 2.0.0
       camelcase:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3403,8 +3403,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /async-cache-dedupe@1.12.0:
-    resolution: {integrity: sha512-LKumaBNhzvZrbrRi3DtIf0ETgjqcGOa/M2U+0DpTp8f+RzIiWubiQmBjuYUaihxetR3cWWC6hQj/uDVBuYajRA==}
+  /async-cache-dedupe@2.0.0:
+    resolution: {integrity: sha512-SrW6PbmCHRQBSpPG8mkPIZZC5AgC08sbzl56GyGemBLVdVUl8mQW4+WCYHp5XZfixIdkL40jKf3UlT/P6Q3p5w==}
     dependencies:
       mnemonist: 0.39.5
       safe-stable-stringify: 2.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1487,6 +1487,9 @@ importers:
       '@platformatic/utils':
         specifier: workspace:*
         version: link:../utils
+      async-cache-dedupe:
+        specifier: ^1.12.0
+        version: 1.12.0
       camelcase:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3398,6 +3401,13 @@ packages:
   /astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+    dev: false
+
+  /async-cache-dedupe@1.12.0:
+    resolution: {integrity: sha512-LKumaBNhzvZrbrRi3DtIf0ETgjqcGOa/M2U+0DpTp8f+RzIiWubiQmBjuYUaihxetR3cWWC6hQj/uDVBuYajRA==}
+    dependencies:
+      mnemonist: 0.39.5
+      safe-stable-stringify: 2.4.3
     dev: false
 
   /async-hook-domain@2.0.4:


### PR DESCRIPTION
Following https://github.com/platformatic/platformatic/pull/1614

> This adds `async-cache-dedupe` to Platformatic DB so that queries can be deduplicated before sending them down, saving quite a bit of DB latency. On my local tests, enabling it gives around 6x more throughput (with just deduping).
> 
> Todo:
> 
> * [x]  Add cache to sql-mapper
> * [ ] ~~Add tests for redis~~
> * [x]  Add options in the schema of Platformatic DB

The target is to add `dedupe` feature at first,  I'll open a new issues with the tasks to add the full cache support
