### PR TITLE
test: increase client-cli test timeout

### DIFF
--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "standard | snazzy",
-    "test": "pnpm run lint && borp --concurrency=1"
+    "test": "pnpm run lint && borp --concurrency=1 --timeout=120000"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Small investigation shows that just windows ci is slow.