### PR TITLE
fix: typo on db error lib

### DIFF
--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -26,7 +26,7 @@ export function buildServer (opts: object, app?: object, ConfigManagerContructor
 export module errors {
 
   export const MigrateMissingMigrationsError: () => FastifyError
-  export const UknonwnDatabaseError: () => FastifyError
+  export const UnknownDatabaseError: () => FastifyError
   export const MigrateMissingMigrationsDirError: (dir: string) => FastifyError
   export const MissingSeedFileError: () => FastifyError
   export const MigrationsToApplyError: () => FastifyError

--- a/packages/db/index.test-d.ts
+++ b/packages/db/index.test-d.ts
@@ -37,7 +37,7 @@ type ErrorWithNoParams = () => FastifyError
 type ErrorWithOneParam = (param: string) => FastifyError
 
 expectType<ErrorWithNoParams>(errors.MigrateMissingMigrationsError)
-expectType<ErrorWithNoParams>(errors.UknonwnDatabaseError)
+expectType<ErrorWithNoParams>(errors.UnknownDatabaseError)
 expectType<ErrorWithOneParam>(errors.MigrateMissingMigrationsDirError)
 expectType<ErrorWithNoParams>(errors.MissingSeedFileError)
 expectType<ErrorWithNoParams>(errors.MigrationsToApplyError)

--- a/packages/db/lib/errors.js
+++ b/packages/db/lib/errors.js
@@ -6,7 +6,7 @@ const ERROR_PREFIX = 'PLT_DB'
 
 module.exports = {
   MigrateMissingMigrationsError: createError(`${ERROR_PREFIX}_MIGRATE_ERROR`, 'Missing "migrations" section in config file'),
-  UknonwnDatabaseError: createError(`${ERROR_PREFIX}_UNKNOWN_DATABASE_ERROR`, 'Unknown database'),
+  UnknownDatabaseError: createError(`${ERROR_PREFIX}_UNKNOWN_DATABASE_ERROR`, 'Unknown database'),
   MigrateMissingMigrationsDirError: createError(`${ERROR_PREFIX}_MIGRATE_ERROR`, 'Migrations directory %s does not exist'),
   MissingSeedFileError: createError(`${ERROR_PREFIX}_MISSING_SEED_FILE_ERROR`, 'Missing seed file'),
   MigrationsToApplyError: createError(`${ERROR_PREFIX}_MIGRATIONS_TO_APPLY_ERROR`, 'You have migrations to apply. Please run `platformatic db migrations apply` first.')


### PR DESCRIPTION
fix typo within the library that handles errors in the DB package.