### PR TITLE
Set `url.scheme` telemetry attribute in HTTP client calls

### DIFF
--- a/packages/telemetry/lib/telemetry.js
+++ b/packages/telemetry/lib/telemetry.js
@@ -97,15 +97,15 @@ const setupProvider = (app, opts) => {
   const exporterObjs = []
   const spanProcessors = []
   for (const exporter of exporters) {
-  // Exporter config:
-  // https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_exporter_zipkin.ExporterConfig.html
+    // Exporter config:
+    // https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_exporter_zipkin.ExporterConfig.html
     const exporterOptions = { ...exporter.options, serviceName }
 
     let exporterObj
     if (exporter.type === 'console') {
       exporterObj = new ConsoleSpanExporter(exporterOptions)
     } else if (exporter.type === 'otlp') {
-    // We require here because this require (and only the require!) creates some issue with c8 on some mjs tests on other modules. Since we need an assignemet here, we don't use a switch.
+      // We require here because this require (and only the require!) creates some issue with c8 on some mjs tests on other modules. Since we need an assignemet here, we don't use a switch.
       const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto')
       exporterObj = new OTLPTraceExporter(exporterOptions)
     } else if (exporter.type === 'zipkin') {
@@ -229,7 +229,12 @@ async function setupTelemetry (app, opts) {
 
     /* istanbul ignore next */
     method = method || ''
-    const name = `${method} ${urlObj.scheme}://${urlObj.host}:${urlObj.port}${urlObj.path}`
+    let name
+    if (urlObj.port) {
+      name = `${method} ${urlObj.scheme}://${urlObj.host}:${urlObj.port}${urlObj.path}`
+    } else {
+      name = `${method} ${urlObj.scheme}://${urlObj.host}${urlObj.path}`
+    }
 
     const span = tracer.startSpan(name, {}, context)
     span.kind = SpanKind.CLIENT
@@ -241,7 +246,8 @@ async function setupTelemetry (app, opts) {
           'server.port': urlObj.port,
           'http.request.method': method,
           'url.full': url,
-          'url.path': urlObj.path
+          'url.path': urlObj.path,
+          'url.scheme': urlObj.scheme
         }
       : {}
     span.setAttributes(attributes)

--- a/packages/telemetry/test/client.test.js
+++ b/packages/telemetry/test/client.test.js
@@ -144,6 +144,7 @@ test('should trace a client request', async () => {
   equal(spanClient.attributes['server.port'], 3000)
   equal(spanClient.attributes['server.address'], 'localhost')
   equal(spanClient.attributes['url.path'], '/test')
+  equal(spanClient.attributes['url.scheme'], 'http')
 
   // The traceparent header is added to the request and propagated to the server
   equal(receivedHeaders.traceparent, telemetryHeaders.traceparent)
@@ -167,7 +168,7 @@ test('should trace a client request failing', async () => {
   const { propagator } = app.openTelemetry
   const context = propagator.extract(new PlatformaticContext(), { headers: {} }, fastifyTextMapGetter)
 
-  const url = 'http://localhost:3000/test'
+  const url = 'http://localhost/test'
   const { span, telemetryHeaders } = startSpanClient(url, 'GET', context)
   const args = {
     method: 'GET',
@@ -192,10 +193,10 @@ test('should trace a client request failing', async () => {
   equal(spanServer.attributes['http.response.status_code'], 404)
 
   const spanClient = finishedSpans[1]
-  equal(spanClient.name, 'GET http://localhost:3000/test')
+  equal(spanClient.name, 'GET http://localhost/test')
   equal(spanClient.kind, SpanKind.CLIENT)
   equal(spanClient.status.code, SpanStatusCode.ERROR)
-  equal(spanClient.attributes['url.full'], 'http://localhost:3000/test')
+  equal(spanClient.attributes['url.full'], 'http://localhost/test')
   equal(spanClient.attributes['http.response.status_code'], 404)
 })
 


### PR DESCRIPTION
Also fixes the span `name` when port is not defined. 