### PR TITLE
chore(docs): Suggest safer CORS RegExp

### DIFF
--- a/docs/guides/generate-frontend-code-to-consume-platformatic-rest-api.md
+++ b/docs/guides/generate-frontend-code-to-consume-platformatic-rest-api.md
@@ -47,7 +47,7 @@ Once the new Platformatic app is ready:
     },
 +   "cors": {
 +     "origin": {
-+       "regexp": "/*/"
++       "regexp": "^http://localhost.*"
 +     }
 +   }
   },

--- a/docs/guides/generate-frontend-code-to-consume-platformatic-rest-api.md
+++ b/docs/guides/generate-frontend-code-to-consume-platformatic-rest-api.md
@@ -34,7 +34,8 @@ the corresponding table, migrations, and REST API to create, read, update, and d
 
 Once the new Platformatic app is ready:
 
-* Set up CORS in `platformatic.db.json`
+* Define a `PLT_SERVER_CORS_ORIGIN` env variable as a valid regexp (f.e. `"^http://localhost.*"` or `"^https://your.awesome.service/*"`)
+* Pass it to `platformatic.db.json`
 
 ```diff
 {
@@ -47,7 +48,7 @@ Once the new Platformatic app is ready:
     },
 +   "cors": {
 +     "origin": {
-+       "regexp": "^http://localhost.*"
++       "regexp": "{PLT_SERVER_CORS_ORIGIN}"
 +     }
 +   }
   },


### PR DESCRIPTION
We shouldn't suggest in the [docs](https://docs.platformatic.dev/docs/guides/generate-frontend-code-to-consume-platformatic-rest-api#configure-the-new-platformatic-app) a setting like `*` for  CORS, since it's highly unsafe. Better a more strict `"^http://localhost.*"`. Happy to update it also with another domain name...