### PR TITLE
Fix linting issues from generated .ts stackable files

### DIFF
--- a/packages/generators/lib/create-stackable-cli.js
+++ b/packages/generators/lib/create-stackable-cli.js
@@ -81,7 +81,7 @@ import { join } from 'node:path'
 import { parseArgs } from 'node:util'
 import { Generator } from '../lib/generator'
 
-async function execute () {
+async function execute (): Promise<void> {
   const args = parseArgs({
     args: process.argv.slice(2),
     options: {
@@ -116,7 +116,9 @@ async function execute () {
   console.log('Application created successfully! Run \`npm run start\` to start an application.')
 }
 
-execute()
+execute().catch(err => {
+  throw err
+})
 `
 }
 

--- a/packages/generators/lib/create-stackable-files.js
+++ b/packages/generators/lib/create-stackable-files.js
@@ -295,8 +295,8 @@ class ${stackableGeneratorType} extends ServiceGenerator {
     return Object.assign({}, baseConfig, config)
   }
 
-  async _beforePrepare () {
-    super._beforePrepare()
+  async _beforePrepare (): Promise<void> {
+    await super._beforePrepare()
 
     this.addEnvVars({
       PLT_GREETING_TEXT: this.config.greeting ?? 'Hello world!'
@@ -309,7 +309,7 @@ class ${stackableGeneratorType} extends ServiceGenerator {
     }
   }
 
-  async _afterPrepare () {
+  async _afterPrepare (): Promise<void> {
     const packageJson = await this.getStackablePackageJson()
     this.addFile({
       path: '',
@@ -328,18 +328,18 @@ class ${stackableGeneratorType} extends ServiceGenerator {
     if (!this._packageJson) {
       const packageJsonPath = join(__dirname, '..', '..', 'package.json')
       const packageJsonFile = await readFile(packageJsonPath, 'utf8')
-      const packageJson = JSON.parse(packageJsonFile)
+      const packageJson: Partial<PackageJson> = JSON.parse(packageJsonFile)
 
-      if (!packageJson.name) {
+      if (packageJson.name === undefined || packageJson.name === null) {
         throw new Error('Missing package name in package.json')
       }
 
-      if (!packageJson.version) {
+      if (packageJson.version === undefined || packageJson.version === null) {
         throw new Error('Missing package version in package.json')
       }
 
-      this._packageJson = packageJson
-      return packageJson
+      this._packageJson = packageJson as PackageJson
+      return packageJson as PackageJson
     }
     return this._packageJson
   }

--- a/packages/generators/lib/create-stackable-plugin.js
+++ b/packages/generators/lib/create-stackable-plugin.js
@@ -16,6 +16,7 @@ module.exports = async function (fastify, opts) {
 
 function getTsStackablePluginFile () {
   return `\
+// eslint-disable-next-line
 /// <reference path="../index.d.ts" />
 import { FastifyInstance, FastifyPluginOptions } from 'fastify'
 


### PR DESCRIPTION
Fixes a few linting errors that are found in the generated typescript files when using `ts-standard` (`standard` but for typescript)