### PR TITLE
Avoid write all process.env entries in .env file

### DIFF
--- a/packages/config/lib/manager.js
+++ b/packages/config/lib/manager.js
@@ -48,22 +48,11 @@ class ConfigManager extends EventEmitter {
     this.schemaOptions = opts.schemaOptions || {}
     this._providedSchema = !!opts.schema
     this._originalEnv = opts.env || {}
-    this.env = { ...this.#getProcessEnvValues(), ...this._originalEnv }
+    this.env = { ...this._originalEnv }
     this._onMissingEnv = opts.onMissingEnv
     if (typeof opts.transformConfig === 'function') {
       this._transformConfig = opts.transformConfig
     }
-  }
-
-  #getProcessEnvValues () {
-    const output = {}
-    return output
-    // Object.entries(process.env).forEach(([key, value]) => {
-    //   if (key.startsWith('PLT_') || key === 'DATABASE_URL' || key === 'PORT') {
-    //     output[key] = value
-    //   }
-    // })
-    // return output
   }
 
   toFastifyPlugin () {
@@ -104,7 +93,7 @@ class ConfigManager extends EventEmitter {
         // do nothing, again
       }
     }
-    let env = { ...this.#getProcessEnvValues(), ...this._originalEnv }
+    let env = { ...this._originalEnv }
     if (dotEnvPath) {
       const data = await readFile(dotEnvPath, 'utf-8')
       const parsed = dotenv.parse(data)

--- a/packages/config/lib/manager.js
+++ b/packages/config/lib/manager.js
@@ -48,11 +48,21 @@ class ConfigManager extends EventEmitter {
     this.schemaOptions = opts.schemaOptions || {}
     this._providedSchema = !!opts.schema
     this._originalEnv = opts.env || {}
-    this.env = this._originalEnv
+    this.env = { ...this.getProcessEnvValues(), ...this._originalEnv }
     this._onMissingEnv = opts.onMissingEnv
     if (typeof opts.transformConfig === 'function') {
       this._transformConfig = opts.transformConfig
     }
+  }
+
+  getProcessEnvValues () {
+    const output = {}
+    Object.entries(process.env).forEach(([key, value]) => {
+      if (key.startsWith('PLT_') || key === 'DATABASE_URL' || key === 'PORT') {
+        output[key] = value
+      }
+    })
+    return output
   }
 
   toFastifyPlugin () {
@@ -93,7 +103,7 @@ class ConfigManager extends EventEmitter {
         // do nothing, again
       }
     }
-    let env = this._originalEnv
+    let env = { ...this.getProcessEnvValues(), ...this._originalEnv }
     if (dotEnvPath) {
       const data = await readFile(dotEnvPath, 'utf-8')
       const parsed = dotenv.parse(data)

--- a/packages/config/lib/manager.js
+++ b/packages/config/lib/manager.js
@@ -127,9 +127,9 @@ class ConfigManager extends EventEmitter {
       return value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n')
     }
     const fullEnv = {
+      ...process.env,
       ...this.env,
-      [PLT_ROOT]: join(this.fullPath, '..'),
-      ...process.env
+      [PLT_ROOT]: join(this.fullPath, '..')
     }
     return this.pupa(configString, fullEnv, { transform: escapeJSONstring })
   }

--- a/packages/config/lib/manager.js
+++ b/packages/config/lib/manager.js
@@ -48,7 +48,7 @@ class ConfigManager extends EventEmitter {
     this.schemaOptions = opts.schemaOptions || {}
     this._providedSchema = !!opts.schema
     this._originalEnv = opts.env || {}
-    this.env = { ...process.env, ...this._originalEnv }
+    this.env = this._originalEnv
     this._onMissingEnv = opts.onMissingEnv
     if (typeof opts.transformConfig === 'function') {
       this._transformConfig = opts.transformConfig
@@ -93,7 +93,7 @@ class ConfigManager extends EventEmitter {
         // do nothing, again
       }
     }
-    let env = { ...process.env, ...this._originalEnv }
+    let env = this._originalEnv
     if (dotEnvPath) {
       const data = await readFile(dotEnvPath, 'utf-8')
       const parsed = dotenv.parse(data)

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -79,9 +79,7 @@ test('should used passed env vars', (t) => {
         PLT_FOOBAR: 'plt_foobar'
       }
     })
-
     assert.deepStrictEqual(cm.env, {
-      ...process.env,
       FOOBAR: 'foobar',
       PLT_FOOBAR: 'plt_foobar'
     })
@@ -95,7 +93,7 @@ test('should used passed env vars', (t) => {
       delete process.env.FOOBAR
       delete process.env.PLT_FOOBAR
     })
-    assert.deepStrictEqual(cm.env, { ...process.env })
+    assert.deepStrictEqual(cm.env, {})
   }
 })
 

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -93,7 +93,7 @@ test('should used passed env vars', (t) => {
       delete process.env.FOOBAR
       delete process.env.PLT_FOOBAR
     })
-    assert.deepStrictEqual(cm.env, { PLT_FOOBAR: 'plt_foobar' })
+    assert.deepStrictEqual(cm.env, {})
   }
 })
 

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -93,7 +93,7 @@ test('should used passed env vars', (t) => {
       delete process.env.FOOBAR
       delete process.env.PLT_FOOBAR
     })
-    assert.deepStrictEqual(cm.env, {})
+    assert.deepStrictEqual(cm.env, { PLT_FOOBAR: 'plt_foobar' })
   }
 })
 

--- a/packages/runtime/test/generator.test.js
+++ b/packages/runtime/test/generator.test.js
@@ -289,7 +289,6 @@ describe('Generator', () => {
       assert.deepEqual(output, {
         targetDirectory,
         env: {
-          ...process.env,
           PLT_FIRST_SERVICE_TYPESCRIPT: false,
           PLT_SECOND_SERVICE_TYPESCRIPT: 'false',
           PLT_SERVER_HOSTNAME: '127.0.0.1',


### PR DESCRIPTION
The bug was introduced in https://github.com/platformatic/platformatic/pull/2456, I removed adding `process.env` to the runtime env.

Fix: #2568 