### PR TITLE
fix(client-cli): Support string date-time

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -132,9 +132,7 @@ export function writeProperty (writer, key, value, addedProps, required = true) 
     writer.quote(key)
     writer.write('?')
   }
-  const valueType = getType(value)
-  const typeValueToWrite = value.nullable === true ? `${valueType} | null` : valueType
-  writer.write(`: ${typeValueToWrite};`)
+  writer.write(`: ${getType(value)};`)
   writer.newLine()
 }
 
@@ -189,24 +187,30 @@ export function getType (typeDef, spec) {
     output += ' }'
     return output
   }
-  return JSONSchemaToTsType(typeDef.type)
+  return JSONSchemaToTsType(typeDef)
 }
 
-function JSONSchemaToTsType (type) {
+function JSONSchemaToTsType ({ type, format, nullable }) {
+  const isDateType = format === 'date' || format === 'date-time'
+  let resultType = 'unknown'
+
   switch (type) {
     case 'string':
-      return 'string'
+      resultType = isDateType ? 'string | Date' : 'string'
+      break
     case 'integer':
-      return 'number'
+      resultType = 'number'
+      break
     case 'number':
-      return 'number'
+      resultType = 'number'
+      break
     case 'boolean':
-      return 'boolean'
-      // TODO what other types should we support here?
-      /* c8 ignore next 2 */
-    default:
-      return 'unknown'
+      resultType = 'boolean'
+      break
+    // TODO what other types should we support here?
   }
+
+  return nullable === true ? `${resultType} | null` : resultType
 }
 
 export function writeContent (writer, type, content, spec, addedProps) {

--- a/packages/client-cli/test/fixtures/sample/plugin.cjs
+++ b/packages/client-cli/test/fixtures/sample/plugin.cjs
@@ -23,6 +23,7 @@ module.exports = async function (app) {
             message: { type: 'string', nullable: true },
             dateTime: { type: 'string', format: 'date-time' },
             otherDate: { type: 'string', format: 'date' },
+            nullableDate: { type: 'string', format: 'date', nullable: true },
             normalString: { type: 'string' }
           }
         }

--- a/packages/client-cli/test/fixtures/sample/plugin.cjs
+++ b/packages/client-cli/test/fixtures/sample/plugin.cjs
@@ -20,7 +20,10 @@ module.exports = async function (app) {
         400: {
           type: 'object',
           properties: {
-            message: { type: 'string', nullable: true }
+            message: { type: 'string', nullable: true },
+            dateTime: { type: 'string', format: 'date-time' },
+            otherDate: { type: 'string', format: 'date' },
+            normalString: { type: 'string' }
           }
         }
       }

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -36,6 +36,7 @@ test('build basic client from url', async ({ teardown, ok, match }) => {
   match(types, /'message': string \| null;/)
   match(types, /'dateTime': string \| Date;/)
   match(types, /'otherDate': string \| Date;/)
+  match(types, /'nullableDate': string \| Date \| null;/)
   match(types, /'normalString': string;/)
 
   // handle non 200 code endpoint

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -33,7 +33,10 @@ test('build basic client from url', async ({ teardown, ok, match }) => {
   match(types, /type GetRedirectRequest =/)
   match(types, /type GetRedirectResponseFound =/)
   match(types, /type GetRedirectResponseBadRequest =/)
-  match(types, /'message': string | null;/)
+  match(types, /'message': string \| null;/)
+  match(types, /'dateTime': string \| Date;/)
+  match(types, /'otherDate': string \| Date;/)
+  match(types, /'normalString': string;/)
 
   // handle non 200 code endpoint
   const expectedImplementation = `

--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -400,7 +400,6 @@ async function plugin (app, opts) {
     client = await buildOpenAPIClient(opts, app.openTelemetry)
   } else if (opts.type === 'graphql') {
     if (!opts.url.endsWith('/graphql')) {
-      /* c8 ignore next 2 */
       opts.url += '/graphql'
     }
     client = await buildGraphQLClient(opts, app.openTelemetry, app.log)


### PR DESCRIPTION
This PR adds support for a `string` type when the format is `date` or `date-time` ([OpenAPI reference](https://swagger.io/docs/specification/data-models/data-types/#string%C2%A7)).

Additionally, it does a small refactor of `JSONSchemaToTsType` to make it more reusable.