### PR TITLE
Changes to prevent the composer process from exiting if it fails to fetch any OpenAPI schemas

### DIFF
--- a/packages/composer/lib/fetch-schemas.mjs
+++ b/packages/composer/lib/fetch-schemas.mjs
@@ -37,15 +37,23 @@ export default async function fetchOpenApiSchemas (_args) {
     const { configManager } = await loadConfig({}, _args, platformaticComposer)
     await configManager.parseAndValidate()
     const config = configManager.current
+    const { services } = config.composer
 
-    const fetchOpenApiRequests = config.composer.services
+    const servicesWithValidOpenApi = services
       .filter(({ openapi }) => openapi && openapi.url && openapi.file)
+
+    const fetchOpenApiRequests = servicesWithValidOpenApi
       .map(service => fetchOpenApiSchema(service))
 
-    // TODO: replace with allSettled
-    await Promise.all(fetchOpenApiRequests)
-
-    logger.info('OpenAPI schemas successfully fetched')
+    const fetchOpenApiResults = await Promise.allSettled(fetchOpenApiRequests)
+    fetchOpenApiResults.forEach((result, index) => {
+      const serviceId = servicesWithValidOpenApi[index].id
+      if (result.status === 'rejected') {
+        logger.error(`Failed to fetch OpenAPI schema for service with id ${serviceId}: ${result.reason}`)
+      } else {
+        logger.info(`Successfully fetched OpenAPI schema for service with id ${serviceId}`)
+      }
+    })
   } catch (error) {
     logger.error(error.message)
     process.exit(1)

--- a/packages/composer/lib/fetch-schemas.mjs
+++ b/packages/composer/lib/fetch-schemas.mjs
@@ -33,31 +33,26 @@ export default async function fetchOpenApiSchemas (_args) {
     ignore: 'hostname,pid'
   }))
 
