### PR TITLE
Update reference configuration docs

### DIFF
--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -89,6 +89,20 @@ A **required** object with the following settings:
   }
   ```
 
+  Enables GraphQL support with the `enabled` option
+
+  ```json
+  {
+    "db": {
+      ...
+      "graphql": {
+        ...
+        "enabled": true
+      }
+    }
+  }
+  ```
+
   Enables GraphQL support with GraphiQL
 
   ```json
@@ -161,6 +175,20 @@ A **required** object with the following settings:
     "db": {
       ...
       "openapi": true
+    }
+  }
+  ```
+
+  Enables OpenAPI using the `enabled` option
+
+  ```json
+  {
+    "db": {
+      ...
+      "openapi": {
+        ...
+        "enabled": true
+      }
     }
   }
   ```
@@ -294,6 +322,20 @@ A **required** object with the following settings:
   It's possible to configure it to use Redis instead.
 
   _Examples_
+
+  Enable events using the `enabled` option.
+
+  ```json
+  {
+    "db": {
+      ...
+      "events": {
+        ...
+        "enabled": true
+      }
+    }
+  }
+  ```
 
   ```json
   {

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -123,6 +123,16 @@ An optional object that defines the plugins loaded by Platformatic Service.
   - `options` (`object`): Optional plugin options.
   - `encapsulate` (`boolean`): if the path is a folder, it instruct Platformatic to not encapsulate those plugins.
   - `maxDepth` (`integer`): if the path is a folder, it limits the depth to load the content from.
+  - `autoHooks` (`boolean`): Apply hooks from autohooks.js file(s) to plugins found in folder.
+  - `autoHooksPattern` (`string`): Regex to override the autohooks naming convention.
+  - `cascadeHooks` (`boolean`): If using autoHooks, cascade hooks to all children. Ignored if autoHooks is false.
+  - `overwriteHooks` (`boolean`): If using cascadeHooks, cascade will be reset when a new autohooks.js file is encountered. Ignored if autoHooks is false.
+  - `routeParams` (`boolean`): Folders prefixed with _ will be turned into route parameters.
+  - `forceESM` (`boolean`): If set to 'true' it always use await import to load plugins or hooks.
+  - `ignoreFilter` (`string`): Filter matching any path that should not be loaded. Can be a RegExp, a string or a function returning a boolean.
+  - `matchFilter` (`string`): Filter matching any path that should be loaded. Can be a RegExp, a string or a function returning a boolean.
+  - `ignorePattern` (`string`): RegExp matching any file or folder that should not be loaded.
+  - `indexPattern` (`string`): Regex to override the index.js naming convention
 - **`typescript`** (`boolean` or `object`): enable TypeScript compilation. A `tsconfig.json` file is required in the same folder. See [TypeScript compilation options](#typescript-compilation-options) for more details.
 
 _Example_


### PR DESCRIPTION
Update documentation to include `enabled` option for `graphql`, `openapi` and `events. Also add documentation for `autoload` options.

Resolves #1695 