### PR TITLE
Remove the prefix from metrics and use labels 

### DIFF
--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -1015,9 +1015,6 @@
               ],
               "additionalProperties": false
             },
-            "prefix": {
-              "type": "string"
-            },
             "auth": {
               "type": "object",
               "properties": {

--- a/packages/control/test/config.test.mjs
+++ b/packages/control/test/config.test.mjs
@@ -30,7 +30,7 @@ test('should get runtime config by pid', async (t) => {
   assert.strictEqual(runtimeConfig.hotReload, false)
   assert.deepStrictEqual(runtimeConfig.autoload, {
     path: join(projectDir, 'services'),
-    exclude: [],
+    exclude: []
   })
   assert.deepStrictEqual(runtimeConfig.managementApi, true)
 })
@@ -55,7 +55,7 @@ test('should get runtime config by name', async (t) => {
   assert.strictEqual(runtimeConfig.hotReload, false)
   assert.deepStrictEqual(runtimeConfig.autoload, {
     path: join(projectDir, 'services'),
-    exclude: [],
+    exclude: []
   })
   assert.deepStrictEqual(runtimeConfig.managementApi, true)
 })
@@ -81,21 +81,23 @@ test('should get runtime service config', async (t) => {
       hostname: '127.0.0.1',
       port: 0,
       logger: {},
-      keepAliveTimeout: 5000,
+      keepAliveTimeout: 5000
     },
     service: { openapi: true },
     plugins: {
       paths: [
-        join(projectDir, 'services', 'service-1', 'plugin.js'),
-      ],
+        join(projectDir, 'services', 'service-1', 'plugin.js')
+      ]
     },
     watch: { enabled: false },
     metrics: {
       defaultMetrics: {
-        enabled: true,
+        enabled: true
       },
-      prefix: 'service_1_',
-      server: 'hide',
-    },
+      labels: {
+        serviceId: 'service-1'
+      },
+      server: 'hide'
+    }
   })
 })

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -170,12 +170,7 @@
             },
             "rounding": {
               "type": "string",
-              "enum": [
-                "floor",
-                "ceil",
-                "round",
-                "trunc"
-              ],
+              "enum": ["floor", "ceil", "round", "trunc"],
               "default": "trunc"
             },
             "debugMode": {
@@ -183,10 +178,7 @@
             },
             "mode": {
               "type": "string",
-              "enum": [
-                "debug",
-                "standalone"
-              ]
+              "enum": ["debug", "standalone"]
             },
             "largeArraySize": {
               "anyOf": [
@@ -201,10 +193,7 @@
             },
             "largeArrayMechanism": {
               "type": "string",
-              "enum": [
-                "default",
-                "json-stringify"
-              ],
+              "enum": ["default", "json-stringify"],
               "default": "default"
             }
           }
@@ -339,10 +328,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "key",
-            "cert"
-          ]
+          "required": ["key", "cert"]
         },
         "cors": {
           "type": "object",
@@ -370,9 +356,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "regexp"
-                        ]
+                        "required": ["regexp"]
                       }
                     ]
                   }
@@ -384,9 +368,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "regexp"
-                  ]
+                  "required": ["regexp"]
                 }
               ]
             },
@@ -667,10 +649,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "method",
-                      "path"
-                    ],
+                    "required": ["method", "path"],
                     "additionalProperties": false
                   }
                 },
@@ -748,9 +727,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "connectionString"
-      ]
+      "required": ["connectionString"]
     },
     "authorization": {
       "type": "object",
@@ -850,9 +827,7 @@
                     "$ref": "#/$defs/crud-operation-auth"
                   }
                 },
-                "required": [
-                  "role"
-                ],
+                "required": ["role"],
                 "additionalProperties": false
               },
               {
@@ -886,9 +861,7 @@
                     "$ref": "#/$defs/crud-operation-auth"
                   }
                 },
-                "required": [
-                  "role"
-                ],
+                "required": ["role"],
                 "additionalProperties": false
               }
             ]
@@ -935,9 +908,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "dir"
-      ]
+      "required": ["dir"]
     },
     "metrics": {
       "anyOf": [
@@ -965,11 +936,7 @@
             },
             "server": {
               "type": "string",
-              "enum": [
-                "own",
-                "parent",
-                "hide"
-              ]
+              "enum": ["own", "parent", "hide"]
             },
             "defaultMetrics": {
               "type": "object",
@@ -978,13 +945,8 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "enabled"
-              ],
+              "required": ["enabled"],
               "additionalProperties": false
-            },
-            "prefix": {
-              "type": "string"
             },
             "auth": {
               "type": "object",
@@ -997,10 +959,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "username",
-                "password"
-              ]
+              "required": ["username", "password"]
             },
             "labels": {
               "type": "object",
@@ -1048,9 +1007,7 @@
                     "additionalProperties": true
                   }
                 },