-  try {
-    const { configManager } = await loadConfig({}, _args, platformaticComposer)
-    await configManager.parseAndValidate()
-    const config = configManager.current
-    const { services } = config.composer
+  const { configManager } = await loadConfig({}, _args, platformaticComposer)
+  await configManager.parseAndValidate()
+  const config = configManager.current
+  const { services } = config.composer
 
-    const servicesWithValidOpenApi = services
-      .filter(({ openapi }) => openapi && openapi.url && openapi.file)
+  const servicesWithValidOpenApi = services
+    .filter(({ openapi }) => openapi && openapi.url && openapi.file)
 
-    const fetchOpenApiRequests = servicesWithValidOpenApi
-      .map(service => fetchOpenApiSchema(service))
+  const fetchOpenApiRequests = servicesWithValidOpenApi
+    .map(service => fetchOpenApiSchema(service))
 
-    const fetchOpenApiResults = await Promise.allSettled(fetchOpenApiRequests)
-    fetchOpenApiResults.forEach((result, index) => {
-      const serviceId = servicesWithValidOpenApi[index].id
-      if (result.status === 'rejected') {
-        logger.error(`Failed to fetch OpenAPI schema for service with id ${serviceId}: ${result.reason}`)
-      } else {
-        logger.info(`Successfully fetched OpenAPI schema for service with id ${serviceId}`)
-      }
-    })
-  } catch (error) {
-    logger.error(error.message)
-    process.exit(1)
-  }
+  const fetchOpenApiResults = await Promise.allSettled(fetchOpenApiRequests)
+  fetchOpenApiResults.forEach((result, index) => {
+    const serviceId = servicesWithValidOpenApi[index].id
+    if (result.status === 'rejected') {
+      logger.error(`Failed to fetch OpenAPI schema for service with id ${serviceId}: ${result.reason}`)
+    } else {
+      logger.info(`Successfully fetched OpenAPI schema for service with id ${serviceId}`)
+    }
+  })
 }
 
 export {

--- a/packages/composer/test/cli/fetch-schema.test.js
+++ b/packages/composer/test/cli/fetch-schema.test.js
@@ -14,7 +14,7 @@ const { createOpenApiService } = require('../helper.js')
 
 const openApiValidator = new OpenAPISchemaValidator({ version: 3 })
 
-test('should fetch the schemas', async (t) => {
+test('should fetch the available schemas', async (t) => {
   const { execa } = await import('execa')
 
   const cwd = await mkdtemp(join(tmpdir(), 'composer-test-'))
@@ -23,10 +23,17 @@ test('should fetch the schemas', async (t) => {
   })
 
   const pathToConfig = join(cwd, 'platformatic.composer.json')
-  const pathToSchema = join(cwd, 'api1.json')
+  const pathToSchema1 = join(cwd, 'api1.json')
+  const pathToSchema2 = join(cwd, 'api2.json')
 
   const api1 = await createOpenApiService(t, ['users'])
   await api1.listen({ port: 0 })
+
+  const api2 = fastify()
+  await api2.listen({ port: 0 })
+  t.after(async () => {
+    await api2.close()
+  })
 
   const config = {
     server: {
@@ -43,7 +50,15 @@ test('should fetch the schemas', async (t) => {
           origin: 'http://127.0.0.1:' + api1.server.address().port,
           openapi: {
             url: '/documentation/json',
-            file: pathToSchema
+            file: pathToSchema1
+          }
+        },
+        {
+          id: 'api2',
+          origin: 'http://127.0.0.1:' + api2.server.address().port,
+          openapi: {
+            url: '/documentation/json',
+            file: pathToSchema2
           }
         }
       ],
@@ -56,7 +71,7 @@ test('should fetch the schemas', async (t) => {
   await writeFile(pathToConfig, JSON.stringify(config))
   await execa('node', [cliPath, 'openapi', 'schemas', 'fetch', '-c', pathToConfig])
 
-  const openApiSchemaFile = await readFile(pathToSchema, 'utf-8')
+  const openApiSchemaFile = await readFile(pathToSchema1, 'utf-8')
   const openApiSchema = JSON.parse(openApiSchemaFile)
   openApiValidator.validate(openApiSchema)
 
@@ -64,57 +79,4 @@ test('should fetch the schemas', async (t) => {
   const usersOpenApiSchemaFile = await readFile(pathToUsersSchema, 'utf-8')
   const usersOpenApiSchema = JSON.parse(usersOpenApiSchemaFile)
   assert.deepEqual(openApiSchema, usersOpenApiSchema)
-})
-
-test('should throw if api is not available', async (t) => {
-  const { execa } = await import('execa')
-
-  const cwd = await mkdtemp(join(tmpdir(), 'composer-test-'))
-  t.after(async () => {
-    await rm(cwd, { recursive: true, force: true })
-  })
-
-  const pathToConfig = join(cwd, 'platformatic.composer.json')
-  const pathToSchema = join(cwd, 'api1.json')
-
-  const api1 = fastify()
-  await api1.listen({ port: 0 })
-
-  t.after(async () => {
-    await api1.close()
-  })
-
-  const config = {
-    server: {
-      hostname: '127.0.0.1',
-      port: 0,
-      logger: {
-        level: 'info'
-      }
-    },
-    composer: {
-      services: [
-        {
-          id: 'api1',
-          origin: 'http://127.0.0.1:' + api1.server.address().port,
-          openapi: {
-            url: '/documentation/json',
-            file: pathToSchema
-          }
-        }
-      ],
-      refreshTimeout: 1000
-    },
-    types: {},
-    watch: false
-  }
-
-  await writeFile(pathToConfig, JSON.stringify(config))
-
-  try {
-    await execa('node', [cliPath, 'openapi', 'schemas', 'fetch', '-c', pathToConfig])
-    assert.fail('should throw')
-  } catch (err) {
-    assert.match(err.stdout, /Failed to fetch OpenAPI schema/)
-  }
 })

--- a/packages/composer/test/openapi/fixtures/schemas/users.json
+++ b/packages/composer/test/openapi/fixtures/schemas/users.json
@@ -1,12 +1,13 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.1.0",
-    "title": "Test"
+    "title": "Test",
+    "version": "0.1.0"
   },
   "components": {
     "schemas": {
       "def-0": {
+        "title": "users",
         "type": "object",
         "properties": {
           "id": {
@@ -15,8 +16,7 @@
           "name": {
             "type": "string"
           }
-        },
-        "title": "users"
+        }
       }
     }
   },
@@ -93,6 +93,16 @@
     },
     "/users/{id}": {
       "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "Default Response",
@@ -107,6 +117,16 @@
         }
       },
       "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "Default Response",
@@ -121,6 +141,16 @@
         }
       },
       "put": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "Default Response",
@@ -135,6 +165,16 @@
         }
       },
       "delete": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "Default Response",

--- a/packages/composer/test/runner.js
+++ b/packages/composer/test/runner.js
@@ -12,7 +12,7 @@ const files = [
   ...glob(path.join(__dirname, '*.test.js')),
   ...glob(path.join(__dirname, 'openapi', '*.test.js')),
   ...glob(path.join(__dirname, 'telemetry', '*.test.js')),
-  ...glob(path.join(__dirname, 'cli', '*.test.mjs'))
+  ...glob(path.join(__dirname, 'cli', '*.test.js'))
 ]
 
 run({


### PR DESCRIPTION
Changed the `fetchOpenApiSchemas` function in `packages/composer/lib/fetch-schemas.mjs` so that the composer CLI does not exit if it fails to fetch even a single schema.
Also, added success/error logs for fetching schema for every OpenAPI service.

Note: there were no tests for `fetchOpenApiSchemas`, so I have not changed any tests after making the above changes.