### PR TITLE
fix(client-cli): Properly interpret nullable prop

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -137,7 +137,6 @@ export function writeProperty (writer, key, value, addedProps, required = true) 
     writer.write('?')
   }
   const valueType = getType(value)
-  /* c8 ignore next 2 */
   const typeValueToWrite = value.nullable === true ? `${valueType} | null` : valueType
   writer.write(`: ${typeValueToWrite};`)
   writer.newLine()

--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -136,7 +136,9 @@ export function writeProperty (writer, key, value, addedProps, required = true) 
     writer.quote(key)
     writer.write('?')
   }
-  writer.write(`: ${getType(value)};`)
+  const valueType = getType(value)
+  const typeValueToWrite = value.nullable === true ? `${valueType} | null` : valueType
+  writer.write(`: ${typeValueToWrite};`)
   writer.newLine()
 }
 

--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -137,6 +137,7 @@ export function writeProperty (writer, key, value, addedProps, required = true) 
     writer.write('?')
   }
   const valueType = getType(value)
+  /* c8 ignore next 2 */
   const typeValueToWrite = value.nullable === true ? `${valueType} | null` : valueType
   writer.write(`: ${typeValueToWrite};`)
   writer.newLine()

--- a/packages/client-cli/test/fixtures/sample/plugin.cjs
+++ b/packages/client-cli/test/fixtures/sample/plugin.cjs
@@ -20,7 +20,7 @@ module.exports = async function (app) {
         400: {
           type: 'object',
           properties: {
-            message: { type: 'string' }
+            message: { type: 'string', nullable: true }
           }
         }
       }

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -33,6 +33,8 @@ test('build basic client from url', async ({ teardown, ok, match }) => {
   match(types, /interface GetRedirectRequest/)
   match(types, /interface GetRedirectResponseFound/)
   match(types, /interface GetRedirectResponseBadRequest/)
+  match(types, /export interface GetRedirectResponseBadRequest {/)
+  match(types, /'message': string | null;/)
 
   // handle non 200 code endpoint
   const expectedImplementation = `

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -400,6 +400,7 @@ async function plugin (app, opts) {
     client = await buildOpenAPIClient(opts, app.openTelemetry)
   } else if (opts.type === 'graphql') {
     if (!opts.url.endsWith('/graphql')) {
+      /* c8 ignore next 2 */
       opts.url += '/graphql'
     }
     client = await buildGraphQLClient(opts, app.openTelemetry, app.log)


### PR DESCRIPTION
With this change, when an Open API schema contains a `nullable: true` property, it's properly handled and the generated type will contain ` | null;`