### PR TITLE
Appends query params to non-GET requests in frontend client generation

### DIFF
--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -121,15 +121,17 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
           writer.writeLine(`const queryParameters${queryParametersType}= [${quotedParams.join(', ')}]`)
           writer.writeLine('const searchParams = new URLSearchParams()')
           writer.write('queryParameters.forEach((qp) =>').inlineBlock(() => {
-            writer.writeLine('searchParams.append(qp, request[qp]?.toString() || \'\')')
-            writer.writeLine('delete request[qp]')
+            writer.write('if (request[qp]) ').block(() => {
+              writer.writeLine('searchParams.append(qp, request[qp]?.toString() || \'\')')
+              writer.writeLine('delete request[qp]')
+            })
           })
           writer.write(')')
           writer.blankLine()
         }
 
         writer
-          .conditionalWrite(queryParams.length > 0, `const response = await fetch(\`\${url}${stringLiteralPath}\${searchParams.toString()}\`, `)
+          .conditionalWrite(queryParams.length > 0, `const response = await fetch(\`\${url}${stringLiteralPath}?\${searchParams.toString()}\`, `)
           .conditionalWrite(queryParams.length === 0, `const response = await fetch(\`\${url}${stringLiteralPath}\`, `)
           .inlineBlock(() => {
             writer.write('method: ').quote().write(method.toUpperCase()).quote().write(',')

--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -114,10 +114,14 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
         if (queryParams.length) {
           // query parameters should be appended to the url
           const quotedParams = queryParams.map((qp) => `'${qp}'`)
-          writer.writeLine(`const queryParameters = [${quotedParams.join(', ')}]`)
+          let queryParametersType = ''
+          if (language === 'ts') {
+            queryParametersType = `: (keyof Types.${operationRequestName})[] `
+          }
+          writer.writeLine(`const queryParameters${queryParametersType}= [${quotedParams.join(', ')}]`)
           writer.writeLine('const searchParams = new URLSearchParams()')
           writer.write('queryParameters.forEach((qp) =>').inlineBlock(() => {
-            writer.writeLine('searchParams.append(qp, request[qp])')
+            writer.writeLine('searchParams.append(qp, request[qp]?.toString() || \'\')')
             writer.writeLine('delete request[qp]')
           })
           writer.write(')')

--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -61,11 +61,20 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
   const allOperations = []
   const originalFullResponse = fullResponse
   let currentFullResponse = originalFullResponse
+  function getQueryParamsString (operationParams) {
+    return operationParams
+      .filter((p) => p.in === 'query')
+      .map((p) => p.name)
+  }
   for (const operation of operations) {
     const { operationId, responses } = operation.operation
     const operationRequestName = `${capitalize(operationId)}Request`
     const underscoredOperationId = `_${operationId}`
+    let queryParams = []
 
+    if (operation.operation.parameters) {
+      queryParams = getQueryParamsString(operation.operation.parameters)
+    }
     allOperations.push(operationId)
     const { method, path } = operation
 
@@ -102,8 +111,22 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
           `const response = await fetch(\`\${url}${stringLiteralPath}?\${new URLSearchParams(Object.entries(request || {})).toString()}\`)`
         )
       } else {
+        if (queryParams.length) {
+          // query parameters should be appended to the url
+          const quotedParams = queryParams.map((qp) => `'${qp}'`)
+          writer.writeLine(`const queryParameters = [${quotedParams.join(', ')}]`)
+          writer.writeLine('const searchParams = new URLSearchParams()')
+          writer.write('queryParameters.forEach((qp) =>').inlineBlock(() => {
+            writer.writeLine('searchParams.append(qp, request[qp])')
+            writer.writeLine('delete request[qp]')
+          })
+          writer.write(')')
+          writer.blankLine()
+        }
+
         writer
-          .write(`const response = await fetch(\`\${url}${stringLiteralPath}\`, `)
+          .conditionalWrite(queryParams.length > 0, `const response = await fetch(\`\${url}${stringLiteralPath}\${searchParams.toString()}\`, `)
+          .conditionalWrite(queryParams.length === 0, `const response = await fetch(\`\${url}${stringLiteralPath}\`, `)
           .inlineBlock(() => {
             writer.write('method: ').quote().write(method.toUpperCase()).quote().write(',')
             writer.writeLine('body: JSON.stringify(request),')

--- a/packages/client-cli/test/fixtures/append-query-params-frontend.openapi.json
+++ b/packages/client-cli/test/fixtures/append-query-params-frontend.openapi.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/": {
+      "post": {
+        "operationId": "postRoot",
+        "parameters": [
+          {
+            "name": "level",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "score": {
+                      "type": "number"
+                    },
+                    "room": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [ "score", "room" ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -257,10 +257,10 @@ test('append query parameters to url in non-GET requests', async ({ teardown, ok
 
   const tsImplementationTemplate = `
 const _postRoot = async (url: string, request: Types.PostRootRequest) => {
-  const queryParameters = ['level']
+  const queryParameters: (keyof Types.PostRootRequest)[] = ['level']
   const searchParams = new URLSearchParams()
   queryParameters.forEach((qp) =>{
-    searchParams.append(qp, request[qp])
+    searchParams.append(qp, request[qp]?.toString() || '')
     delete request[qp]
   })
 `

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -260,9 +260,13 @@ const _postRoot = async (url: string, request: Types.PostRootRequest) => {
   const queryParameters: (keyof Types.PostRootRequest)[] = ['level']
   const searchParams = new URLSearchParams()
   queryParameters.forEach((qp) =>{
-    searchParams.append(qp, request[qp]?.toString() || '')
-    delete request[qp]
+    if (request[qp]) {
+      searchParams.append(qp, request[qp]?.toString() || '')
+      delete request[qp]
+    }
   })
+
+  const response = await fetch(\`\${url}/?\${searchParams.toString()}\`, {
 `
   ok(implementation)
   match(implementation, tsImplementationTemplate)

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -247,3 +247,23 @@ export interface ACustomName {
   match(types, typesTemplate)
   match(implementation, importTemplate)
 })
+
+test('append query parameters to url in non-GET requests', async ({ teardown, ok, match }) => {
+  const dir = await moveToTmpdir(teardown)
+
+  const fileName = join(__dirname, 'fixtures', 'append-query-params-frontend.openapi.json')
+  await execa('node', [cliPath, fileName, '--language', 'ts', '--frontend', '--name', 'fontend'])
+  const implementation = await readFile(join(dir, 'fontend', 'fontend.ts'), 'utf8')
+
+  const tsImplementationTemplate = `
+const _postRoot = async (url: string, request: Types.PostRootRequest) => {
+  const queryParameters = ['level']
+  const searchParams = new URLSearchParams()
+  queryParameters.forEach((qp) =>{
+    searchParams.append(qp, request[qp])
+    delete request[qp]
+  })
+`
+  ok(implementation)
+  match(implementation, tsImplementationTemplate)
+})


### PR DESCRIPTION
This is sample of the new generated code
```js
const _appControllerGetHello = async (url: string, request: Types.AppControllerGetHelloRequest) => {
  const queryParameters = ['level']
  const searchParams = new URLSearchParams()
  queryParameters.forEach((qp) =>{
    searchParams.append(qp, request[qp])
    delete request[qp]
  })

  const response = await fetch(`${url}/${searchParams.toString()}`, {
    method: 'POST',
    body: JSON.stringify(request),
    headers: {
      'Content-type': 'application/json'
    }
  })

  if (!response.ok) {
    throw new Error(await response.text())
  }

  return await response.json()
}
```

Fixes: #1748 