### PR TITLE
fix(client): Do not override client params

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -169,7 +169,6 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
           throw new Error('missing required parameter ' + param.name)
         }
         pathToCall = pathToCall.replace(`{${param.name}}`, args.path[param.name])
-        args.path[param.name] = undefined
       }
 
       for (const param of queryParams) {
@@ -179,7 +178,6 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
           } else {
             query.append(param.name, args.query[param.name])
           }
-          args.query[param.name] = undefined
         }
       }
     } else {

--- a/packages/client/test/openapi.2.test.js
+++ b/packages/client/test/openapi.2.test.js
@@ -175,12 +175,18 @@ test('build basic client from file (path parameter)', async (t) => {
       path: join(__dirname, 'fixtures', 'path-params', 'openapi.json')
     })
 
-    const result = await client.getPath({
+    const params = {
       path: { id: 'baz' },
       query: { name: 'bar' }
-    })
+    }
+    const result = await client.getPath(params)
     assert.equal(result.id, 'baz')
     assert.equal(result.name, 'bar')
+    assert.deepEqual(params, {
+      path: { id: 'baz' },
+      query: { name: 'bar' }
+    },
+    'calling the client should NOT override the sent params')
 
     const { id, name } = await client.getPath({ path: { id: 'ok' }, query: { name: undefined } })
     assert.equal(id, 'ok')


### PR DESCRIPTION
This fixes subtle bugs, since right now the client (when called), overrides the parameters passed.

As an example:
```
const params = {
    path: { id: 'baz' },
    query: { name: 'bar' }
  })
}
const result = await client.getPath(params)
// 🫨 `params` is now { path: { id: undefined }, query: { name: undefined } } 🫣
```