### PR TITLE
Removes useless output on .env file

### DIFF
--- a/packages/create-platformatic/src/db/create-db.mjs
+++ b/packages/create-platformatic/src/db/create-db.mjs
@@ -376,7 +376,6 @@ export async function createDB (params, logger, currentDir, version) {
   const envSample = generateEnv(isRuntimeContext, hostname, port, getConnectionString(database), typescript, envPrefix)
   await appendFile(join(currentDir, '.env'), env)
   await writeFile(join(currentDir, '.env.sample'), envSample)
-  logger.info('Environment file .env found, appending new environment variables to existing .env file.')
 
   const migrationsFolderName = migrations
   if (createMigrations) {

--- a/packages/create-platformatic/src/service/create-service.mjs
+++ b/packages/create-platformatic/src/service/create-service.mjs
@@ -99,7 +99,6 @@ async function createService (params, logger, currentDir = process.cwd(), versio
   const env = generateEnv(isRuntimeContext, hostname, port, typescript, envPrefix)
   await appendFile(join(currentDir, '.env'), env)
   await writeFile(join(currentDir, '.env.sample'), env)
-  logger.info('Environment file .env found, appending new environment variables to existing .env file.')
 
   if (typescript === true) {
     const tsConfigFileName = join(currentDir, 'tsconfig.json')


### PR DESCRIPTION
This was a leftover, when we changed the behavior to overwrite existing files/dirs.

Fixes: #1797 