### PR TITLE
fix: service-readme-documentation-url

### DIFF
--- a/packages/create-platformatic/src/service/README.md
+++ b/packages/create-platformatic/src/service/README.md
@@ -25,7 +25,7 @@ npm start
 
 ### Explore
 - ⚡ The Platformatic DB server is running at http://localhost:3042/
-- 📔 View the REST API's Swagger documentation at http://localhost:3042/documentation/
+- 📔 View the REST API's Swagger documentation at http://localhost:3042/documentation
 - 🔍 Try out the GraphiQL web UI at http://localhost:3042/graphiql
 
 


### PR DESCRIPTION
When creating a new platformatic service with the `create platformatic@latest` command, the link in the readme to the generated `documentation` site fails to load:

Before:
<img width="839" alt="image" src="https://github.com/platformatic/platformatic/assets/9098106/c4ab59a5-9996-4426-8387-1f47fc806019">

It took me a little while to realize this was because of the trailing slash on the URL in the readme:

After:
<img width="1185" alt="image" src="https://github.com/platformatic/platformatic/assets/9098106/d3d45b93-af68-47b5-8b9d-af845c5ecb3c">

Hopefully this helps others trying platformatic for the first time like myself!