### PR TITLE
Avoid creating a client from a runtime root

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -203,6 +203,7 @@ async function downloadAndProcess (options) {
   }
 
   if (config && !typesOnly) {
+    console.log('@@@@@@@', config)
     const meta = await analyze({ file: config })
     meta.config.clients = meta.config.clients || []
     if (runtime) {
@@ -297,6 +298,12 @@ export async function command (argv) {
   if (options.runtime) {
     // TODO add flag to allow specifying a runtime config file
     const runtimeConfigFile = await findUp('platformatic.runtime.json')
+
+    // check we are **not** into the runtime root
+    if (runtimeConfigFile?.replace(`${process.cwd()}/`, '') === 'platformatic.runtime.json') {
+      logger.error('Could not create a client runtime from the runtime root.')
+      process.exit(1)
+    }
 
     if (!runtimeConfigFile) {
       logger.error('Could not find a platformatic.runtime.json file in this or any parent directory.')

--- a/packages/client-cli/test/runtime.test.mjs
+++ b/packages/client-cli/test/runtime.test.mjs
@@ -91,6 +91,22 @@ module.exports = async function (app, opts) {
     title: 'foo'
   })
 })
+test('should return error if in the runtime root', async ({ teardown, comment, fail, match }) => {
+  const dir = await moveToTmpdir(teardown)
+  comment(`working in ${dir}`)
+
+  await cp(join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'runtime'), dir, { recursive: true })
+
+  process.chdir(dir)
+
+  try {
+    await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), '--name', 'movies', '--runtime', 'somber-chariot'])
+
+    fail()
+  } catch (err) {
+    match(err.message, 'Could not create a client runtime from the runtime root.')
+  }
+})
 
 test('graphql client generation (javascript) via the runtime', async ({ teardown, comment, same, match }) => {
   const dir = await moveToTmpdir(teardown)

--- a/packages/client-cli/test/runtime.test.mjs
+++ b/packages/client-cli/test/runtime.test.mjs
@@ -286,7 +286,7 @@ PORT=3005
 PLT_SERVER_LOGGER_LEVEL=info
 `)
 
-  process.chdir(join(dir))
+  process.chdir(join(dir, 'services', 'composer'))
 
   try {
     await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), '--name', 'test-client', '--runtime', 'sample-service'])


### PR DESCRIPTION
This PR is needed because the `platformatic.runtime.json` file would me modified adding a `clients: [ ... ]` property which fails the schema validation