### PR TITLE
Moved a utility function to lib/utils.js in sql-mapper and also made it consistent with another similar function

### DIFF
--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -4,17 +4,13 @@ const camelcase = require('camelcase')
 const {
   toSingular,
   toUpperFirst,
+  toLowerFirst,
   tableName,
   sanitizeLimit
 } = require('./utils')
 const { singularize } = require('inflected')
 const { findNearestString } = require('@platformatic/utils')
 const errors = require('./errors')
-
-function lowerCaseFirst (str) {
-  str = str.toString()
-  return str.charAt(0).toLowerCase() + str.slice(1)
-}
 
 function createMapper (defaultDb, sql, log, table, fields, primaryKeys, relations, queries, autoTimestamp, schema, useSchemaInName, limitConfig, columns, constraintsList) {
   /* istanbul ignore next */ // Ignoring because this won't be fully covered by DB not supporting schemas (SQLite)
@@ -458,7 +454,7 @@ function buildEntity (db, sql, log, table, queries, autoTimestamp, schema, useSc
       field.foreignKey = true
       const foreignEntityName = singularize(camelcase(useSchemaInName ? camelcase(`${constraint.foreign_table_schema} ${constraint.foreign_table_name}`) : constraint.foreign_table_name))
       const entityName = singularize(camelcase(useSchemaInName ? camelcase(`${constraint.table_schema} ${constraint.table_name}`) : constraint.table_name))
-      const loweredTableWithSchemaName = lowerCaseFirst(useSchemaInName ? camelcase(`${constraint.table_schema} ${camelcase(constraint.table_name)}`) : camelcase(constraint.table_name))
+      const loweredTableWithSchemaName = toLowerFirst(useSchemaInName ? camelcase(`${constraint.table_schema} ${camelcase(constraint.table_name)}`) : camelcase(constraint.table_name))
       constraint.loweredTableWithSchemaName = loweredTableWithSchemaName
       constraint.foreignEntityName = foreignEntityName
       constraint.entityName = entityName

--- a/packages/sql-mapper/lib/utils.js
+++ b/packages/sql-mapper/lib/utils.js
@@ -5,7 +5,13 @@ const camelcase = require('camelcase')
 const errors = require('./errors')
 
 function toUpperFirst (str) {
+  str = str.toString()
   return str[0].toUpperCase() + str.slice(1)
+}
+
+function toLowerFirst (str) {
+  str = str.toString()
+  return str.charAt(0).toLowerCase() + str.slice(1)
 }
 
 function toSingular (str) {
@@ -46,6 +52,7 @@ function areSchemasSupported (sql) {
 module.exports = {
   toSingular,
   toUpperFirst,
+  toLowerFirst,
   sanitizeLimit,
   tableName,
   areSchemasSupported


### PR DESCRIPTION
A utility function to convert the first char of a string to lower case was defined in `/lib/entity.js` of the `sql-mapper` package, while a similar function to convert the first char to upper case was defined in `/lib/utils.js`. I've moved the first function to the `utils` file too and made its name consistent with the other function.

Also, the function to convert the first char to upper case was not converting its input to a string before performing a string operation. I've fixed that too.

In short, I moved both functions to the same place (`/lib/utils.js`) and made them consistent.