-                "required": [
-                  "name"
-                ]
+                "required": ["name"]
               }
             ]
           }
@@ -1162,14 +1119,10 @@
       "additionalProperties": false,
       "anyOf": [
         {
-          "required": [
-            "paths"
-          ]
+          "required": ["paths"]
         },
         {
-          "required": [
-            "packages"
-          ]
+          "required": ["packages"]
         }
       ]
     },
@@ -1220,12 +1173,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "console",
-                      "otlp",
-                      "zipkin",
-                      "memory"
-                    ],
+                    "enum": ["console", "otlp", "zipkin", "memory"],
                     "default": "console"
                   },
                   "options": {
@@ -1251,12 +1199,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "console",
-                    "otlp",
-                    "zipkin",
-                    "memory"
-                  ],
+                  "enum": ["console", "otlp", "zipkin", "memory"],
                   "default": "console"
                 },
                 "options": {
@@ -1279,9 +1222,7 @@
           ]
         }
       },
-      "required": [
-        "serviceName"
-      ],
+      "required": ["serviceName"],
       "additionalProperties": false
     },
     "clients": {
@@ -1297,10 +1238,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "openapi",
-              "graphql"
-            ]
+            "enum": ["openapi", "graphql"]
           },
           "path": {
             "type": "string",
@@ -1375,9 +1313,7 @@
     }
   },
   "additionalProperties": false,
-  "required": [
-    "db"
-  ],
+  "required": ["db"],
   "$defs": {
     "info": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#info-object",
@@ -1405,10 +1341,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "title",
-        "version"
-      ],
+      "required": ["title", "version"],
       "$ref": "#/$defs/specification-extensions"
     },
     "contact": {
@@ -1441,9 +1374,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "$ref": "#/$defs/specification-extensions"
     },
     "server": {
@@ -1463,9 +1394,7 @@
           }
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "$ref": "#/$defs/specification-extensions"
     },
     "server-variable": {
@@ -1486,9 +1415,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "default"
-      ],
+      "required": ["default"],
       "$ref": "#/$defs/specification-extensions"
     },
     "components": {
@@ -1617,9 +1544,7 @@
     "path-item-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1694,9 +1619,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "$ref": "#/$defs/specification-extensions"
     },
     "parameter": {
@@ -1707,12 +1630,7 @@
           "type": "string"
         },
         "in": {
-          "enum": [
-            "query",
-            "header",
-            "path",
-            "cookie"
-          ]
+          "enum": ["query", "header", "path", "cookie"]
         },
         "description": {
           "type": "string"
@@ -1728,20 +1646,13 @@
           "maxProperties": 1
         }
       },
-      "required": [
-        "name",
-        "in"
-      ],
+      "required": ["name", "in"],
       "oneOf": [
         {
-          "required": [
-            "schema"
-          ]
+          "required": ["schema"]
         },
         {
-          "required": [
-            "content"
-          ]
+          "required": ["content"]
         }
       ],
       "if": {
@@ -1751,9 +1662,7 @@
             "const": "query"
           }
         },
-        "required": [
-          "in"
-        ]
+        "required": ["in"]
       },
       "then": {
         "type": "object",
@@ -1769,9 +1678,7 @@
     "parameter-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1795,17 +1702,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "content"
-      ],
+      "required": ["content"],
       "$ref": "#/$defs/specification-extensions"
     },
     "request-body-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1856,12 +1759,7 @@
         },
         "style": {
           "default": "form",
-          "enum": [
-            "form",
-            "spaceDelimited",
-            "pipeDelimited",
-            "deepObject"
-          ]
+          "enum": ["form", "spaceDelimited", "pipeDelimited", "deepObject"]
         },
         "explode": {
           "type": "boolean"
@@ -1888,9 +1786,7 @@
                 "const": "form"
               }
             },
-            "required": [
-              "style"
-            ]
+            "required": ["style"]
           },
           "then": {
             "type": "object",
@@ -1943,17 +1839,13 @@
           }
         }
       },
-      "required": [
-        "description"
-      ],
+      "required": ["description"],
       "$ref": "#/$defs/specification-extensions"
     },
     "response-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1973,9 +1865,7 @@
     "callbacks-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -2000,19 +1890,14 @@
         }
       },
       "not": {
-        "required": [
-          "value",
-          "externalValue"
-        ]
+        "required": ["value", "externalValue"]
       },
       "$ref": "#/$defs/specification-extensions"
     },
     "example-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -2044,14 +1929,10 @@
       },
       "oneOf": [
         {
-          "required": [
-            "operationRef"
-          ]
+          "required": ["operationRef"]
         },
         {
-          "required": [
-            "operationId"
-          ]
+          "required": ["operationId"]
         }
       ],
       "$ref": "#/$defs/specification-extensions"
