### PR TITLE
handle headers for get requests too

### DIFF
--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -127,6 +127,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
                 })
               })
             })
+            .write(')')
         }
       } else {
         if (queryParams.length) {

--- a/packages/client-cli/test/fixtures/get-headers-frontend-openapi.json
+++ b/packages/client-cli/test/fixtures/get-headers-frontend-openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getRoot",
+        "parameters": [
+          {
+            "name": "level",
+            "required": true,
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "foo",
+            "required": true,
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "score": {
+                      "type": "number"
+                    },
+                    "room": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [ "score", "room" ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -303,9 +303,8 @@ test('handle headers parameters in get request', async ({ teardown, ok, match })
   const implementation = await readFile(join(dir, 'fontend', 'fontend.ts'), 'utf8')
 
   const tsImplementationTemplate = `
-const _getRoot = async (url: string, request: Types.PostRootRequest) => {
-  const response = await fetch(\`\${url}/\`, {
-    method: 'GET',
+const _getRoot = async (url: string, request: Types.GetRootRequest) => {
+  const response = await fetch(\`\${url}/?\${new URLSearchParams(Object.entries(request || {})).toString()}\`, {
     headers: {
       'level': request['level'],
       'foo': request['foo']

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -294,3 +294,24 @@ const _postRoot = async (url: string, request: Types.PostRootRequest) => {
   ok(implementation)
   match(implementation, tsImplementationTemplate)
 })
+
+test('handle headers parameters in get request', async ({ teardown, ok, match }) => {
+  const dir = await moveToTmpdir(teardown)
+
+  const fileName = join(__dirname, 'fixtures', 'get-headers-frontend-openapi.json')
+  await execa('node', [cliPath, fileName, '--language', 'ts', '--frontend', '--name', 'fontend'])
+  const implementation = await readFile(join(dir, 'fontend', 'fontend.ts'), 'utf8')
+
+  const tsImplementationTemplate = `
+const _getRoot = async (url: string, request: Types.PostRootRequest) => {
+  const response = await fetch(\`\${url}/\`, {
+    method: 'GET',
+    headers: {
+      'level': request['level'],
+      'foo': request['foo']
+    }
+  })
+`
+  ok(implementation)
+  match(implementation, tsImplementationTemplate)
+})


### PR DESCRIPTION
#1821 solved the header problem when running `platformatic client <url> --frontend` for all http methods except for get, so this is the fix.