### PR TITLE
refactor(test): remove tap from metaconfig tests

### DIFF
--- a/packages/metaconfig/package.json
+++ b/packages/metaconfig/package.json
@@ -14,13 +14,12 @@
   "homepage": "https://github.com/plaformatic/platformatic#readme",
   "scripts": {
     "lint": "standard | snazzy",
-    "test": "tap test/*.js"
+    "test": "node --test"
   },
   "devDependencies": {
     "proxyquire": "^2.1.3",
     "snazzy": "^9.0.0",
-    "standard": "^17.1.0",
-    "tap": "^16.3.9"
+    "standard": "^17.1.0"
   },
   "dependencies": {
     "@fastify/error": "^3.3.0",

--- a/packages/metaconfig/test/0.16.0.test.js
+++ b/packages/metaconfig/test/0.16.0.test.js
@@ -1,212 +1,212 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, notDeepEqual } = require('node:assert')
 const { analyze } = require('..')
 const { join } = require('path')
 const { readFile } = require('fs').promises
 const YAML = require('yaml')
 
-test('simple', async (t) => {
+test('simple', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'platformatic.db.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'db')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'db')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'db')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/db')
-  t.equal(meta17.format, 'json')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'db')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/db')
+  equal(meta17.format, 'json')
 
-  t.notSame(meta.config, meta17.config)
-
-  t.match(meta17.config.plugins, {
+  notDeepEqual(meta.config, meta17.config)
+  deepEqual(meta17.config.plugins, {
     paths: ['plugin.js']
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'db')
-    t.equal(meta17FromScratch.path, undefined)
-    t.equal(meta17FromScratch.format, 'json')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'db')
+    equal(meta17FromScratch.path, undefined)
+    equal(meta17FromScratch.format, 'json')
   }
 })
 
-test('typescript', async (t) => {
+test('typescript', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'config-ts.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'db')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'db')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'db')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/db')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'db')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/db')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
+  deepEqual(meta17.config.plugins, {
     paths: ['plugin.ts'],
     typescript: true
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'db')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'db')
   }
 })
 
-test('service', async (t) => {
+test('service', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'platformatic.service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'service')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'service')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
+  deepEqual(meta17.config.plugins, {
     paths: ['plugin.js']
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'service')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'service')
   }
 })
 
-test('array of plugins', async (t) => {
+test('array of plugins', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'array.service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'service')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'service')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
-    paths: ['./plugins/index.js', './routes']
+  deepEqual(meta17.config.plugins, {
+    paths: ['./plugins/index.js', './routes/']
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'service')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'service')
   }
 })
 
-test('no plugin', async (t) => {
+test('no plugin', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'no-plugin.db.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'db')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'db')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'db')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/db')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'db')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/db')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, undefined)
-  t.equal(meta17.config.plugin, undefined)
+  deepEqual(meta17.config.plugins, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'db')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'db')
   }
 })
 
-test('array of plugins (strings)', async (t) => {
+test('array of plugins (strings)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'array-string.service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'service')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'service')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
-    paths: ['./plugins/index.js', './routes']
+  deepEqual(meta17.config.plugins, {
+    paths: ['./plugins/index.js', './routes/']
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'service')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'service')
   }
 })
 
-test('single string', async (t) => {
+test('single string', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'single-string.service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'service')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'service')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
+  deepEqual(meta17.config.plugins, {
     paths: ['plugin.js']
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'service')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'service')
   }
 })
 
