### PR TITLE
Remove the prefix from metrics and use labels [v1.x]

### DIFF
--- a/packages/control/test/config.test.mjs
+++ b/packages/control/test/config.test.mjs
@@ -96,7 +96,9 @@ test('should get runtime service config', async (t) => {
       defaultMetrics: {
         enabled: true
       },
-      prefix: 'service_1_',
+      labels: {
+        serviceId: 'service-1'
+      },
       server: 'hide'
     }
   })

--- a/packages/runtime/lib/api-client.js
+++ b/packages/runtime/lib/api-client.js
@@ -170,10 +170,6 @@ class RuntimeApiClient extends EventEmitter {
 
     if (metrics === null) return null
 
-    const entrypointDetails = await this.getEntrypointDetails()
-    const entrypointConfig = await this.getServiceConfig(entrypointDetails.id)
-    const entrypointMetricsPrefix = entrypointConfig.metrics?.prefix
-
     const cpuMetric = metrics.find(
       (metric) => metric.name === 'process_cpu_percent_usage'
     )
@@ -204,28 +200,27 @@ class RuntimeApiClient extends EventEmitter {
     let p95Value = 0
     let p99Value = 0
 
-    if (entrypointMetricsPrefix) {
-      const metricName = entrypointMetricsPrefix + 'http_request_all_summary_seconds'
-      const httpLatencyMetrics = metrics.find((metric) => metric.name === metricName)
+    const metricName = 'http_request_all_summary_seconds'
+    const httpLatencyMetrics =
+        metrics.find((metric) => metric.name === metricName)
 
-      p50Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.5
-      ).value || 0
-      p90Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.9
-      ).value || 0
-      p95Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.95
-      ).value || 0
-      p99Value = httpLatencyMetrics.values.find(
-        (value) => value.labels.quantile === 0.99
-      ).value || 0
+    p50Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.5
+    ).value || 0
+    p90Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.9
+    ).value || 0
+    p95Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.95
+    ).value || 0
+    p99Value = httpLatencyMetrics.values.find(
+      (value) => value.labels.quantile === 0.99
+    ).value || 0
 
-      p50Value = Math.round(p50Value * 1000)
-      p90Value = Math.round(p90Value * 1000)
-      p95Value = Math.round(p95Value * 1000)
-      p99Value = Math.round(p99Value * 1000)
-    }
+    p50Value = Math.round(p50Value * 1000)
+    p90Value = Math.round(p90Value * 1000)
+    p95Value = Math.round(p95Value * 1000)
+    p99Value = Math.round(p99Value * 1000)
 
     const cpu = cpuMetric.values[0].value
     const rss = rssMetric.values[0].value

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -4,7 +4,6 @@ const { dirname } = require('node:path')
 const { EventEmitter, once } = require('node:events')
 const { FileWatcher } = require('@platformatic/utils')
 const debounce = require('debounce')
-const { snakeCase } = require('change-case-all')
 const { buildServer } = require('./build-server')
 const { loadConfig } = require('./load-config')
 const errors = require('./errors')
