### PR TITLE
Changes to allow provision of custom summaries and descriptions for each route, plus addition of default summaries and descriptions.

### DIFF
--- a/packages/db/snapshots/test/cli/schema2.test.mjs
+++ b/packages/db/snapshots/test/cli/schema2.test.mjs
@@ -43,9 +43,11 @@ export default `\
     "/graphs/": {
       "get": {
         "operationId": "getGraphs",
+        "summary": "Get graphs.",
         "tags": [
           "graphs"
         ],
+        "description": "Fetch graphs from the database.",
         "parameters": [
           {
             "schema": {
@@ -334,9 +336,11 @@ export default `\
       },
       "post": {
         "operationId": "createGraph",
+        "summary": "Create graph.",
         "tags": [
           "graphs"
         ],
+        "description": "Add new graph to the database.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -362,9 +366,11 @@ export default `\
       },
       "put": {
         "operationId": "updateGraphs",
+        "summary": "Update graphs.",
         "tags": [
           "graphs"
         ],
+        "description": "Update one or more graphs in the database.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -615,9 +621,11 @@ export default `\
     "/graphs/{id}": {
       "get": {
         "operationId": "getGraphById",
+        "summary": "Get Graph by id.",
         "tags": [
           "graphs"
         ],
+        "description": "Fetch Graph using its id from the database.",
         "parameters": [
           {
             "schema": {
@@ -659,9 +667,11 @@ export default `\
       },
       "put": {
         "operationId": "updateGraph",
+        "summary": "Update graph.",
         "tags": [
           "graphs"
         ],
+        "description": "Update graph in the database.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -712,9 +722,11 @@ export default `\
       },
       "delete": {
         "operationId": "deleteGraphs",
+        "summary": "Delete graphs.",
         "tags": [
           "graphs"
         ],
+        "description": "Delete one or more graphs from the Database.",
         "parameters": [
           {
             "schema": {

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -86,6 +86,8 @@ async function entityPlugin (app, opts) {
   app.get(`/:${primaryKeyCamelcase}`, {
     schema: {
       operationId: `get${entity.name}By${capitalize(primaryKeyCamelcase)}`,
+      summary: `Get ${entity.name} by ${primaryKeyCamelcase}.`,
+      description: `Fetch ${entity.name} using its ${primaryKeyCamelcase} from the database.`,
       params: primaryKeyParams,
       tags: [entity.table],
       querystring: {
@@ -147,6 +149,8 @@ async function entityPlugin (app, opts) {
       app.get(`/:${camelcase(primaryKey)}/${routePathName}`, {
         schema: {
           operationId,
+          summary: `Get ${targetEntity.pluralName} for ${entity.singularName}.`,
+          description: `Fetch all the ${targetEntity.pluralName} for ${entity.singularName} from the database.`,
           params: getPrimaryKeyParams(entity, ignore),
           tags: [entity.table],
           querystring: {
@@ -237,6 +241,8 @@ async function entityPlugin (app, opts) {
       app.get(`/:${camelcase(primaryKey)}/${targetRelation}`, {
         schema: {
           operationId,
+          summary: `Get ${targetEntity.singularName} for ${entity.singularName}.`,
+          description: `Fetch the ${targetEntity.singularName} for ${entity.singularName} from the database.`,
           params: getPrimaryKeyParams(entity, ignore),
           tags: [entity.table],
           querystring: {
@@ -296,6 +302,8 @@ async function entityPlugin (app, opts) {
     method: 'PUT',
     schema: {
       operationId: 'update' + capitalize(entity.singularName),
+      summary: `Update ${entity.singularName}.`,
+      description: `Update ${entity.singularName} in the database.`,
       body: entitySchemaInput,
       params: primaryKeyParams,
       tags: [entity.table],
@@ -336,6 +344,8 @@ async function entityPlugin (app, opts) {
   app.delete(`/:${primaryKeyCamelcase}`, {
     schema: {
       operationId: 'delete' + capitalize(entity.pluralName),
+      summary: `Delete ${entity.pluralName}.`,
+      description: `Delete one or more ${entity.pluralName} from the Database.`,
       params: primaryKeyParams,
       tags: [entity.table],
       querystring: {

--- a/packages/sql-openapi/lib/many-to-many.js
+++ b/packages/sql-openapi/lib/many-to-many.js
@@ -46,6 +46,8 @@ async function entityPlugin (app, opts) {
   app.get(pathWithParams, {
     schema: {
       operationId: `get${entity.name}By${operationName}`,
+      summary: `Get ${entity.name} by ${operationName}.`,
+      description: `Fetch ${entity.name} by ${operationName} from the database.`,
       params: primaryKeysParams,
       tags: [entity.table],
       querystring: {
@@ -79,6 +81,8 @@ async function entityPlugin (app, opts) {
       url: pathWithParams,
       method,
       schema: {
+        summary: `Update ${entity.name} by ${operationName}.`,
+        description: `Update ${entity.name} by ${operationName} in the database.`,
         body: entitySchemaInput,
         params: primaryKeysParams,
         tags: [entity.table],
@@ -122,6 +126,8 @@ async function entityPlugin (app, opts) {
 
   app.delete(pathWithParams, {
     schema: {
+      summary: `Delete ${entity.name} by ${operationName}.`,
+      description: `Delete ${entity.name} by ${operationName} from the database.`,
       params: primaryKeysParams,
       tags: [entity.table],
       querystring: {

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -65,6 +65,8 @@ function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, ent
   app.get('/', {
     schema: {
       operationId: 'get' + capitalize(entity.pluralName),
+      summary: `Get ${entity.pluralName}.`,
+      description: `Fetch ${entity.pluralName} from the database.`,
       tags: [entity.table],
       querystring: {
         type: 'object',
@@ -161,6 +163,8 @@ function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, ent
   app.post('/', {
     schema: {
       operationId: 'create' + capitalize(entity.singularName),
+      summary: `Create ${entity.singularName}.`,
+      description: `Add new ${entity.singularName} to the database.`,
       body: entitySchemaInput,
       tags: [entity.table],
       response: {
@@ -180,6 +184,8 @@ function rootEntityRoutes (app, entity, whereArgs, orderByArgs, entityLinks, ent
   app.put('/', {
     schema: {
       operationId: 'update' + capitalize(entity.pluralName),
+      summary: `Update ${entity.pluralName}.`,
+      description: `Update one or more ${entity.pluralName} in the database.`,
       body: entitySchemaInput,
       tags: [entity.table],
       querystring: {

--- a/packages/sql-openapi/lib/utils.js
+++ b/packages/sql-openapi/lib/utils.js
@@ -1,0 +1,31 @@
+const openApiPathItemNonOperationKeys = ['summary', 'description', 'servers', 'parameters']
+
+function removeOperationPropertiesFromOpenApiPathItem (pathItem) {
+  const pathItemKeys = new Set(Object.keys(pathItem))
+
+  return openApiPathItemNonOperationKeys.reduce((acc, key) => {
+    if (pathItemKeys.has(key)) {
+      acc[key] = pathItem[key]
+    }
+    return acc
+  }, {})
+}
+
+function getSchemaOverrideFromOpenApiPathItem (pathItem, method) {
+  method = method?.toLowerCase()
+
+  const schemaOverride = removeOperationPropertiesFromOpenApiPathItem(pathItem)
+
+  if (!method || !pathItem[method]) {
+    return schemaOverride
+  }
+
+  Object.keys(pathItem[method]).forEach((key) => {
+    schemaOverride[key] = pathItem[method][key]
+  })
+  return schemaOverride
+}
+
+module.exports = {
+  getSchemaOverrideFromOpenApiPathItem
+}

--- a/packages/sql-openapi/lib/utils.js
+++ b/packages/sql-openapi/lib/utils.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const openApiPathItemNonOperationKeys = ['summary', 'description', 'servers', 'parameters']
 
 function removeOperationPropertiesFromOpenApiPathItem (pathItem) {

--- a/packages/sql-openapi/test/schema-override.test.js
+++ b/packages/sql-openapi/test/schema-override.test.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const { test } = require('tap')
+const fastify = require('fastify')
+const sqlOpenAPI = require('..')
+const sqlMapper = require('@platformatic/sql-mapper')
+const { clear, connInfo, isSQLite } = require('./helper')
+
+async function createBasicPages (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE pages (
+      id INTEGER PRIMARY KEY,
+      title VARCHAR(42)
+    );`)
+    await db.query(sql`CREATE TABLE categories (
+      id INTEGER PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+  } else {
+    await db.query(sql`CREATE TABLE pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(42)
+    );`)
+    await db.query(sql`CREATE TABLE categories (
+      id SERIAL PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+  }
+}
+
+test('path schema override', async ({ pass, teardown, equal }) => {
+  const customSummary1 = 'Custom summary 1'
+  const customDescription1 = 'Custom description 1'
+  const customSummary2 = 'Custom summary 2'
+  const customDescription2 = 'Custom description 2'
+
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      category: true
+    },
+    paths: {
+      '/pages': {
+        summary: customSummary1,
+        description: customDescription1,
+        put: {
+          summary: customSummary2,
+          description: customDescription2
+        }
+      }
+    }
+  })
+  teardown(app.close.bind(app))
+
+  await app.ready()
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json'
+    })
+
+    equal(res.statusCode, 200, 'GET /documentation/json status code')
+    const data = res.json()
+
+    equal(data.paths['/pages/'].get.summary, customSummary1, 'Path level summary override')
+    equal(data.paths['/pages/'].get.description, customDescription1, 'Path level description override')
+
+    equal(data.paths['/pages/'].put.summary, customSummary2, 'Method specific summary override')
+    equal(data.paths['/pages/'].put.description, customDescription2, 'Method specific description override')
+  }
+})

--- a/packages/sql-openapi/test/tap-snapshots/array-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/array-openapi-1.cjs
@@ -65,6 +65,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
+        "description": "Fetch pages from the database.",
         "operationId": "getPages",
         "parameters": Array [
           Object {
@@ -368,11 +369,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get pages.",
         "tags": Array [
           "pages",
         ],
       },
       "post": Object {
+        "description": "Add new page to the database.",
         "operationId": "createPage",
         "requestBody": Object {
           "content": Object {
@@ -396,11 +399,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create page.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update one or more pages in the database.",
         "operationId": "updatePages",
         "parameters": Array [
           Object {
@@ -664,6 +669,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update pages.",
         "tags": Array [
           "pages",
         ],
@@ -671,6 +677,7 @@ Object {
     },
     "/pages/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more pages from the Database.",
         "operationId": "deletePages",
         "parameters": Array [
           Object {
@@ -710,11 +717,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete pages.",
         "tags": Array [
           "pages",
         ],
       },
       "get": Object {
+        "description": "Fetch Page using its id from the database.",
         "operationId": "getPageById",
         "parameters": Array [
           Object {
@@ -755,11 +764,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Page by id.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update page in the database.",
         "operationId": "updatePage",
         "parameters": Array [
           Object {
@@ -809,6 +820,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update page.",
         "tags": Array [
           "pages",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi-recursive.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi-recursive.cjs
@@ -59,6 +59,7 @@ Object {
   "paths": Object {
     "/people/": Object {
       "get": Object {
+        "description": "Fetch people from the database.",
         "operationId": "getPeople",
         "parameters": Array [
           Object {
@@ -454,11 +455,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get people.",
         "tags": Array [
           "people",
         ],
       },
       "post": Object {
+        "description": "Add new person to the database.",
         "operationId": "createPerson",
         "requestBody": Object {
           "content": Object {
@@ -495,11 +498,13 @@ Object {
             },
           },
         },
+        "summary": "Create person.",
         "tags": Array [
           "people",
         ],
       },
       "put": Object {
+        "description": "Update one or more people in the database.",
         "operationId": "updatePeople",
         "parameters": Array [
           Object {
@@ -856,6 +861,7 @@ Object {
             },
           },
         },
+        "summary": "Update people.",
         "tags": Array [
           "people",
         ],
@@ -863,6 +869,7 @@ Object {
     },
     "/people/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more people from the Database.",
         "operationId": "deletePeople",
         "parameters": Array [
           Object {
@@ -902,11 +909,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete people.",
         "tags": Array [
           "people",
         ],
       },
       "get": Object {
+        "description": "Fetch Person using its id from the database.",
         "operationId": "getPersonById",
         "parameters": Array [
           Object {
@@ -960,11 +969,13 @@ Object {
             },
           },
         },
+        "summary": "Get Person by id.",
         "tags": Array [
           "people",
         ],
       },
       "put": Object {
+        "description": "Update person in the database.",
         "operationId": "updatePerson",
         "parameters": Array [
           Object {
@@ -1027,6 +1038,7 @@ Object {
             },
           },
         },
+        "summary": "Update person.",
         "tags": Array [
           "people",
         ],
@@ -1034,6 +1046,7 @@ Object {
     },
     "/people/{id}/parent": Object {
       "get": Object {
+        "description": "Fetch the person for person from the database.",
         "operationId": "getPersonForPerson",
         "parameters": Array [
           Object {
@@ -1087,6 +1100,7 @@ Object {
             },
           },
         },
+        "summary": "Get person for person.",
         "tags": Array [
           "people",
         ],
@@ -1094,6 +1108,7 @@ Object {
     },
     "/people/{id}/people": Object {
       "get": Object {
+        "description": "Fetch all the people for person from the database.",
         "operationId": "getPeopleForPerson",
         "parameters": Array [
           Object {
@@ -1150,6 +1165,7 @@ Object {
             },
           },
         },
+        "summary": "Get people for person.",
         "tags": Array [
           "people",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/nested-routes-openapi.cjs
@@ -102,6 +102,7 @@ Object {
   "paths": Object {
     "/owners/": Object {
       "get": Object {
+        "description": "Fetch owners from the database.",
         "operationId": "getOwners",
         "parameters": Array [
           Object {
@@ -388,11 +389,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get owners.",
         "tags": Array [
           "owners",
         ],
       },
       "post": Object {
+        "description": "Add new owner to the database.",
         "operationId": "createOwner",
         "requestBody": Object {
           "content": Object {
@@ -423,11 +426,13 @@ Object {
             },
           },
         },
+        "summary": "Create owner.",
         "tags": Array [
           "owners",
         ],
       },
       "put": Object {
+        "description": "Update one or more owners in the database.",
         "operationId": "updateOwners",
         "parameters": Array [
           Object {
@@ -681,6 +686,7 @@ Object {
             },
           },
         },
+        "summary": "Update owners.",
         "tags": Array [
           "owners",
         ],
@@ -688,6 +694,7 @@ Object {
     },
     "/owners/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more owners from the Database.",
         "operationId": "deleteOwners",
         "parameters": Array [
           Object {
@@ -726,11 +733,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete owners.",
         "tags": Array [
           "owners",
         ],
       },
       "get": Object {
+        "description": "Fetch Owner using its id from the database.",
         "operationId": "getOwnerById",
         "parameters": Array [
           Object {
@@ -777,11 +786,13 @@ Object {
             },
           },
         },
+        "summary": "Get Owner by id.",
         "tags": Array [
           "owners",
         ],
       },
       "put": Object {
+        "description": "Update owner in the database.",
         "operationId": "updateOwner",
         "parameters": Array [
           Object {
@@ -837,6 +848,7 @@ Object {
             },
           },
         },
+        "summary": "Update owner.",
         "tags": Array [
           "owners",
         ],
@@ -844,6 +856,7 @@ Object {
     },
     "/owners/{id}/posts": Object {
       "get": Object {
+        "description": "Fetch all the posts for owner from the database.",
         "operationId": "getPostsForOwner",
         "parameters": Array [
           Object {
@@ -896,6 +909,7 @@ Object {
             },
           },
         },
+        "summary": "Get posts for owner.",
         "tags": Array [
           "owners",
         ],
@@ -903,6 +917,7 @@ Object {
     },
     "/posts/": Object {
       "get": Object {
+        "description": "Fetch posts from the database.",
         "operationId": "getPosts",
         "parameters": Array [
           Object {
@@ -1516,11 +1531,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get posts.",
         "tags": Array [
           "posts",
         ],
       },
       "post": Object {
+        "description": "Add new post to the database.",
         "operationId": "createPost",
         "requestBody": Object {
           "content": Object {
@@ -1551,11 +1568,13 @@ Object {
             },
           },
         },
+        "summary": "Create post.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update one or more posts in the database.",
         "operationId": "updatePosts",
         "parameters": Array [
           Object {
@@ -2100,6 +2119,7 @@ Object {
             },
           },
         },
+        "summary": "Update posts.",
         "tags": Array [
           "posts",
         ],
@@ -2107,6 +2127,7 @@ Object {
     },
     "/posts/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more posts from the Database.",
         "operationId": "deletePosts",
         "parameters": Array [
           Object {
@@ -2148,11 +2169,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete posts.",
         "tags": Array [
           "posts",
         ],
       },
       "get": Object {
+        "description": "Fetch Post using its id from the database.",
         "operationId": "getPostById",
         "parameters": Array [
           Object {
@@ -2202,11 +2225,13 @@ Object {
             },
           },
         },
+        "summary": "Get Post by id.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update post in the database.",
         "operationId": "updatePost",
         "parameters": Array [
           Object {
@@ -2265,6 +2290,7 @@ Object {
             },
           },
         },
+        "summary": "Update post.",
         "tags": Array [
           "posts",
         ],
@@ -2272,6 +2298,7 @@ Object {
     },
     "/posts/{id}/owner": Object {
       "get": Object {
+        "description": "Fetch the owner for post from the database.",
         "operationId": "getOwnerForPost",
         "parameters": Array [
           Object {
@@ -2318,6 +2345,7 @@ Object {
             },
           },
         },
+        "summary": "Get owner for post.",
         "tags": Array [
           "posts",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/orderby-openapi-1.cjs
@@ -57,6 +57,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
+        "description": "Fetch pages from the database.",
         "operationId": "getPages",
         "parameters": Array [
           Object {
@@ -452,11 +453,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get pages.",
         "tags": Array [
           "pages",
         ],
       },
       "post": Object {
+        "description": "Add new page to the database.",
         "operationId": "createPage",
         "requestBody": Object {
           "content": Object {
@@ -480,11 +483,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create page.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update one or more pages in the database.",
         "operationId": "updatePages",
         "parameters": Array [
           Object {
@@ -828,6 +833,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update pages.",
         "tags": Array [
           "pages",
         ],
@@ -835,6 +841,7 @@ Object {
     },
     "/pages/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more pages from the Database.",
         "operationId": "deletePages",
         "parameters": Array [
           Object {
@@ -874,11 +881,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete pages.",
         "tags": Array [
           "pages",
         ],
       },
       "get": Object {
+        "description": "Fetch Page using its id from the database.",
         "operationId": "getPageById",
         "parameters": Array [
           Object {
@@ -919,11 +928,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Page by id.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update page in the database.",
         "operationId": "updatePage",
         "parameters": Array [
           Object {
@@ -973,6 +984,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update page.",
         "tags": Array [
           "pages",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-1.cjs
@@ -51,6 +51,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
+        "description": "Fetch pages from the database.",
         "operationId": "getPages",
         "parameters": Array [
           Object {
@@ -337,11 +338,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get pages.",
         "tags": Array [
           "pages",
         ],
       },
       "post": Object {
+        "description": "Add new page to the database.",
         "operationId": "createPage",
         "requestBody": Object {
           "content": Object {
@@ -365,11 +368,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create page.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update one or more pages in the database.",
         "operationId": "updatePages",
         "parameters": Array [
           Object {
@@ -616,6 +621,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update pages.",
         "tags": Array [
           "pages",
         ],
@@ -623,6 +629,7 @@ Object {
     },
     "/pages/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more pages from the Database.",
         "operationId": "deletePages",
         "parameters": Array [
           Object {
@@ -661,11 +668,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete pages.",
         "tags": Array [
           "pages",
         ],
       },
       "get": Object {
+        "description": "Fetch Page using its id from the database.",
         "operationId": "getPageById",
         "parameters": Array [
           Object {
@@ -705,11 +714,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Page by id.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update page in the database.",
         "operationId": "updatePage",
         "parameters": Array [
           Object {
@@ -758,6 +769,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update page.",
         "tags": Array [
           "pages",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-2.cjs
@@ -49,6 +49,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
+        "description": "Fetch pages from the database.",
         "operationId": "getPages",
         "parameters": Array [
           Object {
@@ -335,11 +336,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get pages.",
         "tags": Array [
           "pages",
         ],
       },
       "post": Object {
+        "description": "Add new page to the database.",
         "operationId": "createPage",
         "requestBody": Object {
           "content": Object {
@@ -363,11 +366,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create page.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update one or more pages in the database.",
         "operationId": "updatePages",
         "parameters": Array [
           Object {
@@ -614,6 +619,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update pages.",
         "tags": Array [
           "pages",
         ],
@@ -621,6 +627,7 @@ Object {
     },
     "/pages/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more pages from the Database.",
         "operationId": "deletePages",
         "parameters": Array [
           Object {
@@ -659,11 +666,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete pages.",
         "tags": Array [
           "pages",
         ],
       },
       "get": Object {
+        "description": "Fetch Page using its id from the database.",
         "operationId": "getPageById",
         "parameters": Array [
           Object {
@@ -703,11 +712,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Page by id.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update page in the database.",
         "operationId": "updatePage",
         "parameters": Array [
           Object {
@@ -756,6 +767,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update page.",
         "tags": Array [
           "pages",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-3.cjs
@@ -51,6 +51,7 @@ Object {
   "paths": Object {
     "/pages/": Object {
       "get": Object {
+        "description": "Fetch pages from the database.",
         "operationId": "getPages",
         "parameters": Array [
           Object {
@@ -337,11 +338,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get pages.",
         "tags": Array [
           "pages",
         ],
       },
       "post": Object {
+        "description": "Add new page to the database.",
         "operationId": "createPage",
         "requestBody": Object {
           "content": Object {
@@ -365,11 +368,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create page.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update one or more pages in the database.",
         "operationId": "updatePages",
         "parameters": Array [
           Object {
@@ -616,6 +621,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update pages.",
         "tags": Array [
           "pages",
         ],
@@ -623,6 +629,7 @@ Object {
     },
     "/pages/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more pages from the Database.",
         "operationId": "deletePages",
         "parameters": Array [
           Object {
@@ -661,11 +668,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete pages.",
         "tags": Array [
           "pages",
         ],
       },
       "get": Object {
+        "description": "Fetch Page using its id from the database.",
         "operationId": "getPageById",
         "parameters": Array [
           Object {
@@ -705,11 +714,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Page by id.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update page in the database.",
         "operationId": "updatePage",
         "parameters": Array [
           Object {
@@ -758,6 +769,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update page.",
         "tags": Array [
           "pages",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/simple-openapi-4.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/simple-openapi-4.cjs
@@ -51,6 +51,7 @@ Object {
   "paths": Object {
     "/api/pages/": Object {
       "get": Object {
+        "description": "Fetch pages from the database.",
         "operationId": "getPages",
         "parameters": Array [
           Object {
@@ -337,11 +338,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get pages.",
         "tags": Array [
           "pages",
         ],
       },
       "post": Object {
+        "description": "Add new page to the database.",
         "operationId": "createPage",
         "requestBody": Object {
           "content": Object {
@@ -365,11 +368,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create page.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update one or more pages in the database.",
         "operationId": "updatePages",
         "parameters": Array [
           Object {
@@ -616,6 +621,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update pages.",
         "tags": Array [
           "pages",
         ],
@@ -623,6 +629,7 @@ Object {
     },
     "/api/pages/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more pages from the Database.",
         "operationId": "deletePages",
         "parameters": Array [
           Object {
@@ -661,11 +668,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete pages.",
         "tags": Array [
           "pages",
         ],
       },
       "get": Object {
+        "description": "Fetch Page using its id from the database.",
         "operationId": "getPageById",
         "parameters": Array [
           Object {
@@ -705,11 +714,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Page by id.",
         "tags": Array [
           "pages",
         ],
       },
       "put": Object {
+        "description": "Update page in the database.",
         "operationId": "updatePage",
         "parameters": Array [
           Object {
@@ -758,6 +769,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update page.",
         "tags": Array [
           "pages",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/updateMany-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/updateMany-openapi-1.cjs
@@ -65,6 +65,7 @@ Object {
   "paths": Object {
     "/posts/": Object {
       "get": Object {
+        "description": "Fetch posts from the database.",
         "operationId": "getPosts",
         "parameters": Array [
           Object {
@@ -569,11 +570,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get posts.",
         "tags": Array [
           "posts",
         ],
       },
       "post": Object {
+        "description": "Add new post to the database.",
         "operationId": "createPost",
         "requestBody": Object {
           "content": Object {
@@ -597,11 +600,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create post.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update one or more posts in the database.",
         "operationId": "updatePosts",
         "parameters": Array [
           Object {
@@ -1042,6 +1047,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update posts.",
         "tags": Array [
           "posts",
         ],
@@ -1049,6 +1055,7 @@ Object {
     },
     "/posts/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more posts from the Database.",
         "operationId": "deletePosts",
         "parameters": Array [
           Object {
@@ -1089,11 +1096,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete posts.",
         "tags": Array [
           "posts",
         ],
       },
       "get": Object {
+        "description": "Fetch Post using its id from the database.",
         "operationId": "getPostById",
         "parameters": Array [
           Object {
@@ -1135,11 +1144,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Post by id.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update post in the database.",
         "operationId": "updatePost",
         "parameters": Array [
           Object {
@@ -1190,6 +1201,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update post.",
         "tags": Array [
           "posts",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-1.cjs
@@ -65,6 +65,7 @@ Object {
   "paths": Object {
     "/posts/": Object {
       "get": Object {
+        "description": "Fetch posts from the database.",
         "operationId": "getPosts",
         "parameters": Array [
           Object {
@@ -569,11 +570,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get posts.",
         "tags": Array [
           "posts",
         ],
       },
       "post": Object {
+        "description": "Add new post to the database.",
         "operationId": "createPost",
         "requestBody": Object {
           "content": Object {
@@ -597,11 +600,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create post.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update one or more posts in the database.",
         "operationId": "updatePosts",
         "parameters": Array [
           Object {
@@ -1042,6 +1047,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update posts.",
         "tags": Array [
           "posts",
         ],
@@ -1049,6 +1055,7 @@ Object {
     },
     "/posts/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more posts from the Database.",
         "operationId": "deletePosts",
         "parameters": Array [
           Object {
@@ -1089,11 +1096,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete posts.",
         "tags": Array [
           "posts",
         ],
       },
       "get": Object {
+        "description": "Fetch Post using its id from the database.",
         "operationId": "getPostById",
         "parameters": Array [
           Object {
@@ -1135,11 +1144,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Post by id.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update post in the database.",
         "operationId": "updatePost",
         "parameters": Array [
           Object {
@@ -1190,6 +1201,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update post.",
         "tags": Array [
           "posts",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-2.cjs
@@ -102,6 +102,7 @@ Object {
   "paths": Object {
     "/owners/": Object {
       "get": Object {
+        "description": "Fetch owners from the database.",
         "operationId": "getOwners",
         "parameters": Array [
           Object {
@@ -388,11 +389,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get owners.",
         "tags": Array [
           "owners",
         ],
       },
       "post": Object {
+        "description": "Add new owner to the database.",
         "operationId": "createOwner",
         "requestBody": Object {
           "content": Object {
@@ -423,11 +426,13 @@ Object {
             },
           },
         },
+        "summary": "Create owner.",
         "tags": Array [
           "owners",
         ],
       },
       "put": Object {
+        "description": "Update one or more owners in the database.",
         "operationId": "updateOwners",
         "parameters": Array [
           Object {
@@ -681,6 +686,7 @@ Object {
             },
           },
         },
+        "summary": "Update owners.",
         "tags": Array [
           "owners",
         ],
@@ -688,6 +694,7 @@ Object {
     },
     "/owners/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more owners from the Database.",
         "operationId": "deleteOwners",
         "parameters": Array [
           Object {
@@ -726,11 +733,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete owners.",
         "tags": Array [
           "owners",
         ],
       },
       "get": Object {
+        "description": "Fetch Owner using its id from the database.",
         "operationId": "getOwnerById",
         "parameters": Array [
           Object {
@@ -777,11 +786,13 @@ Object {
             },
           },
         },
+        "summary": "Get Owner by id.",
         "tags": Array [
           "owners",
         ],
       },
       "put": Object {
+        "description": "Update owner in the database.",
         "operationId": "updateOwner",
         "parameters": Array [
           Object {
@@ -837,6 +848,7 @@ Object {
             },
           },
         },
+        "summary": "Update owner.",
         "tags": Array [
           "owners",
         ],
@@ -844,6 +856,7 @@ Object {
     },
     "/owners/{id}/posts": Object {
       "get": Object {
+        "description": "Fetch all the posts for owner from the database.",
         "operationId": "getPostsForOwner",
         "parameters": Array [
           Object {
@@ -896,6 +909,7 @@ Object {
             },
           },
         },
+        "summary": "Get posts for owner.",
         "tags": Array [
           "owners",
         ],
@@ -903,6 +917,7 @@ Object {
     },
     "/posts/": Object {
       "get": Object {
+        "description": "Fetch posts from the database.",
         "operationId": "getPosts",
         "parameters": Array [
           Object {
@@ -1516,11 +1531,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get posts.",
         "tags": Array [
           "posts",
         ],
       },
       "post": Object {
+        "description": "Add new post to the database.",
         "operationId": "createPost",
         "requestBody": Object {
           "content": Object {
@@ -1551,11 +1568,13 @@ Object {
             },
           },
         },
+        "summary": "Create post.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update one or more posts in the database.",
         "operationId": "updatePosts",
         "parameters": Array [
           Object {
@@ -2100,6 +2119,7 @@ Object {
             },
           },
         },
+        "summary": "Update posts.",
         "tags": Array [
           "posts",
         ],
@@ -2107,6 +2127,7 @@ Object {
     },
     "/posts/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more posts from the Database.",
         "operationId": "deletePosts",
         "parameters": Array [
           Object {
@@ -2148,11 +2169,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete posts.",
         "tags": Array [
           "posts",
         ],
       },
       "get": Object {
+        "description": "Fetch Post using its id from the database.",
         "operationId": "getPostById",
         "parameters": Array [
           Object {
@@ -2202,11 +2225,13 @@ Object {
             },
           },
         },
+        "summary": "Get Post by id.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update post in the database.",
         "operationId": "updatePost",
         "parameters": Array [
           Object {
@@ -2265,6 +2290,7 @@ Object {
             },
           },
         },
+        "summary": "Update post.",
         "tags": Array [
           "posts",
         ],
@@ -2272,6 +2298,7 @@ Object {
     },
     "/posts/{id}/owner": Object {
       "get": Object {
+        "description": "Fetch the owner for post from the database.",
         "operationId": "getOwnerForPost",
         "parameters": Array [
           Object {
@@ -2318,6 +2345,7 @@ Object {
             },
           },
         },
+        "summary": "Get owner for post.",
         "tags": Array [
           "posts",
         ],

--- a/packages/sql-openapi/test/tap-snapshots/where-openapi-3.cjs
+++ b/packages/sql-openapi/test/tap-snapshots/where-openapi-3.cjs
@@ -67,6 +67,7 @@ Object {
   "paths": Object {
     "/posts/": Object {
       "get": Object {
+        "description": "Fetch posts from the database.",
         "operationId": "getPosts",
         "parameters": Array [
           Object {
@@ -571,11 +572,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Get posts.",
         "tags": Array [
           "posts",
         ],
       },
       "post": Object {
+        "description": "Add new post to the database.",
         "operationId": "createPost",
         "requestBody": Object {
           "content": Object {
@@ -599,11 +602,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Create post.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update one or more posts in the database.",
         "operationId": "updatePosts",
         "parameters": Array [
           Object {
@@ -1044,6 +1049,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update posts.",
         "tags": Array [
           "posts",
         ],
@@ -1051,6 +1057,7 @@ Object {
     },
     "/posts/{id}": Object {
       "delete": Object {
+        "description": "Delete one or more posts from the Database.",
         "operationId": "deletePosts",
         "parameters": Array [
           Object {
@@ -1091,11 +1098,13 @@ Object {
             "description": "Default Response",
           },
         },
+        "summary": "Delete posts.",
         "tags": Array [
           "posts",
         ],
       },
       "get": Object {
+        "description": "Fetch Post using its id from the database.",
         "operationId": "getPostById",
         "parameters": Array [
           Object {
@@ -1137,11 +1146,13 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Get Post by id.",
         "tags": Array [
           "posts",
         ],
       },
       "put": Object {
+        "description": "Update post in the database.",
         "operationId": "updatePost",
         "parameters": Array [
           Object {
@@ -1192,6 +1203,7 @@ Object {
             "links": Object {},
           },
         },
+        "summary": "Update post.",
         "tags": Array [
           "posts",
         ],


### PR DESCRIPTION
Fixes #1774 

The schema for `platformatic.db.json` config file already provides the property `db.openapi.paths` that can be used to override path summaries or descriptions. These are in accordance with the OpenAPI 3 specs.

Here is a summary of the changes:
1. For every route, the `sql-openapi` package will check for and apply any schema overrides for that route. The properties provided at the method level will override those at the path level, in case both are provided.
2. Added `schema-override.test.js` to test the above functionality.
3. Added default `summary` and `description` to each route.
4. Updated test snapshots: added default summaries and descriptions.

To add a custom summary or description, the following configuration can be used in the `platformatic.db` config file:
```
{
  ...
  "db": {
    ...
    "openapi": {
      "paths": {
        "/quotes/": {
          "summary": "Summary for quotes",
          "description": "Description for quotes"
          "GET": {
            "summary": "Summary for quotes but GET method only"
          }
        },
        "/quotes/:id": {
            "summary": "foo",
            "description": "bar"
        }
      }
    },
    ...
  }
}
```





