### PR TITLE
feat: update runtime metrics overriding

### DIFF
--- a/packages/runtime/fixtures/management-api/services/service-1/platformatic.json
+++ b/packages/runtime/fixtures/management-api/services/service-1/platformatic.json
@@ -6,5 +6,6 @@
   "plugins": {
     "paths": ["plugin.js"]
   },
-  "watch": true
+  "watch": true,
+  "metrics": true
 }

--- a/packages/runtime/fixtures/management-api/services/service-2/platformatic.json
+++ b/packages/runtime/fixtures/management-api/services/service-2/platformatic.json
@@ -5,5 +5,6 @@
   },
   "plugins": {
     "paths": ["plugin.js"]
-  }
+  },
+  "metrics": true
 }

--- a/packages/runtime/lib/api.js
+++ b/packages/runtime/lib/api.js
@@ -33,7 +33,7 @@ class RuntimeApi {
         }
       }
 
-      const app = new PlatformaticApp(service, loaderPort, logger, serviceTelemetryConfig, serverConfig, !!config.managementApi)
+      const app = new PlatformaticApp(service, loaderPort, logger, serviceTelemetryConfig, serverConfig)
 
       this.#services.set(service.id, app)
     }

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -20,9 +20,8 @@ class PlatformaticApp {
   #telemetryConfig
   #serverConfig
   #debouncedRestart
-  #hasManagementApi
 
-  constructor (appConfig, loaderPort, logger, telemetryConfig, serverConfig, hasManagementApi) {
+  constructor (appConfig, loaderPort, logger, telemetryConfig, serverConfig) {
     this.appConfig = appConfig
     this.config = null
     this.#hotReload = false
@@ -32,7 +31,6 @@ class PlatformaticApp {
     this.#started = false
     this.#originalWatch = null
     this.#fileWatcher = null
-    this.#hasManagementApi = !!hasManagementApi
     this.#logger = logger.child({
       name: this.appConfig.id
     })
@@ -246,7 +244,7 @@ class PlatformaticApp {
       })
     }
 
-    if (this.#hasManagementApi || configManager.current.metrics) {
+    if (configManager.current.metrics) {
       configManager.update({
         ...configManager.current,
         metrics: {

--- a/packages/runtime/test/api/service-config.test.js
+++ b/packages/runtime/test/api/service-config.test.js
@@ -52,7 +52,7 @@ test('should get service config', async (t) => {
   })
 })
 
-test('do not force enable metrics without the management api', async (t) => {
+test('do not force enable metrics if they are not set', async (t) => {
   const configFile = join(fixturesDir, 'configs', 'monorepo.json')
   const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
   const app = await buildServer(config.configManager.current)

--- a/packages/runtime/test/api/service-config.test.js
+++ b/packages/runtime/test/api/service-config.test.js
@@ -48,13 +48,6 @@ test('should get service config', async (t) => {
     },
     watch: {
       enabled: false
-    },
-    metrics: {
-      server: 'hide',
-      defaultMetrics: {
-        enabled: false
-      },
-      prefix: 'with_logger_'
     }
   })
 })

--- a/packages/runtime/test/management-api/service-config.test.js
+++ b/packages/runtime/test/management-api/service-config.test.js
@@ -67,6 +67,13 @@ test('should get service config', async (t) => {
     },
     watch: {
       enabled: false
+    },
+    metrics: {
+      server: 'hide',
+      defaultMetrics: {
+        enabled: true
+      },
+      prefix: 'service_1_'
     }
   })
 })

--- a/packages/runtime/test/management-api/service-config.test.js
+++ b/packages/runtime/test/management-api/service-config.test.js
@@ -67,13 +67,6 @@ test('should get service config', async (t) => {
     },
     watch: {
       enabled: false
-    },
-    metrics: {
-      server: 'hide',
-      defaultMetrics: {
-        enabled: true
-      },
-      prefix: 'service_1_'
     }
   })
 })


### PR DESCRIPTION
This PR fixes and simplifies logic of metrics overriding:
- service metrics overriding are not related to management api anymore
- service metrics config will be overwritten only if it exists in the service config and service is running inside of the runtime

Alternative PR: https://github.com/platformatic/platformatic/pull/2345