### PR TITLE
fixes(#1641) sql-graphql enum values may contain spaces

### DIFF
--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -69,7 +69,7 @@ function constructGraph (app, entity, opts, ignore) {
       meta.type = new graphql.GraphQLList(listType)
     } else if (field.enum) {
       const enumValues = field.enum.reduce((acc, enumValue, index) => {
-        let key = enumValue.replace(/[^\w\s]/g, '_')
+        let key = enumValue.replace(/[^\w]/g, '_')
 
         const keyStartsWithLetterOrUnderscore = !!key.match(/^[_a-zA-Z]/g)
         if (!keyStartsWithLetterOrUnderscore) {

--- a/packages/sql-graphql/test/enum.test.js
+++ b/packages/sql-graphql/test/enum.test.js
@@ -47,6 +47,47 @@ test('should properly setup the enum types', { skip: isSQLite }, async ({ pass, 
   }
 })
 
+test('should not fail if enum value contains a space ', { skip: isSQLite }, async ({ pass, teardown, same }) => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isPg) {
+        await db.query(sql`
+        CREATE TYPE custom_enum AS ENUM('Field 1', 'Field .', '. Field', ' f 1 ');
+
+        CREATE TABLE enum_tests (
+          id INTEGER NOT NULL,
+          test_enum custom_enum,
+          PRIMARY KEY (id)
+        );`)
+      } else {
+        await db.query(sql`
+        CREATE TABLE enum_tests (
+          id INTEGER NOT NULL,
+          test_enum ENUM ('Field 1', 'Field .', '. Field', ' f 1 ') DEFAULT NULL,
+          PRIMARY KEY (id)
+        );`)
+      }
+    }
+  })
+
+  app.register(sqlGraphQL)
+  teardown(app.close.bind(app))
+
+  try {
+    await app.ready()
+    same(true, true, 'Enum with spaces are properly interpreted')
+  } catch (err) {
+    console.log(err)
+    same(true, false, 'Previous call should never fail')
+  }
+})
+
 test('should not fail if tables have duplicate enum names', { skip: isSQLite }, async ({ pass, teardown, same }) => {
   const app = fastify()
   app.register(sqlMapper, {


### PR DESCRIPTION
fixes(#1641) Bug where enums could not be parsed when generating graphql schema.