### PR TITLE
fix(#1881): @platformatic/client doesn't validate in fullResponse mode

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -237,14 +237,6 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
         // maybe the response is a 302, 301, or anything with empty payload
         responseBody = {}
       }
-      if (fullResponse) {
-        return {
-          statusCode: res.statusCode,
-          headers: res.headers,
-          body: responseBody
-        }
-      }
-
       if (validateResponse) {
         try {
           // validate response first
@@ -265,6 +257,13 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
           }
         } catch (err) {
           responseBody = createErrorResponse(err.message)
+        }
+      }
+      if (fullResponse) {
+        return {
+          statusCode: res.statusCode,
+          headers: res.headers,
+          body: responseBody
         }
       }
       return responseBody

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -804,6 +804,25 @@ test('validate response', async (t) => {
     id: 123,
     title: 'Harry Potter'
   })
+
+  // Validate bodies when getting full response
+  const fullResponseClient = await buildOpenAPIClient({
+    url: `${app.url}`,
+    path: join(tmpDir, 'openapi.json'),
+    validateResponse: true,
+    fullResponse: true
+  })
+
+  // invalid response format
+  const invalidFullResult = await fullResponseClient.getInvalid()
+  assert.deepEqual(invalidFullResult.body, {
+    statusCode: 500,
+    message: 'Invalid response format'
+  })
+
+  // valid response
+  const validFullResult = await fullResponseClient.getValid()
+  assert.deepEqual(validFullResult.body.message, 'This is a valid response')
 })
 
 test('build client with common parameters', async (t) => {


### PR DESCRIPTION
Fix: #1881

Ensure response validation applies whether `fullResponse` is enabled or not.