### PR TITLE
Add typescript dependency on runtime

### DIFF
--- a/packages/create-platformatic/src/composer/create-composer-cli.mjs
+++ b/packages/create-platformatic/src/composer/create-composer-cli.mjs
@@ -135,6 +135,11 @@ const createPlatformaticComposer = async (_args, opts) => {
     await execa(pkgManager, ['install'], { cwd: projectDir })
     spinner.succeed()
   }
+
+  // returns metadata that can be used to make some further actions
+  return {
+    typescript: useTypescript
+  }
 }
 
 export default createPlatformaticComposer

--- a/packages/create-platformatic/src/create-package-json.mjs
+++ b/packages/create-platformatic/src/create-package-json.mjs
@@ -47,11 +47,12 @@ const packageJsonTemplate = async (addTSBuild, fastifyVersion, platVersion) => {
  * @param {object} scripts Package.json scripts list
  * @param {object} dependencies Package.json dependencies list
  */
-export const createPackageJson = async (platVersion, fastifyVersion, logger, dir, addTSBuild = false, scripts = {}, dependencies = {}) => {
+export const createPackageJson = async (platVersion, fastifyVersion, logger, dir, addTSBuild = false, scripts = {}, dependencies = {}, devDependencies = {}) => {
   const packageJsonFileName = join(dir, 'package.json')
   const pkg = await packageJsonTemplate(addTSBuild, fastifyVersion, platVersion)
   Object.assign(pkg.scripts, scripts)
   Object.assign(pkg.dependencies, dependencies)
+  Object.assign(pkg.devDependencies, devDependencies)
   await writeFile(packageJsonFileName, JSON.stringify(pkg, null, 2))
   logger.debug(`${packageJsonFileName} successfully created.`)
 }

--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -256,6 +256,10 @@ const createPlatformaticDB = async (_args, opts) => {
       }
     }
   }
+  // returns metadata that can be used to make some further actions
+  return {
+    typescript: useTypescript
+  }
 }
 
 export default createPlatformaticDB

--- a/packages/create-platformatic/src/index.mjs
+++ b/packages/create-platformatic/src/index.mjs
@@ -31,14 +31,11 @@ export async function chooseKind (argv, opts = {}) {
 
   switch (options.type) {
     case 'db':
-      await createPlatformaticDB(argv, opts)
-      break
+      return await createPlatformaticDB(argv, opts)
     case 'service':
-      await createPlatformaticService(argv, opts)
-      break
+      return await createPlatformaticService(argv, opts)
     case 'composer':
-      await createPlatformaticComposer(argv, opts)
-      break
+      return await createPlatformaticComposer(argv, opts)
     case 'runtime':
       await createPlatformaticRuntime(argv, opts)
       break

--- a/packages/create-platformatic/src/runtime/create-runtime.mjs
+++ b/packages/create-platformatic/src/runtime/create-runtime.mjs
@@ -26,7 +26,7 @@ async function createRuntime (params, logger, currentDir = process.cwd(), versio
     entrypointPort,
     staticWorkspaceGitHubAction,
     dynamicWorkspaceGitHubAction,
-    initGitRepository,
+    initGitRepository
   } = params
   if (!version) {
     const pkg = await readFile(desm.join(import.meta.url, '..', '..', 'package.json'))

--- a/packages/create-platformatic/src/runtime/create-runtime.mjs
+++ b/packages/create-platformatic/src/runtime/create-runtime.mjs
@@ -26,7 +26,7 @@ async function createRuntime (params, logger, currentDir = process.cwd(), versio
     entrypointPort,
     staticWorkspaceGitHubAction,
     dynamicWorkspaceGitHubAction,
-    initGitRepository
+    initGitRepository,
   } = params
   if (!version) {
     const pkg = await readFile(desm.join(import.meta.url, '..', '..', 'package.json'))

--- a/packages/create-platformatic/src/service/create-service-cli.mjs
+++ b/packages/create-platformatic/src/service/create-service-cli.mjs
@@ -122,5 +122,9 @@ const createPlatformaticService = async (_args, opts = {}) => {
     logger.trace({ err })
     spinner.fail('Failed to generate Types. Try again by running "platformatic service types"')
   }
+  // returns metadata that can be used to make some further actions
+  return {
+    typescript: useTypescript
+  }
 }
 export default createPlatformaticService

--- a/packages/create-platformatic/test/create-package-json.test.mjs
+++ b/packages/create-platformatic/test/create-package-json.test.mjs
@@ -44,7 +44,10 @@ test('creates package.json file for service project', async ({ equal }) => {
   const version = '1.2.3'
   const fastifyVersion = '4.5.6'
   const addTSBuild = false
-  await createPackageJson(version, fastifyVersion, fakeLogger, tmpDir, addTSBuild)
+  const devDependencies = {
+    typescript: '^5.2.2'
+  }
+  await createPackageJson(version, fastifyVersion, fakeLogger, tmpDir, addTSBuild, {}, {}, devDependencies)
   equal(log, `${join(tmpDir, 'package.json')} successfully created.`)
   const accessible = await isFileAccessible(join(tmpDir, 'package.json'))
   equal(accessible, true)
@@ -52,6 +55,7 @@ test('creates package.json file for service project', async ({ equal }) => {
   equal(packageJson.scripts.start, 'platformatic start')
   equal(packageJson.dependencies.platformatic, `^${version}`)
   equal(packageJson.devDependencies.fastify, `^${fastifyVersion}`)
+  equal(packageJson.devDependencies.typescript, '^5.2.2')
 })
 
 test('creates package.json file with TS build', async ({ equal }) => {

--- a/packages/create-platformatic/test/utils.test.mjs
+++ b/packages/create-platformatic/test/utils.test.mjs
@@ -110,6 +110,11 @@ test('getDependencyVersion', async ({ equal }) => {
   // We cannot assert the exact version because it changes
   equal(semver.valid(fastifyVersion), fastifyVersion)
   equal(semver.gt(fastifyVersion, '4.10.0'), true)
+
+  const typescriptVersion = await getDependencyVersion('typescript')
+  // We cannot assert the exact version because it changes
+  equal(semver.valid(typescriptVersion), typescriptVersion)
+  equal(semver.gt(typescriptVersion, '5.0.0'), true)
 })
 
 test('findDBConfigFile', async ({ end, equal, mock }) => {

--- a/packages/create-platformatic/test/utils.test.mjs
+++ b/packages/create-platformatic/test/utils.test.mjs
@@ -115,6 +115,11 @@ test('getDependencyVersion', async ({ equal }) => {
   // We cannot assert the exact version because it changes
   equal(semver.valid(typescriptVersion), typescriptVersion)
   equal(semver.gt(typescriptVersion, '5.0.0'), true)
+
+  const platformaticConfig = await getDependencyVersion('@platformatic/config')
+  // We cannot assert the exact version because it changes
+  equal(semver.valid(platformaticConfig), platformaticConfig)
+  equal(semver.gt(platformaticConfig, '1.0.0'), true)
 })
 
 test('findDBConfigFile', async ({ end, equal, mock }) => {


### PR DESCRIPTION
Main changes
- all `createXXX` function will return an object `{ typescript: true | false }` 
- `createPackagejson()` will accept a `devDependencies` parameter
- `getDependencyVersion` will find where exactly the dep `package.json` file is located 

Fixes: #1752 