### PR TITLE
ci: drop runtime node 18.9 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [18.18, 18.19, 20]
+        node-version: [18.18, 20]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
@mcollina let's disable node js 18.9 for the runtime and create an issue to enable it when nodejs fix will arive. It fails everytime anyway. WDYT?