### PR TITLE
fix(#1878): only POST, PUT, PATCH & OPTIONS can send bodies from client

### DIFF
--- a/packages/client/test/fixtures/no-bodies/openapi.json
+++ b/packages/client/test/fixtures/no-bodies/openapi.json
@@ -1,0 +1,158 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "operationId": "getHello",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "postHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "putHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "patchHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "operationId": "headHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "optionsHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "trace": {
+        "operationId": "traceHello",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client/test/fixtures/no-bodies/package.json
+++ b/packages/client/test/fixtures/no-bodies/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": "^18.8.0"
+  }
+}

--- a/packages/client/test/fixtures/no-bodies/platformatic.service.json
+++ b/packages/client/test/fixtures/no-bodies/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.38.1/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client/test/fixtures/no-bodies/plugins/example.js
+++ b/packages/client/test/fixtures/no-bodies/plugins/example.js
@@ -1,0 +1,34 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify, opts) {
+  function returnRequestBody (request, reply) {
+    if (request.body) {
+      reply.send(request.body)
+      return
+    }
+    let body = ''
+    request.raw.on('data', (chunk) => {
+      body += chunk
+    })
+    request.raw.on('end', () => {
+      reply.header['Content-Type'] = 'application/json'
+      reply.send(body)
+    })
+  }
+
+  fastify.route({
+    url: '/hello',
+    method: [
+      'GET',
+      'POST',
+      'PUT',
+      'PATCH',
+      'DELETE',
+      'HEAD',
+      'OPTIONS',
+      'TRACE'
+    ],
+    handler: returnRequestBody
+  })
+}


### PR DESCRIPTION
Fixes #1878

My original approach was to not send content for methods which did not have request bodies defined in their openAPI specs, but the default @platformatic/client functionality is to send all unmapped params in the request body. Instead I've decided to not send a body where the method SHOULD NOT or MUST NOT have one according to [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110).

Hope this is ok!

Ta