### PR TITLE
fix: parsing runtime service remote dependencies

### DIFF
--- a/packages/runtime/fixtures/configs/monorepo-with-dependencies.json
+++ b/packages/runtime/fixtures/configs/monorepo-with-dependencies.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v1.44.0/runtime",
+  "entrypoint": "main",
+  "hotReload": true,
+  "autoload": {
+    "path": "../monorepo-with-dependencies"
+  }
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-1/package.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-1/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "service-1"
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-1/schema.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-1/schema.json
@@ -1,0 +1,204 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "8.3.1",
+    "title": "@fastify/swagger"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/posts": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-2/package.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-2/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "service-2"
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-2/schema.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/main/clients/service-2/schema.json
@@ -1,0 +1,204 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "8.3.1",
+    "title": "@fastify/swagger"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/posts": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/main/external-service.schema.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/main/external-service.schema.json
@@ -1,0 +1,204 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "8.3.1",
+    "title": "@fastify/swagger"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/posts": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/main/platformatic.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/main/platformatic.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v1.44.0/composer",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    },
+    "pluginTimeout": 0
+  },
+  "composer": {
+    "services": [
+      {
+        "id": "service-1",
+        "openapi": {
+          "url": "/documentation/json",
+          "prefix": "/service-1"
+        }
+      },
+      {
+        "id": "external-service-1",
+        "origin": "http://external-dependency-1",
+        "openapi": {
+          "file": "./external-service.schema.json",
+          "prefix": "/external-service-1"
+        }
+      }
+    ]
+  },
+  "clients": [
+    {
+      "schema": "./clients/service-1/schema.json",
+      "serviceId": "service-1",
+      "name": "service1",
+      "type": "openapi",
+      "url": "{PLT_SERVICE1_URL}"
+    },
+    {
+      "path": "./clients/service-2",
+      "name": "service2",
+      "type": "openapi",
+      "url": "{PLT_SERVICE2_URL}"
+    }
+  ],
+  "watch": false
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/service-1/clients/service-2/package.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/service-1/clients/service-2/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "service-2"
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/service-1/clients/service-2/schema.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/service-1/clients/service-2/schema.json
@@ -1,0 +1,204 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "8.3.1",
+    "title": "@fastify/swagger"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/posts": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/service-1/external-service.schema.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/service-1/external-service.schema.json
@@ -1,0 +1,204 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "8.3.1",
+    "title": "@fastify/swagger"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/posts": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/service-1/platformatic.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/service-1/platformatic.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v1.44.0/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    },
+    "pluginTimeout": 0
+  },
+  "service": {
+    "openapi": true
+  },
+  "clients": [
+    {
+      "schema": "./clients/service-2/schema.json",
+      "name": "service2",
+      "type": "openapi",
+      "serviceId": "service-2"
+    },
+    {
+      "schema": "./external-service.schema.json",
+      "name": "external-service-1",
+      "type": "openapi",
+      "url": "http://external-dependency-1"
+    }
+  ],
+  "watch": false
+}

--- a/packages/runtime/fixtures/monorepo-with-dependencies/service-2/platformatic.json
+++ b/packages/runtime/fixtures/monorepo-with-dependencies/service-2/platformatic.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v1.44.0/service",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    },
+    "pluginTimeout": 0
+  },
+  "service": {
+    "openapi": true
+  },
+  "watch": false
+}

--- a/packages/runtime/test/dependencies.test.js
+++ b/packages/runtime/test/dependencies.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const assert = require('node:assert')
+const { join } = require('node:path')
+const { test } = require('node:test')
+const { loadConfig } = require('@platformatic/config')
+const { platformaticRuntime } = require('..')
+
+const fixturesDir = join(__dirname, '..', 'fixtures')
+
+test('parses composer and client dependencies', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo-with-dependencies.json')
+  const loaded = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const services = loaded.configManager.current.services
+
+  const mainService = services.find((service) => service.id === 'main')
+  assert.deepStrictEqual(mainService.dependencies, [
+    { id: 'service-1', url: 'http://service-1.plt.local', local: true },
+    {
+      id: 'external-service-1',
+      url: 'http://external-dependency-1',
+      local: false
+    },
+    { id: 'service-1', url: 'http://service-1.plt.local', local: true },
+    { id: 'service-2', url: 'http://service-2.plt.local', local: true }
+  ])
+  assert.deepStrictEqual(
+    Object.fromEntries(mainService.localServiceEnvVars.entries()),
+    {
+      PLT_SERVICE1_URL: 'http://service-1.plt.local',
+      PLT_SERVICE2_URL: 'http://service-2.plt.local'
+    }
+  )
+
+  const service1 = services.find((service) => service.id === 'service-1')
+  assert.deepStrictEqual(service1.dependencies, [
+    { id: 'service-2', url: 'http://service-2.plt.local', local: true },
+    { id: undefined, url: 'http://external-dependency-1', local: false }
+  ])
+  assert.strictEqual(service1.localServiceEnvVars.size, 0)
+
+  const service2 = services.find((service) => service.id === 'service-2')
+  assert.deepStrictEqual(service2.dependencies, [])
+  assert.strictEqual(service2.localServiceEnvVars.size, 0)
+})


### PR DESCRIPTION
@mcollina Can I drop the `dependents` property? It's bacisally the reversed `depencendies` that we never use. Just to not spend time on mainaning it. 