### PR TITLE
feat(client): Add optional query parser

### DIFF
--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -21,6 +21,7 @@ interface PlatformaticClientOptions {
   throwOnError: boolean;
   headers?: Headers;
   validateResponse?: boolean;
+  queryParser?: (query: URLSearchParams) => string
 }
 
 type BuildOpenAPIClientOptions  = PlatformaticClientOptions & {

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -62,6 +62,7 @@ const client = await buildOpenAPIClient<MyType>({
     const { url } = options;
     return { href: url.href };
   },
+  queryParser: (query) => `${query.toString()}[]`
 }, openTelemetry)
 
 // All params and generic passed


### PR DESCRIPTION
Similarly to `fastify`, where we can pass an optional `querystringParser`, this PR introduces support for an optional query parser when calling the `client`