### PR TITLE
feat(client-cli): Add endpoints map

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -7,11 +7,13 @@ import jsonpointer from 'jsonpointer'
 import errors from './errors.mjs'
 import camelcase from 'camelcase'
 
-export function writeOperations (interfacesWriter, mainWriter, operations, { fullRequest, fullResponse, optionalHeaders, schema }) {
+export function writeOperations (interfacesWriter, mainWriter, operations, { fullRequest, fullResponse, optionalHeaders, schema }, map, mapName) {
   const originalFullResponse = fullResponse
   let currentFullResponse = originalFullResponse
+  map?.writeLine(`export const ${mapName} = {`)
   for (const operation of operations) {
     const operationId = operation.operation.operationId
+    map?.writeLine(`${operationId}: "${operation.path}",`)
     const camelCaseOperationId = camelcase(operationId)
     const { parameters, responses, requestBody } = operation.operation
     const forceFullRequest = fullRequest || hasDuplicatedParameters(operation.operation)
@@ -106,6 +108,8 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
     mainWriter.writeLine(`${camelCaseOperationId}(req?: ${operationRequestName}): Promise<${allResponsesName}>;`)
     currentFullResponse = originalFullResponse
   }
+  map?.writeLine('} as const;')
+  map?.blankLine()
 }
 
 export function writeProperties (writer, blockName, parameters, addedProps) {

--- a/packages/client-cli/lib/openapi-generator.mjs
+++ b/packages/client-cli/lib/openapi-generator.mjs
@@ -97,6 +97,12 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
     useTabs: false,
     useSingleQuote: true
   })
+
+  const map = new CodeBlockWriter({
+    indentNumberOfSpaces: 2,
+    useTabs: false,
+    useSingleQuote: true
+  })
   /* eslint-enable new-cap */
 
   writer.writeLine('import { type FastifyReply, type FastifyPluginAsync } from \'fastify\'')
@@ -117,7 +123,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
     writer.write(`export interface ${capitalizedName}`).block(() => {
       writeOperations(interfaces, writer, operations, {
         fullRequest, fullResponse, optionalHeaders, schema
-      })
+      }, map, `${camelcasedName}EndpointsMap`)
     })
 
     writer.write(`export interface ${optionsName}`).block(() => {
@@ -128,6 +134,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
     writer.writeLine(`export { ${camelcasedName} as default };`)
 
     writer.write(interfaces.toString())
+    writer.write(map.toString())
   })
 
   writer.blankLine()

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -27,6 +27,9 @@ test('generates only types in target folder with --types-only flag', async ({ te
   match(fileContents, /export interface GetMoviesRequest {/)
   match(fileContents, /export interface GetMoviesResponseOK {/)
   match(fileContents, /export interface Movies {/)
+  match(fileContents, /export const moviesEndpointsMap = {/)
+  match(fileContents, /getMovies: "\/movies\/",/)
+  match(fileContents, /getHelloWorld: "\/hello-world",/)
 })
 
 test('openapi client generation (javascript)', async ({ teardown, comment, same }) => {


### PR DESCRIPTION
This exports an object that maps every operation ID with a URL, for instance:
```
export const clientEndpointsMap = {
  getHealthCheck = '/health-check',
  getSomethingElse = '/something-else'
} as const;
```

It's useful to get in `O(1)` time the endpoint starting from the operation ID