### PR TITLE
Do not generate types if no schema is found

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -212,7 +212,6 @@ async function downloadAndProcess (options) {
   }
 
   if (config && !typesOnly) {
-    console.log('@@@@@@@', config)
     const meta = await analyze({ file: config })
     meta.config.clients = meta.config.clients || []
     if (runtime) {

--- a/packages/create-platformatic/src/db/create-db-cli.mjs
+++ b/packages/create-platformatic/src/db/create-db-cli.mjs
@@ -234,18 +234,20 @@ const createPlatformaticDB = async (_args, opts) => {
     // - run the migrations
     // - generate types
     // if we don't generate migrations, we don't ask to apply them (the folder might not exist)
+    let migrationApplied = false
     if (wizardOptions.defaultMigrations && wizardOptions.applyMigrations) {
       const spinner = ora('Applying migrations...').start()
       // We need to apply migrations using the platformatic installed in the project
       try {
         await execa(pkgManager, ['exec', 'platformatic', 'db', 'migrations', 'apply'], { cwd: projectDir })
         spinner.succeed()
+        migrationApplied = true
       } catch (err) {
         logger.trace({ err })
         spinner.fail('Failed applying migrations! Try again by running "platformatic db migrations apply"')
       }
     }
-    if (generatePlugin) {
+    if (generatePlugin && migrationApplied) {
       const spinner = ora('Generating types...').start()
       try {
         await execa(pkgManager, ['exec', 'platformatic', 'db', 'types'], { cwd: projectDir })

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -137,8 +137,9 @@ test('Creates a Platformatic DB service with migrations and plugin', async ({ eq
   equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.undo.sql')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.js')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.js')), true)
-  equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.git', 'config')), false)
+  // types are not generated if migrations are not applied
+  equal(!await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true) 
 })
 
 test('Creates a Platformatic DB service with plugin using typescript, creating all the github actions', async ({ equal, same, match, teardown }) => {
@@ -203,9 +204,10 @@ test('Creates a Platformatic DB service with plugin using typescript, creating a
   equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.undo.sql')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.ts')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.ts')), true)
-  equal(await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'global.d.ts')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'tsconfig.json')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-dynamic-workspace-deploy.yml')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-static-workspace-deploy.yml')), true)
+  // types are not generated if migrations are not applied
+  equal(!await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true) 
 })

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -204,10 +204,11 @@ test('Creates a Platformatic DB service with plugin using typescript, creating a
   equal(await isFileAccessible(join(baseProjectDir, 'migrations', '001.undo.sql')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'plugins', 'example.ts')), true)
   equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.ts')), true)
-  equal(await isFileAccessible(join(baseProjectDir, 'global.d.ts')), true)
+
   equal(await isFileAccessible(join(baseProjectDir, 'tsconfig.json')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-dynamic-workspace-deploy.yml')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-static-workspace-deploy.yml')), true)
   // types are not generated if migrations are not applied
   equal(!await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
+  equal(!await isFileAccessible(join(baseProjectDir, 'global.d.ts')), true)
 })

--- a/packages/create-platformatic/test/cli/db.test.mjs
+++ b/packages/create-platformatic/test/cli/db.test.mjs
@@ -139,7 +139,7 @@ test('Creates a Platformatic DB service with migrations and plugin', async ({ eq
   equal(await isFileAccessible(join(baseProjectDir, 'routes', 'root.js')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.git', 'config')), false)
   // types are not generated if migrations are not applied
-  equal(!await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true) 
+  equal(!await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
 })
 
 test('Creates a Platformatic DB service with plugin using typescript, creating all the github actions', async ({ equal, same, match, teardown }) => {
@@ -209,5 +209,5 @@ test('Creates a Platformatic DB service with plugin using typescript, creating a
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-dynamic-workspace-deploy.yml')), true)
   equal(await isFileAccessible(join(baseProjectDir, '.github', 'workflows', 'platformatic-static-workspace-deploy.yml')), true)
   // types are not generated if migrations are not applied
-  equal(!await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true) 
+  equal(!await isFileAccessible(join(baseProjectDir, 'types', 'index.d.ts')), true)
 })

--- a/packages/db/lib/gen-types.mjs
+++ b/packages/db/lib/gen-types.mjs
@@ -147,7 +147,10 @@ async function writeFileIfChanged (filename, content) {
 async function execute ({ logger, config }) {
   const wrap = await setupDB(logger, config.db)
   const { db, entities } = wrap
-
+  if (Object.keys(entities).length === 0) {
+    // do not generate types if no schema is found
+    return 0
+  }
   const typesFolderPath = getTypesFolderPath(config)
   const isTypeFolderExists = await isFileAccessible(typesFolderPath)
   if (isTypeFolderExists) {
@@ -195,7 +198,8 @@ async function generateTypes (_args) {
 
   const count = await execute({ logger, config })
   if (count === 0) {
-    logger.warn('No table found. Please run `platformatic db migrations apply` to generate types.')
+    logger.warn('No entities found in your schema. Types were NOT generated.')
+    logger.warn('Please run `platformatic db migrations apply` to generate types.')
   }
   await checkForDependencies(logger, args, createRequire(import.meta.url), config, ['@platformatic/db'])
 }

--- a/packages/db/test/cli/gen-types.test.mjs
+++ b/packages/db/test/cli/gen-types.test.mjs
@@ -132,7 +132,6 @@ test('should show warning if there is no entities', async (t) => {
     assert.ok(stdout.includes('WARN: No entities found in your schema. Types were NOT generated.'))
     assert.ok(stdout.includes('WARN: Please run `platformatic db migrations apply` to generate types.'))
   } catch (err) {
-    console.log(err)
     assert.fail('Failed to generate types')
   }
 })

--- a/packages/db/test/cli/gen-types.test.mjs
+++ b/packages/db/test/cli/gen-types.test.mjs
@@ -129,9 +129,10 @@ test('should show warning if there is no entities', async (t) => {
 
   try {
     const { stdout } = await execa('node', [cliPath, 'types'], { cwd })
-    assert.ok(stdout.includes('WARN: No entities found in your schema. Types were NOT generated.'))
-    assert.ok(stdout.includes('WARN: Please run `platformatic db migrations apply` to generate types.'))
+    assert.ok(stdout.includes('No entities found in your schema. Types were NOT generated.'))
+    assert.ok(stdout.includes('Please run `platformatic db migrations apply` to generate types.'))
   } catch (err) {
+    console.log(err)
     assert.fail('Failed to generate types')
   }
 })

--- a/packages/db/test/cli/gen-types.test.mjs
+++ b/packages/db/test/cli/gen-types.test.mjs
@@ -129,7 +129,8 @@ test('should show warning if there is no entities', async (t) => {
 
   try {
     const { stdout } = await execa('node', [cliPath, 'types'], { cwd })
-    assert.match(stdout, /(.*)No table found. Please run `platformatic db migrations apply` to generate types./)
+    assert.ok(stdout.includes('WARN: No entities found in your schema. Types were NOT generated.'))
+    assert.ok(stdout.includes('WARN: Please run `platformatic db migrations apply` to generate types.'))
   } catch (err) {
     console.log(err)
     assert.fail('Failed to generate types')


### PR DESCRIPTION
After some work on this issue, the Occam's Razor is to **not** generate types if no schema is found.

Fixes: #1798 