@@ -2059,9 +1940,7 @@
     "link-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -2090,14 +1969,10 @@
       },
       "oneOf": [
         {
-          "required": [
-            "schema"
-          ]
+          "required": ["schema"]
         },
         {
-          "required": [
-            "content"
-          ]
+          "required": ["content"]
         }
       ],
       "$ref": "#/$defs/specification-extensions"
@@ -2105,9 +1980,7 @@
     "header-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -2130,9 +2003,7 @@
           "$ref": "#/$defs/external-documentation"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "$ref": "#/$defs/specification-extensions"
     },
     "reference": {
@@ -2152,31 +2023,20 @@
     },
     "schema": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#schema-object",
-      "type": [
-        "object",
-        "boolean"
-      ]
+      "type": ["object", "boolean"]
     },
     "security-scheme": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#security-scheme-object",
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "apiKey",
-            "http",
-            "mutualTLS",
-            "oauth2",
-            "openIdConnect"
-          ]
+          "enum": ["apiKey", "http", "mutualTLS", "oauth2", "openIdConnect"]
         },
         "description": {
           "type": "string"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/$defs/specification-extensions"
@@ -2206,9 +2066,7 @@
                 "const": "apiKey"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "type": "object",
@@ -2217,17 +2075,10 @@
                 "type": "string"
               },
               "in": {
-                "enum": [
-                  "query",
-                  "header",
-                  "cookie"
-                ]
+                "enum": ["query", "header", "cookie"]
               }
             },
-            "required": [
-              "name",
-              "in"
-            ]
+            "required": ["name", "in"]
           }
         },
         "type-http": {
@@ -2238,9 +2089,7 @@
                 "const": "http"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "type": "object",
@@ -2249,9 +2098,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "scheme"
-            ]
+            "required": ["scheme"]
           }
         },
         "type-http-bearer": {
@@ -2266,10 +2113,7 @@
                 "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
               }
             },
-            "required": [
-              "type",
-              "scheme"
-            ]
+            "required": ["type", "scheme"]
           },
           "then": {
             "type": "object",
@@ -2288,9 +2132,7 @@
                 "const": "oauth2"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "type": "object",
@@ -2299,9 +2141,7 @@
                 "$ref": "#/$defs/oauth-flows"
               }
             },
-            "required": [
-              "flows"
-            ]
+            "required": ["flows"]
           }
         },
         "type-oidc": {
@@ -2312,9 +2152,7 @@
                 "const": "openIdConnect"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "type": "object",
@@ -2323,9 +2161,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "openIdConnectUrl"
-            ]
+            "required": ["openIdConnectUrl"]
           }
         }
       }
@@ -2333,9 +2169,7 @@
     "security-scheme-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -2375,10 +2209,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "authorizationUrl",
-            "scopes"
-          ],
+          "required": ["authorizationUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions"
         },
         "password": {
@@ -2394,10 +2225,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions"
         },
         "client-credentials": {
@@ -2413,10 +2241,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions"
         },
         "authorization-code": {
@@ -2435,11 +2260,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "authorizationUrl",
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["authorizationUrl", "tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions"
         }
       }

--- a/packages/runtime/lib/api-client.js
+++ b/packages/runtime/lib/api-client.js
@@ -170,10 +170,6 @@ class RuntimeApiClient extends EventEmitter {
 
     if (metrics === null) return null
 
-    const entrypointDetails = await this.getEntrypointDetails()
-    const entrypointConfig = await this.getServiceConfig(entrypointDetails.id)
-    const entrypointMetricsPrefix = entrypointConfig.metrics?.prefix
-
     const cpuMetric = metrics.find(
       (metric) => metric.name === 'process_cpu_percent_usage'
     )
@@ -204,28 +200,27 @@ class RuntimeApiClient extends EventEmitter {
     let p95Value = 0
     let p99Value = 0
 
-    if (entrypointMetricsPrefix) {
-      const metricName = entrypointMetricsPrefix + 'http_request_all_summary_seconds'
-      const httpLatencyMetrics = metrics.find((metric) => metric.name === metricName)
+    const metricName = 'http_request_all_summary_seconds'
+    const httpLatencyMetrics =
+        metrics.find((metric) => metric.name === metricName)
 
-      p50Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.5
-      ).value || 0
-      p90Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.9
-      ).value || 0
-      p95Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.95
-      ).value || 0
-      p99Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.99
-      ).value || 0
+    p50Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.5
+    ).value || 0
+    p90Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.9
+    ).value || 0
+    p95Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.95
+    ).value || 0
+    p99Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.99
+    ).value || 0
 
