### PR TITLE
Fixed a couple of typos in the client-cli package

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -257,8 +257,8 @@ export async function command (argv) {
     ext: '.txt'
   })
   let { _: [url], ...options } = parseArgs(argv, {
-    string: ['name', 'folder', 'runtime', 'optional-headers', 'lannguage'],
-    boolean: ['typescript', 'full-response', 'types-only', 'full-response', 'full', 'frontend', 'validate-response'],
+    string: ['name', 'folder', 'runtime', 'optional-headers', 'language'],
+    boolean: ['typescript', 'full-response', 'types-only', 'full-request', 'full', 'frontend', 'validate-response'],
     default: {
       typescript: false,
       language: 'js'


### PR DESCRIPTION
The `full-response` argument was given twice in the `minimist` arg parser and the `full-request` arg was not given. I've corrected it.
There was also another typo with the `language` argument.