### PR TITLE
Suuport complex object in where.or clause

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -13,14 +13,17 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
   let currentFullResponse = originalFullResponse
   for (const operation of operations) {
     const operationId = operation.operation.operationId
+
     const camelCaseOperationId = camelcase(operationId)
+    const capitalizedCamelCaseOperationId = capitalize(camelCaseOperationId)
+
     const { parameters, responses, requestBody } = operation.operation
     const forceFullRequest = fullRequest || hasDuplicatedParameters(operation.operation)
     const successResponses = Object.entries(responses).filter(([s]) => s.startsWith('2'))
     if (successResponses.length !== 1) {
       currentFullResponse = true
     }
-    const capitalizedCamelCaseOperationId = capitalize(camelCaseOperationId)
+
     const operationRequestName = `${capitalizedCamelCaseOperationId}Request`
 
     interfacesWriter.write(`export type ${operationRequestName} =`).block(() => {
@@ -62,7 +65,11 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
             }
             // We do not check for addedProps here because it's the first
             // group of properties
-            writeProperty(interfacesWriter, name, parameter, addedProps, required, 'req', schema)
+            if (parameter.name === 'where.or') {
+              interfacesWriter.writeLine(`'${parameter.name}'${required ? '' : '?'}: Partial<Record<keyof typeof ${capitalizedCamelCaseOperationId}Fields, Partial<Record<keyof typeof SQLOperations, any>>>>[],`)
+            } else {
+              writeProperty(interfacesWriter, name, parameter, addedProps, required, 'req', schema)
+            }
           }
         }
       }

--- a/packages/client-cli/lib/openapi-generator.mjs
+++ b/packages/client-cli/lib/openapi-generator.mjs
@@ -2,6 +2,7 @@ import CodeBlockWriter from 'code-block-writer'
 import { generateOperationId } from '@platformatic/client'
 import { capitalize, toJavaScriptName } from './utils.mjs'
 import { writeOperations } from './openapi-common.mjs'
+import { SQLOperations } from '../../sql-openapi/lib/shared.js'
 
 export function processOpenAPI ({ schema, name, fullResponse, fullRequest, optionalHeaders, validateResponse }) {
   return {
@@ -61,6 +62,23 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
   const capitalizedName = capitalize(camelcasedName)
   const { paths } = schema
   const generatedOperationIds = []
+  /* eslint-disable new-cap */
+  const writer = new CodeBlockWriter({
+    indentNumberOfSpaces: 2,
+    useTabs: false,
+    useSingleQuote: true
+  })
+
+  const interfaces = new CodeBlockWriter({
+    indentNumberOfSpaces: 2,
+    useTabs: false,
+    useSingleQuote: true
+  })
+
+  writer.writeLine('import { type FastifyReply, type FastifyPluginAsync } from \'fastify\'')
+  writer.blankLine()
+
+  /* eslint-enable new-cap */
   const operations = Object.entries(paths).flatMap(([path, methods]) => {
     let commonParameters = []
     if (methods.parameters) {
@@ -75,6 +93,15 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
         operation.parameters = commonParameters
       }
       const opId = generateOperationId(path, method, operation, generatedOperationIds)
+      const entityFields = operation.parameters.find((p) => p.name === 'fields')
+      if (entityFields) {
+        const enumFields = entityFields.schema.items.enum
+        // write fields list for each operation as type
+        // TODO: Should get entity fields instead
+        writer.write(`enum ${capitalize(opId)}Fields`).block(() => {
+          enumFields.forEach((f) => writer.writeLine(`'${f}',`))
+        })
+      }
       return {
         path,
         method,
@@ -85,22 +112,10 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
       }
     })
   })
-  /* eslint-disable new-cap */
-  const writer = new CodeBlockWriter({
-    indentNumberOfSpaces: 2,
-    useTabs: false,
-    useSingleQuote: true
+  // write enum for common operations
+  writer.write('enum SQLOperations').block(() => {
+    SQLOperations.forEach((op) => writer.writeLine(`'${op}',`))
   })
-
-  const interfaces = new CodeBlockWriter({
-    indentNumberOfSpaces: 2,
-    useTabs: false,
-    useSingleQuote: true
-  })
-  /* eslint-enable new-cap */
-
-  writer.writeLine('import { type FastifyReply, type FastifyPluginAsync } from \'fastify\'')
-  writer.blankLine()
 
   const pluginName = `${capitalizedName}Plugin`
   const optionsName = `${capitalizedName}Options`

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -2,6 +2,10 @@
 
 const { mapSQLTypeToOpenAPIType } = require('@platformatic/sql-json-schema-mapper')
 
+const stringOperations = ['in', 'nin', 'contains', 'contained', 'overlaps']
+const typedOperations = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like']
+module.exports.SQLOperations = [...stringOperations, ...typedOperations]
+
 function generateArgs (entity, ignore) {
   const sortedEntityFields = Object.keys(entity.fields).sort()
 
@@ -18,12 +22,12 @@ function generateArgs (entity, ignore) {
         acc[key] = { type: mapSQLTypeToOpenAPIType(field.sqlType) }
       }
     } else {
-      for (const modifier of ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like']) {
+      for (const modifier of typedOperations) {
         const key = baseKey + modifier
         acc[key] = { type: mapSQLTypeToOpenAPIType(field.sqlType), enum: field.enum }
       }
 
-      for (const modifier of ['in', 'nin', 'contains', 'contained', 'overlaps']) {
+      for (const modifier of stringOperations) {
         const key = baseKey + modifier
         acc[key] = { type: 'string' }
       }


### PR DESCRIPTION
At the moment the `where.or` clause in a generated client for a db app supports the following format

```js
const output = await req.dbtest.getMovies({
  "where.or": ['(id.eq=1|title.eq=Matrix)']
})
```
With this PR a better type is created for such clause and you can use this
```js
const output = await req.dbtest.getMovies({
  "where.or": [
    { id: { eq: 2 } }, 
    { title: { eq: 'Matrix' } }
  ]
})
```

This will also enable suggestion from the editor based on the entity fields

Fixes: #1806 