### PR TITLE
feat: compose responses with empty bodies

### DIFF
--- a/docs/reference/composer/configuration.md
+++ b/docs/reference/composer/configuration.md
@@ -91,6 +91,8 @@ the services managed by the composer. Each service object supports the following
 
 - **`refreshTimeout`** (`number`) - The number of milliseconds to wait for check for changes in the services. If not specified, the default value is `1000`; set to `0` to disable.
 
+- **`addEmptySchema`** (`boolean`) - If true, the composer will add an empty response schema to the composed OpenAPI specification. Default is `false`.
+
 #### `openapi`
 
 - **`url`** (`string`) - A path of the route that exposes the OpenAPI specification. If a service is a Platformatic Service or Platformatic DB, use `/documentation/json` as a value. Use this or `file` option to specify the OpenAPI specification.

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticComposer {
         | string;
       addEntitiesResolvers?: boolean;
     };
+    addEmptySchema?: boolean;
     refreshTimeout?: number;
   };
   metrics?:

--- a/packages/composer/lib/openapi-generator.js
+++ b/packages/composer/lib/openapi-generator.js
@@ -85,6 +85,7 @@ async function composeOpenAPI (app, opts) {
 
   await app.register(await import('fastify-openapi-glue'), {
     specification: composedOpenApiSchema,
+    addEmptySchema: opts.addEmptySchema,
     operationResolver: (operationId, method, openApiPath) => {
       const { origin, prefix, schema } = apiByApiRoutes[openApiPath]
       const originPath = schema[originPathSymbol]

--- a/packages/composer/lib/schema.js
+++ b/packages/composer/lib/schema.js
@@ -149,6 +149,7 @@ const composer = {
     },
     openapi: openApiBase,
     graphql: graphqlComposerOptions,
+    addEmptySchema: { type: 'boolean', default: false },
     refreshTimeout: { type: 'integer', minimum: 0, default: 1000 }
   },
   required: ['services'],

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -61,7 +61,7 @@
     "execa": "^8.0.1",
     "fast-deep-equal": "^3.1.3",
     "fastify": "^4.26.2",
-    "fastify-openapi-glue": "^4.4.3",
+    "fastify-openapi-glue": "^4.6.0",
     "fastify-plugin": "^4.5.1",
     "graphql": "^16.8.1",
     "help-me": "^5.0.0",

--- a/packages/composer/test/helper.js
+++ b/packages/composer/test/helper.js
@@ -47,6 +47,19 @@ async function createBasicService (t) {
     throw new Error('KA-BOOM!!!')
   })
 
+  app.get('/empty', {
+    schema: {
+      response: {
+        204: {
+          type: 'null'
+        },
+        302: {
+          type: 'null'
+        }
+      }
+    }
+  }, async () => {})
+
   app.get('/object', {
     schema: {
       response: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,8 +400,8 @@ importers:
         specifier: ^4.26.2
         version: 4.26.2
       fastify-openapi-glue:
-        specifier: ^4.4.3
-        version: 4.5.0
+        specifier: ^4.6.0
+        version: 4.6.0
       fastify-plugin:
         specifier: ^4.5.1
         version: 4.5.1
@@ -5924,6 +5924,17 @@ packages:
 
   /fastify-openapi-glue@4.5.0:
     resolution: {integrity: sha512-ynmdpV8F17TUs3tdLuicM0nprHF+qQ4S3CYpQJcmkqFyeVrk1AltwOUJ64qmCGXy8K0an+DXlsvTLcDnX6nd9Q==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      '@seriousme/openapi-schema-validator': 2.2.1
+      fastify-plugin: 4.5.1
+      js-yaml: 4.1.0
+      minimist: 1.2.8
+    dev: false
+
+  /fastify-openapi-glue@4.6.0:
+    resolution: {integrity: sha512-7fe/P/WRR9BB3T5jWUznl+5yP3x9nX+rgF5CYyzQV4YkIRsCZazg7k98Xeiq0GmnCJOSw8SMXdetUoZOfT3ujA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Fix #2121

@mikaelkaron ptal. Unfortunaltelly it still will create a default description (it's another problem of how service schema is generated), but at least it will create a correct status codes with correct empty schemas.