### PR TITLE
Update 'core' link for 'connectionString' config reference

### DIFF
--- a/docs/reference/db/introduction.md
+++ b/docs/reference/db/introduction.md
@@ -48,7 +48,7 @@ Get up and running in 2 minutes using our
 
 
 The required database driver is automatically inferred and loaded based on the
-value of the [`connectionString`](/reference/db/configuration.md#core)
+value of the [`connectionString`](/reference/db/configuration.md#db)
 configuration setting.
 
 ## Issues


### PR DESCRIPTION
Update 'core' link for 'connectionString' config reference to point to 'db', and not 'core' for better documentation.

Fixes #2060 