### PR TITLE
refactor(test): remove tap from telemetry tests

### DIFF
--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -4,7 +4,7 @@
   "description": "OpenTelemetry integration for Platformatic",
   "main": "index.js",
   "scripts": {
-    "test": "npm run lint | snazzy && tap test/*test.js",
+    "test": "npm run lint | snazzy && node --test",
     "lint": "standard | snazzy"
   },
   "author": "Marco Piraccini <marco.piraccini@gmail.com>",
@@ -16,8 +16,7 @@
   "devDependencies": {
     "fastify": "^4.23.2",
     "snazzy": "^9.0.0",
-    "standard": "^17.1.0",
-    "tap": "^16.3.9"
+    "standard": "^17.1.0"
   },
   "dependencies": {
     "@fastify/swagger": "^8.10.1",

--- a/packages/telemetry/test/internal.test.js
+++ b/packages/telemetry/test/internal.test.js
@@ -1,12 +1,13 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { deepEqual, equal } = require('node:assert')
 const { SpanStatusCode, SpanKind } = require('@opentelemetry/api')
 const { PlatformaticContext } = require('../lib/platformatic-context')
 const { fastifyTextMapGetter } = require('../lib/fastify-text-map')
 const { setupApp } = require('./helper')
 
-test('start and ends an internal span', async ({ equal, same, teardown }) => {
+test('start and ends an internal span', async () => {
   const traceId = '5e994e8fb53b27c91dcd2fec22771d15'
   const spanId = '166f3ab30f21800b'
   const traceparent = `00-${traceId}-${spanId}-01`
@@ -21,7 +22,7 @@ test('start and ends an internal span', async ({ equal, same, teardown }) => {
     exporter: {
       type: 'memory'
     }
-  }, handler, teardown)
+  }, handler, test.after)
 
   const { startInternalSpan, endInternalSpan } = app.openTelemetry
 
@@ -36,23 +37,23 @@ test('start and ends an internal span', async ({ equal, same, teardown }) => {
     'test-attribute': 'test-value'
   }
   const span = startInternalSpan('TEST', context, attributes)
-  same(span._spanContext.traceId, traceId)
-  same(span._ended, false)
-  same(span.attributes, attributes)
+  deepEqual(span._spanContext.traceId, traceId)
+  equal(span._ended, false)
+  deepEqual(span.attributes, attributes)
   endInternalSpan(span)
-  same(span._ended, true)
+  equal(span._ended, true)
 
   const { exporters } = app.openTelemetry
   const exporter = exporters[0]
   const finishedSpans = exporter.getFinishedSpans()
   equal(finishedSpans.length, 1)
   const [finishedSpan] = finishedSpans
-  same(finishedSpan.name, 'TEST')
-  same(finishedSpan.kind, SpanKind.INTERNAL)
-  same(finishedSpan.status.code, SpanStatusCode.OK)
+  deepEqual(finishedSpan.name, 'TEST')
+  deepEqual(finishedSpan.kind, SpanKind.INTERNAL)
+  deepEqual(finishedSpan.status.code, SpanStatusCode.OK)
 })
 
-test('start and ends an internal span with no parent context and no attributes', async ({ equal, same, teardown }) => {
+test('start and ends an internal span with no parent context and no attributes', async () => {
   const handler = async (request, reply) => {
     return { foo: 'bar' }
   }
@@ -63,27 +64,27 @@ test('start and ends an internal span with no parent context and no attributes',
     exporter: {
       type: 'memory'
     }
-  }, handler, teardown)
+  }, handler, test.after)
 
   const { startInternalSpan, endInternalSpan } = app.openTelemetry
 
   const span = startInternalSpan('TEST')
-  same(span._ended, false)
-  same(span.attributes, {})
+  equal(span._ended, false)
+  deepEqual(span.attributes, {})
   endInternalSpan(span)
-  same(span._ended, true)
+  equal(span._ended, true)
 
   const { exporters } = app.openTelemetry
   const exporter = exporters[0]
   const finishedSpans = exporter.getFinishedSpans()
   equal(finishedSpans.length, 1)
   const [finishedSpan] = finishedSpans
-  same(finishedSpan.name, 'TEST')
-  same(finishedSpan.kind, SpanKind.INTERNAL)
-  same(finishedSpan.status.code, SpanStatusCode.OK)
+  deepEqual(finishedSpan.name, 'TEST')
+  deepEqual(finishedSpan.kind, SpanKind.INTERNAL)
+  deepEqual(finishedSpan.status.code, SpanStatusCode.OK)
 })
 
-test('start and ends an internal span with error', async ({ equal, same, teardown }) => {
+test('start and ends an internal span with error', async () => {
   const traceId = '5e994e8fb53b27c91dcd2fec22771d15'
   const spanId = '166f3ab30f21800b'
   const traceparent = `00-${traceId}-${spanId}-01`
@@ -98,7 +99,7 @@ test('start and ends an internal span with error', async ({ equal, same, teardow
     exporter: {
       type: 'memory'
     }
-  }, handler, teardown)
+  }, handler, test.after)
 
   const { startInternalSpan, endInternalSpan } = app.openTelemetry
 
@@ -113,20 +114,20 @@ test('start and ends an internal span with error', async ({ equal, same, teardow
     'test-attribute': 'test-value'
   }
   const span = startInternalSpan('TEST', context, attributes)
-  same(span._spanContext.traceId, traceId)
-  same(span._ended, false)
-  same(span.attributes, attributes)
+  deepEqual(span._spanContext.traceId, traceId)
+  deepEqual(span._ended, false)
+  deepEqual(span.attributes, attributes)
   const error = new Error('test error')
   endInternalSpan(span, error)
-  same(span._ended, true)
+  deepEqual(span._ended, true)
 
   const { exporters } = app.openTelemetry
   const exporter = exporters[0]
   const finishedSpans = exporter.getFinishedSpans()
-  equal(finishedSpans.length, 1)
+  deepEqual(finishedSpans.length, 1)
   const [finishedSpan] = finishedSpans
-  same(finishedSpan.name, 'TEST')
-  same(finishedSpan.kind, SpanKind.INTERNAL)
-  same(finishedSpan.status.code, SpanStatusCode.ERROR)
-  same(finishedSpan.status.message, 'test error')
+  deepEqual(finishedSpan.name, 'TEST')
+  deepEqual(finishedSpan.kind, SpanKind.INTERNAL)
+  deepEqual(finishedSpan.status.code, SpanStatusCode.ERROR)
+  deepEqual(finishedSpan.status.message, 'test error')
 })

--- a/packages/telemetry/test/multispan-processor.test.js
+++ b/packages/telemetry/test/multispan-processor.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal } = require('node:assert')
 const { MultiSpanProcessor } = require('../lib/multispan-processor')
 
-test('should add multiple processors', async ({ equal, same, teardown }) => {
+test('should add multiple processors', async () => {
   const mockSpanProcessor = {
     onStart: () => {},
     onEnd: () => {},
@@ -19,7 +20,7 @@ test('should add multiple processors', async ({ equal, same, teardown }) => {
   }
 })
 
-test('should call onStart on every processor', async ({ equal, same, teardown }) => {
+test('should call onStart on every processor', async () => {
   let called1 = false
   let called2 = false
   const mockSpanProcessor1 = {
@@ -35,7 +36,7 @@ test('should call onStart on every processor', async ({ equal, same, teardown })
   equal(called2, true)
 })
 
-test('should call onEnd on every processor', async ({ equal, same, teardown }) => {
+test('should call onEnd on every processor', async () => {
   let called1 = false
   let called2 = false
   const mockSpanProcessor1 = {
@@ -50,7 +51,7 @@ test('should call onEnd on every processor', async ({ equal, same, teardown }) =
   equal(called2, true)
 })
 
-test('should call shutdown on every processor', async ({ equal, same, teardown }) => {
+test('should call shutdown on every processor', async () => {
   let called1 = false
   let called2 = false
   const mockSpanProcessor1 = {
@@ -65,7 +66,7 @@ test('should call shutdown on every processor', async ({ equal, same, teardown }
   equal(called2, true)
 })
 
-test('should call forceFlush on every processor', async ({ equal, same, teardown }) => {
+test('should call forceFlush on every processor', async () => {
   let called1 = false
   let called2 = false
   const mockSpanProcessor1 = {

--- a/packages/telemetry/test/platformatic-trace-provider.test.js
+++ b/packages/telemetry/test/platformatic-trace-provider.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal } = require('node:assert')
 const { PlatformaticTracerProvider } = require('../lib/platformatic-trace-provider')
 
-test('should propagate forceFlush to all registered processors ', async ({ equal, same, teardown }) => {
+test('should propagate forceFlush to all registered processors ', async () => {
   let called1 = false
   let called2 = false
   const mockSpanProcessor1 = {
@@ -24,7 +25,7 @@ test('should propagate forceFlush to all registered processors ', async ({ equal
   equal(called2, true)
 })
 
-test('should propagate shutdown to the active span processor, which should propagate to all the processors ', async ({ equal, same, teardown }) => {
+test('should propagate shutdown to the active span processor, which should propagate to all the processors ', async () => {
   let called1 = false
   let called2 = false
   const mockSpanProcessor1 = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1663,9 +1663,6 @@ importers:
       standard:
         specifier: ^17.1.0
         version: 17.1.0(@typescript-eslint/parser@5.62.0)
-      tap:
-        specifier: ^16.3.9
-        version: 16.3.9(typescript@5.2.2)
 
   packages/utils:
     dependencies:


### PR DESCRIPTION
This PR follows the https://github.com/platformatic/platformatic/issues/1796 by migrating tests from `tap` to `node:test`.

## Migrated test

- [x] client.test.js
- [x] internal.test.js
- [x] multispan-processor.test.js
- [x] platformatic-trace-provider.test.js
- [x] telemetry.test.js
