### PR TITLE
fix(sql-mapper): fix type for "gt" where clause

### DIFF
--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -82,7 +82,7 @@ export interface WhereCondition {
     /**
      * Greater than value.
      */
-    gr?: any,
+    gt?: any,
     /**
      * Greater than or equal to value.
      */


### PR DESCRIPTION
It should be `gt` instead of `gr` as declared here: https://github.com/platformatic/platformatic/blob/main/packages/sql-mapper/lib/entity.js#L200