-      p50Value = Math.round(p50Value * 1000)
-      p90Value = Math.round(p90Value * 1000)
-      p95Value = Math.round(p95Value * 1000)
-      p99Value = Math.round(p99Value * 1000)
-    }
+    p50Value = Math.round(p50Value * 1000)
+    p90Value = Math.round(p90Value * 1000)
+    p95Value = Math.round(p95Value * 1000)
+    p99Value = Math.round(p99Value * 1000)
 
     const cpu = cpuMetric.values[0].value
     const rss = rssMetric.values[0].value

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -4,7 +4,6 @@ const { dirname } = require('node:path')
 const { EventEmitter, once } = require('node:events')
 const { FileWatcher } = require('@platformatic/utils')
 const debounce = require('debounce')
-const { snakeCase } = require('change-case-all')
 const { buildServer } = require('./build-server')
 const { loadConfig } = require('./load-config')
 const errors = require('./errors')
@@ -36,7 +35,7 @@ class PlatformaticApp extends EventEmitter {
     this.#fileWatcher = null
     this.#hasManagementApi = !!hasManagementApi
     this.#logger = logger.child({
-      name: this.appConfig.id,
+      name: this.appConfig.id
     })
     this.#telemetryConfig = telemetryConfig
     this.#metricsConfig = metricsConfig
@@ -123,7 +122,7 @@ class PlatformaticApp extends EventEmitter {
         app: this.config.app,
         ...config,
         id: this.appConfig.id,
-        configManager,
+        configManager
       })
     } catch (err) {
       this.#logAndExit(err)
@@ -193,8 +192,8 @@ class PlatformaticApp extends EventEmitter {
       this.server.log.error({
         err: {
           message: err?.message,
-          stack: err?.stack,
-        },
+          stack: err?.stack
+        }
       }, 'exiting')
     } else if (signal) {
       this.server.log.info({ signal }, 'received signal')
@@ -217,7 +216,7 @@ class PlatformaticApp extends EventEmitter {
     try {
       _config = await loadConfig({}, ['-c', appConfig.config], {
         onMissingEnv: this.#fetchServiceUrl,
-        context: appConfig,
+        context: appConfig
       }, true, this.#logger)
     } catch (err) {
       this.#logAndExit(err)
@@ -276,20 +275,20 @@ class PlatformaticApp extends EventEmitter {
     configManager.update({
       ...configManager.current,
       telemetry: this.#telemetryConfig,
-      metrics: this.#metricsConfig,
+      metrics: this.#metricsConfig
     })
 
     if (configManager.current.metrics !== false) {
       configManager.update({
         ...configManager.current,
-        metrics: this.#metricsConfig,
+        metrics: this.#metricsConfig
       })
     }
 
     if (this.#serverConfig) {
       configManager.update({
         ...configManager.current,
-        server: this.#serverConfig,
+        server: this.#serverConfig
       })
     }
 
@@ -297,14 +296,18 @@ class PlatformaticApp extends EventEmitter {
       (this.#hasManagementApi && configManager.current.metrics === undefined) ||
       configManager.current.metrics
     ) {
+      const labels = configManager.current.metrics?.labels || {}
       configManager.update({
         ...configManager.current,
         metrics: {
           server: 'hide',
           defaultMetrics: { enabled: this.appConfig.entrypoint },
-          prefix: snakeCase(this.appConfig.id) + '_',
-          ...configManager.current.metrics,
-        },
+          labels: {
+            serviceId: this.appConfig.id,
+            ...labels
+          },
+          ...configManager.current.metrics
+        }
       })
     }
 
@@ -313,8 +316,8 @@ class PlatformaticApp extends EventEmitter {
         ...configManager.current,
         server: {
           ...(configManager.current.server || {}),
-          trustProxy: true,
-        },
+          trustProxy: true
+        }
       })
     }
   }
@@ -348,7 +351,7 @@ class PlatformaticApp extends EventEmitter {
       path: dirname(configManager.fullPath),
       /* c8 ignore next 2 */
       allowToWatch: this.#originalWatch?.allow,
-      watchIgnore: this.#originalWatch?.ignore || [],
+      watchIgnore: this.#originalWatch?.ignore || []
     })
 
     fileWatcher.on('update', this.#debouncedRestart)

--- a/packages/runtime/test/api/service-config.test.js
+++ b/packages/runtime/test/api/service-config.test.js
@@ -27,8 +27,8 @@ test('should get service config', async (t) => {
   if (process.stdout.isTTY) {
     logger = {
       transport: {
-        target: 'pino-pretty',
-      },
+        target: 'pino-pretty'
+      }
     }
   }
 
@@ -38,24 +38,26 @@ test('should get service config', async (t) => {
       port: 0,
       logger,
       keepAliveTimeout: 5000,
-      trustProxy: true,
+      trustProxy: true
     },
     service: { openapi: true },
     plugins: {
       paths: [
-        join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'plugin.js'),
-      ],
+        join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'plugin.js')
+      ]
     },
     watch: {
-      enabled: false,
+      enabled: false
     },
     metrics: {
       server: 'hide',
       defaultMetrics: {
-        enabled: false,
+        enabled: false
       },
-      prefix: 'with_logger_',
-    },
+      labels: {
+        serviceId: 'with-logger'
+      }
+    }
   })
 })
 
