### PR TITLE
fix(sql-mapper/types): enhance null value type support and documentation

### DIFF
--- a/docs/reference/sql-mapper/entities/api.md
+++ b/docs/reference/sql-mapper/entities/api.md
@@ -34,7 +34,7 @@ The `where` object's key is the field you want to check, the value is a key/valu
 
 ### Handling Null Values
 
-When using the `eq` and `neq` operators with a null value, the comparison logic adheres to standard SQL rules for null value handling. Below is an explanation of how these operators are interpreted when the value is null:
+When using the `eq` and `neq` operators with a null value, the comparison logic adheres to standard SQL rules for null value handling.
 
 ### Examples
 

--- a/docs/reference/sql-mapper/entities/api.md
+++ b/docs/reference/sql-mapper/entities/api.md
@@ -20,17 +20,21 @@ The entity operation methods accept a `where` option to allow limiting of the da
 
 The `where` object's key is the field you want to check, the value is a key/value map where the key is an operator (see the table below) and the value is the value you want to run the operator against.
 
-| Platformatic operator | SQL operator |
+| Platformatic operator | SQL operator | Note |
 |--- | ---|
-| eq | `'='` |
-| in | `'IN'` |
-| nin | `'NOT IN'` |
-| neq | `'<>'` |
-| gt | `'>'` |
-| gte | `'>='` |
-| lt | `'<'` |
-| lte | `'<='` |
-| like | `'LIKE'` |
+| eq | '=' | If value is `null`, translates to `IS NULL`. |
+| in | 'IN' | |
+| nin | 'NOT IN' | |
+| neq | '<>' | If value is `null`, translates to `IS NOT NULL`. |
+| gt | '>' | |
+| gte | '>=' | |
+| lt | '<' | |
+| lte | '<=' | |
+| like | 'LIKE' | |
+
+### Handling Null Values
+
+When using the `eq` and `neq` operators with a null value, the comparison logic adheres to standard SQL rules for null value handling. Below is an explanation of how these operators are interpreted when the value is null:
 
 ### Examples
 
@@ -92,6 +96,7 @@ Where clause operations are by default combined with the `AND` operator. To comb
   }
 }
 ```
+
 ### Select all rows with id 1 or 3 and title like 'foo%'
 ```
 {
@@ -111,6 +116,30 @@ Where clause operations are by default combined with the `AND` operator. To comb
     ],
     title: {
       like: 'foo%'
+    }
+  }
+}
+```
+
+### Select all rows where title is null
+```
+{
+  ...
+  "where": {
+    title: {
+      eq: null
+    }
+  }
+}
+```
+
+### Select all rows where title is not null
+```
+{
+  ...
+  "where": {
+    title: {
+      neq: null
     }
   }
 }

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -74,11 +74,11 @@ export interface WhereCondition {
     /**
      * Equal to value.
      */
-    eq?: string,
+    eq?: string | null,
     /**
      * Not equal to value.
      */
-    neq?: string,
+    neq?: string | null,
     /**
      * Greater than value.
      */

--- a/packages/sql-mapper/test/types/mapper.test-d.ts
+++ b/packages/sql-mapper/test/types/mapper.test-d.ts
@@ -96,6 +96,8 @@ expectType<Partial<EntityFields>[]>(await entity.insert({ inputs: [{ id: 1, name
 expectType<Partial<EntityFields>>(await entity.save({ input: { id: 1, name: 'test' }, tx: pluginOptions.db }))
 expectType<Partial<EntityFields>[]>(await entity.delete({ tx: pluginOptions.db }))
 expectType<number>(await entity.count({ tx: pluginOptions.db }))
+expectType<Partial<EntityFields>[]>(await entity.find({ where: { id: { eq: null } } }))
+expectType<Partial<EntityFields>[]>(await entity.find({ where: { id: { neq: null } } }))
 
 const whereCondition: WhereCondition = {
   eq: {eq: ""},


### PR DESCRIPTION
For instance, without explicit support for null values in the WhereCondition interface, developers could inadvertently produce queries that do not behave as expected in scenarios involving null. Similarly, lacking clear documentation might lead to inconsistent query formulations or misunderstandings about how null comparisons are conducted in SQL, affecting data retrieval or manipulation tasks.

With these enhancements, the interface now directly accommodates null values, reducing potential for errors and increasing query precision. Improved documentation further aids developers, offering detailed insights into the operation of eq and neq with null, thereby standardizing practices and bolstering the robustness of applications built on our platform.

♻️ (mapper.d.ts): Update WhereCondition interface to allow null values for eq and neq properties
This update introduces the ability to explicitly set null values for the eq and neq properties within the WhereCondition interface. This change promotes greater flexibility and accuracy in query formulation, aligning with SQL standards for null handling.

✨ (api.md): Enhance documentation on null value handling with eq and neq operators in SQL queries
The documentation has been further refined with additional details on how null values are treated when using the eq and neq operators in SQL queries, enhancing understanding and usability for developers.

🔎 Use-case:
Prior to these updates, developers might face ambiguity when setting null values for eq and neq properties or when interpreting documentation regarding null handling in SQL queries. Misinterpretations or misconfigurations could lead to unintended query results or typescript errors.

![image](https://github.com/platformatic/platformatic/assets/30497555/89cd1bf9-23b8-4cdd-9894-f76303251532)