@@ -275,12 +274,16 @@ class PlatformaticApp extends EventEmitter {
       (this.#hasManagementApi && configManager.current.metrics === undefined) ||
       configManager.current.metrics
     ) {
+      const labels = configManager.current.metrics?.labels || {}
       configManager.update({
         ...configManager.current,
         metrics: {
           server: 'hide',
           defaultMetrics: { enabled: this.appConfig.entrypoint },
-          prefix: snakeCase(this.appConfig.id) + '_',
+          labels: {
+            serviceId: this.appConfig.id,
+            ...labels
+          },
           ...configManager.current.metrics
         }
       })

--- a/packages/runtime/test/api/metrics.test.js
+++ b/packages/runtime/test/api/metrics.test.js
@@ -8,6 +8,18 @@ const { loadConfig } = require('@platformatic/config')
 const { buildServer, platformaticRuntime } = require('../..')
 const fixturesDir = join(__dirname, '..', '..', 'fixtures')
 
+function findPrometheusLinesForMetric (metric, output) {
+  const ret = []
+  const lines = output.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.startsWith(metric)) {
+      ret.push(line)
+    }
+  }
+  return ret
+}
+
 test('should get runtime metrics in a json format', async (t) => {
   const projectDir = join(fixturesDir, 'management-api')
   const configFile = join(projectDir, 'platformatic.json')
@@ -53,13 +65,11 @@ test('should get runtime metrics in a json format', async (t) => {
     'process_cpu_user_seconds_total',
     'process_resident_memory_bytes',
     'process_start_time_seconds',
-    'service_1_http_request_all_summary_seconds',
-    'service_1_http_request_duration_seconds',
-    'service_1_http_request_summary_seconds',
-    'service_2_http_request_all_summary_seconds',
-    'service_2_http_request_duration_seconds',
-    'service_2_http_request_summary_seconds'
+    'http_request_all_summary_seconds',
+    'http_request_duration_seconds',
+    'http_request_summary_seconds'
   ]
+  // TODO: check the labels
   for (const metricName of expectedMetricNames) {
     assert.ok(metricsNames.includes(metricName))
   }
@@ -111,17 +121,27 @@ test('should get runtime metrics in a text format', async (t) => {
     'process_cpu_system_seconds_total',
     'process_cpu_user_seconds_total',
     'process_resident_memory_bytes',
-    'process_start_time_seconds',
-    'service_1_http_request_all_summary_seconds',
-    'service_1_http_request_duration_seconds',
-    'service_1_http_request_summary_seconds',
-    'service_2_http_request_all_summary_seconds',
-    'service_2_http_request_duration_seconds',
-    'service_2_http_request_summary_seconds'
+    'process_start_time_seconds'
   ]
   for (const metricName of expectedMetricNames) {
     assert.ok(metricsNames.includes(metricName))
   }
+
+  // Check that the serviceId labels are present in the metrics
+  const httpRequestsSummary = findPrometheusLinesForMetric('http_request_all_summary_seconds', metrics.metrics)
+  const httpRequestsSummaryLabels = httpRequestsSummary.map((line) => line.split('{')[1].split('}')[0].split(','))
+  const services = httpRequestsSummaryLabels.flat()
+    .filter((label) => label.startsWith('serviceId='))
+    .reduce((acc, label) => {
+      const service = label.split('"')[1]
+      if (service) {
+        acc.push(service)
+      }
+      return acc
+    }, [])
+
+  const serviceIds = [...new Set(services)].sort()
+  assert.deepEqual(serviceIds, ['service-1', 'service-2', 'service-db'])
 })
 
 function getMetricsLines (metrics) {

--- a/packages/runtime/test/api/service-config.test.js
+++ b/packages/runtime/test/api/service-config.test.js
@@ -54,7 +54,9 @@ test('should get service config', async (t) => {
       defaultMetrics: {
         enabled: false
       },
-      prefix: 'with_logger_'
+      labels: {
+        serviceId: 'with-logger'
+      }
     }
   })
 })

--- a/packages/runtime/test/management-api/service-config.test.js
+++ b/packages/runtime/test/management-api/service-config.test.js
@@ -73,7 +73,9 @@ test('should get service config', async (t) => {
       defaultMetrics: {
         enabled: true
       },
-      prefix: 'service_1_'
+      labels: {
+        serviceId: 'service-1'
+      }
     }
   })
 })

