### PR TITLE
(db-authorization): fix a bug in handling jwt namespace option

### DIFF
--- a/packages/db-authorization/index.js
+++ b/packages/db-authorization/index.js
@@ -22,7 +22,7 @@ async function auth (app, opts) {
   const anonymousRole = opts.anonymousRole || 'anonymous'
 
   if (opts.jwt && opts.jwt.namespace) {
-    opts.jwt.namespace = opts.jwt.namespace.replace(/\/?$/, '/');
+    opts.jwt.namespace = opts.jwt.namespace.replace(/\/?$/, '/')
   }
 
   app.decorateRequest('setupDBAuthorizationUser', setupUser)

--- a/packages/db-authorization/index.js
+++ b/packages/db-authorization/index.js
@@ -21,6 +21,10 @@ async function auth (app, opts) {
   const roleKey = opts.roleKey || 'X-PLATFORMATIC-ROLE'
   const anonymousRole = opts.anonymousRole || 'anonymous'
 
+  if (opts.jwt && opts.jwt.namespace) {
+    opts.jwt.namespace = opts.jwt.namespace.replace(/\/?$/, '/');
+  }
+
   app.decorateRequest('setupDBAuthorizationUser', setupUser)
 
   async function setupUser () {


### PR DESCRIPTION
The update is designed to streamline and enhance the robustness of the jwt namespace handling mechanism, thereby eradicating any inconsistencies and potential formatting issues that may arise from improper namespace configuration.

Regardless of whether the "authorization" → "jwt" → "namespace" object is assigned a URL with or without a trailing slash, it will now be correctly work.

🔧 fix(db-authorization): Correct the jwt namespace option handling
The jwt namespace option within the authentication configuration now automatically appends a forward slash if missing. This modification ensures a uniform format across the board, eliminating any ambiguity and enhancing the system's reliability when parsing or utilizing the namespace.

💡 refactor(authentication.js): Enforce trailing slash for jwt namespace
The jwt namespace option's handling has been refined to include a trailing slash, if not already present, by modifying the authentication logic. This adjustment guarantees that the namespace is consistently formatted, preventing errors related to incorrect path concatenation or resource identification.

🔎 Use-case:
Previously, developers might encounter issues if the jwt namespace option did not conclude with a forward slash, leading to potential mishandling of resource paths or authorization checks. With the current update, specifying the jwt namespace in the authentication configuration object automatically ensures the inclusion of a trailing slash, thus standardizing the format and eliminating related errors. (check screenshot)

![image](https://github.com/platformatic/platformatic/assets/30497555/373340ef-cc8f-40f3-8938-ea4cc29068a3)