-test('plugin options', async (t) => {
+test('plugin options', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'options.service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'service')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'service')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
+  deepEqual(meta17.config.plugins, {
     paths: [{
       path: 'plugin.js',
       options: {
@@ -216,30 +216,30 @@ test('plugin options', async (t) => {
     hotReload: true,
     stopTimeout: 10000
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'service')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'service')
   }
 })
 
-test('plugin options (array)', async (t) => {
+test('plugin options (array)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'options-array.service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'service')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'service')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
+  deepEqual(meta17.config.plugins, {
     paths: [{
       path: 'plugin.ts',
       options: {
@@ -256,40 +256,40 @@ test('plugin options (array)', async (t) => {
     stopTimeout: 10000,
     typescript: true
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'service')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'service')
   }
 })
 
-test('yaml loading', async (t) => {
+test('yaml loading', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'single-string.service.yaml')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.16.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, YAML.parse(await readFile(file, 'utf8')))
-  t.equal(meta.format, 'yaml')
+  equal(meta.version, '0.16.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, YAML.parse(await readFile(file, 'utf8')))
+  equal(meta.format, 'yaml')
 
   const meta17 = meta.up()
-  t.equal(meta17.version, '0.17.0')
-  t.equal(meta17.kind, 'service')
-  t.equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
-  t.equal(meta.format, 'yaml')
+  equal(meta17.version, '0.17.0')
+  equal(meta17.kind, 'service')
+  equal(meta17.config.$schema, 'https://platformatic.dev/schemas/v0.17.0/service')
+  equal(meta.format, 'yaml')
 
-  t.notSame(meta.config, meta17.config)
+  notDeepEqual(meta.config, meta17.config)
 
-  t.match(meta17.config.plugins, {
+  deepEqual(meta17.config.plugins, {
     paths: ['plugin.js']
   })
-  t.equal(meta17.config.plugin, undefined)
+  equal(meta17.config.plugin, undefined)
 
   {
     const meta17FromScratch = await analyze({ config: meta17.config })
-    t.equal(meta17FromScratch.version, '0.17.0')
-    t.equal(meta17FromScratch.kind, 'service')
-    t.equal(meta17FromScratch.format, 'json')
+    equal(meta17FromScratch.version, '0.17.0')
+    equal(meta17FromScratch.kind, 'service')
+    equal(meta17FromScratch.format, 'json')
   }
 })

--- a/packages/metaconfig/test/0.17.0.test.js
+++ b/packages/metaconfig/test/0.17.0.test.js
@@ -1,62 +1,63 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, notDeepEqual } = require('node:assert')
 const { analyze } = require('..')
 const { join } = require('path')
 const { readFile } = require('fs').promises
 
-test('up to 18 (db)', async (t) => {
+test('up to 18 (db)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.17.0', 'db.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.17.0')
-  t.equal(meta.kind, 'db')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.17.0')
+  equal(meta.kind, 'db')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.18.0')
-  t.equal(meta18.kind, 'db')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.18.0/db')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.18.0')
+  equal(meta18.kind, 'db')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.18.0/db')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
-  t.same(meta18.config.db, meta.config.core)
+  deepEqual(meta18.config.db, meta.config.core)
 
-  t.equal(meta18.config.core, undefined)
+  equal(meta18.config.core, undefined)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.18.0')
-    t.equal(meta18FromScratch.kind, 'db')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.18.0')
+    equal(meta18FromScratch.kind, 'db')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })
 
-test('up to 18 (service)', async (t) => {
+test('up to 18 (service)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.17.0', 'service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.17.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.17.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.18.0')
-  t.equal(meta18.kind, 'service')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.18.0/service')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.18.0')
+  equal(meta18.kind, 'service')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.18.0/service')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.18.0')
-    t.equal(meta18FromScratch.kind, 'service')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.18.0')
+    equal(meta18FromScratch.kind, 'service')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })

--- a/packages/metaconfig/test/0.18.0.test.js
+++ b/packages/metaconfig/test/0.18.0.test.js
@@ -1,60 +1,61 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, notDeepEqual } = require('node:assert')
 const { analyze } = require('..')
 const { join } = require('path')
 const { readFile } = require('fs').promises
 
-test('up to 19 (db)', async (t) => {
+test('up to 19 (db)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.18.0', 'db.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.18.0')
-  t.equal(meta.kind, 'db')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.18.0')
+  equal(meta.kind, 'db')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.19.0')
-  t.equal(meta18.kind, 'db')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.19.0/db')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.19.0')
+  equal(meta18.kind, 'db')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.19.0/db')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
-  t.same(meta18.config.db, meta.config.db)
+  deepEqual(meta18.config.db, meta.config.db)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.19.0')
-    t.equal(meta18FromScratch.kind, 'db')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.19.0')
+    equal(meta18FromScratch.kind, 'db')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })
 
-test('up to 19 (service)', async (t) => {
+test('up to 19 (service)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.18.0', 'service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.18.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.18.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.19.0')
-  t.equal(meta18.kind, 'service')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.19.0/service')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.19.0')
+  equal(meta18.kind, 'service')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.19.0/service')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.19.0')
-    t.equal(meta18FromScratch.kind, 'service')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.19.0')
+    equal(meta18FromScratch.kind, 'service')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })

--- a/packages/metaconfig/test/0.19.0.test.js
+++ b/packages/metaconfig/test/0.19.0.test.js
@@ -1,60 +1,61 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, notDeepEqual } = require('node:assert')
 const { analyze } = require('..')
 const { join } = require('path')
 const { readFile } = require('fs').promises
 
-test('up to 19 (db)', async (t) => {
+test('up to 19 (db)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.19.0', 'db.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.19.0')
-  t.equal(meta.kind, 'db')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.19.0')
+  equal(meta.kind, 'db')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.20.0')
-  t.equal(meta18.kind, 'db')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.20.0/db')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.20.0')
+  equal(meta18.kind, 'db')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.20.0/db')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
-  t.same(meta18.config.db, meta.config.db)
+  deepEqual(meta18.config.db, meta.config.db)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.20.0')
-    t.equal(meta18FromScratch.kind, 'db')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.20.0')
+    equal(meta18FromScratch.kind, 'db')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })
 
