### PR TITLE
feat(client): Allow getHeaders to be called when using buildOpenAPIClient

### DIFF
--- a/docs/reference/client/programmatic.md
+++ b/docs/reference/client/programmatic.md
@@ -43,7 +43,33 @@ console.log(mapping)
 
 ```
 
-If you use Typescript you can take advantage of the generated types file 
+You're also able to pass an asynchronous function that modifies the headers for each request with the `getHeaders` option. This function will be executed before each request, just like the plugin `getHeaders` options. Note that `headers` and `getHeaders` are not mutually exclusive, and can work together:
+
+```js
+import { buildOpenAPIClient } from '@platformatic/client'
+
+const client = await buildOpenAPIClient({
+  url: `https://yourapi.com/documentation/json`, 
+  headers: {
+    'foo': 'bar'
+  },
+  getHeaders(options) {
+    const { url, method, body, headers, telemetryHeaders } = options
+
+    // generate your dynamic headers
+
+    return {
+      myDynamicHeader: 'my-value',
+    }
+  }
+})
+
+const res = await client.yourOperationName({ foo: 'bar' })
+
+console.log(res)
+```
+
+If you use Typescript you can take advantage of the generated types file:
 
 ```ts
 import { buildOpenAPIClient } from '@platformatic/client'

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -5,7 +5,15 @@ interface Headers {
   [key: string]: string
 }
 
-interface BuildOpenAPIClientOptions {
+export interface GetHeadersOptions {
+  url: URL;
+  method: string;
+  body: object;
+  headers: Headers;
+  telemetryHeaders?: Headers;
+}
+
+interface PlatformaticClientOptions {
   url: string;
   path?: string;
   fullResponse: boolean;
@@ -15,11 +23,15 @@ interface BuildOpenAPIClientOptions {
   validateResponse?: boolean;
 }
 
-export type PlatformaticClientPluginOptions = BuildOpenAPIClientOptions & {
+type BuildOpenAPIClientOptions  = PlatformaticClientOptions & {
+  getHeaders?: (options: GetHeadersOptions) => Promise<Headers>;
+}
+
+export type PlatformaticClientPluginOptions = PlatformaticClientOptions & {
   type: 'openapi' | 'graphql';
   name?: string;
   serviceId?: string;
-  getHeaders?: (request: FastifyRequest, reply: FastifyReply, options: { url: URL, method: string, headers: Headers, telemetryHeaders?: Headers, body: object }) => Promise<Headers>;
+  getHeaders?: (request: FastifyRequest, reply: FastifyReply, options: GetHeadersOptions) => Promise<Headers>;
 }
 
 interface AbstractLogger {

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -53,6 +53,14 @@ async function buildOpenAPIClient (options, openTelemetry) {
   const client = {}
   let spec
   let baseUrl
+
+  if (typeof options.getHeaders === 'function') {
+    const getHeaders = options.getHeaders
+    options = { ...options }
+    client[kGetHeaders] = getHeaders
+    options.getHeaders = undefined
+  }
+
   const { validateResponse } = options
   // this is tested, not sure why c8 is not picking it up
   if (!options.url) {
@@ -70,6 +78,7 @@ async function buildOpenAPIClient (options, openTelemetry) {
   const kOperationIdMap = Symbol.for('plt.operationIdMap')
   client[kOperationIdMap] = {}
   client[kHeaders] = options.headers || {}
+
   let { fullRequest, fullResponse, throwOnError } = options
   const generatedOperationIds = []
   for (const path of Object.keys(spec.paths)) {
@@ -119,6 +128,7 @@ function hasDuplicatedParameters (methodMeta) {
   })
   return s.size !== methodMeta.parameters.length
 }
+
 async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throwOnError, openTelemetry, fullRequest, fullResponse, validateResponse) {
   await $RefParser.dereference(spec)
   const ajv = new Ajv()

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import fastify, { HTTPMethods } from 'fastify'
-import pltClient, { type PlatformaticClientPluginOptions, type buildOpenAPIClient, type GetHeadersOptions, errors } from '.'
+import pltClient, { type PlatformaticClientPluginOptions, type GetHeadersOptions, buildOpenAPIClient, errors } from '.'
 import { FastifyError } from '@fastify/error'
 
 const server = await fastify()
@@ -58,7 +58,7 @@ const client = await buildOpenAPIClient<MyType>({
   throwOnError: false,
   validateResponse: false,
   headers: { foo: 'bar' },
-  getHeaders(options: GetHeadersOptions) {
+  getHeaders: async (options: GetHeadersOptions) => {
     const { url } = options;
     return { href: url.href };
   },

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import fastify, { HTTPMethods } from 'fastify'
-import pltClient, { type PlatformaticClientPluginOptions, buildOpenAPIClient, errors } from '.'
+import pltClient, { type PlatformaticClientPluginOptions, type buildOpenAPIClient, type GetHeadersOptions, errors } from '.'
 import { FastifyError } from '@fastify/error'
 
 const server = await fastify()
@@ -57,7 +57,11 @@ const client = await buildOpenAPIClient<MyType>({
   fullResponse: false,
   throwOnError: false,
   validateResponse: false,
-  headers: { foo: 'bar' }
+  headers: { foo: 'bar' },
+  getHeaders(options: GetHeadersOptions) {
+    const { url } = options;
+    return { href: url.href };
+  },
 }, openTelemetry)
 
 // All params and generic passed
@@ -74,4 +78,3 @@ expectType<Promise<unknown>>(buildOpenAPIClient({
 }))
 
 expectType<() => FastifyError>(errors.OptionsUrlRequiredError)
-


### PR DESCRIPTION
Hello! 👋🏼 

While using `@platformatic/client` and its `buildOpenAPIClient`, I realised `getHeaders` is not being passed down (nor there was the chance to do so). Since `buildCallFunction` already makes use of it, it would be fantastic if that could be passed down so that headers can be injected in the request if needed. We have this use case where we'd like to call this function to build dynamic headers (like signature headers), without having to inject them, before calling platformatic client methods.

The functionality would remain the same as in the plugin (excluding the `request` and `reply` objects). This PR makes sure:
- The `getHeaders` function is received by `buildOpenAPIClient` and gets added to `client`
- There is a test to prove the function gets called upon request
- There is TypeScript support for `getHeaders` in `buildOpenAPIClient`

What do you folks think? Happy to answer any questions and modify based on feedback! 🚀 