@@ -78,8 +80,8 @@ test('do not force enable metrics without the management api', async (t) => {
   if (process.stdout.isTTY) {
     logger = {
       transport: {
-        target: 'pino-pretty',
-      },
+        target: 'pino-pretty'
+      }
     }
   }
 
@@ -89,17 +91,17 @@ test('do not force enable metrics without the management api', async (t) => {
       port: 0,
       logger,
       keepAliveTimeout: 5000,
-      trustProxy: true,
+      trustProxy: true
     },
     service: { openapi: true },
     plugins: {
       paths: [
-        join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'plugin.js'),
-      ],
+        join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'plugin.js')
+      ]
     },
     watch: {
-      enabled: false,
-    },
+      enabled: false
+    }
   })
 })
 
@@ -122,8 +124,8 @@ test('do not force enable metrics if they are set to false', async (t) => {
   if (process.stdout.isTTY) {
     logger = {
       transport: {
-        target: 'pino-pretty',
-      },
+        target: 'pino-pretty'
+      }
     }
   }
 
@@ -133,28 +135,28 @@ test('do not force enable metrics if they are set to false', async (t) => {
       port: 0,
       logger,
       keepAliveTimeout: 5000,
-      trustProxy: true,
+      trustProxy: true
     },
     service: { openapi: true },
     plugins: {
       paths: [
         {
           options: {
-            name: 'plugin1',
+            name: 'plugin1'
           },
-          path: join(fixturesDir, 'monorepo', 'serviceAppWithMultiplePlugins', 'plugin.js'),
+          path: join(fixturesDir, 'monorepo', 'serviceAppWithMultiplePlugins', 'plugin.js')
         },
         {
           options: {
-            name: 'plugin2',
+            name: 'plugin2'
           },
-          path: join(fixturesDir, 'monorepo', 'serviceAppWithMultiplePlugins', 'plugin2.mjs'),
-        },
-      ],
+          path: join(fixturesDir, 'monorepo', 'serviceAppWithMultiplePlugins', 'plugin2.mjs')
+        }
+      ]
     },
     watch: {
-      enabled: false,
+      enabled: false
     },
-    metrics: false,
+    metrics: false
   })
 })

--- a/packages/runtime/test/management-api/service-config.test.js
+++ b/packages/runtime/test/management-api/service-config.test.js
@@ -20,24 +20,24 @@ test('should get service config', async (t) => {
 
   const client = new Client({
     hostname: 'localhost',
-    protocol: 'http:',
+    protocol: 'http:'
   }, {
     socketPath: app.managementApi.server.address(),
     keepAliveTimeout: 10,
-    keepAliveMaxTimeout: 10,
+    keepAliveMaxTimeout: 10
   })
 
   t.after(async () => {
     await Promise.all([
       client.close(),
       app.close(),
-      app.managementApi.close(),
+      app.managementApi.close()
     ])
   })
 
   const { statusCode, body } = await client.request({
     method: 'GET',
-    path: '/api/v1/services/service-1/config',
+    path: '/api/v1/services/service-1/config'
   })
 
   assert.strictEqual(statusCode, 200)
@@ -47,7 +47,7 @@ test('should get service config', async (t) => {
   const logger = {}
   if (isatty(1) && !logger.transport) {
     logger.transport = {
-      target: 'pino-pretty',
+      target: 'pino-pretty'
     }
   }
 
@@ -57,23 +57,25 @@ test('should get service config', async (t) => {
       hostname: '127.0.0.1',
       port: 0,
       logger,
-      keepAliveTimeout: 5000,
+      keepAliveTimeout: 5000
     },
     service: { openapi: true },
     plugins: {
       paths: [
-        join(projectDir, 'services', 'service-1', 'plugin.js'),
-      ],
+        join(projectDir, 'services', 'service-1', 'plugin.js')
+      ]
     },
     watch: {
-      enabled: false,
+      enabled: false
     },
     metrics: {
       server: 'hide',
       defaultMetrics: {
-        enabled: true,
+        enabled: true
       },
-      prefix: 'service_1_',
-    },
+      labels: {
+        serviceId: 'service-1'
+      }
+    }
   })
 })