-test('up to 19 (service)', async (t) => {
+test('up to 19 (service)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.19.0', 'service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.19.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.19.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.20.0')
-  t.equal(meta18.kind, 'service')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.20.0/service')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.20.0')
+  equal(meta18.kind, 'service')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.20.0/service')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.20.0')
-    t.equal(meta18FromScratch.kind, 'service')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.20.0')
+    equal(meta18FromScratch.kind, 'service')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })

--- a/packages/metaconfig/test/0.20.0.test.js
+++ b/packages/metaconfig/test/0.20.0.test.js
@@ -1,60 +1,61 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, notDeepEqual } = require('node:assert')
 const { analyze } = require('..')
 const { join } = require('path')
 const { readFile } = require('fs').promises
 
-test('up to 21 (db)', async (t) => {
+test('up to 21 (db)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.20.0', 'db.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.20.0')
-  t.equal(meta.kind, 'db')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.20.0')
+  equal(meta.kind, 'db')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.21.0')
-  t.equal(meta18.kind, 'db')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.21.0/db')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.21.0')
+  equal(meta18.kind, 'db')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.21.0/db')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
-  t.same(meta18.config.db, meta.config.db)
+  deepEqual(meta18.config.db, meta.config.db)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.21.0')
-    t.equal(meta18FromScratch.kind, 'db')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.21.0')
+    equal(meta18FromScratch.kind, 'db')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })
 
