### PR TITLE
Generator support for relative paths 

### DIFF
--- a/packages/generators/lib/base-generator.d.ts
+++ b/packages/generators/lib/base-generator.d.ts
@@ -6,7 +6,7 @@ export namespace BaseGenerator {
     module: string
     inquirer?: object
   }
-  
+
   export type Env = {
     [key: string]: string | number | boolean
   }
@@ -14,13 +14,13 @@ export namespace BaseGenerator {
     [key: string]: string | number | undefined | null | boolean | object
   }
   type JSONValue =
-      | string
-      | number
-      | boolean
-      | { [x: string]: JSONValue }
-      | object
-      | Array<JSONValue>
-  
+    | string
+    | number
+    | boolean
+    | { [x: string]: JSONValue }
+    | object
+    | Array<JSONValue>
+
   type Dependency = {
     [key: string]: string
   }
@@ -34,7 +34,7 @@ export namespace BaseGenerator {
     hostname?: string
     plugin?: boolean
     dependencies?: Dependency
-    devDependencies?: Dependency  
+    devDependencies?: Dependency
     typescript?: boolean
     initGitRepository?: boolean
     staticWorkspaceGitHubActions?: boolean
@@ -44,12 +44,12 @@ export namespace BaseGenerator {
     serviceName?: string,
     envPrefix?: string
   }
-  
+
   type WhereClause = {
     before?: string
     after?: string
   }
-  
+
   type GeneratorMetadata = {
     targetDirectory: string
     env: KeyValue
@@ -59,7 +59,7 @@ export namespace BaseGenerator {
     label: string
     var: string
     default: string
-    type: 'number' | 'string' | 'boolean'
+    type: 'number' | 'string' | 'boolean' | 'path'
     configValue?: 'string'
 
   }
@@ -72,22 +72,22 @@ export namespace BaseGenerator {
     logger: BaseLogger
     platformaticVersion: string
     fastifyVersion: string
-    
+
     config: BaseGeneratorConfig
     questions: Array<object>
-  
+
     packages: PackageConfiguration[]
     constructor(opts?: BaseGeneratorOptions)
-  
+
     setConfig(config?: BaseGeneratorConfig): void
-    setEnv(env?: Env ): void
-  
+    setEnv(env?: Env): void
+
     getDefaultConfig(): JSONValue
-    getDefaultEnv(): Env 
-  
+    getDefaultEnv(): Env
+
     getFastifyVersion(): Promise<string>
     getPlatformaticVersion(): Promise<string>
-  
+
     addPackage(pkg: PackageDefinition): void
 
     prepare(): Promise<GeneratorMetadata>
@@ -95,7 +95,7 @@ export namespace BaseGenerator {
     addQuestion(question: any, where?: WhereClause): Promise<void>
     removeQuestion(variableName: string): void
     getTSConfig(): JSONValue
-    
+
     getConfigFieldsDefinitions(): ConfigFieldDefinition[]
     setConfigFields(fields: ConfigField[]): void
 

--- a/packages/generators/lib/base-generator.js
+++ b/packages/generators/lib/base-generator.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { readFile } = require('node:fs/promises')
-const { stripVersion, convertServiceNameToPrefix, addPrefixToEnv, extractEnvVariablesFromText, getPackageConfigurationObject } = require('./utils')
+const { stripVersion, convertServiceNameToPrefix, addPrefixToEnv, extractEnvVariablesFromText, getPackageConfigurationObject, PLT_ROOT } = require('./utils')
 const { join } = require('node:path')
 const { FileGenerator } = require('./file-generator')
 const { generateTests, generatePlugins } = require('./create-plugin')
@@ -203,16 +203,20 @@ class BaseGenerator extends FileGenerator {
   }
 
   checkEnvVariablesInConfigFile () {
+    const excludedEnvs = [PLT_ROOT]
     const configFileName = 'platformatic.json'
     const fileOjbect = this.getFileObject(configFileName)
     const envVars = extractEnvVariablesFromText(fileOjbect.contents)
     const envKeys = Object.keys(this.config.env)
     if (envVars.length > 0) {
-      envVars.forEach((ev) => {
+      for (const ev of envVars) {
+        if (excludedEnvs.includes(ev)) {
+          continue
+        }
         if (!envKeys.includes(ev)) {
           throw new MissingEnvVariable(ev, configFileName)
         }
-      })
+      }
     }
 
     return true

--- a/packages/generators/lib/utils.d.ts
+++ b/packages/generators/lib/utils.d.ts
@@ -3,7 +3,7 @@ type Env = {
 }
 
 export type PackageConfiguration = {
-  type: 'number' | 'string' | 'boolean'
+  type: 'number' | 'string' | 'boolean' | 'path'
   path: string
   value: number | string | boolean
 }
@@ -17,4 +17,5 @@ export namespace GeneratorUtils {
   export function envObjectToString(env: Env): string
   export function extractEnvVariablesFromText(text: string): string[]
   export function getPackageConfigurationObject(config: PackageConfiguration[]): object
+  export const PLT_ROOT: string
 }

--- a/packages/generators/test/base-generator.test.js
+++ b/packages/generators/test/base-generator.test.js
@@ -488,6 +488,85 @@ test('support packages', async (t) => {
       ]
     })
   }
+
+  {
+    // with relative path type but no name
+    const svc = new BaseGenerator({
+      module: '@platformatic/service'
+    })
+    svc.setConfig({
+      isRuntimeContext: true,
+      plugin: true
+    })
+    const packageDefinitions = [
+      {
+        name: '@fastify/static',
+        options: [
+          {
+            path: 'root',
+            value: 'public',
+            type: 'path'
+          }
+        ]
+      }
+    ]
+    svc.addPackage(packageDefinitions[0])
+    await svc.prepare()
+
+    const platformaticConfigFile = svc.getFileObject('platformatic.json')
+    const contents = JSON.parse(platformaticConfigFile.contents)
+
+    assert.deepEqual(contents.plugins, {
+      packages: [
+        {
+          name: '@fastify/static',
+          options: {
+            root: '{PLT_ROOT}/public'
+          }
+        }
+      ]
+    })
+  }
+  {
+    // with relative path type and name
+    const svc = new BaseGenerator({
+      module: '@platformatic/service'
+    })
+    svc.setConfig({
+      isRuntimeContext: true,
+      plugin: true,
+      serviceName: 'my-service'
+    })
+    const packageDefinitions = [
+      {
+        name: '@fastify/static',
+        options: [
+          {
+            path: 'root',
+            value: 'public',
+            type: 'path',
+            name: 'FST_PLUGIN_STATIC_ROOT'
+          }
+        ]
+      }
+    ]
+    svc.addPackage(packageDefinitions[0])
+    await svc.prepare()
+
+    const platformaticConfigFile = svc.getFileObject('platformatic.json')
+    const contents = JSON.parse(platformaticConfigFile.contents)
+
+    assert.deepEqual(contents.plugins, {
+      packages: [
+        {
+          name: '@fastify/static',
+          options: {
+            root: '{PLT_ROOT}/{PLT_MY_SERVICE_FST_PLUGIN_STATIC_ROOT}'
+          }
+        }
+      ]
+    })
+  }
 })
 
 describe('runtime context', () => {


### PR DESCRIPTION
If the `path` type is specified for value `xxx`, the generator creates a configuration with `{PLT_ROOT}/xxx` 

Fixes: https://github.com/platformatic/platformatic/issues/1895

Note that the `relativePath` has been renamed `path`. The path is always relative now, if we want to add the possibility of setting an absloute path in generator, we need a new type.
