### PR TITLE
chore(client-cli): Add error info

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -139,7 +139,7 @@ async function readFromFileAndWrite (logger, file, folder, name, generateImpleme
     await writeOpenAPIClient(folder, name, text, generateImplementation, typesOnly, fullRequest, fullResponse, optionalHeaders, validateResponse, isFrontend, language)
     return 'openapi'
   } catch (err) {
-    logger.error(`Error parsing OpenAPI definition: ${err.message} Trying with GraphQL`)
+    logger.error(err, `Error parsing OpenAPI definition: ${err.message} Trying with GraphQL`)
     // try GraphQL
     const schema = graphql.buildSchema(text)
     const introspectionResult = graphql.introspectionFromSchema(schema)


### PR DESCRIPTION
Extremely useful to better debug.

Changing from this:
```
[13:56:45] ERROR: Error parsing OpenAPI definition: Type undefined not supported Trying with GraphQL
```

To this:
```
[13:55:55] ERROR: Error parsing OpenAPI definition: Type undefined not supported Trying with GraphQL
    err: {
      "type": "FastifyError",
      "message": "Type undefined not supported",
      "stack":
          FastifyError: Type undefined not supported
              at writeObjectProperties (/node_modules/@platformatic/client-cli/lib/openapi-common.mjs:259:11)
              at writeContent (/node_modules/@platformatic/client-cli/lib/openapi-common.mjs:234:9)
              at /node_modules/@platformatic/client-cli/lib/openapi-common.mjs:91:27
              at CodeBlockWriter._indentBlockInternal (/node_modules/code-block-writer/esm/mod.js:261:13)
              at CodeBlockWriter.inlineBlock (/node_modules/code-block-writer/esm/mod.js:236:14)
              at CodeBlockWriter.block (/node_modules/code-block-writer/esm/mod.js:225:14)
              at /node_modules/@platformatic/client-cli/lib/openapi-common.mjs:90:58
              at Array.map (<anonymous>)
              at writeOperations (/node_modules/@platformatic/client-cli/lib/openapi-common.mjs:74:53)
              at /node_modules/@platformatic/client-cli/lib/openapi-generator.mjs:118:7
      "code": "PLT_CLIENT_CLI_TYPE_NOT_SUPPORTED",
      "name": "FastifyError",
      "statusCode": 500
    }
```