### PR TITLE
Load roles from path from user context

### DIFF
--- a/docs/reference/db/authorization/user-roles-metadata.md
+++ b/docs/reference/db/authorization/user-roles-metadata.md
@@ -84,6 +84,28 @@ The roles key in user metadata defaults to `X-PLATFORMATIC-ROLE`. It's possible 
   }
 ```
 
+Another option is to use the `rolePath` field to specify a path to the role in the user metadata. This is useful when the role is nested in the user data extracted from the JWT claims, e.g. if we have a JWT token with:
+
+```json
+{
+  "user": {
+    "roles": ["admin", "editor"]
+  }
+}
+
+```
+
+We can specify the `rolePath` as `user.roles`:
+
+```json
+ "authorization": {
+    "rolePath": "user.roles",
+    ...
+  }
+```
+
+Note that the `roleKey` has the precedence on `rolePath`. If both are set, the `roleKey` will be used and the `rolePath` will be ignored.
+
 ## User metadata
 
 User roles and other user data, such as `userId`, are referred to by Platformatic

--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -435,6 +435,8 @@ calls. Use an [environment variable placeholder](#environment-variable-placehold
 to securely provide the value for this setting.
 - `roleKey` (`string`, default: `X-PLATFORMATIC-ROLE`): The name of the key in user
   metadata that is used to store the user's roles. See [Role configuration](/docs/reference/db/authorization/user-roles-metadata#role-configuration).
+- `rolePath` (`string`): The name of the dot-separated path in user
+  metadata that is used to store the user's roles. See [Role configuration](/docs/reference/db/authorization/user-roles-metadata#role-configuration).
 - `anonymousRole` (`string`, default: `anonymous`): The name of the anonymous role. See [Role configuration](/docs/reference/db/authorization/user-roles-metadata#role-configuration).
 - `jwt` (`object`): Configuration for the [JWT authorization strategy](/docs/reference/db/authorization/strategies#json-web-token-jwt).
   Any option accepted by [`@fastify/jwt`](https://github.com/fastify/fastify-jwt)

--- a/packages/db-authorization/index.d.ts
+++ b/packages/db-authorization/index.d.ts
@@ -50,6 +50,7 @@ export type AddRulesForRoles = <T>(rules: Iterable<AuthorizationRule<T>>) => voi
 export interface DBAuthorizationPluginOptions<T = any> extends FastifyUserPluginOptions {
   adminSecret?: string
   roleKey?: string
+  isRolePath?: boolean
   anonymousRole?: string
   rules: Array<AuthorizationRule<T>>
 }

--- a/packages/db-authorization/index.js
+++ b/packages/db-authorization/index.js
@@ -18,7 +18,8 @@ const PLT_ADMIN_ROLE = 'platformatic-admin'
 async function auth (app, opts) {
   app.register(fastifyUser, opts)
   const adminSecret = opts.adminSecret
-  const roleKey = opts.roleKey || 'X-PLATFORMATIC-ROLE'
+  const roleKey = opts.roleKey || opts.rolePath || 'X-PLATFORMATIC-ROLE'
+  const isRolePath = !!opts.rolePath // if `true` the role is intepreted as path like `user.role`
   const anonymousRole = opts.anonymousRole || 'anonymous'
 
   app.decorateRequest('setupDBAuthorizationUser', setupUser)
@@ -174,7 +175,7 @@ async function auth (app, opts) {
             return originalFind({ ...restOpts, where, ctx, fields })
           }
           const request = getRequestFromContext(ctx)
-          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
+          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole, isRolePath)
           checkFieldsFromRule(rule.find, fields || Object.keys(app.platformatic.entities[entityKey].fields))
           where = await fromRuleToWhere(ctx, rule.find, where, request.user)
 
@@ -186,7 +187,7 @@ async function auth (app, opts) {
             return originalSave({ ctx, input, fields, ...restOpts })
           }
           const request = getRequestFromContext(ctx)
-          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
+          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole, isRolePath)
 
           if (!rule.save) {
             throw new Unauthorized()
@@ -236,7 +237,7 @@ async function auth (app, opts) {
             return originalInsert({ inputs, ctx, fields, ...restOpts })
           }
           const request = getRequestFromContext(ctx)
-          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
+          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole, isRolePath)
 
           if (!rule.save) {
             throw new Unauthorized()
@@ -267,7 +268,7 @@ async function auth (app, opts) {
             return originalDelete({ where, ctx, fields, ...restOpts })
           }
           const request = getRequestFromContext(ctx)
-          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
+          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole, isRolePath)
 
           where = await fromRuleToWhere(ctx, rule.delete, where, request.user)
 
@@ -279,7 +280,7 @@ async function auth (app, opts) {
             return originalUpdateMany({ ...restOpts, where, ctx, fields })
           }
           const request = getRequestFromContext(ctx)
-          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole)
+          const rule = await findRuleForRequestUser(ctx, rules, roleKey, anonymousRole, isRolePath)
 
           where = await fromRuleToWhere(ctx, rule.updateMany, where, request.user)
 
@@ -356,10 +357,10 @@ async function fromRuleToWhere (ctx, rule, where, user) {
   return where
 }
 
-async function findRuleForRequestUser (ctx, rules, roleKey, anonymousRole) {
+async function findRuleForRequestUser (ctx, rules, roleKey, anonymousRole, isRolePath = false) {
   const request = getRequestFromContext(ctx)
   await request.setupDBAuthorizationUser()
-  const roles = getRoles(request, roleKey, anonymousRole)
+  const roles = getRoles(request, roleKey, anonymousRole, isRolePath)
   const rule = findRule(rules, roles)
   if (!rule) {
     ctx.reply.request.log.warn({ roles, rules }, 'no rule for roles')

--- a/packages/db-authorization/lib/utils.d.ts
+++ b/packages/db-authorization/lib/utils.d.ts
@@ -2,4 +2,4 @@ import { MercuriusContext } from "mercurius";
 import { FastifyRequest } from "fastify";
 
 export function getRequestFromContext(ctx: MercuriusContext): FastifyRequest
-export function getRoles(request: FastifyRequest, roleKey: string, anonymousRole: string): string[]
+export function getRoles(request: FastifyRequest, roleKey: string, anonymousRole: string, isRolePath: boolean): string[]

--- a/packages/db-authorization/lib/utils.js
+++ b/packages/db-authorization/lib/utils.js
@@ -7,7 +7,7 @@ function getRequestFromContext (ctx) {
   return ctx.reply.request
 }
 
-function getRoles (request, roleKey, anonymousRole) {
+function getRoles (request, roleKey, anonymousRole, isRolePath = false) {
   let output = []
   const user = request.user
   if (!user) {
@@ -15,7 +15,17 @@ function getRoles (request, roleKey, anonymousRole) {
     return output
   }
 
-  const rolesRaw = user[roleKey]
+  let rolesRaw
+  if (isRolePath) {
+    const roleKeys = roleKey.split('.')
+    rolesRaw = user
+    for (const key of roleKeys) {
+      rolesRaw = rolesRaw[key]
+    }
+  } else {
+    rolesRaw = user[roleKey]
+  }
+
   if (typeof rolesRaw === 'string') {
     output = rolesRaw.split(',')
   } else if (Array.isArray(rolesRaw)) {
@@ -24,6 +34,7 @@ function getRoles (request, roleKey, anonymousRole) {
   if (output.length === 0) {
     output.push(anonymousRole)
   }
+
   return output
 }
 module.exports = {

--- a/packages/db-authorization/schema.js
+++ b/packages/db-authorization/schema.js
@@ -7,6 +7,14 @@ const AuthSchema = {
     adminSecret: {
       type: 'string',
       description: 'The password should be used to access routes under /_admin prefix.'
+    },
+    roleKey: {
+      type: 'string',
+      description: 'The key in the user object that contains the roles.'
+    },
+    rolePath: {
+      type: 'string',
+      description: 'The path in the user object that contains the roles.'
     }
   },
   additionalProperties: true // TODO remove and add proper validation for the rules

--- a/packages/db-authorization/test/role-path.test.js
+++ b/packages/db-authorization/test/role-path.test.js
@@ -1,0 +1,282 @@
+'use strict'
+
+const { test } = require('node:test')
+const { equal, deepEqual, ok } = require('node:assert')
+const fastify = require('fastify')
+const core = require('@platformatic/db-core')
+const { connInfo, clear, createBasicPages } = require('./helper')
+const auth = require('..')
+
+test('roles defined in objects and extracted with rolePath', async () => {
+  const app = fastify()
+  app.register(core, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      ok('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(auth, {
+    jwt: {
+      secret: 'supersecret'
+    },
+    rolePath: 'resource_access.account.roles',
+    anonymousRole: 'anonymous',
+    rules: [{
+      role: 'moderator',
+      entity: 'page',
+      find: true,
+      delete: true,
+      save: true,
+      defaults: {
+        userId: 'X-PLATFORMATIC-USER-ID'
+      }
+    }, {
+      role: 'user',
+      entity: 'page',
+      find: true,
+      delete: false,
+      defaults: {
+        userId: 'X-PLATFORMATIC-USER-ID'
+      },
+      save: {
+        checks: {
+          userId: 'X-PLATFORMATIC-USER-ID'
+        }
+      }
+    }, {
+      role: 'anonymous',
+      entity: 'page',
+      find: false,
+      delete: false,
+      save: false
+    }]
+  })
+  test.after(() => {
+    app.close()
+  })
+
+  await app.ready()
+
+  // Token with user and moderator roles as array
+  const token = await app.jwt.sign({
+    'X-PLATFORMATIC-USER-ID': 42,
+    resource_access: {
+      account: {
+        roles: ['user', 'moderator']
+      }
+    }
+  })
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          mutation {
+            savePage(input: { title: "Hello" }) {
+              id
+              title
+              userId
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'savePage status code')
+    deepEqual(res.json(), {
+      data: {
+        savePage: {
+          id: 1,
+          title: 'Hello',
+          userId: 42
+        }
+      }
+    }, 'savePage response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          mutation {
+            deletePages(where: { title: { eq: "Hello" } }) {
+              id
+              title
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'deletePages status code')
+    deepEqual(res.json(), {
+      data: {
+        deletePages: [{
+          id: 1,
+          title: 'Hello'
+        }]
+      }
+    }, 'deletePages response')
+  }
+
+  // Token with user and moderator roles as comma separated string
+  const token2 = await app.jwt.sign({
+    'X-PLATFORMATIC-USER-ID': 42,
+    resource_access: {
+      account: {
+        roles: 'moderator, user'
+      }
+    }
+  })
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token2}`
+      },
+      body: {
+        query: `
+          mutation {
+            savePage(input: { title: "Hello" }) {
+              id
+              title
+              userId
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'savePage status code')
+    deepEqual(res.json(), {
+      data: {
+        savePage: {
+          id: 2,
+          title: 'Hello',
+          userId: 42
+        }
+      }
+    }, 'savePage response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token2}`
+      },
+      body: {
+        query: `
+          mutation {
+            deletePages(where: { title: { eq: "Hello" } }) {
+              id
+              title
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'deletePages status code')
+    deepEqual(res.json(), {
+      data: {
+        deletePages: [{
+          id: 2,
+          title: 'Hello'
+        }]
+      }
+    }, 'deletePages response')
+  }
+
+  const token3 = await app.jwt.sign({
+    'X-PLATFORMATIC-USER-ID': 43,
+    resource_access: {
+      account: {
+        roles: 'user'
+      }
+    }
+  })
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token3}`
+      },
+      body: {
+        query: `
+          mutation {
+            savePage(input: { title: "Hello" }) {
+              id
+              title
+              userId
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'savePage status code')
+    deepEqual(res.json(), {
+      data: {
+        savePage: {
+          id: 3,
+          title: 'Hello',
+          userId: 43
+        }
+      }
+    }, 'savePage response')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token3}`
+      },
+      body: {
+        query: `
+          mutation {
+            deletePages(where: { title: { eq: "Hello" } }) {
+              id
+              title
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'deletePages status code')
+    deepEqual(res.json(), {
+      data: {
+        deletePages: null
+      },
+      errors: [
+        {
+          message: 'operation not allowed',
+          locations: [
+            {
+              line: 3,
+              column: 13
+            }
+          ],
+          path: [
+            'deletePages'
+          ]
+        }
+      ]
+    }, 'deletePages response')
+  }
+})

--- a/packages/db-authorization/test/utils.test.js
+++ b/packages/db-authorization/test/utils.test.js
@@ -60,3 +60,58 @@ test('should get roles from user', (t) => {
     deepEqual(getRoles(requestWithOtherKindOfRole, roleKey, ANONYMOUS_ROLE), [ANONYMOUS_ROLE])
   }
 })
+
+test('should get roles from user with path', (t) => {
+  const { deepEqual } = tspl(t, { plan: 4 })
+  const roleKey = 'role'
+  const isRolePath = true
+  {
+    const requestWithNoUser = {}
+    deepEqual(getRoles(requestWithNoUser, roleKey, ANONYMOUS_ROLE, isRolePath), [ANONYMOUS_ROLE])
+  }
+  {
+    // Past is set, but it is not a path
+    const requestWithStringRoles = {
+      user: {
+        [roleKey]: 'role1,role2,role3'
+      }
+    }
+    deepEqual(getRoles(requestWithStringRoles, roleKey, ANONYMOUS_ROLE, isRolePath), ['role1', 'role2', 'role3'])
+  }
+
+  {
+    // Proper path with array
+    const roleKey = 'resource_access.rest-api.roles'
+    // Past is set, but it is not a path
+    const requestWithStringRoles = {
+      user: {
+        resource_access: {
+          'rest-api': {
+            roles: [
+              'role1',
+              'role2',
+              'role3'
+            ]
+          }
+        }
+      }
+    }
+    deepEqual(getRoles(requestWithStringRoles, roleKey, ANONYMOUS_ROLE, isRolePath), ['role1', 'role2', 'role3'])
+  }
+
+  {
+    // Proper path with comma separated string
+    const roleKey = 'resource_access.rest-api.roles'
+    // Past is set, but it is not a path
+    const requestWithStringRoles = {
+      user: {
+        resource_access: {
+          'rest-api': {
+            roles: 'role1,role2,role3'
+          }
+        }
+      }
+    }
+    deepEqual(getRoles(requestWithStringRoles, roleKey, ANONYMOUS_ROLE, isRolePath), ['role1', 'role2', 'role3'])
+  }
+})

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -7,19 +7,19 @@
 
 export type CrudOperationAuth =
   | {
-      /**
-       * checks for the operation
-       */
-      checks?: {
-        [k: string]: {
-          [k: string]: unknown;
-        };
+    /**
+     * checks for the operation
+     */
+    checks?: {
+      [k: string]: {
+        [k: string]: unknown;
       };
-      /**
-       * array of enabled field for the operation
-       */
-      fields?: string[];
-    }
+    };
+    /**
+     * array of enabled field for the operation
+     */
+    fields?: string[];
+  }
   | boolean;
 
 export interface PlatformaticDB {
@@ -28,12 +28,12 @@ export interface PlatformaticDB {
     port?: number | string;
     pluginTimeout?: number;
     healthCheck?:
-      | boolean
-      | {
-          enabled?: boolean;
-          interval?: number;
-          [k: string]: unknown;
-        };
+    | boolean
+    | {
+      enabled?: boolean;
+      interval?: number;
+      [k: string]: unknown;
+    };
     ignoreTrailingSlash?: boolean;
     ignoreDuplicateSlashes?: boolean;
     connectionTimeout?: number;
@@ -46,38 +46,38 @@ export interface PlatformaticDB {
     disableRequestLogging?: boolean;
     exposeHeadRoutes?: boolean;
     logger?:
-      | boolean
+    | boolean
+    | {
+      level?: string;
+      transport?:
       | {
-          level?: string;
-          transport?:
-            | {
-                target?: string;
-                options?: {
-                  [k: string]: unknown;
-                };
-              }
-            | {
-                targets?: {
-                  target?: string;
-                  options?: {
-                    [k: string]: unknown;
-                  };
-                  level?: string;
-                  additionalProperties?: never;
-                  [k: string]: unknown;
-                }[];
-                options?: {
-                  [k: string]: unknown;
-                };
-              };
-          pipeline?: {
-            target?: string;
-            options?: {
-              [k: string]: unknown;
-            };
-          };
+        target?: string;
+        options?: {
           [k: string]: unknown;
         };
+      }
+      | {
+        targets?: {
+          target?: string;
+          options?: {
+            [k: string]: unknown;
+          };
+          level?: string;
+          additionalProperties?: never;
+          [k: string]: unknown;
+        }[];
+        options?: {
+          [k: string]: unknown;
+        };
+      };
+      pipeline?: {
+        target?: string;
+        options?: {
+          [k: string]: unknown;
+        };
+      };
+      [k: string]: unknown;
+    };
     serializerOpts?: {
       schema?: {
         [k: string]: unknown;
@@ -99,45 +99,45 @@ export interface PlatformaticDB {
     trustProxy?: boolean | string | string[] | number;
     https?: {
       key:
+      | string
+      | {
+        path?: string;
+      }
+      | (
         | string
         | {
-            path?: string;
-          }
-        | (
-            | string
-            | {
-                path?: string;
-              }
-          )[];
+          path?: string;
+        }
+      )[];
       cert:
+      | string
+      | {
+        path?: string;
+      }
+      | (
         | string
         | {
-            path?: string;
-          }
-        | (
-            | string
-            | {
-                path?: string;
-              }
-          )[];
+          path?: string;
+        }
+      )[];
       requestCert?: boolean;
       rejectUnauthorized?: boolean;
     };
     cors?: {
       origin?:
-        | boolean
+      | boolean
+      | string
+      | (
         | string
-        | (
-            | string
-            | {
-                regexp: string;
-                [k: string]: unknown;
-              }
-          )[]
         | {
-            regexp: string;
-            [k: string]: unknown;
-          };
+          regexp: string;
+          [k: string]: unknown;
+        }
+      )[]
+      | {
+        regexp: string;
+        [k: string]: unknown;
+      };
       methods?: string[];
       /**
        * Comma separated string of allowed headers.
@@ -157,81 +157,81 @@ export interface PlatformaticDB {
     connectionString: string;
     schema?: string[];
     schemalock?:
-      | boolean
-      | {
-          path?: string;
-          [k: string]: unknown;
-        };
+    | boolean
+    | {
+      path?: string;
+      [k: string]: unknown;
+    };
     poolSize?: number;
     idleTimeoutMilliseconds?: number;
     queueTimeoutMilliseconds?: number;
     acquireLockTimeoutMilliseconds?: number;
     autoTimestamp?:
-      | {
-          createdAt?: string;
-          updatedAt?: string;
-          [k: string]: unknown;
-        }
-      | boolean;
+    | {
+      createdAt?: string;
+      updatedAt?: string;
+      [k: string]: unknown;
+    }
+    | boolean;
     graphql?:
-      | boolean
-      | {
-          graphiql?: boolean;
-          include?: {
-            [k: string]: boolean;
-          };
-          ignore?: {
-            [k: string]:
-              | boolean
-              | {
-                  [k: string]: boolean;
-                };
-          };
-          subscriptionIgnore?: string[];
-          schema?: string;
-          schemaPath?: string;
-          enabled?: boolean | string;
-          [k: string]: unknown;
+    | boolean
+    | {
+      graphiql?: boolean;
+      include?: {
+        [k: string]: boolean;
+      };
+      ignore?: {
+        [k: string]:
+        | boolean
+        | {
+          [k: string]: boolean;
         };
+      };
+      subscriptionIgnore?: string[];
+      schema?: string;
+      schemaPath?: string;
+      enabled?: boolean | string;
+      [k: string]: unknown;
+    };
     openapi?:
-      | boolean
-      | {
-          info?: Info;
-          jsonSchemaDialect?: string;
-          servers?: Server[];
-          paths?: Paths;
-          webhooks?: {
-            [k: string]: PathItemOrReference;
-          };
-          components?: Components;
-          security?: SecurityRequirement[];
-          tags?: Tag[];
-          externalDocs?: ExternalDocumentation;
-          /**
-           * Base URL for the OpenAPI Swagger Documentation
-           */
-          swaggerPrefix?: string;
-          /**
-           * Path to an OpenAPI spec file
-           */
-          path?: string;
-          allowPrimaryKeysInInput?: boolean;
-          include?: {
-            [k: string]: boolean;
-          };
-          ignore?: {
-            [k: string]:
-              | boolean
-              | {
-                  [k: string]: boolean;
-                };
-          };
-          enabled?: boolean | string;
-          /**
-           * Base URL for generated Platformatic DB routes
-           */
-          prefix?: string;
+    | boolean
+    | {
+      info?: Info;
+      jsonSchemaDialect?: string;
+      servers?: Server[];
+      paths?: Paths;
+      webhooks?: {
+        [k: string]: PathItemOrReference;
+      };
+      components?: Components;
+      security?: SecurityRequirement[];
+      tags?: Tag[];
+      externalDocs?: ExternalDocumentation;
+      /**
+       * Base URL for the OpenAPI Swagger Documentation
+       */
+      swaggerPrefix?: string;
+      /**
+       * Path to an OpenAPI spec file
+       */
+      path?: string;
+      allowPrimaryKeysInInput?: boolean;
+      include?: {
+        [k: string]: boolean;
+      };
+      ignore?: {
+        [k: string]:
+        | boolean
+        | {
+          [k: string]: boolean;
         };
+      };
+      enabled?: boolean | string;
+      /**
+       * Base URL for generated Platformatic DB routes
+       */
+      prefix?: string;
+    };
     include?: {
       [k: string]: boolean;
     };
@@ -244,11 +244,11 @@ export interface PlatformaticDB {
       [k: string]: unknown;
     };
     events?:
-      | boolean
-      | {
-          connectionString?: string;
-          enabled?: boolean | string;
-        };
+    | boolean
+    | {
+      connectionString?: string;
+      enabled?: boolean | string;
+    };
     cache?: boolean;
     [k: string]: unknown;
   };
@@ -262,24 +262,28 @@ export interface PlatformaticDB {
      */
     roleKey?: string;
     /**
+     * The user metadata path to store user roles
+     */
+    rolePath?: string;
+    /**
      * The role name for anonymous users
      */
     anonymousRole?: string;
     jwt?: {
       secret?:
-        | string
-        | {
-            [k: string]: unknown;
-          };
+      | string
+      | {
+        [k: string]: unknown;
+      };
       /**
        * the namespace for JWT custom claims
        */
       namespace?: string;
       jwks?:
-        | boolean
-        | {
-            [k: string]: unknown;
-          };
+      | boolean
+      | {
+        [k: string]: unknown;
+      };
       [k: string]: unknown;
     };
     webhook?: {
@@ -290,43 +294,43 @@ export interface PlatformaticDB {
     };
     rules?: (
       | {
-          /**
-           * the DB entity type to which the rule applies
-           */
-          entity?: string;
-          /**
-           * the role name to match the rule
-           */
-          role: string;
-          /**
-           * defaults for entity creation
-           */
-          defaults?: {
-            [k: string]: string;
-          };
-          find?: CrudOperationAuth;
-          save?: CrudOperationAuth;
-          delete?: CrudOperationAuth;
-        }
+        /**
+         * the DB entity type to which the rule applies
+         */
+        entity?: string;
+        /**
+         * the role name to match the rule
+         */
+        role: string;
+        /**
+         * defaults for entity creation
+         */
+        defaults?: {
+          [k: string]: string;
+        };
+        find?: CrudOperationAuth;
+        save?: CrudOperationAuth;
+        delete?: CrudOperationAuth;
+      }
       | {
-          /**
-           * the DB entity types to which the rule applies
-           */
-          entities?: string[];
-          /**
-           * the role name to match the rule
-           */
-          role: string;
-          /**
-           * defaults for entity creation
-           */
-          defaults?: {
-            [k: string]: string;
-          };
-          find?: CrudOperationAuth;
-          save?: CrudOperationAuth;
-          delete?: CrudOperationAuth;
-        }
+        /**
+         * the DB entity types to which the rule applies
+         */
+        entities?: string[];
+        /**
+         * the role name to match the rule
+         */
+        role: string;
+        /**
+         * defaults for entity creation
+         */
+        defaults?: {
+          [k: string]: string;
+        };
+        find?: CrudOperationAuth;
+        save?: CrudOperationAuth;
+        delete?: CrudOperationAuth;
+      }
     )[];
   };
   migrations?: {
@@ -353,17 +357,17 @@ export interface PlatformaticDB {
     currentSchema?: string;
   };
   metrics?:
-    | boolean
-    | {
-        port?: number | string;
-        hostname?: string;
-        endpoint?: string;
-        server?: "own" | "parent";
-        auth?: {
-          username: string;
-          password: string;
-        };
-      };
+  | boolean
+  | {
+    port?: number | string;
+    hostname?: string;
+    endpoint?: string;
+    server?: "own" | "parent";
+    auth?: {
+      username: string;
+      password: string;
+    };
+  };
   types?: {
     autogenerate?: boolean;
     /**
@@ -384,16 +388,16 @@ export interface PlatformaticDB {
     url?: string;
   }[];
   watch?:
-    | {
-        enabled?: boolean | string;
-        /**
-         * @minItems 1
-         */
-        allow?: [string, ...string[]];
-        ignore?: string[];
-      }
-    | boolean
-    | string;
+  | {
+    enabled?: boolean | string;
+    /**
+     * @minItems 1
+     */
+    allow?: [string, ...string[]];
+    ignore?: string[];
+  }
+  | boolean
+  | string;
   $schema?: string;
 }
 export interface Info {
@@ -614,46 +618,46 @@ export interface OpenTelemetry {
     [k: string]: unknown;
   }[];
   exporter?:
-    | {
-        type?: "console" | "otlp" | "zipkin" | "memory";
-        /**
-         * Options for the exporter. These are passed directly to the exporter.
-         */
-        options?: {
-          /**
-           * The URL to send the traces to. Not used for console or memory exporters.
-           */
-          url?: string;
-          /**
-           * Headers to send to the exporter. Not used for console or memory exporters.
-           */
-          headers?: {
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        additionalProperties?: never;
-        [k: string]: unknown;
-      }[]
-    | {
-        type?: "console" | "otlp" | "zipkin" | "memory";
-        /**
-         * Options for the exporter. These are passed directly to the exporter.
-         */
-        options?: {
-          /**
-           * The URL to send the traces to. Not used for console or memory exporters.
-           */
-          url?: string;
-          /**
-           * Headers to send to the exporter. Not used for console or memory exporters.
-           */
-          headers?: {
-            [k: string]: unknown;
-          };
-          [k: string]: unknown;
-        };
-        additionalProperties?: never;
+  | {
+    type?: "console" | "otlp" | "zipkin" | "memory";
+    /**
+     * Options for the exporter. These are passed directly to the exporter.
+     */
+    options?: {
+      /**
+       * The URL to send the traces to. Not used for console or memory exporters.
+       */
+      url?: string;
+      /**
+       * Headers to send to the exporter. Not used for console or memory exporters.
+       */
+      headers?: {
         [k: string]: unknown;
       };
+      [k: string]: unknown;
+    };
+    additionalProperties?: never;
+    [k: string]: unknown;
+  }[]
+  | {
+    type?: "console" | "otlp" | "zipkin" | "memory";
+    /**
+     * Options for the exporter. These are passed directly to the exporter.
+     */
+    options?: {
+      /**
+       * The URL to send the traces to. Not used for console or memory exporters.
+       */
+      url?: string;
+      /**
+       * Headers to send to the exporter. Not used for console or memory exporters.
+       */
+      headers?: {
+        [k: string]: unknown;
+      };
+      [k: string]: unknown;
+    };
+    additionalProperties?: never;
+    [k: string]: unknown;
+  };
 }

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -246,6 +246,10 @@ const authorization = {
       description: 'The user metadata key to store user roles',
       default: 'X-PLATFORMATIC-ROLE'
     },
+    rolePath: {
+      type: 'string',
+      description: 'The user metadata path to store user roles'
+    },
     anonymousRole: {
       type: 'string',
       description: 'The role name for anonymous users',

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -736,8 +736,12 @@
         },
         "roleKey": {
           "type": "string",
-          "description": "The user metadata key to store user roles",
+          "description": "The user metadata key to get user roles",
           "default": "X-PLATFORMATIC-ROLE"
+        },
+        "rolePath": {
+          "type": "string",
+          "description": "The user metadata path to get user roles"
         },
         "anonymousRole": {
           "type": "string",


### PR DESCRIPTION
This to load roles from structured objects that can be loaded from JWT claims, e.g.:

```
  "resource_access": {
    "rest-api": {
      "roles": [
        "admin",
        "user"
      ]
    },
```

To support that, a `rolePath` can be used, specifying a dot-separated path. In this case we would need:
```
{ 
   (...)
   rolePath: "resource_access.rest-api.roles"
   (...)
}