### PR TITLE
feat(client): Allow passing timeout options

### DIFF
--- a/docs/client/programmatic.md
+++ b/docs/client/programmatic.md
@@ -72,6 +72,25 @@ const res = await client.yourOperationName({ foo: 'bar' })
 console.log(res)
 ```
 
+## Optional properties
+You can also pass the following properties to `buildOpenAPIClient`:
+```ts
+import { buildOpenAPIClient } from '@platformatic/client'
+
+const client = await buildOpenAPIClient({
+  url: 'string', // the URL of the service to be called
+  path: 'string', // the path to the Open API schema
+  fullResponse: true, // require or not a full response object
+  fullRequest: true, // require or not a full request object
+  throwOnError: true, // if there is an error, the client will throw depending ton this option
+  headers: {}, // additional headers to be passed
+  bodyTimeout: 900000, // body timeout passed to the undici request method
+  headersTimeout: 900000, // headers timeout passed to the undici request method
+  validateResponse: true, // validate or not the response received against the expected schema
+  queryParser: (query) => `${query.toString()}[]` // override the default query parser logic
+})
+```
+
 ## TypeScript Support 
 
 If you use Typescript, you can take advantage of the generated types file:

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -30,6 +30,8 @@ interface PlatformaticClientOptions {
   fullRequest: boolean;
   throwOnError: boolean;
   headers?: Headers;
+  bodyTimeout?: number;
+  headersTimeout?: number;
   validateResponse?: boolean;
   queryParser?: (query: URLSearchParams) => string
 }

--- a/packages/client/index.test-d.ts
+++ b/packages/client/index.test-d.ts
@@ -73,6 +73,8 @@ const client = await buildOpenAPIClient<MyType>({
   throwOnError: false,
   validateResponse: false,
   headers: { foo: 'bar' },
+  bodyTimeout: 900000,
+  headersTimeout: 900000,
   getHeaders: async (options: GetHeadersOptions) => {
     const { url } = options;
     return { href: url.href };

--- a/packages/client/test/openapi.2.test.js
+++ b/packages/client/test/openapi.2.test.js
@@ -215,6 +215,22 @@ test('build basic client from file (path parameter)', async (t) => {
     assert.equal(result.id, 'baz')
     assert.equal(result.name, 'foo')
   }
+  {
+    // with timeout options
+    const client = await buildOpenAPIClient({
+      fullRequest: false,
+      url: `${app.url}`,
+      path: join(__dirname, 'fixtures', 'path-params', 'openapi.json'),
+      bodyTimeout: 900000,
+      headersTimeout: 900000
+    })
+    const result = await client.getPath({
+      id: 'fracchia',
+      name: 'fantozzi'
+    })
+    assert.equal(result.id, 'fracchia')
+    assert.equal(result.name, 'fantozzi')
+  }
 })
 
 test('validate response', async (t) => {


### PR DESCRIPTION
With this new feature, 2 new optional options can be passed down to `undici` (as by [doc](https://github.com/nodejs/undici/blob/040d9da4a81f278270d0f73243815f89e4ce1b65/docs/docs/api/Client.md?plain=1#L22))