### PR TITLE
skip the schema type starting with __

### DIFF
--- a/packages/sql-graphql/lib/telemetry.js
+++ b/packages/sql-graphql/lib/telemetry.js
@@ -44,7 +44,7 @@ const setupTelemetry = app => {
     const schemaTypeName = schemaType.name.toLowerCase() // query, mutation, subscription
     if (typeof schemaType.getFields === 'function') {
       for (const [fieldName, field] of Object.entries(schemaType.getFields())) {
-        if (typeof field.resolve === 'function') {
+        if (typeof field.resolve === 'function' && !schemaTypeName.startsWith('__')) {
           field.resolve = telemetryWrapper(app, field.resolve, schemaTypeName, fieldName)
         }
       }

--- a/packages/sql-graphql/lib/telemetry.js
+++ b/packages/sql-graphql/lib/telemetry.js
@@ -46,6 +46,7 @@ const setupTelemetry = app => {
       for (const [fieldName, field] of Object.entries(schemaType.getFields())) {
         if (typeof field.resolve === 'function' && !schemaTypeName.startsWith('__')) {
           field.resolve = telemetryWrapper(app, field.resolve, schemaTypeName, fieldName)
+          field.resolve.__wrapped = true
         }
       }
     }


### PR DESCRIPTION
This to avoid to wrap all the schema type with name starting with `__`  like `__schema`, `__type`, `__field` (which is useless).
