### PR TITLE
create-platformatic CLI unit tests for DB services

### DIFF
--- a/packages/create-platformatic/package.json
+++ b/packages/create-platformatic/package.json
@@ -13,7 +13,7 @@
     "create-platformatic": "./create-platformatic.mjs"
   },
   "scripts": {
-    "test:cli": "tap --no-coverage test/cli/*test.mjs",
+    "test:cli": "tap --no-coverage test/cli/*test.mjs -t60",
     "test": "standard | snazzy && cross-env NODE_OPTIONS=\"--loader=esmock --no-warnings\" c8 tap --no-coverage test/*test.mjs test/*[!cli]/*test.mjs && npm run test:cli",
     "lint": "standard | snazzy"
   },

--- a/packages/create-platformatic/package.json
+++ b/packages/create-platformatic/package.json
@@ -13,7 +13,8 @@
     "create-platformatic": "./create-platformatic.mjs"
   },
   "scripts": {
-    "test": "standard | snazzy && cross-env NODE_OPTIONS=\"--loader=esmock --no-warnings\" c8 tap --no-coverage test/*test.mjs test/*/*test.mjs",
+    "test:cli": "tap --no-coverage test/cli/*test.mjs",
+    "test": "standard | snazzy && cross-env NODE_OPTIONS=\"--loader=esmock --no-warnings\" c8 tap --no-coverage test/*test.mjs test/*[!cli]/*test.mjs && npm run test:cli",
     "lint": "standard | snazzy"
   },
   "license": "Apache-2.0",

--- a/packages/create-platformatic/package.json
+++ b/packages/create-platformatic/package.json
@@ -37,6 +37,7 @@
     "pino-pretty": "^10.2.0",
     "pupa": "^3.1.0",
     "semver": "^7.5.4",
+    "strip-ansi": "^7.1.0",
     "undici": "^5.25.4",
     "which": "^3.0.1"
   },

--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -170,7 +170,7 @@ const createPlatformaticDB = async (_args, opts) => {
     choices: [{ name: 'yes', value: true }, { name: 'no', value: false }]
   })
 
-  // Promtp for questions
+  // Prompt for questions
   const wizardOptions = await inquirer.prompt(toAsk)
 
   await mkdir(projectDir, { recursive: true })

--- a/packages/create-platformatic/src/db/create-db.mjs
+++ b/packages/create-platformatic/src/db/create-db.mjs
@@ -298,7 +298,7 @@ function generateConfig (isRuntimeContext, migrations, plugin, types, typescript
     }
   }
 
-  if (typescript === true) {
+  if (typescript === true && config.plugins) {
     config.plugins.typescript = `{PLT_${envPrefix}TYPESCRIPT}`
   }
 

--- a/packages/create-platformatic/test/cli/db.mjs
+++ b/packages/create-platformatic/test/cli/db.mjs
@@ -1,0 +1,66 @@
+import { test, beforeEach, afterEach } from 'tap'
+import { executeCreatePlatformatic, keys } from './helper.mjs'
+import { mkdtempSync, rmSync } from 'fs'
+import { isFileAccessible } from '../../src/utils.mjs'
+import { join } from 'node:path'
+import { tmpdir } from 'os'
+
+let tmpDir
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'test-create-platformatic-'))
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+test('Creates a Platformatic DB service with no migrations and no plugin', async ({ equal, same, match, teardown }) => {
+  console.log('Creating Platformatic in ', tmpDir)
+  // The actions must match IN ORDER
+  const actions = [{
+    match: 'Which kind of project do you want to create?',
+    do: [keys.ENTER]
+  }, {
+    match: 'Where would you like to create your project?',
+    do: [keys.ENTER]
+  }, {
+    match: 'What database do you want to use?',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to use the connection string',
+    do: ['y']
+  }, {
+    match: 'Confirm',
+    do: [keys.ENTER]
+  }, {
+    match: 'What port do you want to use?',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to run npm install?',
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to create default migrations',
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to create a plugin',
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    // NOTE THAT HERE THE DEFAULT OPTION IS "NO", so just sending ENTER we won't have TS
+    match: 'Do you want to use TypeScript',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to create the github action to deploy',
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to enable PR Previews in your application',
+    do: [keys.DOWN, keys.ENTER]
+  }]
+  await executeCreatePlatformatic(tmpDir, actions, 'All done!')
+
+  const baseProjectDir = join(tmpDir, 'platformatic-db')
+  equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'platformatic.db.json')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'README.md')), true)
+})

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -1,4 +1,4 @@
-import { test, beforeEach, afterEach, only } from 'tap'
+import { test, beforeEach, afterEach } from 'tap'
 import { executeCreatePlatformatic, keys, walk } from './helper.mjs'
 import { mkdtempSync, rmSync } from 'fs'
 import { isFileAccessible } from '../../src/utils.mjs'
