### PR TITLE
feat(client-cli): Export main definition as type

### DIFF
--- a/packages/client-cli/lib/openapi-generator.mjs
+++ b/packages/client-cli/lib/openapi-generator.mjs
@@ -114,7 +114,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
       interfaces.writeLine('\'body\': T;')
     })
     interfaces.blankLine()
-    writer.write(`export interface ${capitalizedName}`).block(() => {
+    writer.write(`export type ${capitalizedName} =`).block(() => {
       writeOperations(interfaces, writer, operations, {
         fullRequest, fullResponse, optionalHeaders, schema
       })

--- a/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
+++ b/packages/client-cli/test/cli-openapi-no-implementation.test.mjs
@@ -28,7 +28,7 @@ test('generates only types in target folder with --types-only flag', async (t) =
   match(fileContents, /'body': T;/)
   match(fileContents, /export type GetMoviesRequest = {/)
   match(fileContents, /export type GetMoviesResponseOK = Array/)
-  match(fileContents, /export interface Movies {/)
+  match(fileContents, /export type Movies = {/)
 })
 
 test('openapi client generation (javascript)', async (t) => {

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -892,7 +892,7 @@ test('openapi client generation (javascript) from file with fullRequest, fullRes
   }
 `), true)
     equal(data.includes(`
-  export interface Full {
+  export type Full = {
     postHello(req?: PostHelloRequest): Promise<PostHelloResponses>;
   }`), true)
     const implementationFile = join(dir, 'full', 'full.cjs')
@@ -960,7 +960,7 @@ test('do not generate implementation file if in platformatic service', async (t)
   }
 `), true)
     equal(data.includes(`
-  export interface Full {
+  export type Full = {
     postHello(req?: PostHelloRequest): Promise<PostHelloResponses>;
   }`), true)
   }


### PR DESCRIPTION
The rationale of this switch:
* Allows the creation of aliases for complex types
* Supports union types and intersection types directly