### PR TITLE
chore(client): Add status code types

### DIFF
--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -1,22 +1,13 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify'
 import { FastifyError } from '@fastify/error'
+import { CodeClasses, Digit, StringAsNumber } from 'fastify/types/utils';
 
-type Enumerate<
-  N extends number,
-  Acc extends number[] = [],
-> = Acc["length"] extends N
-  ? Acc[number]
-  : Enumerate<N, [...Acc, Acc["length"]]>;
-type IntRange<F extends number, T extends number> = Exclude<
-  Enumerate<T>,
-  Enumerate<F>
->;
-
-export type StatusCode1xx = IntRange<100, 200>;
-export type StatusCode2xx = IntRange<200, 300>;
-export type StatusCode3xx = IntRange<300, 400>;
-export type StatusCode4xx = IntRange<400, 500>;
-export type StatusCode5xx = IntRange<500, 600>;
+type StatusCodes<T extends CodeClasses> = StringAsNumber<`${T}${Digit}${Digit}`>
+export type StatusCode1xx = StatusCodes<1>;
+export type StatusCode2xx = StatusCodes<2>;
+export type StatusCode3xx = StatusCodes<3>;
+export type StatusCode4xx = StatusCodes<4>;
+export type StatusCode5xx = StatusCodes<5>;
 
 interface Headers {
   [key: string]: string

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -1,8 +1,10 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify'
 import { FastifyError } from '@fastify/error'
-import { CodeClasses, Digit, StringAsNumber } from 'fastify/types/utils';
 
-type StatusCodes<T extends CodeClasses> = StringAsNumber<`${T}${Digit}${Digit}`>
+type CodeClasses = 1 | 2 | 3 | 4 | 5;
+type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+type StringAsNumber<T extends string> = T extends `${infer N extends number}` ? N : never;
+type StatusCodes<T extends CodeClasses> = StringAsNumber<`${T}${Digit}${Digit}`>;
 export type StatusCode1xx = StatusCodes<1>;
 export type StatusCode2xx = StatusCodes<2>;
 export type StatusCode3xx = StatusCodes<3>;

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -1,6 +1,23 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify'
 import { FastifyError } from '@fastify/error'
 
+type Enumerate<
+  N extends number,
+  Acc extends number[] = [],
+> = Acc["length"] extends N
+  ? Acc[number]
+  : Enumerate<N, [...Acc, Acc["length"]]>;
+type IntRange<F extends number, T extends number> = Exclude<
+  Enumerate<T>,
+  Enumerate<F>
+>;
+
+export type InformationalStatus = IntRange<100, 200>;
+export type SuccessfulStatus = IntRange<200, 300>;
+export type RedirectionStatus = IntRange<300, 400>;
+export type ClientErrorStatus = IntRange<400, 500>;
+export type ServerErrorStatus = IntRange<500, 600>;
+
 interface Headers {
   [key: string]: string
 }

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -12,11 +12,11 @@ type IntRange<F extends number, T extends number> = Exclude<
   Enumerate<F>
 >;
 
-export type InformationalStatus = IntRange<100, 200>;
-export type SuccessfulStatus = IntRange<200, 300>;
-export type RedirectionStatus = IntRange<300, 400>;
-export type ClientErrorStatus = IntRange<400, 500>;
-export type ServerErrorStatus = IntRange<500, 600>;
+export type StatusCode1xx = IntRange<100, 200>;
+export type StatusCode2xx = IntRange<200, 300>;
+export type StatusCode3xx = IntRange<300, 400>;
+export type StatusCode4xx = IntRange<400, 500>;
+export type StatusCode5xx = IntRange<500, 600>;
 
 interface Headers {
   [key: string]: string

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -1,7 +1,22 @@
-import { expectError, expectType } from 'tsd'
+import { 
+  expectAssignable,
+  expectError,
+  expectNotAssignable,
+  expectType
+} from 'tsd'
 import fastify, { HTTPMethods } from 'fastify'
-import pltClient, { type PlatformaticClientPluginOptions, type GetHeadersOptions, buildOpenAPIClient, errors } from '.'
-import { FastifyError } from '@fastify/error'
+import pltClient, {
+  errors,
+  buildOpenAPIClient,
+  type PlatformaticClientPluginOptions,
+  type GetHeadersOptions,
+  type StatusCode2xx,
+  type StatusCode1xx,
+  type StatusCode3xx,
+  type StatusCode4xx,
+  type StatusCode5xx,
+} from ".";
+import { FastifyError } from "@fastify/error";
 
 const server = await fastify()
 
@@ -64,6 +79,54 @@ const client = await buildOpenAPIClient<MyType>({
   },
   queryParser: (query) => `${query.toString()}[]`
 }, openTelemetry)
+
+const isSuccessfulResponse = (
+  status: number,
+): status is StatusCode2xx => status >= 200 && status <= 299;
+
+const exampleUsageOfStatusCodeType = (status: number) => {
+  if (isSuccessfulResponse(status)) {
+    // now status type equals to `StatusCode2xx`
+    expectAssignable<StatusCode2xx>(status)
+  } else {
+    expectNotAssignable<StatusCode2xx>(status)
+  }
+}
+
+expectNotAssignable<StatusCode1xx>(99)
+expectAssignable<StatusCode1xx>(100)
+expectAssignable<StatusCode1xx>(101)
+expectAssignable<StatusCode1xx>(150)
+expectAssignable<StatusCode1xx>(199)
+expectNotAssignable<StatusCode1xx>(200)
+
+expectNotAssignable<StatusCode2xx>(199)
+expectAssignable<StatusCode2xx>(200)
+expectAssignable<StatusCode2xx>(201)
+expectAssignable<StatusCode2xx>(250)
+expectAssignable<StatusCode2xx>(299)
+expectNotAssignable<StatusCode2xx>(300)
+
+expectNotAssignable<StatusCode3xx>(299)
+expectAssignable<StatusCode3xx>(300)
+expectAssignable<StatusCode3xx>(301)
+expectAssignable<StatusCode3xx>(350)
+expectAssignable<StatusCode3xx>(399)
+expectNotAssignable<StatusCode3xx>(400)
+
+expectNotAssignable<StatusCode4xx>(399)
+expectAssignable<StatusCode4xx>(400)
+expectAssignable<StatusCode4xx>(401)
+expectAssignable<StatusCode4xx>(450)
+expectAssignable<StatusCode4xx>(499)
+expectNotAssignable<StatusCode4xx>(500)
+
+expectNotAssignable<StatusCode5xx>(399)
+expectAssignable<StatusCode5xx>(500)
+expectAssignable<StatusCode5xx>(501)
+expectAssignable<StatusCode5xx>(550)
+expectAssignable<StatusCode5xx>(599)
+expectNotAssignable<StatusCode5xx>(600)
 
 // All params and generic passed
 expectType<MyType>(client)

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -86,10 +86,9 @@ const isSuccessfulResponse = (
 
 const exampleUsageOfStatusCodeType = (status: number) => {
   if (isSuccessfulResponse(status)) {
-    // now status type equals to `StatusCode2xx`
-    expectAssignable<StatusCode2xx>(status)
+    expectType<StatusCode2xx>(status)
   } else {
-    expectNotAssignable<StatusCode2xx>(status)
+    expectError<StatusCode2xx>(status)
   }
 }
 

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import fastify, { HTTPMethods } from 'fastify'
-import pltClient, { type PlatformaticClientPluginOptions, type GetHeadersOptions, buildOpenAPIClient, errors, InformationalStatus, ClientErrorStatus, RedirectionStatus, ServerErrorStatus, SuccessfulStatus } from '.'
+import pltClient, { type PlatformaticClientPluginOptions, type GetHeadersOptions, buildOpenAPIClient, errors } from '.'
 import { FastifyError } from '@fastify/error'
 
 const server = await fastify()
@@ -79,33 +79,3 @@ expectType<Promise<unknown>>(buildOpenAPIClient({
 }))
 
 expectType<() => FastifyError>(errors.OptionsUrlRequiredError)
-
-expectError<InformationalStatus>(99)
-expectType<InformationalStatus>(100)
-expectType<InformationalStatus>(150)
-expectType<InformationalStatus>(199)
-expectError<InformationalStatus>(200)
-
-expectError<SuccessfulStatus>(199)
-expectType<SuccessfulStatus>(200)
-expectType<SuccessfulStatus>(250)
-expectType<SuccessfulStatus>(299)
-expectError<SuccessfulStatus>(300)
-
-expectError<RedirectionStatus>(299)
-expectType<RedirectionStatus>(300)
-expectType<RedirectionStatus>(350)
-expectType<RedirectionStatus>(399)
-expectError<RedirectionStatus>(400)
-
-expectError<ClientErrorStatus>(399)
-expectType<ClientErrorStatus>(400)
-expectType<ClientErrorStatus>(450)
-expectType<ClientErrorStatus>(499)
-expectError<ClientErrorStatus>(500)
-
-expectError<ServerErrorStatus>(499)
-expectType<ServerErrorStatus>(500)
-expectType<ServerErrorStatus>(550)
-expectType<ServerErrorStatus>(599)
-expectError<ServerErrorStatus>(600)

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import fastify, { HTTPMethods } from 'fastify'
-import pltClient, { type PlatformaticClientPluginOptions, type GetHeadersOptions, buildOpenAPIClient, errors } from '.'
+import pltClient, { type PlatformaticClientPluginOptions, type GetHeadersOptions, buildOpenAPIClient, errors, InformationalStatus, ClientErrorStatus, RedirectionStatus, ServerErrorStatus, SuccessfulStatus } from '.'
 import { FastifyError } from '@fastify/error'
 
 const server = await fastify()
@@ -79,3 +79,33 @@ expectType<Promise<unknown>>(buildOpenAPIClient({
 }))
 
 expectType<() => FastifyError>(errors.OptionsUrlRequiredError)
+
+expectError<InformationalStatus>(99)
+expectType<InformationalStatus>(100)
+expectType<InformationalStatus>(150)
+expectType<InformationalStatus>(199)
+expectError<InformationalStatus>(200)
+
+expectError<SuccessfulStatus>(199)
+expectType<SuccessfulStatus>(200)
+expectType<SuccessfulStatus>(250)
+expectType<SuccessfulStatus>(299)
+expectError<SuccessfulStatus>(300)
+
+expectError<RedirectionStatus>(299)
+expectType<RedirectionStatus>(300)
+expectType<RedirectionStatus>(350)
+expectType<RedirectionStatus>(399)
+expectError<RedirectionStatus>(400)
+
+expectError<ClientErrorStatus>(399)
+expectType<ClientErrorStatus>(400)
+expectType<ClientErrorStatus>(450)
+expectType<ClientErrorStatus>(499)
+expectError<ClientErrorStatus>(500)
+
+expectError<ServerErrorStatus>(499)
+expectType<ServerErrorStatus>(500)
+expectType<ServerErrorStatus>(550)
+expectType<ServerErrorStatus>(599)
+expectError<ServerErrorStatus>(600)


### PR DESCRIPTION
Extremely useful to better narrow down the types to the proper status code (f.e. in [this case](https://github.com/platformatic/platformatic/issues/2213))