### PR TITLE
fix(client-cli): Date only for request

### DIFF
--- a/packages/client-cli/test/fixtures/sample/plugin.cjs
+++ b/packages/client-cli/test/fixtures/sample/plugin.cjs
@@ -12,6 +12,17 @@ module.exports = async function (app) {
 
   app.get('/redirect', {
     schema: {
+      params: {
+        type: 'object',
+        properties: {
+          messageReq: { type: 'string', nullable: true },
+          dateTimeReq: { type: 'string', format: 'date-time' },
+          otherDateReq: { type: 'string', format: 'date' },
+          nullableDateReq: { type: 'string', format: 'date', nullable: true },
+          normalStringReq: { type: 'string' }
+        },
+        required: ['id', 'title']
+      },
       response: {
         302: {
           type: 'object',
@@ -20,11 +31,11 @@ module.exports = async function (app) {
         400: {
           type: 'object',
           properties: {
-            message: { type: 'string', nullable: true },
-            dateTime: { type: 'string', format: 'date-time' },
-            otherDate: { type: 'string', format: 'date' },
-            nullableDate: { type: 'string', format: 'date', nullable: true },
-            normalString: { type: 'string' }
+            messageRes: { type: 'string', nullable: true },
+            dateTimeRes: { type: 'string', format: 'date-time' },
+            otherDateRes: { type: 'string', format: 'date' },
+            nullableDateRes: { type: 'string', format: 'date', nullable: true },
+            normalStringRes: { type: 'string' }
           }
         }
       }

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -35,11 +35,20 @@ test('build basic client from url', async (t) => {
   match(types, /interface GetRedirectRequest/)
   match(types, /interface GetRedirectResponseFound/)
   match(types, /interface GetRedirectResponseBadRequest/)
-  match(types, /'message': string \| null;/)
-  match(types, /'dateTime': string \| Date;/)
-  match(types, /'otherDate': string \| Date;/)
-  match(types, /'nullableDate': string \| Date \| null;/)
-  match(types, /'normalString': string;/)
+
+  // Request can contain a `Date` type
+  ok(types.includes("'messageReq': string | null;"))
+  ok(types.includes("'dateTimeReq': string | Date;"))
+  ok(types.includes("'otherDateReq': string | Date;"))
+  ok(types.includes("'nullableDateReq': string | Date | null;"))
+  ok(types.includes("'normalStringReq': string;"))
+
+  // Response shouldn't contain `Date` for the same fields as above
+  ok(types.includes("'messageRes': string | null;"))
+  ok(types.includes("'dateTimeRes': string;"))
+  ok(types.includes("'otherDateRes': string;"))
+  ok(types.includes("'nullableDateRes': string | null;"))
+  ok(types.includes("'normalStringRes': string;"))
 
   // handle non 200 code endpoint
   const expectedImplementation = `


### PR DESCRIPTION
The request object values are stringified before being sent, so it's completely fine to generate a `Date` type, if needed, inside the `Request` object.
The same behaviour is misleading for the `Response`: considering that a JSON response is always a `string`, and can't be a "real" `Date`, even though it's contained inside it, you should always convert it to a real `Date` object.

This PR handle this scenario.