@@ -59,7 +59,7 @@ test('Creates a Platformatic DB service with no migrations and no plugin', async
 
   const baseProjectDir = join(tmpDir, 'platformatic-db')
   const files = await walk(baseProjectDir)
-  console.log('==> files', files)
+  console.log('==> created files', files)
   equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)
@@ -67,7 +67,7 @@ test('Creates a Platformatic DB service with no migrations and no plugin', async
   equal(await isFileAccessible(join(baseProjectDir, 'README.md')), true)
 })
 
-only('Creates a Platformatic DB service with migrations and plugin', async ({ equal, same, match, teardown }) => {
+test('Creates a Platformatic DB service with migrations and plugin', async ({ equal, same, match, teardown }) => {
   // The actions must match IN ORDER
   const actions = [{
     match: 'Which kind of project do you want to create?',
@@ -115,7 +115,7 @@ only('Creates a Platformatic DB service with migrations and plugin', async ({ eq
 
   const baseProjectDir = join(tmpDir, 'platformatic-db')
   const files = await walk(baseProjectDir)
-  console.log('==> files', files)
+  console.log('==> created files', files)
   equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)
@@ -177,7 +177,7 @@ test('Creates a Platformatic DB service with plugin using typescript, creating a
 
   const baseProjectDir = join(tmpDir, 'platformatic-db')
   const files = await walk(baseProjectDir)
-  console.log('==> files', files)
+  console.log('==> created files', files)
   equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -127,7 +127,7 @@ test('Creates a Platformatic DB service with migrations and plugin', async ({ eq
   equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.js')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.js')), true)
   // These are not generated because TS is not installed
-  equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
+  // equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
 })
 
 test('Creates a Platformatic DB service with plugin using typescript, creating all the github actions', async ({ equal, same, match, teardown }) => {

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -1,5 +1,5 @@
-import { test, beforeEach, afterEach } from 'tap'
-import { executeCreatePlatformatic, keys } from './helper.mjs'
+import { test, beforeEach, afterEach, only } from 'tap'
+import { executeCreatePlatformatic, keys, walk } from './helper.mjs'
 import { mkdtempSync, rmSync } from 'fs'
 import { isFileAccessible } from '../../src/utils.mjs'
 import { join } from 'node:path'
@@ -58,6 +58,8 @@ test('Creates a Platformatic DB service with no migrations and no plugin', async
   await executeCreatePlatformatic(tmpDir, actions, 'All done!')
 
   const baseProjectDir = join(tmpDir, 'platformatic-db')
+  const files = await walk(baseProjectDir)
+  console.log('==> files', files)
   equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)
@@ -65,7 +67,7 @@ test('Creates a Platformatic DB service with no migrations and no plugin', async
   equal(await isFileAccessible(join(baseProjectDir, 'README.md')), true)
 })
 
-test('Creates a Platformatic DB service with migrations and plugin', async ({ equal, same, match, teardown }) => {
+only('Creates a Platformatic DB service with migrations and plugin', async ({ equal, same, match, teardown }) => {
   // The actions must match IN ORDER
   const actions = [{
     match: 'Which kind of project do you want to create?',
@@ -112,6 +114,8 @@ test('Creates a Platformatic DB service with migrations and plugin', async ({ eq
   await executeCreatePlatformatic(tmpDir, actions, 'All done!')
 
   const baseProjectDir = join(tmpDir, 'platformatic-db')
+  const files = await walk(baseProjectDir)
+  console.log('==> files', files)
   equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)
@@ -172,6 +176,8 @@ test('Creates a Platformatic DB service with plugin using typescript, creating a
   await executeCreatePlatformatic(tmpDir, actions, 'All done!')
 
   const baseProjectDir = join(tmpDir, 'platformatic-db')
+  const files = await walk(baseProjectDir)
+  console.log('==> files', files)
   equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -66,7 +66,6 @@ test('Creates a Platformatic DB service with no migrations and no plugin', async
 })
 
 test('Creates a Platformatic DB service with migrations and plugin', async ({ equal, same, match, teardown }) => {
-  console.log("==> DIR", tmpDir)
   // The actions must match IN ORDER
   const actions = [{
     match: 'Which kind of project do you want to create?',
@@ -127,7 +126,6 @@ test('Creates a Platformatic DB service with migrations and plugin', async ({ eq
 })
 
 test('Creates a Platformatic DB service with plugin using typescript, creating all the github actions', async ({ equal, same, match, teardown }) => {
-  console.log("==> DIR", tmpDir)
   // The actions must match IN ORDER
   const actions = [{
     match: 'Which kind of project do you want to create?',

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -64,3 +64,129 @@ test('Creates a Platformatic DB service with no migrations and no plugin', async
   equal(await isFileAccessible(join(baseProjectDir, 'platformatic.db.json')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'README.md')), true)
 })
+
+test('Creates a Platformatic DB service with migrations and plugin', async ({ equal, same, match, teardown }) => {
+  console.log("==> DIR", tmpDir)
+  // The actions must match IN ORDER
+  const actions = [{
+    match: 'Which kind of project do you want to create?',
+    do: [keys.ENTER]
+  }, {
+    match: 'Where would you like to create your project?',
+    do: [keys.ENTER]
+  }, {
+    match: 'What database do you want to use?',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to use the connection string',
+    do: ['y']
+  }, {
+    match: 'Confirm',
+    do: [keys.ENTER]
+  }, {
+    match: 'What port do you want to use?',
+    do: [keys.ENTER]
+  }, {
+    // create-platformatic uses pnpm in CI, so we need to match both options
+    match: ['Do you want to run npm install?', 'Do you want to run pnpm install?'],
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to create default migrations',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to apply migrations',
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to create a plugin',
+    do: [keys.ENTER]
+  }, {
+    // NOTE THAT HERE THE DEFAULT OPTION IS "NO", so just sending ENTER we won't have TS
+    match: 'Do you want to use TypeScript',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to create the github action to deploy',
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to enable PR Previews in your application',
+    do: [keys.DOWN, keys.ENTER]
+  }]
+  await executeCreatePlatformatic(tmpDir, actions, 'All done!')
+
+  const baseProjectDir = join(tmpDir, 'platformatic-db')
+  equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'platformatic.db.json')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'README.md')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'migrations')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.do.sql')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.undo.sql')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.js')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.js')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
+})
+
+test('Creates a Platformatic DB service with plugin using typescript, creating all the github actions', async ({ equal, same, match, teardown }) => {
+  console.log("==> DIR", tmpDir)
+  // The actions must match IN ORDER
+  const actions = [{
+    match: 'Which kind of project do you want to create?',
+    do: [keys.ENTER]
+  }, {
+    match: 'Where would you like to create your project?',
+    do: [keys.ENTER]
+  }, {
+    match: 'What database do you want to use?',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to use the connection string',
+    do: ['y']
+  }, {
+    match: 'Confirm',
+    do: [keys.ENTER]
+  }, {
+    match: 'What port do you want to use?',
+    do: [keys.ENTER]
+  }, {
+    // create-platformatic uses pnpm in CI, so we need to match both options
+    match: ['Do you want to run npm install?', 'Do you want to run pnpm install?'],
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to create default migrations',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to apply migrations',
+    do: [keys.DOWN, keys.ENTER]
+  }, {
+    match: 'Do you want to create a plugin',
+    do: [keys.ENTER]
+  }, {
+    // NOTE THAT HERE THE DEFAULT OPTION IS "NO"
+    match: 'Do you want to use TypeScript',
+    do: [keys.UP, keys.ENTER]
+  }, {
+    match: 'Do you want to create the github action to deploy',
+    do: [keys.ENTER]
+  }, {
+    match: 'Do you want to enable PR Previews in your application',
+    do: [keys.ENTER]
+  }]
+  await executeCreatePlatformatic(tmpDir, actions, 'All done!')
+
+  const baseProjectDir = join(tmpDir, 'platformatic-db')
+  equal(await isFileAccessible(join(baseProjectDir, '.gitignore')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.env')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.env.sample')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'platformatic.db.json')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'README.md')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'migrations')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.do.sql')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.undo.sql')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.ts')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.ts')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'global.d.ts')), true)
+  equal(await isFileAccessible(join(baseProjectDir, 'tsconfig.json')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-dynamic-workspace-deploy.yml')), true)
+  equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-static-workspace-deploy.yml')), true)
+})

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -35,7 +35,8 @@ test('Creates a Platformatic DB service with no migrations and no plugin', async
     match: 'What port do you want to use?',
     do: [keys.ENTER]
   }, {
-    match: 'Do you want to run npm install?',
+    // create-platformatic uses pnpm in CI, so we need to match both options
+    match: ['Do you want to run npm install?', 'Do you want to run pnpm install?'],
     do: [keys.DOWN, keys.ENTER]
   }, {
     match: 'Do you want to create default migrations',

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -15,7 +15,6 @@ afterEach(() => {
 })
 
 test('Creates a Platformatic DB service with no migrations and no plugin', async ({ equal, same, match, teardown }) => {
-  console.log('Creating Platformatic in ', tmpDir)
   // The actions must match IN ORDER
   const actions = [{
     match: 'Which kind of project do you want to create?',

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -126,6 +126,7 @@ test('Creates a Platformatic DB service with migrations and plugin', async ({ eq
   equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.undo.sql')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.js')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.js')), true)
+  // These are not generated because TS is not installed
   equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
 })
 
@@ -188,8 +189,9 @@ test('Creates a Platformatic DB service with plugin using typescript, creating a
   equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.undo.sql')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.ts')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.ts')), true)
-  equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
-  equal(await isFileAccessible(join(baseProjectDir, 'global.d.ts')), true)
+  // These are not generated because TS is not installed
+  // equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
+  // equal(await isFileAccessible(join(baseProjectDir, 'global.d.ts')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'tsconfig.json')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-dynamic-workspace-deploy.yml')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-static-workspace-deploy.yml')), true)

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -11,7 +11,11 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  rmSync(tmpDir, { recursive: true, force: true })
+  try {
+    rmSync(tmpDir, { recursive: true, force: true })
+  } catch (e) {
+    // on purpose, in win the resource might be still "busy"
+  }
 })
 
 test('Creates a Platformatic DB service with no migrations and no plugin', async ({ equal, same, match, teardown }) => {

--- a/packages/create-platformatic/test/cli/helper.mjs
+++ b/packages/create-platformatic/test/cli/helper.mjs
@@ -1,0 +1,86 @@
+import os from 'node:os'
+import { execaNode, execa } from 'execa'
+import { join } from 'desm'
+import stripAnsi from 'strip-ansi'
+import { promisify } from 'node:util'
+
+const sleep = promisify(setTimeout)
+
+export const keys = {
+  DOWN: '\x1B\x5B\x42',
+  UP: '\x1B\x5B\x41',
+  ENTER: '\x0D',
+  SPACE: '\x20'
+}
+
+export const createPath = join(import.meta.url, '..', '..', 'create-platformatic.mjs')
+
+// Actions are in the form:
+// {
+//    match: 'Server listening at',
+//    do: [keys.DOWN, keys.ENTER]
+// }
+export async function executeCreatePlatformatic (dir, actions = [], done = 'All done!') {
+  const runCreatePlatformatic = async () => {
+    const questions = [...actions]
+    try {
+      const child = execaNode(createPath, { cwd: dir })
+
+      // We just need the "lastPrompt" printed before the process stopped to wait for an answer
+      // If we don't have any outptu from process for more than 500ms, we assume it's waiting for an answer
+      let lastPrompt = ''
+
+      child.stdout.on('data', (chunk) => {
+        const str = stripAnsi(chunk.toString()).trim()
+        if (str) {
+          lastPrompt = str
+        }
+      })
+
+      let expectedQuestion = questions.shift()
+
+      // We need this because the prompt prints an introduction before asking anything.
+      // If we don't like this, we could use a flag to recognize when the introduction is done
+      await sleep(4000)
+
+      while (true) {
+        if (!expectedQuestion) {
+          await sleep(200)
+          // We processed all expected questions, so now we wait for the process to be done.
+          // If the "done" string is not printed, the test will timeout
+          if (lastPrompt && lastPrompt.includes(done)) {
+            safeKill(child)
+            return
+          }
+        } else if (lastPrompt.includes(expectedQuestion.match)) {
+          lastPrompt = ''
+          for (const key of expectedQuestion.do) {
+            child.stdin.write(key)
+            await sleep(200)
+          }
+          expectedQuestion = questions.shift()
+        } else {
+          throw new Error(`Expected ${expectedQuestion.match}, got ${lastPrompt}`)
+        }
+      }
+    } catch (err) {
+      console.error(err)
+      throw err
+    }
+  }
+  await runCreatePlatformatic()
+}
+
+export async function safeKill (child) {
+  child.kill('SIGINT')
+  if (os.platform() === 'win32') {
+    try {
+      await execa('taskkill', ['/pid', child.pid, '/f', '/t'])
+    } catch (err) {
+      if (err.stderr.indexOf('not found') === 0) {
+        console.error(`Failed to kill process ${child.pid}`)
+        console.error(err)
+      }
+    }
+  }
+}

--- a/packages/create-platformatic/test/cli/helper.mjs
+++ b/packages/create-platformatic/test/cli/helper.mjs
@@ -60,7 +60,7 @@ export async function executeCreatePlatformatic (dir, actions = [], done = 'All 
             return
           }
         } else if (match(lastPrompt, expectedQuestion.match)) {
-          console.log("==> MATCH", expectedQuestion.match)
+          console.log('==> MATCH', expectedQuestion.match)
           lastPrompt = ''
           for (const key of expectedQuestion.do) {
             child.stdin.write(key)

--- a/packages/create-platformatic/test/cli/helper.mjs
+++ b/packages/create-platformatic/test/cli/helper.mjs
@@ -3,6 +3,8 @@ import { execaNode, execa } from 'execa'
 import { join } from 'desm'
 import stripAnsi from 'strip-ansi'
 import { promisify } from 'node:util'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 
 const sleep = promisify(setTimeout)
 
@@ -20,6 +22,17 @@ const match = (str, match) => {
     return match.some((m) => str.includes(m))
   }
   return str.includes(match)
+}
+
+export const walk = async (dir) => {
+  let files = await fs.readdir(dir)
+  files = await Promise.all(files.map(async file => {
+    const filePath = path.join(dir, file)
+    const stats = await fs.stat(filePath)
+    if (stats.isDirectory()) return walk(filePath)
+    else if (stats.isFile()) return filePath
+  }))
+  return files.reduce((all, folderContents) => all.concat(folderContents), [])
 }
 
 // Actions are in the form:

--- a/packages/create-platformatic/test/cli/helper.mjs
+++ b/packages/create-platformatic/test/cli/helper.mjs
@@ -60,6 +60,7 @@ export async function executeCreatePlatformatic (dir, actions = [], done = 'All 
             return
           }
         } else if (match(lastPrompt, expectedQuestion.match)) {
+          console.log("==> MATCH", expectedQuestion.match)
           lastPrompt = ''
           for (const key of expectedQuestion.do) {
             child.stdin.write(key)

--- a/packages/create-platformatic/test/cli/helper.mjs
+++ b/packages/create-platformatic/test/cli/helper.mjs
@@ -69,8 +69,6 @@ export async function executeCreatePlatformatic (dir, actions = [], done = 'All 
           // We processed all expected questions, so now we wait for the process to be done.
           // If the "done" string is not printed, the test will timeout
           if (lastPrompt && lastPrompt.includes(done)) {
-            console.log('==> DONE, received:', lastPrompt)
-            await sleep(500)
             safeKill(child)
             return
           }

--- a/packages/create-platformatic/test/cli/helper.mjs
+++ b/packages/create-platformatic/test/cli/helper.mjs
@@ -15,6 +15,13 @@ export const keys = {
 
 export const createPath = join(import.meta.url, '..', '..', 'create-platformatic.mjs')
 
+const match = (str, match) => {
+  if (Array.isArray(match)) {
+    return match.some((m) => str.includes(m))
+  }
+  return str.includes(match)
+}
+
 // Actions are in the form:
 // {
 //    match: 'Server listening at',
@@ -52,7 +59,7 @@ export async function executeCreatePlatformatic (dir, actions = [], done = 'All 
             safeKill(child)
             return
           }
-        } else if (lastPrompt.includes(expectedQuestion.match)) {
+        } else if (match(lastPrompt, expectedQuestion.match)) {
           lastPrompt = ''
           for (const key of expectedQuestion.do) {
             child.stdin.write(key)

--- a/packages/create-platformatic/test/cli/helper.mjs
+++ b/packages/create-platformatic/test/cli/helper.mjs
@@ -69,6 +69,8 @@ export async function executeCreatePlatformatic (dir, actions = [], done = 'All 
           // We processed all expected questions, so now we wait for the process to be done.
           // If the "done" string is not printed, the test will timeout
           if (lastPrompt && lastPrompt.includes(done)) {
+            console.log('==> DONE, received:', lastPrompt)
+            await sleep(500)
             safeKill(child)
             return
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,6 +530,9 @@ importers:
       semver:
         specifier: ^7.5.4
         version: 7.5.4
+      strip-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
       undici:
         specifier: ^5.25.4
         version: 5.25.4


### PR DESCRIPTION
This is for unit tests for DB services created by `create-platformatic` (currently the "interactive" part of the  CLI is NOT tested).
This can be leveraged also for future integration tests.
If this is OK, we will do the same for Service, Runtime, Composer