### PR TITLE
Support array query parameters in frontend client requests

### DIFF
--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -156,9 +156,16 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
         writer.write('queryParameters.forEach((qp) => ').inlineBlock(() => {
           writer.write('if (request[qp]) ').inlineBlock(() => {
             writer.write('if (Array.isArray(request[qp])) ').inlineBlock(() => {
-              writer.write('request[qp].forEach((p) => ').inlineBlock(() => {
-                writer.write('searchParams.append(qp, p)')
-              })
+              if (language === 'ts') {
+                writer.write('(request[qp] as string[]).forEach((p) => ').inlineBlock(() => {
+                  writer.write('searchParams.append(qp, p)')
+                })
+              } else {
+                writer.write('request[qp].forEach((p) => ').inlineBlock(() => {
+                  writer.write('searchParams.append(qp, p)')
+                })
+              }
+
               writer.write(')')
             })
             writer.write(' else ').inlineBlock(() => {

--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -90,12 +90,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
   function getQueryParamsString (operationParams) {
     return operationParams
       .filter((p) => p.in === 'query')
-      .map((p) => {
-        if (p.type === 'array') {
-          return `${p.name}[]`
-        }
-        return p.name
-      })
+      .map((p) => p.name)
   }
 
   function getHeaderParams (operationParams) {
@@ -162,7 +157,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
           writer.write('if (request[qp]) ').inlineBlock(() => {
             writer.write('if (Array.isArray(request[qp])) ').inlineBlock(() => {
               writer.write('request[qp].forEach((p) => ').inlineBlock(() => {
-                writer.write('searchParams.append(qp + \'[]\', qp[p].toString() || \'\')')
+                writer.write('searchParams.append(qp, p)')
               })
               writer.write(')')
             })

--- a/packages/client-cli/test/fixtures/array-query-parameters-openapi.json
+++ b/packages/client-cli/test/fixtures/array-query-parameters-openapi.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/movies": {
+      "get": {
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "getMovies",
+        "responses": {
+          "200": {
+            "description": "Default 302 Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Foo bar response",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/fixtures/array-query-params/.gitignore
+++ b/packages/client-cli/test/fixtures/array-query-params/.gitignore
@@ -1,0 +1,21 @@
+dist 
+.DS_Store
+
+# dotenv environment variable files
+.env
+
+# database files
+*.sqlite
+*.sqlite3
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Dependency directories
+node_modules/

--- a/packages/client-cli/test/fixtures/array-query-params/openapi.json
+++ b/packages/client-cli/test/fixtures/array-query-params/openapi.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/query-params-array": {
+      "get": {
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "getQueryParamsArray",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": { "type": "string" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ids": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/fixtures/array-query-params/platformatic.db.json
+++ b/packages/client-cli/test/fixtures/array-query-params/platformatic.db.json
@@ -1,0 +1,17 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "db": {
+    "connectionString": "sqlite://./db.sqlite",
+    "graphql": true,
+    "openapi": true
+  },
+  "plugins": {
+    "paths": ["./plugin.cjs"]
+  }
+}

--- a/packages/client-cli/test/fixtures/array-query-params/plugin.cjs
+++ b/packages/client-cli/test/fixtures/array-query-params/plugin.cjs
@@ -1,0 +1,12 @@
+'use strict'
+
+/** @param {import('fastify').FastifyInstance} app */
+module.exports = async function (app) {
+  app.get('/query-params-array', async (req, res) => {
+    const { ids } = req.query
+    return {
+      message: 'ok',
+      data: ids
+    }
+  })
+}

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -297,7 +297,7 @@ const _postRoot = async (url: string, request: Types.PostRootRequest): Promise<T
   queryParameters.forEach((qp) => {
     if (request[qp]) {
       if (Array.isArray(request[qp])) {
-        request[qp].forEach((p) => {
+        (request[qp] as string[]).forEach((p) => {
           searchParams.append(qp, p)
         })
       } else {
@@ -537,14 +537,13 @@ test('serialize correctly array query parameters', async (t) => {
     await execa('node', [join(__dirname, '..', 'cli.mjs'), openAPIfile, '--name', 'movies', '--language', 'ts', '--frontend'])
     const implementationFile = join(dir, 'movies', 'movies.ts')
     const implementation = await readFile(implementationFile, 'utf-8')
-    console.log(implementation)
     const expected = `
   const queryParameters: (keyof Types.GetMoviesRequest)[]  = ['ids']
   const searchParams = new URLSearchParams()
   queryParameters.forEach((qp) => {
     if (request[qp]) {
       if (Array.isArray(request[qp])) {
-        request[qp].forEach((p) => {
+        (request[qp] as string[]).forEach((p) => {
           searchParams.append(qp, p)
         })
       } else {
@@ -588,6 +587,5 @@ console.log(await client.getQueryParamsArray({ ids: ['foo', 'bar']}))
   const output = await execa('node', [join(dir, 'foobar', 'test.mjs')])
   /* eslint-disable no-control-regex */
   const lines = output.stdout.replace(/\u001b\[.*?m/g, '').split('\n') // remove ANSI colors, if any
-  console.log(lines)
   equal(lines[0], '{ message: \'ok\', data: [ \'foo\', \'bar\' ] }')
 })


### PR DESCRIPTION
When an OpenAPI spec defines a query parameter as `array` the previous generated code as follows

```js
queryParameters.forEach((qp) => {
    if (request[qp]) {
      if (Array.isArray(request[qp])) {
        request[qp].forEach((p) => {
          searchParams.append(`${qp}[]`, qp[p].toString() || '')  
        })
      } else {
        searchParams.append(qp, request[qp]?.toString() || '')
      }
      
      delete request[qp]
    }
  })
```
would send a parameter like `ids=foo,bar,foobar` which would not be serialized back as an array

The new generated code show as follows

```js
queryParameters.forEach((qp) => {
    if (request[qp]) {
      if (Array.isArray(request[qp])) {
        request[qp].forEach((p) => {
          searchParams.append(qp + '[]', qp[p].toString() || '')
        })
      } else {
        searchParams.append(qp, request[qp]?.toString() || '')
      }
    }
    delete request[qp]
  })
```

So basically we are running
```
searchParams.append('ids[]', 'foo')
searchParams.append('ids[]', 'bar')
searchParams.append('ids[]', 'foobar')
```

which is natively supported on when de-serializing