### PR TITLE
fix: client body on 204 is null not undefined

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -227,7 +227,7 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
       const contentType = sanitizeContentType(res.headers['content-type']) || 'application/json'
       try {
         if (res.statusCode === 204) {
-          responseBody = await res.body.dump()
+          await res.body.dump()
         } else if (contentType === 'application/json') {
           responseBody = await res.body.json()
         } else {


### PR DESCRIPTION
The @platformatic/client tests are currently failing as they assert that the body of a 204 response should be `undefined`, yet it is actually `null` as the client returns the value of `res.body.dump()` (looks like undici changed to returning null in 5.28.0 with [perf: optimize Readable.dump](https://github.com/nodejs/undici/pull/2402)).