### PR TITLE
feat: add telemetry id to the service http metrics

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -213,10 +213,15 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
     urlToCall.pathname = pathToCall
 
     const { span, telemetryHeaders } = openTelemetry?.startSpanClient(urlToCall.toString(), method, telemetryContext) || { span: null, telemetryHeaders: {} }
+    const telemetryId = openTelemetry?.tracer?.resource?._attributes?.['service.name']
 
     if (this[kGetHeaders]) {
       const options = { url: urlToCall, method, headers, telemetryHeaders, body }
       headers = { ...headers, ...(await this[kGetHeaders](options)) }
+    }
+
+    if (telemetryId) {
+      headers['x-telemetry-id'] = telemetryId
     }
 
     let res
@@ -321,15 +326,23 @@ function isArrayQueryParam ({ schema }) {
 // TODO: For some unknown reason c8 is not picking up the coverage for this function
 async function graphql (url, log, headers, query, variables, openTelemetry, telemetryContext) {
   const { span, telemetryHeaders } = openTelemetry?.startSpanClient(url.toString(), 'POST', telemetryContext) || { span: null, telemetryHeaders: {} }
+  const telemetryId = openTelemetry?.tracer?.resource?._attributes?.['service.name']
+
+  headers = {
+    ...headers,
+    ...telemetryHeaders,
+    'content-type': 'application/json; charset=utf-8'
+  }
+
+  if (telemetryId) {
+    headers['x-telemetry-id'] = telemetryId
+  }
+
   let res
   try {
     res = await request(url, {
       method: 'POST',
-      headers: {
-        ...headers,
-        ...telemetryHeaders,
-        'content-type': 'application/json; charset=utf-8'
-      },
+      headers,
       body: JSON.stringify({
         query,
         variables

--- a/packages/client/test/telemetry.test.js
+++ b/packages/client/test/telemetry.test.js
@@ -27,6 +27,14 @@ test('telemetry correctly propagates from a service client to a server for an Op
     await targetApp.close()
     await rm(tmpDir, { recursive: true })
   })
+
+  targetApp.addHook('onRequest', async (req) => {
+    if (req.url === '/movies/') {
+      const clientTelemetryId = req.headers['x-telemetry-id']
+      assert.strictEqual(clientTelemetryId, 'test-client')
+    }
+  })
+
   await targetApp.start()
   const targetAppUrl = targetApp.url
 
@@ -86,172 +94,172 @@ test('telemetry correctly propagates from a service client to a server for an Op
   assert.equal(serverTraceId, clientTraceId)
 })
 
-test('telemetry correctly propagates from a generic client through a service client and then to another service, propagating the traceId', async (t) => {
-  const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
-  const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
-  await cp(fixtureDirPath, tmpDir, { recursive: true })
+// test('telemetry correctly propagates from a generic client through a service client and then to another service, propagating the traceId', async (t) => {
+//   const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
+//   const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
+//   await cp(fixtureDirPath, tmpDir, { recursive: true })
 
-  try {
-    await unlink(join(fixtureDirPath, 'db.sqlite'))
-  } catch {
-    // noop
-  }
-  // Server app
-  const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
-  t.after(async () => {
-    await targetApp.close()
-    await rm(tmpDir, { recursive: true })
-  })
-  await targetApp.start()
-  const targetAppUrl = targetApp.url
+//   try {
+//     await unlink(join(fixtureDirPath, 'db.sqlite'))
+//   } catch {
+//     // noop
+//   }
+//   // Server app
+//   const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
+//   t.after(async () => {
+//     await targetApp.close()
+//     await rm(tmpDir, { recursive: true })
+//   })
+//   await targetApp.start()
+//   const targetAppUrl = targetApp.url
 
-  // Client app
-  const app = Fastify()
-  app.register(telemetry, {
-    serviceName: 'test-client',
-    exporter: {
-      type: 'memory'
-    }
-  })
+//   // Client app
+//   const app = Fastify()
+//   app.register(telemetry, {
+//     serviceName: 'test-client',
+//     exporter: {
+//       type: 'memory'
+//     }
+//   })
 
-  await app.register(client, {
-    type: 'openapi',
-    url: `${targetApp.url}/documentation/json`,
-    name: 'movies'
-  })
+//   await app.register(client, {
+//     type: 'openapi',
+//     url: `${targetApp.url}/documentation/json`,
+//     name: 'movies'
+//   })
 
-  app.post('/', async (req) => {
-    const movie = await req.movies.createMovie({
-      title: 'The Matrix'
-    })
-    return movie
-  })
+//   app.post('/', async (req) => {
+//     const movie = await req.movies.createMovie({
+//       title: 'The Matrix'
+//     })
+//     return movie
+//   })
 
-  // This is the traceId we want to propagate
-  const traceId = '5e994e8fb53b27c91dcd2fec22771d15'
-  const spanId = '166f3ab30f21800b'
-  const traceparent = `00-${traceId}-${spanId}-01`
-  await app.inject({
-    method: 'POST',
-    url: '/',
-    headers: {
-      traceparent
-    }
-  })
+//   // This is the traceId we want to propagate
+//   const traceId = '5e994e8fb53b27c91dcd2fec22771d15'
+//   const spanId = '166f3ab30f21800b'
+//   const traceparent = `00-${traceId}-${spanId}-01`
+//   await app.inject({
+//     method: 'POST',
+//     url: '/',
+//     headers: {
+//       traceparent
+//     }
+//   })
 
-  const { exporters } = app.openTelemetry
-  const finishedSpans = exporters[0].getFinishedSpans()
+//   const { exporters } = app.openTelemetry
+//   const finishedSpans = exporters[0].getFinishedSpans()
 
-  // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
-  assert.equal(finishedSpans.length, 2)
-  const clientSpan = finishedSpans[0]
-  const postSpan = finishedSpans[1]
-  // The parent of the client span is the post span
-  // and both have the same traceId
-  assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
-  assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
-  assert.equal(clientSpan.name, `POST ${targetAppUrl}/movies/`)
-  assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/movies/`)
-  assert.equal(clientSpan.attributes['http.response.status_code'], 200)
-  const clientTraceId = clientSpan.spanContext().traceId
-  const clientSpanId = clientSpan.spanContext().spanId
-  assert.equal(clientTraceId, traceId)
+//   // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
+//   assert.equal(finishedSpans.length, 2)
+//   const clientSpan = finishedSpans[0]
+//   const postSpan = finishedSpans[1]
+//   // The parent of the client span is the post span
+//   // and both have the same traceId
+//   assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
+//   assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
+//   assert.equal(clientSpan.name, `POST ${targetAppUrl}/movies/`)
+//   assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/movies/`)
+//   assert.equal(clientSpan.attributes['http.response.status_code'], 200)
+//   const clientTraceId = clientSpan.spanContext().traceId
+//   const clientSpanId = clientSpan.spanContext().spanId
+//   assert.equal(clientTraceId, traceId)
 
-  // Target app
-  assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
-  // The first span is the client call to `/documentation/json`, the second is the server call to `/movies/
-  const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
-  assert.equal(serverSpan.name, 'POST /movies/')
-  const serverTraceId = serverSpan.spanContext().traceId
-  const serverParentSpanId = serverSpan.parentSpanId
-  // The propagation works. Note that the `parentSpan` is changed, but the traceId is the same
-  assert.equal(serverParentSpanId, clientSpanId)
-  assert.equal(serverTraceId, traceId)
-})
+//   // Target app
+//   assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
+//   // The first span is the client call to `/documentation/json`, the second is the server call to `/movies/
+//   const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
+//   assert.equal(serverSpan.name, 'POST /movies/')
+//   const serverTraceId = serverSpan.spanContext().traceId
+//   const serverParentSpanId = serverSpan.parentSpanId
+//   // The propagation works. Note that the `parentSpan` is changed, but the traceId is the same
+//   assert.equal(serverParentSpanId, clientSpanId)
+//   assert.equal(serverTraceId, traceId)
+// })
 
-test('telemetry correctly propagates from a service client to a server for a GraphQL endpoint', async (t) => {
-  const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
-  const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
-  await cp(fixtureDirPath, tmpDir, { recursive: true })
+// test('telemetry correctly propagates from a service client to a server for a GraphQL endpoint', async (t) => {
+//   const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
+//   const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
+//   await cp(fixtureDirPath, tmpDir, { recursive: true })
 
-  try {
-    await unlink(join(fixtureDirPath, 'db.sqlite'))
-  } catch {
-    // noop
-  }
-  // Server app
-  const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
-  t.after(async () => {
-    await targetApp.close()
-    await rm(tmpDir, { recursive: true })
-  })
-  await targetApp.start()
-  const targetAppUrl = targetApp.url
+//   try {
+//     await unlink(join(fixtureDirPath, 'db.sqlite'))
+//   } catch {
+//     // noop
+//   }
+//   // Server app
+//   const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
+//   t.after(async () => {
+//     await targetApp.close()
+//     await rm(tmpDir, { recursive: true })
+//   })
+//   await targetApp.start()
+//   const targetAppUrl = targetApp.url
 
-  // Client app
-  const app = Fastify()
-  app.register(telemetry, {
-    serviceName: 'test-client',
-    exporter: {
-      type: 'memory'
-    }
-  })
+//   // Client app
+//   const app = Fastify()
+//   app.register(telemetry, {
+//     serviceName: 'test-client',
+//     exporter: {
+//       type: 'memory'
+//     }
+//   })
 
-  await app.register(client, {
-    type: 'graphql',
-    url: `${targetApp.url}/graphql`
-  })
+//   await app.register(client, {
+//     type: 'graphql',
+//     url: `${targetApp.url}/graphql`
+//   })
 
-  app.post('/', async (req) => {
-    const movie = await req.client.graphql({
-      query: `
-        mutation createMovie($title: String!) {
-          saveMovie(input: {title: $title}) {
-            id
-            title
-          }
-        }
-      `,
-      variables: {
-        title: 'The Matrix'
-      }
-    })
-    return movie
-  })
+//   app.post('/', async (req) => {
+//     const movie = await req.client.graphql({
+//       query: `
+//         mutation createMovie($title: String!) {
+//           saveMovie(input: {title: $title}) {
+//             id
+//             title
+//           }
+//         }
+//       `,
+//       variables: {
+//         title: 'The Matrix'
+//       }
+//     })
+//     return movie
+//   })
 
-  await app.inject({
-    method: 'POST',
-    url: '/'
-  })
+//   await app.inject({
+//     method: 'POST',
+//     url: '/'
+//   })
 
-  const { exporters } = app.openTelemetry
-  const finishedSpans = exporters[0].getFinishedSpans()
-  // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
-  assert.equal(finishedSpans.length, 2)
-  const clientSpan = finishedSpans[0]
-  const postSpan = finishedSpans[1]
-  // The parent of the client span is the post span
-  // and both have the same traceId
-  assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
-  assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
-  assert.equal(clientSpan.name, `POST ${targetAppUrl}/graphql`)
-  assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/graphql`)
-  assert.equal(clientSpan.attributes['http.response.status_code'], 200)
-  const clientTraceId = clientSpan.spanContext().traceId
-  const clientSpanId = clientSpan.spanContext().spanId
+//   const { exporters } = app.openTelemetry
+//   const finishedSpans = exporters[0].getFinishedSpans()
+//   // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
+//   assert.equal(finishedSpans.length, 2)
+//   const clientSpan = finishedSpans[0]
+//   const postSpan = finishedSpans[1]
+//   // The parent of the client span is the post span
+//   // and both have the same traceId
+//   assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
+//   assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
+//   assert.equal(clientSpan.name, `POST ${targetAppUrl}/graphql`)
+//   assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/graphql`)
+//   assert.equal(clientSpan.attributes['http.response.status_code'], 200)
+//   const clientTraceId = clientSpan.spanContext().traceId
+//   const clientSpanId = clientSpan.spanContext().spanId
 
-  // Target app, we check that propagation works
-  assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
-  const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
-  assert.equal(serverSpan.name, 'POST /graphql')
-  const serverTraceId = serverSpan.spanContext().traceId
-  const serverParentSpanId = serverSpan.parentSpanId
-  // The propagation works
-  assert.equal(serverParentSpanId, clientSpanId)
-  assert.equal(serverTraceId, clientTraceId)
+//   // Target app, we check that propagation works
+//   assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
+//   const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
+//   assert.equal(serverSpan.name, 'POST /graphql')
+//   const serverTraceId = serverSpan.spanContext().traceId
+//   const serverParentSpanId = serverSpan.parentSpanId
+//   // The propagation works
+//   assert.equal(serverParentSpanId, clientSpanId)
+//   assert.equal(serverTraceId, clientTraceId)
 
-  const graphqlSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[0]
-  assert.equal(graphqlSpan.name, 'mutation saveMovie')
-  assert.equal(graphqlSpan.spanContext().traceId, clientTraceId)
-  assert.equal(graphqlSpan.parentSpanId, serverSpan.spanContext().spanId)
-})
+//   const graphqlSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[0]
+//   assert.equal(graphqlSpan.name, 'mutation saveMovie')
+//   assert.equal(graphqlSpan.spanContext().traceId, clientTraceId)
+//   assert.equal(graphqlSpan.parentSpanId, serverSpan.spanContext().spanId)
+// })

--- a/packages/client/test/telemetry.test.js
+++ b/packages/client/test/telemetry.test.js
@@ -94,172 +94,172 @@ test('telemetry correctly propagates from a service client to a server for an Op
   assert.equal(serverTraceId, clientTraceId)
 })
 
-// test('telemetry correctly propagates from a generic client through a service client and then to another service, propagating the traceId', async (t) => {
-//   const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
-//   const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
-//   await cp(fixtureDirPath, tmpDir, { recursive: true })
+test('telemetry correctly propagates from a generic client through a service client and then to another service, propagating the traceId', async (t) => {
+  const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
+  const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
+  await cp(fixtureDirPath, tmpDir, { recursive: true })
 
-//   try {
-//     await unlink(join(fixtureDirPath, 'db.sqlite'))
-//   } catch {
-//     // noop
-//   }
-//   // Server app
-//   const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
-//   t.after(async () => {
-//     await targetApp.close()
-//     await rm(tmpDir, { recursive: true })
-//   })
-//   await targetApp.start()
-//   const targetAppUrl = targetApp.url
+  try {
+    await unlink(join(fixtureDirPath, 'db.sqlite'))
+  } catch {
+    // noop
+  }
+  // Server app
+  const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
+  t.after(async () => {
+    await targetApp.close()
+    await rm(tmpDir, { recursive: true })
+  })
+  await targetApp.start()
+  const targetAppUrl = targetApp.url
 
-//   // Client app
-//   const app = Fastify()
-//   app.register(telemetry, {
-//     serviceName: 'test-client',
-//     exporter: {
-//       type: 'memory'
-//     }
-//   })
+  // Client app
+  const app = Fastify()
+  app.register(telemetry, {
+    serviceName: 'test-client',
+    exporter: {
+      type: 'memory'
+    }
+  })
 
-//   await app.register(client, {
-//     type: 'openapi',
-//     url: `${targetApp.url}/documentation/json`,
-//     name: 'movies'
-//   })
+  await app.register(client, {
+    type: 'openapi',
+    url: `${targetApp.url}/documentation/json`,
+    name: 'movies'
+  })
 
-//   app.post('/', async (req) => {
-//     const movie = await req.movies.createMovie({
-//       title: 'The Matrix'
-//     })
-//     return movie
-//   })
+  app.post('/', async (req) => {
+    const movie = await req.movies.createMovie({
+      title: 'The Matrix'
+    })
+    return movie
+  })
 
-//   // This is the traceId we want to propagate
-//   const traceId = '5e994e8fb53b27c91dcd2fec22771d15'
-//   const spanId = '166f3ab30f21800b'
-//   const traceparent = `00-${traceId}-${spanId}-01`
-//   await app.inject({
-//     method: 'POST',
-//     url: '/',
-//     headers: {
-//       traceparent
-//     }
-//   })
+  // This is the traceId we want to propagate
+  const traceId = '5e994e8fb53b27c91dcd2fec22771d15'
+  const spanId = '166f3ab30f21800b'
+  const traceparent = `00-${traceId}-${spanId}-01`
+  await app.inject({
+    method: 'POST',
+    url: '/',
+    headers: {
+      traceparent
+    }
+  })
 
-//   const { exporters } = app.openTelemetry
-//   const finishedSpans = exporters[0].getFinishedSpans()
+  const { exporters } = app.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
 
-//   // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
-//   assert.equal(finishedSpans.length, 2)
-//   const clientSpan = finishedSpans[0]
-//   const postSpan = finishedSpans[1]
-//   // The parent of the client span is the post span
-//   // and both have the same traceId
-//   assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
-//   assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
-//   assert.equal(clientSpan.name, `POST ${targetAppUrl}/movies/`)
-//   assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/movies/`)
-//   assert.equal(clientSpan.attributes['http.response.status_code'], 200)
-//   const clientTraceId = clientSpan.spanContext().traceId
-//   const clientSpanId = clientSpan.spanContext().spanId
-//   assert.equal(clientTraceId, traceId)
+  // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
+  assert.equal(finishedSpans.length, 2)
+  const clientSpan = finishedSpans[0]
+  const postSpan = finishedSpans[1]
+  // The parent of the client span is the post span
+  // and both have the same traceId
+  assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
+  assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
+  assert.equal(clientSpan.name, `POST ${targetAppUrl}/movies/`)
+  assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/movies/`)
+  assert.equal(clientSpan.attributes['http.response.status_code'], 200)
+  const clientTraceId = clientSpan.spanContext().traceId
+  const clientSpanId = clientSpan.spanContext().spanId
+  assert.equal(clientTraceId, traceId)
 
-//   // Target app
-//   assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
-//   // The first span is the client call to `/documentation/json`, the second is the server call to `/movies/
-//   const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
-//   assert.equal(serverSpan.name, 'POST /movies/')
-//   const serverTraceId = serverSpan.spanContext().traceId
-//   const serverParentSpanId = serverSpan.parentSpanId
-//   // The propagation works. Note that the `parentSpan` is changed, but the traceId is the same
-//   assert.equal(serverParentSpanId, clientSpanId)
-//   assert.equal(serverTraceId, traceId)
-// })
+  // Target app
+  assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
+  // The first span is the client call to `/documentation/json`, the second is the server call to `/movies/
+  const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
+  assert.equal(serverSpan.name, 'POST /movies/')
+  const serverTraceId = serverSpan.spanContext().traceId
+  const serverParentSpanId = serverSpan.parentSpanId
+  // The propagation works. Note that the `parentSpan` is changed, but the traceId is the same
+  assert.equal(serverParentSpanId, clientSpanId)
+  assert.equal(serverTraceId, traceId)
+})
 
-// test('telemetry correctly propagates from a service client to a server for a GraphQL endpoint', async (t) => {
-//   const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
-//   const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
-//   await cp(fixtureDirPath, tmpDir, { recursive: true })
+test('telemetry correctly propagates from a service client to a server for a GraphQL endpoint', async (t) => {
+  const fixtureDirPath = join(__dirname, 'fixtures', 'telemetry')
+  const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-client-'))
+  await cp(fixtureDirPath, tmpDir, { recursive: true })
 
-//   try {
-//     await unlink(join(fixtureDirPath, 'db.sqlite'))
-//   } catch {
-//     // noop
-//   }
-//   // Server app
-//   const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
-//   t.after(async () => {
-//     await targetApp.close()
-//     await rm(tmpDir, { recursive: true })
-//   })
-//   await targetApp.start()
-//   const targetAppUrl = targetApp.url
+  try {
+    await unlink(join(fixtureDirPath, 'db.sqlite'))
+  } catch {
+    // noop
+  }
+  // Server app
+  const targetApp = await buildServer(join(tmpDir, 'platformatic.db.json'))
+  t.after(async () => {
+    await targetApp.close()
+    await rm(tmpDir, { recursive: true })
+  })
+  await targetApp.start()
+  const targetAppUrl = targetApp.url
 
-//   // Client app
-//   const app = Fastify()
-//   app.register(telemetry, {
-//     serviceName: 'test-client',
-//     exporter: {
-//       type: 'memory'
-//     }
-//   })
+  // Client app
+  const app = Fastify()
+  app.register(telemetry, {
+    serviceName: 'test-client',
+    exporter: {
+      type: 'memory'
+    }
+  })
 
-//   await app.register(client, {
-//     type: 'graphql',
-//     url: `${targetApp.url}/graphql`
-//   })
+  await app.register(client, {
+    type: 'graphql',
+    url: `${targetApp.url}/graphql`
+  })
 
-//   app.post('/', async (req) => {
-//     const movie = await req.client.graphql({
-//       query: `
-//         mutation createMovie($title: String!) {
-//           saveMovie(input: {title: $title}) {
-//             id
-//             title
-//           }
-//         }
-//       `,
-//       variables: {
-//         title: 'The Matrix'
-//       }
-//     })
-//     return movie
-//   })
+  app.post('/', async (req) => {
+    const movie = await req.client.graphql({
+      query: `
+        mutation createMovie($title: String!) {
+          saveMovie(input: {title: $title}) {
+            id
+            title
+          }
+        }
+      `,
+      variables: {
+        title: 'The Matrix'
+      }
+    })
+    return movie
+  })
 
-//   await app.inject({
-//     method: 'POST',
-//     url: '/'
-//   })
+  await app.inject({
+    method: 'POST',
+    url: '/'
+  })
 
-//   const { exporters } = app.openTelemetry
-//   const finishedSpans = exporters[0].getFinishedSpans()
-//   // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
-//   assert.equal(finishedSpans.length, 2)
-//   const clientSpan = finishedSpans[0]
-//   const postSpan = finishedSpans[1]
-//   // The parent of the client span is the post span
-//   // and both have the same traceId
-//   assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
-//   assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
-//   assert.equal(clientSpan.name, `POST ${targetAppUrl}/graphql`)
-//   assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/graphql`)
-//   assert.equal(clientSpan.attributes['http.response.status_code'], 200)
-//   const clientTraceId = clientSpan.spanContext().traceId
-//   const clientSpanId = clientSpan.spanContext().spanId
+  const { exporters } = app.openTelemetry
+  const finishedSpans = exporters[0].getFinishedSpans()
+  // The first span is the client span, the second (because ended after the first) is the span for the POST that triggers the client
+  assert.equal(finishedSpans.length, 2)
+  const clientSpan = finishedSpans[0]
+  const postSpan = finishedSpans[1]
+  // The parent of the client span is the post span
+  // and both have the same traceId
+  assert.equal(clientSpan.parentSpanId, postSpan.spanContext().spanId)
+  assert.equal(clientSpan.spanContext().traceId, postSpan.spanContext().traceId)
+  assert.equal(clientSpan.name, `POST ${targetAppUrl}/graphql`)
+  assert.equal(clientSpan.attributes['url.full'], `${targetAppUrl}/graphql`)
+  assert.equal(clientSpan.attributes['http.response.status_code'], 200)
+  const clientTraceId = clientSpan.spanContext().traceId
+  const clientSpanId = clientSpan.spanContext().spanId
 
-//   // Target app, we check that propagation works
-//   assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
-//   const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
-//   assert.equal(serverSpan.name, 'POST /graphql')
-//   const serverTraceId = serverSpan.spanContext().traceId
-//   const serverParentSpanId = serverSpan.parentSpanId
-//   // The propagation works
-//   assert.equal(serverParentSpanId, clientSpanId)
-//   assert.equal(serverTraceId, clientTraceId)
+  // Target app, we check that propagation works
+  assert.equal(targetApp.openTelemetry.exporters[0].getFinishedSpans().length, 2)
+  const serverSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[1]
+  assert.equal(serverSpan.name, 'POST /graphql')
+  const serverTraceId = serverSpan.spanContext().traceId
+  const serverParentSpanId = serverSpan.parentSpanId
+  // The propagation works
+  assert.equal(serverParentSpanId, clientSpanId)
+  assert.equal(serverTraceId, clientTraceId)
 
-//   const graphqlSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[0]
-//   assert.equal(graphqlSpan.name, 'mutation saveMovie')
-//   assert.equal(graphqlSpan.spanContext().traceId, clientTraceId)
-//   assert.equal(graphqlSpan.parentSpanId, serverSpan.spanContext().spanId)
-// })
+  const graphqlSpan = targetApp.openTelemetry.exporters[0].getFinishedSpans()[0]
+  assert.equal(graphqlSpan.name, 'mutation saveMovie')
+  assert.equal(graphqlSpan.spanContext().traceId, clientTraceId)
+  assert.equal(graphqlSpan.parentSpanId, serverSpan.spanContext().spanId)
+})

--- a/packages/composer/test/telemetry/proxy.test.js
+++ b/packages/composer/test/telemetry/proxy.test.js
@@ -11,6 +11,14 @@ const {
 
 test('should proxy openapi requests with telemetry span', async (t) => {
   const service1 = await createOpenApiService(t, ['users'])
+
+  service1.addHook('onRequest', async (req, reply) => {
+    if (req.url === '/users') {
+      const telemetryId = req.headers['x-telemetry-id']
+      assert.strictEqual(telemetryId, 'test-composer')
+    }
+  })
+
   const origin1 = await service1.listen({ host: '127.0.0.1', port: 0 })
 
   const config = {

--- a/packages/composer/test/telemetry/routes-composition-telemetry.test.js
+++ b/packages/composer/test/telemetry/routes-composition-telemetry.test.js
@@ -10,6 +10,14 @@ const {
 
 test('should compose openapi with prefixes', async (t) => {
   const api1 = await createOpenApiService(t, ['users'])
+
+  api1.addHook('onRequest', async (req, reply) => {
+    if (req.url === '/users') {
+      const telemetryId = req.headers['x-telemetry-id']
+      assert.strictEqual(telemetryId, 'test-composer')
+    }
+  })
+
   const api1Origin = await api1.listen({ host: '127.0.0.1', port: 0 })
 
   const composer = await createComposer(t, {

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -43,9 +43,9 @@ async function buildRuntime (configManager, env) {
   env = env || process.env
   const config = configManager.current
 
-  if (inspector.url()) {
-    throw new errors.NodeInspectorFlagsNotSupportedError()
-  }
+  // if (inspector.url()) {
+  //   throw new errors.NodeInspectorFlagsNotSupportedError()
+  // }
 
   if (configManager.args) {
     parseInspectorOptions(configManager)

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -43,9 +43,9 @@ async function buildRuntime (configManager, env) {
   env = env || process.env
   const config = configManager.current
 
-  // if (inspector.url()) {
-  //   throw new errors.NodeInspectorFlagsNotSupportedError()
-  // }
+  if (inspector.url()) {
+    throw new errors.NodeInspectorFlagsNotSupportedError()
+  }
 
   if (configManager.args) {
     parseInspectorOptions(configManager)

--- a/packages/service/lib/plugins/metrics.js
+++ b/packages/service/lib/plugins/metrics.js
@@ -33,6 +33,9 @@ const metricsPlugin = fp(async function (app, opts = {}) {
     },
     routeMetrics: {
       enabled: true,
+      customLabels: {
+        telemetry_id: (req) => req.headers['x-telemetry-id'] ?? 'unknown'
+      },
       overrides: {
         histogram: {
           name: prefix + 'http_request_duration_seconds',


### PR DESCRIPTION
This PR add a _client_ (sender) telemetry id as label to the server http metrics. In that way we can get the latency and requests amount between two different telemetry services. This is a draft, I would like to here what do you think first.

- [ ] add telemetry header to the plt client
- [ ] add tests