### PR TITLE
fix(#1820): openTelemetry param should be optional

### DIFF
--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -57,8 +57,8 @@ type OpenTelemetry = {
 }
 
 export function generateOperationId(path: string, method: string, methodMeta: MethodMetaInterface, all: string[]): string
-export function buildOpenAPIClient<T>(options: BuildOpenAPIClientOptions, openTelemetry: OpenTelemetry): Promise<T>
-export function buildGraphQLClient(options: BuildGraphQLClientOptions, openTelemetry: OpenTelemetry, logger: AbstractLogger): Promise<BuildGraphQLClientOutput>
+export function buildOpenAPIClient<T>(options: BuildOpenAPIClientOptions, openTelemetry?: OpenTelemetry): Promise<T>
+export function buildGraphQLClient(options: BuildGraphQLClientOptions, openTelemetry?: OpenTelemetry, logger?: AbstractLogger): Promise<BuildGraphQLClientOutput>
 export function hasDuplicatedParameters(methodMeta: MethodMetaInterface): boolean
 
 export const plugin: FastifyPluginAsync<PlatformaticClientPluginOptions>

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -48,14 +48,25 @@ type MyType = {
   foo: string
 }
 
+// All params passed
 const openTelemetryClient = {}
 expectType<Promise<MyType>>(buildOpenAPIClient<MyType>({
   url: 'http://foo.bar',
   path: 'foobar',
   fullRequest: true,
   fullResponse: false,
-  throwOnError: false
+  throwOnError: false,
+  validateResponse: false,
+  headers: { foo: 'bar' }
 }, openTelemetryClient))
+
+// Only required params
+expectType<Promise<MyType>>(buildOpenAPIClient<MyType>({
+  url: 'https://undici.com/piscina',
+  fullRequest: true,
+  fullResponse: false,
+  throwOnError: false
+}))
 
 expectType<() => FastifyError>(errors.OptionsUrlRequiredError)
 


### PR DESCRIPTION
Probably related to this [issue](https://github.com/platformatic/platformatic/issues/1820).

In any case, `openTelemetry` param should not be mandatory to be passed, considering how it's used for example [here](https://github.com/platformatic/platformatic/blob/main/packages/client/index.js#L193). In any case, in the entire [client](https://github.com/platformatic/platformatic/blob/main/packages/client/index.js), it's always called with the question mark, so it can be `undefined` 😉 