### PR TITLE
fix(client-cli): Make type generation backward compatible

### DIFF
--- a/packages/client-cli/lib/responses-writer.mjs
+++ b/packages/client-cli/lib/responses-writer.mjs
@@ -44,7 +44,7 @@ function responsesWriter (operationId, responsesArray, isFullResponse, writer, s
     writer.blankLine()
     return allResponsesName
   }
-  return 'unknown'
+  return 'FullResponse<unknown, 200>'
 
   function writeResponse (typeName, responseSchema) {
     if (!responseSchema) {

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -111,10 +111,10 @@ export const getCustomSwagger = async (request) => {
     const typesTemplate = `
 export interface Sample {
   setBaseUrl(newUrl: string) : void;
-  getCustomSwagger(req?: GetCustomSwaggerRequest): Promise<unknown>;
+  getCustomSwagger(req?: GetCustomSwaggerRequest): Promise<FullResponse<unknown, 200>>;
   getRedirect(req?: GetRedirectRequest): Promise<GetRedirectResponses>;
-  getReturnUrl(req?: GetReturnUrlRequest): Promise<unknown>;
-  postFoobar(req?: PostFoobarRequest): Promise<unknown>;
+  getReturnUrl(req?: GetReturnUrlRequest): Promise<FullResponse<unknown, 200>>;
+  postFoobar(req?: PostFoobarRequest): Promise<FullResponse<unknown, 200>>;
 }`
 
     const unionTypesTemplate = `export type GetRedirectResponses =


### PR DESCRIPTION
In case of a non-defined response in an OpenAPI schema, we previously returned something like this:
```
get(req?: GetRequest): Promise<GetResponses>;

type GetResponses = FullResponse<GetResponseOK, 200>;
```

while we now return:
```
 get(req?: GetRequest): Promise<unknown>;
```

This PR makes the type backwards compatible, by returning a `FullResponse` of `unknown` type in case of missing response schema, so:
```
get(req?: GetRequest): Promise<FullResponse<unknown, 200>>;
```