--- a/packages/runtime/test/prom-metrics.test.js
+++ b/packages/runtime/test/prom-metrics.test.js
@@ -64,10 +64,9 @@ test('should start a prometheus server on port 9090', async (t) => {
     'process_cpu_user_seconds_total',
     'process_resident_memory_bytes',
     'process_start_time_seconds',
-    'service_1_http_request_all_summary_seconds',
-    'service_1_http_request_duration_seconds',
-    'service_1_http_request_summary_seconds'
-
+    'http_request_all_summary_seconds',
+    'http_request_duration_seconds',
+    'http_request_summary_seconds'
   ]
   for (const metricName of expectedMetricNames) {
     assert.ok(metricsNames.includes(metricName))

--- a/packages/service/lib/plugins/metrics.js
+++ b/packages/service/lib/plugins/metrics.js
@@ -12,10 +12,12 @@ const metricsPlugin = fp(async function (app, opts = {}) {
   const register = new promClient.Registry()
 
   const defaultMetrics = opts.defaultMetrics ?? { enabled: true }
-  const prefix = opts.prefix ?? ''
 
-  if (opts.labels) {
+  if (opts.labels || opts.prefix) {
     const labels = opts.labels ?? {}
+    if (opts.prefix) {
+      labels.prefix = opts.prefix
+    }
     register.setDefaultLabels(labels)
   }
 
@@ -34,15 +36,16 @@ const metricsPlugin = fp(async function (app, opts = {}) {
     routeMetrics: {
       enabled: true,
       customLabels: {
+        // TODO: check if this is set in prom
         telemetry_id: (req) => req.headers['x-telemetry-id'] ?? 'unknown'
       },
       overrides: {
         histogram: {
-          name: prefix + 'http_request_duration_seconds',
+          name: 'http_request_duration_seconds',
           registers: [register]
         },
         summary: {
-          name: prefix + 'http_request_summary_seconds',
+          name: 'http_request_summary_seconds',
           registers: [register]
         }
       }
@@ -51,7 +54,7 @@ const metricsPlugin = fp(async function (app, opts = {}) {
 
   app.register(fp(async (app) => {
     const httpLatencyMetric = new app.metrics.client.Summary({
-      name: prefix + 'http_request_all_summary_seconds',
+      name: 'http_request_all_summary_seconds',
       help: 'request duration in seconds summary for all requests',
       collect: () => {
         process.nextTick(() => httpLatencyMetric.reset())
@@ -130,9 +133,10 @@ const metricsPlugin = fp(async function (app, opts = {}) {
   }
 
   function cleanMetrics () {
+    const httpMetrics = ['http_request_duration_seconds', 'http_request_summary_seconds', 'http_request_all_summary_seconds']
     const metrics = app.metrics.client.register._metrics
     for (const metricName in metrics) {
-      if (defaultMetrics.enabled || metricName.startsWith(prefix)) {
+      if (defaultMetrics.enabled || httpMetrics.includes(metricName)) {
         delete metrics[metricName]
       }
     }

--- a/packages/service/test/metrics.test.js
+++ b/packages/service/test/metrics.test.js
@@ -188,7 +188,8 @@ test('support basic auth with metrics on parent server', async (t) => {
       auth: {
         username: 'foo',
         password: 'bar'
-      }
+      },
+      prefix: 'test'
     }
   })
 
@@ -224,6 +225,9 @@ test('support basic auth with metrics on parent server', async (t) => {
     assert.match(res.headers['content-type'], /^text\/plain/)
     const body = await res.body.text()
     testPrometheusOutput(body)
+    const cpu = findFirstPrometheusLineForMetric('process_cpu_percent_usage', body)
+    const labels = parseLabels(cpu)
+    assert.strictEqual(labels.prefix, 'test')
   }
 })
 
@@ -367,7 +371,8 @@ test('specify custom labels', async (t) => {
     metrics: {
       labels: {
         foo: 'bar'
-      }
+      },
+      prefix: 'test'
     }
   })
 
@@ -393,6 +398,7 @@ test('specify custom labels', async (t) => {
     const cpu = findFirstPrometheusLineForMetric('process_cpu_percent_usage', body)
     const labels = parseLabels(cpu)
     assert.strictEqual(labels.foo, 'bar')
+    assert.strictEqual(labels.prefix, 'test')
   }
 
   {


### PR DESCRIPTION
This is the same as https://github.com/platformatic/platformatic/pull/2875 but without removing the `prefix` from the config, so is not a breaking change