-test('up to 21 (service)', async (t) => {
+test('up to 21 (service)', async () => {
   const file = join(__dirname, 'fixtures', 'v0.20.0', 'service.json')
   const meta = await analyze({ file })
-  t.equal(meta.version, '0.20.0')
-  t.equal(meta.kind, 'service')
-  t.same(meta.config, JSON.parse(await readFile(file)))
-  t.equal(meta.path, file)
-  t.equal(meta.format, 'json')
+  equal(meta.version, '0.20.0')
+  equal(meta.kind, 'service')
+  deepEqual(meta.config, JSON.parse(await readFile(file)))
+  equal(meta.path, file)
+  equal(meta.format, 'json')
 
   const meta18 = meta.up()
-  t.equal(meta18.version, '0.21.0')
-  t.equal(meta18.kind, 'service')
-  t.equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.21.0/service')
-  t.equal(meta18.format, 'json')
+  equal(meta18.version, '0.21.0')
+  equal(meta18.kind, 'service')
+  equal(meta18.config.$schema, 'https://platformatic.dev/schemas/v0.21.0/service')
+  equal(meta18.format, 'json')
 
-  t.notSame(meta.config, meta18.config)
+  notDeepEqual(meta.config, meta18.config)
 
   {
     const meta18FromScratch = await analyze({ config: meta18.config })
-    t.equal(meta18FromScratch.version, '0.21.0')
-    t.equal(meta18FromScratch.kind, 'service')
-    t.equal(meta18FromScratch.path, undefined)
-    t.equal(meta18FromScratch.format, 'json')
+    equal(meta18FromScratch.version, '0.21.0')
+    equal(meta18FromScratch.kind, 'service')
+    equal(meta18FromScratch.path, undefined)
+    equal(meta18FromScratch.format, 'json')
   }
 })

--- a/packages/metaconfig/test/1.x.x.test.js
+++ b/packages/metaconfig/test/1.x.x.test.js
@@ -1,24 +1,25 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, notDeepEqual, ok } = require('node:assert')
 const semver = require('semver')
 const OneXX = require('../versions/1.x.x')
 const pkg = require('../package.json')
 const proxyquire = require('proxyquire')
 
-test('specified version is bigger than the current version (minor)', async (t) => {
+test('specified version is bigger than the current version (minor)', async () => {
   const version = semver.inc(pkg.version, 'minor')
   const meta = new OneXX({ version, config: {} })
-  t.equal(meta.up, undefined)
+  equal(meta.up, undefined)
 })
 
-test('specified version is bigger than the current version (major)', async (t) => {
+test('specified version is bigger than the current version (major)', async () => {
   const version = semver.inc(pkg.version, 'major')
   const meta = new OneXX({ version, config: {} })
-  t.equal(meta.up, undefined)
+  equal(meta.up, undefined)
 })
 
-test('upgrade minor versions', async (t) => {
+test('upgrade minor versions', async () => {
   const OneXX = proxyquire('../versions/1.x.x.js', {
     '../package.json': {
       version: '1.1.0'
@@ -27,12 +28,11 @@ test('upgrade minor versions', async (t) => {
   const version = '1.0.1'
   const meta = new OneXX({ version, config: { } })
   const upped = meta.up()
-  t.match(upped, {
-    version: '1.1.0'
-  })
+
+  equal(upped.version, '1.1.0')
 })
 
-test('upgrade patch versions', async (t) => {
+test('upgrade patch versions', async () => {
   const OneXX = proxyquire('../versions/1.x.x.js', {
     '../package.json': {
       version: '1.0.2'
@@ -41,12 +41,10 @@ test('upgrade patch versions', async (t) => {
   const version = '1.0.1'
   const meta = new OneXX({ version, config: { } })
   const upped = meta.up()
-  t.match(upped, {
-    version: '1.0.2'
-  })
+  equal(upped.version, '1.0.2')
 })
 
-test('deletes watch', async (t) => {
+test('deletes watch', async () => {
   const OneXX = proxyquire('../versions/1.x.x.js', {
     '../package.json': {
       version: '1.1.0'
@@ -55,9 +53,7 @@ test('deletes watch', async (t) => {
   const version = '1.0.1'
   const meta = new OneXX({ version, config: { watch: true, entrypoint: 'foo' } })
   const upped = meta.up()
-  t.match(upped, {
-    version: '1.1.0'
-  })
+  equal(upped.version, '1.1.0')
 
-  t.equal(upped.config.watch, undefined)
+  equal(upped.config.watch, undefined)
 })

--- a/packages/metaconfig/test/base.test.js
+++ b/packages/metaconfig/test/base.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, throws, rejects, ok } = require('node:assert')
 const { analyze, getParser, getStringifier, write, upgrade } = require('..')
 const ZeroSeventeen = require('../versions/0.17.x.js')
 const YAML = require('yaml')
@@ -13,63 +14,71 @@ const pkg = require('../package.json')
 const semver = require('semver')
 const createError = require('@fastify/error')
 
-test('throws if no config or file is provided', async (t) => {
-  await t.rejects(analyze({}), new Error('missing file or config to analyze'))
+test('throws if no config or file is provided', async () => {
+  await rejects(analyze({}), {
+    message: 'missing file or config to analyze'
+  })
 })
 
-test('throws if no $schema is set', async (t) => {
-  await t.rejects(analyze({ config: {} }), new Error('missing $schema, unable to determine the version'))
+test('throws if no $schema is set', async () => {
+  await rejects(analyze({ config: {} }), {
+    message: 'missing $schema, unable to determine the version'
+  })
 })
 
-test('throws if $schema is not a matching URL', async (t) => {
-  await t.rejects(analyze({ config: { $schema: 'https://foo' } }), new Error('unable to determine the version'))
+test('throws if $schema is not a matching URL', async () => {
+  await rejects(analyze({ config: { $schema: 'https://foo' } }), {
+    message: 'unable to determine the version'
+  })
 })
 
-test('loads the previous semver minor for a patch release', async (t) => {
+test('loads the previous semver minor for a patch release', async () => {
   const meta = await analyze({ config: { $schema: 'https://platformatic.dev/schemas/v0.17.1/db' } })
-  t.type(meta, ZeroSeventeen)
-  t.equal(meta.version, '0.17.1')
+  ok(meta instanceof ZeroSeventeen)
+  equal(meta.version, '0.17.1')
 })
 
-test('throws if version is unknown', async (t) => {
-  await t.rejects(analyze({ config: { $schema: 'https://platformatic.dev/schemas/v0.2.0/db' } }), new Error('unable to determine the version'))
+test('throws if version is unknown', async () => {
+  await rejects(analyze({ config: { $schema: 'https://platformatic.dev/schemas/v0.2.0/db' } }), {
+    message: 'unable to determine the version'
+  })
 })
 
-test('gets the parser for a given format', async (t) => {
-  t.equal(getParser('file.json'), JSON.parse)
-  t.equal(getParser('file.yaml'), YAML.parse)
-  t.equal(getParser('file.yml'), YAML.parse)
-  t.equal(getParser('file.toml'), TOML.parse)
-  t.equal(getParser('file.json5'), JSON5.parse)
+test('gets the parser for a given format', async () => {
+  equal(getParser('file.json'), JSON.parse)
+  equal(getParser('file.yaml'), YAML.parse)
+  equal(getParser('file.yml'), YAML.parse)
+  equal(getParser('file.toml'), TOML.parse)
+  equal(getParser('file.json5'), JSON5.parse)
 })
 
-test('gets the stringify for a given format', async (t) => {
-  t.equal(getStringifier('file.yaml'), YAML.stringify)
-  t.equal(getStringifier('file.yml'), YAML.stringify)
-  t.equal(getStringifier('file.toml'), TOML.stringify)
+test('gets the stringify for a given format', async () => {
+  equal(getStringifier('file.yaml'), YAML.stringify)
+  equal(getStringifier('file.yml'), YAML.stringify)
+  equal(getStringifier('file.toml'), TOML.stringify)
 
   {
     const stringify = getStringifier('file.json')
-    t.equal(stringify({ foo: 'bar' }), JSON.stringify({ foo: 'bar' }, null, 2))
+    equal(stringify({ foo: 'bar' }), JSON.stringify({ foo: 'bar' }, null, 2))
   }
 
   {
     const stringify = getStringifier('file.json5')
-    t.equal(stringify({ foo: 'bar' }), JSON5.stringify({ foo: 'bar' }, null, 2))
+    equal(stringify({ foo: 'bar' }), JSON5.stringify({ foo: 'bar' }, null, 2))
   }
 })
 
-test('throws if the stringifier is unknown', async (t) => {
+test('throws if the stringifier is unknown', async () => {
   const expectedError = new (createError('PLT_SQL_METACONFIG_INVALID_CONFIG_FILE_EXTENSION', 'Invalid config file extension. Only yml, yaml, json, json5, toml, tml are supported.'))()
-  t.throws(() => { getStringifier('file.foo') }, expectedError)
+  throws(() => { getStringifier('file.foo') }, expectedError)
 })
 
-test('throws if the parser is unknown', async (t) => {
+test('throws if the parser is unknown', async () => {
   const expectedError = new (createError('PLT_SQL_METACONFIG_INVALID_CONFIG_FILE_EXTENSION', 'Invalid config file extension. Only yml, yaml, json, json5, toml, tml are supported.'))()
-  t.throws(() => { getParser('file.foo') }, expectedError)
+  throws(() => { getParser('file.foo') }, expectedError)
 })
 
-test('writes a config file', async (t) => {
+test('writes a config file', async () => {
   const dest = join(tmpdir(), `test-metaconfig-${process.pid}.json`)
   await cp(join(__dirname, 'fixtures', 'v0.16.0', 'array.db.json'), dest)
   const meta = await analyze({ file: dest })
@@ -78,22 +87,22 @@ test('writes a config file', async (t) => {
   await write(meta)
 
   const meta2 = await analyze({ file: meta.path })
-  t.equal(meta2.format, 'yaml')
-  t.equal(meta2.path, meta.path)
-  t.same(meta2.config, meta.config)
+  equal(meta2.format, 'yaml')
+  equal(meta2.path, meta.path)
+  deepEqual(meta2.config, meta.config)
 })
 
-test('current version must be matched', async (t) => {
+test('current version must be matched', async () => {
   const version = pkg.version.replace('-dev', '')
   const meta = await analyze({ config: { $schema: `https://platformatic.dev/schemas/v${version}/db` } })
-  t.equal(meta.version, version)
+  equal(meta.version, version)
 })
 
-test('upgrade to latest version', async (t) => {
+test('upgrade to latest version', async () => {
   const file = join(__dirname, 'fixtures', 'v0.16.0', 'array.db.json')
   const meta = await analyze({ file })
   const upgraded = upgrade(meta)
   const version = pkg.version.replace('-dev', '')
-  t.comment(`upgraded to ${upgraded.version}`)
-  t.equal(semver.satisfies(version, '^' + upgraded.version), true)
+  console.log(`upgraded to ${upgraded.version}`)
+  equal(semver.satisfies(version, '^' + upgraded.version), true)
 })

--- a/packages/metaconfig/test/from-eighteen-to-will-see.test.js
+++ b/packages/metaconfig/test/from-eighteen-to-will-see.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const { equal, deepEqual, notDeepEqual, ok } = require('node:assert')
 const semver = require('semver')
 const FromZeroEighteenToWillSee = require('../versions/from-zero-eighteen-to-will-see')
 const pkg = require('../package.json')
@@ -9,13 +10,13 @@ const proxyquire = require('proxyquire')
 test('specified version is bigger than the current version (minor)', async (t) => {
   const version = semver.inc(pkg.version, 'minor')
   const meta = new FromZeroEighteenToWillSee({ version, config: {} })
-  t.equal(meta.up, undefined)
+  equal(meta.up, undefined)
 })
 
 test('specified version is bigger than the current version (major)', async (t) => {
   const version = semver.inc(pkg.version, 'major')
   const meta = new FromZeroEighteenToWillSee({ version, config: {} })
-  t.equal(meta.up, undefined)
+  equal(meta.up, undefined)
 })
 
 test('handles composer apps', async (t) => {
@@ -24,7 +25,7 @@ test('handles composer apps', async (t) => {
     version,
     config: { composer: {} }
   })
-  t.equal(meta.kind, 'composer')
+  equal(meta.kind, 'composer')
 })
 
 test('handles runtime apps', async (t) => {
@@ -33,14 +34,14 @@ test('handles runtime apps', async (t) => {
     version,
     config: { entrypoint: 'foo' }
   })
-  t.equal(meta.kind, 'runtime')
+  equal(meta.kind, 'runtime')
 })
 
 test('adds watch.ignore if watch is undefined', async (t) => {
   const version = '0.26.0'
   const meta = new FromZeroEighteenToWillSee({ version, config: {} })
   const upped = meta.up()
-  t.same(upped.config.watch, {
+  deepEqual(upped.config.watch, {
     ignore: ['*.sqlite', '*.sqlite-journal']
   })
 })
@@ -49,7 +50,7 @@ test('adds watch.ignore if watch is an object', async (t) => {
   const version = '0.26.0'
   const meta = new FromZeroEighteenToWillSee({ version, config: { watch: {} } })
   const upped = meta.up()
-  t.same(upped.config.watch, {
+  deepEqual(upped.config.watch, {
     ignore: ['*.sqlite', '*.sqlite-journal']
   })
 })
@@ -58,7 +59,7 @@ test('does not add watch.ignore if watch.ignore is an array', async (t) => {
   const version = '0.26.0'
   const meta = new FromZeroEighteenToWillSee({ version, config: { watch: { ignore: [] } } })
   const upped = meta.up()
-  t.same(upped.config.watch, {
+  deepEqual(upped.config.watch, {
     ignore: []
   })
 })
@@ -67,7 +68,7 @@ test('adds watch.ignore if watch is true', async (t) => {
   const version = '0.26.0'
   const meta = new FromZeroEighteenToWillSee({ version, config: { watch: true } })
   const upped = meta.up()
-  t.same(upped.config.watch, {
+  deepEqual(upped.config.watch, {
     ignore: ['*.sqlite', '*.sqlite-journal']
   })
 })
@@ -76,7 +77,7 @@ test('does not add watch if it is set to false', async (t) => {
   const version = '0.26.0'
   const meta = new FromZeroEighteenToWillSee({ version, config: { watch: false } })
   const upped = meta.up()
-  t.equal(upped.config.watch, false)
+  equal(upped.config.watch, false)
 })
 
 test('removes plugins.hotReload if it exists', async (t) => {
@@ -87,9 +88,9 @@ test('removes plugins.hotReload if it exists', async (t) => {
       version,
       config: { plugins: { hotReload: true } }
     })
-    t.equal('hotReload' in meta.config.plugins, true)
+    equal('hotReload' in meta.config.plugins, true)
     const upped = meta.up()
-    t.equal('hotReload' in upped.config.plugins, false)
+    equal('hotReload' in upped.config.plugins, false)
   }
 
   {
@@ -97,9 +98,9 @@ test('removes plugins.hotReload if it exists', async (t) => {
       version,
       config: { plugins: { hotReload: false } }
     })
-    t.equal('hotReload' in meta.config.plugins, true)
+    equal('hotReload' in meta.config.plugins, true)
     const upped = meta.up()
-    t.equal('hotReload' in upped.config.plugins, false)
+    equal('hotReload' in upped.config.plugins, false)
   }
 
   {
@@ -107,9 +108,9 @@ test('removes plugins.hotReload if it exists', async (t) => {
       version,
       config: { plugins: {} }
     })
-    t.equal('hotReload' in meta.config.plugins, false)
+    equal('hotReload' in meta.config.plugins, false)
     const upped = meta.up()
-    t.equal('hotReload' in upped.config.plugins, false)
+    equal('hotReload' in upped.config.plugins, false)
   }
 })
 
@@ -121,9 +122,9 @@ test('removes db.dashboard if it exists', async (t) => {
       version,
       config: { db: { dashboard: true } }
     })
-    t.equal('dashboard' in meta.config.db, true)
+    equal('dashboard' in meta.config.db, true)
     const upped = meta.up()
-    t.equal('dashboard' in upped.config.db, false)
+    equal('dashboard' in upped.config.db, false)
   }
 
   {
@@ -131,9 +132,9 @@ test('removes db.dashboard if it exists', async (t) => {
       version,
       config: { db: { dashboard: false } }
     })
-    t.equal('dashboard' in meta.config.db, true)
+    equal('dashboard' in meta.config.db, true)
     const upped = meta.up()
-    t.equal('dashboard' in upped.config.db, false)
+    equal('dashboard' in upped.config.db, false)
   }
 
   {
@@ -141,9 +142,9 @@ test('removes db.dashboard if it exists', async (t) => {
       version,
       config: { db: {} }
     })
-    t.equal('dashboard' in meta.config.db, false)
+    equal('dashboard' in meta.config.db, false)
     const upped = meta.up()
-    t.equal('dashboard' in upped.config.db, false)
+    equal('dashboard' in upped.config.db, false)
   }
 })
 
@@ -156,7 +157,5 @@ test('upgrade patch versions', async (t) => {
   const version = '0.33.0'
   const meta = new FromZeroEighteenToWillSee({ version, config: { } })
   const upped = meta.up()
-  t.match(upped, {
-    version: '0.33.1'
-  })
+  equal(upped.version, '0.33.1')
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1098,9 +1098,6 @@ importers:
       standard:
         specifier: ^17.1.0
         version: 17.1.0(@typescript-eslint/parser@5.62.0)
-      tap:
-        specifier: ^16.3.9
-        version: 16.3.9(typescript@5.2.2)
 
   packages/runtime:
     dependencies:


### PR DESCRIPTION
This PR follows the https://github.com/platformatic/platformatic/issues/1796 by migrating tests from `tap` to `node:test`.

## Migrated test

- [x] 0.16.0.test.js
- [x] 0.17.0.test.js
- [x] 0.18.0.test.js
- [x] 0.19.0.test.js
- [x] 0.20.0.test.js
- [x] 1.x.x.test.js
- [x] base.test.js
- [x] from-eighteen-to-will-see.test.js
