### PR TITLE
refactor(test): remove tap from utils tests

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,7 @@
   "description": "Platformatic DB Utils",
   "main": "index.js",
   "scripts": {
-    "test": "standard | snazzy && c8 --100 tap --no-coverage test/*test.js",
+    "test": "standard | snazzy && c8 --100 node --test test/*test.js",
     "lint": "standard | snazzy"
   },
   "repository": {
@@ -18,11 +18,11 @@
   },
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "devDependencies": {
+    "@matteo.collina/tspl": "^0.1.0",
     "c8": "^8.0.1",
     "fastify": "^4.23.2",
     "snazzy": "^9.0.0",
-    "standard": "^17.1.0",
-    "tap": "^16.3.9"
+    "standard": "^17.1.0"
   },
   "dependencies": {
     "@fastify/deepmerge": "^1.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,7 @@
   "description": "Platformatic DB Utils",
   "main": "index.js",
   "scripts": {
-    "test": "standard | snazzy && c8 --100 node --test test/*test.js",
+    "test": "standard | snazzy && c8 --100 node --test",
     "lint": "standard | snazzy"
   },
   "repository": {

--- a/packages/utils/test/create-server-config.test.js
+++ b/packages/utils/test/create-server-config.test.js
@@ -1,11 +1,12 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { deepEqual } = require('node:assert')
 const { createServerConfig } = require('..')
 
 test('createServerConfig', async (t) => {
   const data = createServerConfig({ server: { foo: 'bar' }, something: 'else' })
-  t.same(data, {
+  deepEqual(data, {
     foo: 'bar',
     something: 'else'
   })

--- a/packages/utils/test/deepmerge.test.js
+++ b/packages/utils/test/deepmerge.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { deepEqual } = require('node:assert')
 const { deepmerge } = require('..')
 
 test('deepmerge', async (t) => {
@@ -15,7 +16,7 @@ test('deepmerge', async (t) => {
     }]
   }
   const result = deepmerge(first, second)
-  t.same(result, {
+  deepEqual(result, {
     b: [{
       a: 'foo',
       b: 'bar'

--- a/packages/utils/test/file-watcher.test.js
+++ b/packages/utils/test/file-watcher.test.js
@@ -3,21 +3,22 @@
 const os = require('os')
 const { mkdtemp, writeFile } = require('fs/promises')
 const { join } = require('path')
-const { test } = require('tap')
+const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
 const { FileWatcher } = require('..')
 const { setTimeout: sleep } = require('timers/promises')
 
-test('should throw an error if there is no path argument', async ({ throws, plan }) => {
-  plan(1)
-  throws(() => new FileWatcher({}), 'path option is required')
+test('should throw an error if there is no path argument', async (t) => {
+  const { throws } = tspl(t, { plan: 1 })
+  throws(() => new FileWatcher({}), { message: 'path option is required' })
 })
 
-test('initialize watchIgnore and allowToWatch arrays', async ({ same, plan }) => {
-  plan(4)
+test('initialize watchIgnore and allowToWatch arrays', async (t) => {
+  const { deepEqual } = tspl(t, { plan: 4 })
   {
     const fileWatcher = new FileWatcher({ path: os.tmpdir() })
-    same(fileWatcher.watchIgnore, null)
-    same(fileWatcher.allowToWatch, null)
+    deepEqual(fileWatcher.watchIgnore, null)
+    deepEqual(fileWatcher.allowToWatch, null)
   }
   {
     const fileWatcher = new FileWatcher({
@@ -25,12 +26,14 @@ test('initialize watchIgnore and allowToWatch arrays', async ({ same, plan }) =>
       watchIgnore: ['foo'],
       allowToWatch: ['bar']
     })
-    same(fileWatcher.watchIgnore, ['foo'])
-    same(fileWatcher.allowToWatch, ['bar'])
+    deepEqual(fileWatcher.watchIgnore, ['foo'])
+    deepEqual(fileWatcher.allowToWatch, ['bar'])
   }
 })
 
-test('should not watch ignored files', async ({ equal, plan }) => {
+test('should not watch ignored files', async (t) => {
+  const { equal } = tspl(t, { plan: 5 })
+
   const fileWatcher = new FileWatcher({
     path: os.tmpdir(),
     watchIgnore: ['test.file', 'test2.file', './test3.file', '.\\test4.file']
@@ -42,7 +45,9 @@ test('should not watch ignored files', async ({ equal, plan }) => {
   equal(true, fileWatcher.shouldFileBeWatched('another.file'))
 })
 
-test('should not watch not allowed files', async ({ equal, plan }) => {
+test('should not watch not allowed files', async (t) => {
+  const { equal } = tspl(t, { plan: 5 })
+
   const fileWatcher = new FileWatcher({
     path: os.tmpdir(),
     allowToWatch: ['test.file', 'test2.file', './test3.file', '.\\test4.file']
@@ -54,7 +59,9 @@ test('should not watch not allowed files', async ({ equal, plan }) => {
   equal(false, fileWatcher.shouldFileBeWatched('another.file'))
 })
 
-test('should emit event if file is updated', async ({ end, pass }) => {
+test('should emit event if file is updated', async (t) => {
+  const { ok } = tspl(t, { plan: 1 })
+
   const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
   const filename = join(tmpDir, 'test.file')
   const fileWatcher = new FileWatcher({ path: tmpDir })
@@ -65,7 +72,7 @@ test('should emit event if file is updated', async ({ end, pass }) => {
   })
 
   fileWatcher.once('update', async () => {
-    pass('update is emitted')
+    ok('update is emitted')
     await fileWatcher.stopWatching()
     _resolve()
   })
@@ -78,7 +85,9 @@ test('should emit event if file is updated', async ({ end, pass }) => {
   await Promise.race([sleep(5000), p])
 })
 
-test('should not call fs watch twice', async ({ pass, plan }) => {
+test('should not call fs watch twice', async (t) => {
+  const { ok } = tspl(t, { plan: 1 })
+
   const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
   const filename = join(tmpDir, 'test.file')
   const fileWatcher = new FileWatcher({ path: tmpDir })
@@ -89,7 +98,7 @@ test('should not call fs watch twice', async ({ pass, plan }) => {
   })
 
   fileWatcher.once('update', async () => {
-    pass('update is emitted')
+    ok('update is emitted')
     await fileWatcher.stopWatching()
     await fileWatcher.stopWatching()
     _resolve()

--- a/packages/utils/test/find-nearest-string.test.js
+++ b/packages/utils/test/find-nearest-string.test.js
@@ -1,41 +1,42 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal } = require('node:assert')
 const { findNearestString } = require('..')
 
 test('findNearestString - exact match', async (t) => {
   const strings = ['foo', 'bar', 'baz']
-  t.equal(findNearestString(strings, 'foo'), 'foo')
-  t.equal(findNearestString(strings, 'bar'), 'bar')
-  t.equal(findNearestString(strings, 'baz'), 'baz')
+  equal(findNearestString(strings, 'foo'), 'foo')
+  equal(findNearestString(strings, 'bar'), 'bar')
+  equal(findNearestString(strings, 'baz'), 'baz')
 })
 
 test('findNearestString - one character distance', async (t) => {
   const strings = ['foo', 'bar', 'baz']
-  t.equal(findNearestString(strings, 'fo'), 'foo')
-  t.equal(findNearestString(strings, 'ba'), 'bar')
-  t.equal(findNearestString(strings, 'bz'), 'baz')
+  equal(findNearestString(strings, 'fo'), 'foo')
+  equal(findNearestString(strings, 'ba'), 'bar')
+  equal(findNearestString(strings, 'bz'), 'baz')
 })
 
 test('findNearestString - two character distance', async (t) => {
   const strings = ['foo', 'bar', 'baz']
-  t.equal(findNearestString(strings, 'f'), 'foo')
-  t.equal(findNearestString(strings, 'b'), 'bar')
-  t.equal(findNearestString(strings, 'z'), 'baz')
+  equal(findNearestString(strings, 'f'), 'foo')
+  equal(findNearestString(strings, 'b'), 'bar')
+  equal(findNearestString(strings, 'z'), 'baz')
 })
 
 test('findNearestString - different cases with long words', async (t) => {
   const strings = ['fooBarBaz', 'barBazFoo', 'bazFooBar']
 
-  t.equal(findNearestString(strings, 'FooBarBaz'), 'fooBarBaz')
-  t.equal(findNearestString(strings, 'BarBazFoo'), 'barBazFoo')
-  t.equal(findNearestString(strings, 'BazFooBar'), 'bazFooBar')
+  equal(findNearestString(strings, 'FooBarBaz'), 'fooBarBaz')
+  equal(findNearestString(strings, 'BarBazFoo'), 'barBazFoo')
+  equal(findNearestString(strings, 'BazFooBar'), 'bazFooBar')
 
-  t.equal(findNearestString(strings, 'foo_bar_baz'), 'fooBarBaz')
-  t.equal(findNearestString(strings, 'bar_baz_foo'), 'barBazFoo')
-  t.equal(findNearestString(strings, 'baz_foo_bar'), 'bazFooBar')
+  equal(findNearestString(strings, 'foo_bar_baz'), 'fooBarBaz')
+  equal(findNearestString(strings, 'bar_baz_foo'), 'barBazFoo')
+  equal(findNearestString(strings, 'baz_foo_bar'), 'bazFooBar')
 
-  t.equal(findNearestString(strings, 'foo-bar-baz'), 'fooBarBaz')
-  t.equal(findNearestString(strings, 'bar-baz-foo'), 'barBazFoo')
-  t.equal(findNearestString(strings, 'baz-foo-bar'), 'bazFooBar')
+  equal(findNearestString(strings, 'foo-bar-baz'), 'fooBarBaz')
+  equal(findNearestString(strings, 'bar-baz-foo'), 'barBazFoo')
+  equal(findNearestString(strings, 'baz-foo-bar'), 'bazFooBar')
 })

--- a/packages/utils/test/is-file-accessible.test.js
+++ b/packages/utils/test/is-file-accessible.test.js
@@ -1,22 +1,23 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
 const { isFileAccessible } = require('..')
 const { basename } = require('node:path')
 
-test('isFileAccessible', async ({ same, plan }) => {
-  plan(4)
+test('isFileAccessible', async (t) => {
+  const { deepEqual } = tspl(t, { plan: 4 })
   {
     // single filename
     const file = basename(__filename)
-    same(await isFileAccessible(file, __dirname), true)
-    same(await isFileAccessible('impossible.file', __dirname), false)
+    deepEqual(await isFileAccessible(file, __dirname), true)
+    deepEqual(await isFileAccessible('impossible.file', __dirname), false)
   }
 
   {
     // full path
     const file = __filename
-    same(await isFileAccessible(file), true)
-    same(await isFileAccessible('/impossible/path/impossible.file'), false)
+    deepEqual(await isFileAccessible(file), true)
+    deepEqual(await isFileAccessible('/impossible/path/impossible.file'), false)
   }
 })

--- a/packages/utils/test/is-key-enabled.test.js
+++ b/packages/utils/test/is-key-enabled.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal } = require('node:assert')
 const { isKeyEnabled } = require('..')
 
 test('isKeyEnabled', async (t) => {
@@ -11,9 +12,9 @@ test('isKeyEnabled', async (t) => {
     },
     baz: false
   }
-  t.equal(isKeyEnabled('foo', a), true)
-  t.equal(isKeyEnabled('bar', a), true)
-  t.equal(isKeyEnabled('baz', a), false)
-  t.equal(isKeyEnabled('nope', a), false)
-  t.equal(isKeyEnabled('something', undefined), false)
+  equal(isKeyEnabled('foo', a), true)
+  equal(isKeyEnabled('bar', a), true)
+  equal(isKeyEnabled('baz', a), false)
+  equal(isKeyEnabled('nope', a), false)
+  equal(isKeyEnabled('something', undefined), false)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1685,6 +1685,9 @@ importers:
         specifier: ^5.25.4
         version: 5.27.2
     devDependencies:
+      '@matteo.collina/tspl':
+        specifier: ^0.1.0
+        version: 0.1.0
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1697,9 +1700,6 @@ importers:
       standard:
         specifier: ^17.1.0
         version: 17.1.0(@typescript-eslint/parser@5.62.0)
-      tap:
-        specifier: ^16.3.9
-        version: 16.3.9(typescript@5.2.2)
 
 packages:
 
@@ -2631,6 +2631,10 @@ packages:
       '@databases/sql': 3.3.0
       '@databases/sqlite-sync': 1.1.0
     dev: false
+
+  /@matteo.collina/tspl@0.1.0:
+    resolution: {integrity: sha512-2aMJfoKtuOBosiDEqwJEjjfbfm1q4A621bn8jkuZth6Z6c3AfAp4sS2Y+MnzPEAp7YhiHAvyLp488VB84p3w5A==}
+    dev: true
 
   /@mercuriusjs/federation@1.0.1:
     resolution: {integrity: sha512-aski6H8SRfjK73Bruzh5kQ20OS0s0pkbFvcOex46Qm17bYWoJ3daMrbTw4caOSkru7R8pIA/bvAjSq97xkDJkQ==}


### PR DESCRIPTION
This PR follows the #1796 by migrating from `tap` to `node:test`.

## Migrated test:

- [x] create-server-config.test.js
- [x] deepmerge.test.js
- [x] file-watcher.test.js
- [x] find-nearest-string.test.js
- [x] is-file-accessible.test.js
- [x] is-key-enabled.test.js
- [x] packages.test.js
