### PR TITLE
Read OpenAPI spec from file

### DIFF
--- a/packages/service/lib/plugins/openapi.js
+++ b/packages/service/lib/plugins/openapi.js
@@ -33,10 +33,10 @@ async function setupOpenAPI (app, opts) {
     }
   }
 
-  if (opts.file) {
+  if (opts.path) {
     swaggerOptions.mode = 'static'
     swaggerOptions.specification = {
-      path: opts.file
+      path: opts.path
     }
   }
   await app.register(Swagger, swaggerOptions)

--- a/packages/service/lib/plugins/openapi.js
+++ b/packages/service/lib/plugins/openapi.js
@@ -19,7 +19,7 @@ async function setupOpenAPI (app, opts) {
     }
   }, typeof opts === 'object' ? opts : {})
   app.log.trace({ openapi: openapiConfig })
-  await app.register(Swagger, {
+  const swaggerOptions = {
     exposeRoute: openapiConfig.exposeRoute,
     openapi: {
       ...openapiConfig
@@ -31,7 +31,15 @@ async function setupOpenAPI (app, opts) {
         return json.$id || `def-${i}`
       }
     }
-  })
+  }
+
+  if (opts.file) {
+    swaggerOptions.mode = 'static'
+    swaggerOptions.specification = {
+      path: opts.file
+    }
+  }
+  await app.register(Swagger, swaggerOptions)
 
   const { default: theme } = await import('@platformatic/swagger-ui-theme')
   app.register(SwaggerUI, {

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -600,6 +600,10 @@ const openApiBase = {
     prefix: {
       type: 'string',
       description: 'Base URL for the OpenAPI'
+    },
+    file: {
+      type: 'string',
+      description: 'Path to an OpenAPI spec file'
     }
   }
 }

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -601,9 +601,10 @@ const openApiBase = {
       type: 'string',
       description: 'Base URL for the OpenAPI'
     },
-    file: {
+    path: {
       type: 'string',
-      description: 'Path to an OpenAPI spec file'
+      description: 'Path to an OpenAPI spec file',
+      resolvePath: true
     }
   }
 }

--- a/packages/service/test/fixtures/openapi-spec-test.json
+++ b/packages/service/test/fixtures/openapi-spec-test.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "post": {
+        "operationId": "postHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "getHello",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/service/test/openapi.test.js
+++ b/packages/service/test/openapi.test.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const assert = require('node:assert')
+const { test } = require('node:test')
+const { join } = require('node:path')
+const { request } = require('undici')
+const { buildServer } = require('..')
+
+test('provide openapi spec from a file', async (t) => {
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    service: {
+      openapi: {
+        file: join(__dirname, 'fixtures', 'openapi-spec-test.json')
+      }
+    },
+    watch: false,
+    metrics: false
+  }
+
+  const app = await buildServer(config)
+  t.after(async () => {
+    await app.close()
+  })
+  await app.start()
+
+  {
+    const res = await request(`${app.url}/documentation/json`)
+    assert.strictEqual(res.statusCode, 200, 'status code')
+    const body = await res.body.json()
+    assert.deepEqual(body.paths['/hello'].post, {
+      operationId: 'postHello',
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'string'
+                  },
+                  bar: {
+                    type: 'string'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    assert.deepEqual(body.paths['/hello'].get, {
+      operationId: 'getHello',
+      parameters: [],
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'string'
+                  },
+                  bar: {
+                    type: 'string'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  }
+})

--- a/packages/service/test/openapi.test.js
+++ b/packages/service/test/openapi.test.js
@@ -14,7 +14,7 @@ test('provide openapi spec from a file', async (t) => {
     },
     service: {
       openapi: {
-        file: join(__dirname, 'fixtures', 'openapi-spec-test.json')
+        path: join(__dirname, 'fixtures', 'openapi-spec-test.json')
       }
     },
     watch: false,


### PR DESCRIPTION
I think this is a missing feature in Platformatic and can be useful.

Before this all routes should have a `schema` object (which btw provides serialization and validation out of the box though)

With this new feature the with a config like this
```json
{
  "service": {
    "openapi": {
      "file": "./path/to/openapi.json"
    }
  }
}
```
swagger plugin is loaded and read the spec from that file using the simplest [static](https://github.com/fastify/fastify-swagger#static) configuration option of the plugin