### PR TITLE
fix(#1826): Add missing type options build open api client

### DIFF
--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -5,25 +5,21 @@ interface Headers {
   [key: string]: string
 }
 
-export type PlatformaticClientPluginOptions = {
+interface BuildOpenAPIClientOptions {
   url: string;
   path?: string;
-  headers?: Headers;
-  throwOnError: boolean;
-  fullRequest: boolean;
   fullResponse: boolean;
+  fullRequest: boolean;
+  throwOnError: boolean;
+  headers?: Headers;
   validateResponse?: boolean;
+}
+
+export type PlatformaticClientPluginOptions = BuildOpenAPIClientOptions & {
   type: 'openapi' | 'graphql';
   name?: string;
   serviceId?: string;
   getHeaders?: (request: FastifyRequest, reply: FastifyReply, options: { url: URL, method: string, headers: Headers, telemetryHeaders?: Headers, body: object }) => Promise<Headers>;
-}
-
-interface BuildOpenAPIClientOptions {
-  url: string;
-  path: string;
-  headers?: Headers,
-  validateResponse?: boolean
 }
 
 interface AbstractLogger {

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -51,7 +51,10 @@ type MyType = {
 const openTelemetryClient = {}
 expectType<Promise<MyType>>(buildOpenAPIClient<MyType>({
   url: 'http://foo.bar',
-  path: 'foobar'
+  path: 'foobar',
+  fullRequest: true,
+  fullResponse: false,
+  throwOnError: false
 }, openTelemetryClient))
 
 expectType<() => FastifyError>(errors.OptionsUrlRequiredError)


### PR DESCRIPTION
Fix for https://github.com/platformatic/platformatic/issues/1826