### PR TITLE
Fix typing of configValue in config fields

### DIFF
--- a/packages/generators/index.test-d.ts
+++ b/packages/generators/index.test-d.ts
@@ -1,0 +1,16 @@
+import { expectAssignable } from 'tsd'
+import { BaseGenerator } from './lib/base-generator';
+
+expectAssignable<BaseGenerator.ConfigFieldDefinition>({
+  label: 'PLT_TESTING',
+  var: 'testing',
+  default: 'hello world',
+  type: 'string',
+  configValue: 'someConfigValue'
+})
+
+expectAssignable<BaseGenerator.ConfigField>({
+  var: 'testing',
+  configValue: 'someConfigValue',
+  value: 'asd123'
+})

--- a/packages/generators/lib/base-generator.d.ts
+++ b/packages/generators/lib/base-generator.d.ts
@@ -61,13 +61,13 @@ export namespace BaseGenerator {
     var: string
     default: string
     type: 'number' | 'string' | 'boolean' | 'path'
-    configValue?: 'string'
+    configValue?: string
   }
 
   type ConfigField = {
     var: string
-    configValue?: 'string'
-    value: 'string'
+    configValue?: string
+    value: string
   }
 
   type AddEnvVarOptions = {

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "standard | snazzy",
-    "test": "pnpm run lint && borp -C -X fixtures -X test --concurrency=1"
+    "test": "pnpm run lint && borp -C -X fixtures -X test --concurrency=1 && tsd"
   },
   "keywords": [],
   "author": "",
@@ -24,6 +24,7 @@
     "c8": "^9.1.0",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
+    "tsd": "^0.30.4",
     "typescript": "^5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,6 +1331,9 @@ importers:
       standard:
         specifier: ^17.1.0
         version: 17.1.0(@typescript-eslint/parser@5.62.0)
+      tsd:
+        specifier: ^0.30.4
+        version: 0.30.7
       typescript:
         specifier: ^5.3.3
         version: 5.4.2


### PR DESCRIPTION
The only value `configValue` can have is `string` in typescript, which appears to be incorrect (using code from platformatic db's generator added in the same pr as this property for reference https://github.com/platformatic/platformatic/pull/1846/files#diff-5f2c6dbe9a4fd864242b3a0bcd3a30f6877d36729bdfa61c4a971a9d6c6a2f1dR205)

cc @mcollina @leorossi 