--- a/packages/runtime/test/prom-metrics.test.js
+++ b/packages/runtime/test/prom-metrics.test.js
@@ -25,7 +25,7 @@ test('should start a prometheus server on port 9090', async (t) => {
 
   const { statusCode, body } = await request('http://127.0.0.1:9090', {
     method: 'GET',
-    path: '/metrics',
+    path: '/metrics'
   })
   assert.strictEqual(statusCode, 200)
 
@@ -64,10 +64,9 @@ test('should start a prometheus server on port 9090', async (t) => {
     'process_cpu_user_seconds_total',
     'process_resident_memory_bytes',
     'process_start_time_seconds',
-    'service_1_http_request_all_summary_seconds',
-    'service_1_http_request_duration_seconds',
-    'service_1_http_request_summary_seconds',
-
+    'http_request_all_summary_seconds',
+    'http_request_duration_seconds',
+    'http_request_summary_seconds'
   ]
   for (const metricName of expectedMetricNames) {
     assert.ok(metricsNames.includes(metricName))

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -190,7 +190,6 @@ const metrics = {
           required: ['enabled'],
           additionalProperties: false,
         },
-        prefix: { type: 'string' },
         auth: {
           type: 'object',
           properties: {

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -635,9 +635,6 @@
               ],
               "additionalProperties": false
             },
-            "prefix": {
-              "type": "string"
-            },
             "auth": {
               "type": "object",
               "properties": {

--- a/packages/service/test/metrics.test.js
+++ b/packages/service/test/metrics.test.js
@@ -105,7 +105,7 @@ test('has /metrics endpoint on configured port', async (t) => {
   testPrometheusOutput(body)
 })
 
-test.only('support basic auth', async (t) => {
+test('support basic auth', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
@@ -177,7 +177,7 @@ test('has /metrics endpoint on parent server', async (t) => {
   testPrometheusOutput(body)
 })
 
-test.only('support basic auth with metrics on parent server', async (t) => {
+test('support basic auth with metrics on parent server', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',

--- a/packages/service/test/metrics.test.js
+++ b/packages/service/test/metrics.test.js
@@ -13,12 +13,12 @@ test('should auto set server to "parent" if port conflict', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042
+      port: 3042,
     },
     metrics: {
       server: 'own',
-      port: 3042
-    }
+      port: 3042,
+    },
   })
 
   t.after(async () => {
@@ -35,9 +35,9 @@ test('has /metrics endpoint on default prometheus port', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
     },
-    metrics: true
+    metrics: true,
   })
 
   t.after(async () => {
@@ -58,9 +58,9 @@ test('has /metrics endpoint with accept application/json', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
     },
-    metrics: true
+    metrics: true,
   })
 
   t.after(async () => {
@@ -72,8 +72,8 @@ test('has /metrics endpoint with accept application/json', async (t) => {
     'http://127.0.0.1:9090/metrics',
     {
       headers: {
-        accept: 'application/json'
-      }
+        accept: 'application/json',
+      },
     }
   ))
   assert.match(res.headers['content-type'], /^application\/json/)
@@ -86,11 +86,11 @@ test('has /metrics endpoint on configured port', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
     },
     metrics: {
-      port: 9999
-    }
+      port: 9999,
+    },
   })
 
   t.after(async () => {
@@ -105,18 +105,18 @@ test('has /metrics endpoint on configured port', async (t) => {
   testPrometheusOutput(body)
 })
 
-test('support basic auth', async (t) => {
+test.only('support basic auth', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
     },
     metrics: {
       auth: {
         username: 'foo',
-        password: 'bar'
-      }
-    }
+        password: 'bar',
+      },
+    },
   })
 
   t.after(async () => {
@@ -134,8 +134,8 @@ test('support basic auth', async (t) => {
     // wrong credentials
     const res = await (request('http://127.0.0.1:9090/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`
-      }
+        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`,
+      },
     }))
     assert.strictEqual(res.statusCode, 401)
     assert.match(res.headers['content-type'], /^application\/json/)
@@ -144,8 +144,8 @@ test('support basic auth', async (t) => {
   {
     const res = await (request('http://127.0.0.1:9090/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`
-      }
+        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`,
+      },
     }))
     assert.strictEqual(res.statusCode, 200)
     assert.match(res.headers['content-type'], /^text\/plain/)
@@ -158,11 +158,11 @@ test('has /metrics endpoint on parent server', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042
+      port: 3042,
     },
     metrics: {
-      server: 'parent'
-    }
+      server: 'parent',
+    },
   })
 
   t.after(async () => {
@@ -177,19 +177,19 @@ test('has /metrics endpoint on parent server', async (t) => {
   testPrometheusOutput(body)
 })
 
-test('support basic auth with metrics on parent server', async (t) => {
+test.only('support basic auth with metrics on parent server', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042
+      port: 3042,
     },
     metrics: {
       server: 'parent',
       auth: {
         username: 'foo',
-        password: 'bar'
-      }
-    }
+        password: 'bar',
+      },
+    },
   })
 
   t.after(async () => {
@@ -207,8 +207,8 @@ test('support basic auth with metrics on parent server', async (t) => {
     // wrong credentials
     const res = await (request('http://127.0.0.1:3042/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`
-      }
+        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`,
+      },
     }))
     assert.strictEqual(res.statusCode, 401)
     assert.match(res.headers['content-type'], /^application\/json/)
@@ -217,16 +217,13 @@ test('support basic auth with metrics on parent server', async (t) => {
   {
     const res = await (request('http://127.0.0.1:3042/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`
-      }
+        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`,
+      },
     }))
     assert.strictEqual(res.statusCode, 200)
     assert.match(res.headers['content-type'], /^text\/plain/)
     const body = await res.body.text()
     testPrometheusOutput(body)
-    const cpu = findFirstPrometheusLineForMetric('process_cpu_percent_usage', body)
-    const labels = parseLabels(cpu)
-    assert.strictEqual(labels.prefix, 'test')
   }
 })
 
@@ -234,9 +231,9 @@ test('do not error on restart', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
     },
-    metrics: true
+    metrics: true,
   })
 
   t.after(async () => {
@@ -259,9 +256,9 @@ test('restarting 10 times does not leak', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
     },
-    metrics: true
+    metrics: true,
   })
 
   t.after(async () => {
@@ -279,11 +276,11 @@ test('should not expose metrics if server hide is set', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042
+      port: 3042,
     },
     metrics: {
-      server: 'hide'
-    }
+      server: 'hide',
+    },
   })
 
   t.after(async () => {
@@ -365,13 +362,13 @@ test('specify custom labels', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 30001
+      port: 30001,
     },
     metrics: {
       labels: {
-        foo: 'bar'
-      }
-    }
+        foo: 'bar',
+      },
+    },
   })
 
   app.get('/test', async (req, reply) => {
@@ -396,7 +393,6 @@ test('specify custom labels', async (t) => {
     const cpu = findFirstPrometheusLineForMetric('process_cpu_percent_usage', body)
     const labels = parseLabels(cpu)
     assert.strictEqual(labels.foo, 'bar')
-    assert.strictEqual(labels.prefix, 'test')
   }
 
   {
@@ -427,15 +423,15 @@ test('specify different custom labels on two different services', async (t) => {
   const app1 = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042
+      port: 3042,
     },
     metrics: {
       server: 'own',
       port: 3042,
       labels: {
-        foo: 'bar1'
-      }
-    }
+        foo: 'bar1',
+      },
+    },
   })
 
   t.after(async () => {
@@ -446,15 +442,15 @@ test('specify different custom labels on two different services', async (t) => {
   const app2 = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3043
+      port: 3043,
     },
     metrics: {
       server: 'own',
       port: 3043,
       labels: {
-        foo: 'bar2'
-      }
-    }
+        foo: 'bar2',
+      },
+    },
   })
 
   t.after(async () => {

--- a/packages/service/test/metrics.test.js
+++ b/packages/service/test/metrics.test.js
@@ -13,12 +13,12 @@ test('should auto set server to "parent" if port conflict', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042,
+      port: 3042
     },
     metrics: {
       server: 'own',
-      port: 3042,
-    },
+      port: 3042
+    }
   })
 
   t.after(async () => {
@@ -35,9 +35,9 @@ test('has /metrics endpoint on default prometheus port', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0,
+      port: 0
     },
-    metrics: true,
+    metrics: true
   })
 
   t.after(async () => {
@@ -58,9 +58,9 @@ test('has /metrics endpoint with accept application/json', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0,
+      port: 0
     },
-    metrics: true,
+    metrics: true
   })
 
   t.after(async () => {
@@ -72,8 +72,8 @@ test('has /metrics endpoint with accept application/json', async (t) => {
     'http://127.0.0.1:9090/metrics',
     {
       headers: {
-        accept: 'application/json',
-      },
+        accept: 'application/json'
+      }
     }
   ))
   assert.match(res.headers['content-type'], /^application\/json/)
@@ -86,11 +86,11 @@ test('has /metrics endpoint on configured port', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0,
+      port: 0
     },
     metrics: {
-      port: 9999,
-    },
+      port: 9999
+    }
   })
 
   t.after(async () => {
@@ -109,14 +109,14 @@ test('support basic auth', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0,
+      port: 0
     },
     metrics: {
       auth: {
         username: 'foo',
-        password: 'bar',
-      },
-    },
+        password: 'bar'
+      }
+    }
   })
 
   t.after(async () => {
@@ -134,8 +134,8 @@ test('support basic auth', async (t) => {
     // wrong credentials
     const res = await (request('http://127.0.0.1:9090/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`,
-      },
+        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`
+      }
     }))
     assert.strictEqual(res.statusCode, 401)
     assert.match(res.headers['content-type'], /^application\/json/)
@@ -144,8 +144,8 @@ test('support basic auth', async (t) => {
   {
     const res = await (request('http://127.0.0.1:9090/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`,
-      },
+        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`
+      }
     }))
     assert.strictEqual(res.statusCode, 200)
     assert.match(res.headers['content-type'], /^text\/plain/)
@@ -158,11 +158,11 @@ test('has /metrics endpoint on parent server', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042,
+      port: 3042
     },
     metrics: {
-      server: 'parent',
-    },
+      server: 'parent'
+    }
   })
 
   t.after(async () => {
@@ -181,15 +181,15 @@ test('support basic auth with metrics on parent server', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042,
+      port: 3042
     },
     metrics: {
       server: 'parent',
       auth: {
         username: 'foo',
-        password: 'bar',
-      },
-    },
+        password: 'bar'
+      }
+    }
   })
 
   t.after(async () => {
@@ -207,8 +207,8 @@ test('support basic auth with metrics on parent server', async (t) => {
     // wrong credentials
     const res = await (request('http://127.0.0.1:3042/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`,
-      },
+        authorization: `Basic ${Buffer.from('bar:foo').toString('base64')}`
+      }
     }))
     assert.strictEqual(res.statusCode, 401)
     assert.match(res.headers['content-type'], /^application\/json/)
@@ -217,13 +217,16 @@ test('support basic auth with metrics on parent server', async (t) => {
   {
     const res = await (request('http://127.0.0.1:3042/metrics', {
       headers: {
-        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`,
-      },
+        authorization: `Basic ${Buffer.from('foo:bar').toString('base64')}`
+      }
     }))
     assert.strictEqual(res.statusCode, 200)
     assert.match(res.headers['content-type'], /^text\/plain/)
     const body = await res.body.text()
     testPrometheusOutput(body)
+    const cpu = findFirstPrometheusLineForMetric('process_cpu_percent_usage', body)
+    const labels = parseLabels(cpu)
+    assert.strictEqual(labels.prefix, 'test')
   }
 })
 
@@ -231,9 +234,9 @@ test('do not error on restart', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0,
+      port: 0
     },
-    metrics: true,
+    metrics: true
   })
 
   t.after(async () => {
@@ -256,9 +259,9 @@ test('restarting 10 times does not leak', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 0,
+      port: 0
     },
-    metrics: true,
+    metrics: true
   })
 
   t.after(async () => {
@@ -276,11 +279,11 @@ test('should not expose metrics if server hide is set', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042,
+      port: 3042
     },
     metrics: {
-      server: 'hide',
-    },
+      server: 'hide'
+    }
   })
 
   t.after(async () => {
@@ -362,13 +365,13 @@ test('specify custom labels', async (t) => {
   const app = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 30001,
+      port: 30001
     },
     metrics: {
       labels: {
-        foo: 'bar',
-      },
-    },
+        foo: 'bar'
+      }
+    }
   })
 
   app.get('/test', async (req, reply) => {
@@ -393,6 +396,7 @@ test('specify custom labels', async (t) => {
     const cpu = findFirstPrometheusLineForMetric('process_cpu_percent_usage', body)
     const labels = parseLabels(cpu)
     assert.strictEqual(labels.foo, 'bar')
+    assert.strictEqual(labels.prefix, 'test')
   }
 
   {
@@ -423,15 +427,15 @@ test('specify different custom labels on two different services', async (t) => {
   const app1 = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3042,
+      port: 3042
     },
     metrics: {
       server: 'own',
       port: 3042,
       labels: {
-        foo: 'bar1',
-      },
-    },
+        foo: 'bar1'
+      }
+    }
   })
 
   t.after(async () => {
@@ -442,15 +446,15 @@ test('specify different custom labels on two different services', async (t) => {
   const app2 = await buildServer({
     server: {
       hostname: '127.0.0.1',
-      port: 3043,
+      port: 3043
     },
     metrics: {
       server: 'own',
       port: 3043,
       labels: {
-        foo: 'bar2',
-      },
-    },
+        foo: 'bar2'
+      }
+    }
   })
 
   t.after(async () => {


### PR DESCRIPTION
We have prefixes in Prometheus metrics names, but doing that is a problem e.g. when aggregating the same metrics per labels. Also this multiplies the number of metrics in prometheus with no reason. 
In this Pr the prefix is removed from metrics name and added as label instead. 