### PR TITLE
Set the `serviceId` on the runtime metrics services config

### DIFF
--- a/packages/runtime/fixtures/configs/monorepo-with-metrics.json
+++ b/packages/runtime/fixtures/configs/monorepo-with-metrics.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://platformatic.dev/schemas/v0.20.0/runtime",
+  "entrypoint": "serviceApp",
+  "allowCycles": true,
+  "hotReload": false,
+  "managementApi": false,
+  "autoload": {
+    "path": "../monorepo",
+    "exclude": [
+      "docs",
+      "composerApp"
+    ],
+    "mappings": {
+      "serviceAppWithLogger": {
+        "id": "with-logger",
+        "config": "platformatic.service.json"
+      },
+      "serviceAppWithMultiplePlugins": {
+        "id": "multi-plugin-service",
+        "config": "platformatic.service.json"
+      },
+      "dbApp": {
+        "id": "db-app",
+        "config": "platformatic.db.json"
+      }
+    }
+  },
+  "metrics": {
+    "labels": {
+      "app": "serviceApp"
+    }
+  }
+}

--- a/packages/runtime/lib/app.js
+++ b/packages/runtime/lib/app.js
@@ -275,16 +275,17 @@ class PlatformaticApp extends EventEmitter {
       configManager.current.metrics
     ) {
       const labels = configManager.current.metrics?.labels || {}
+      const serviceId = this.appConfig.id
       configManager.update({
         ...configManager.current,
         metrics: {
           server: 'hide',
           defaultMetrics: { enabled: this.appConfig.entrypoint },
+          ...configManager.current.metrics,
           labels: {
-            serviceId: this.appConfig.id,
+            serviceId,
             ...labels
-          },
-          ...configManager.current.metrics
+          }
         }
       })
     }

--- a/packages/runtime/test/api/service-config.test.js
+++ b/packages/runtime/test/api/service-config.test.js
@@ -160,3 +160,57 @@ test('do not force enable metrics if they are set to false', async (t) => {
     metrics: false
   })
 })
+
+test('set serviceId in metrics as label in all services', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo-with-metrics.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const serviceConfig = await app.getServiceConfig('with-logger')
+
+  delete serviceConfig.$schema
+
+  let logger = {}
+  if (process.stdout.isTTY) {
+    logger = {
+      transport: {
+        target: 'pino-pretty'
+      }
+    }
+  }
+
+  assert.deepStrictEqual(serviceConfig, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger,
+      keepAliveTimeout: 5000,
+      trustProxy: true
+    },
+    service: { openapi: true },
+    plugins: {
+      paths: [
+        join(fixturesDir, 'monorepo', 'serviceAppWithLogger', 'plugin.js')
+      ]
+    },
+    watch: {
+      enabled: false
+    },
+    metrics: {
+      server: 'hide',
+      defaultMetrics: {
+        enabled: false
+      },
+      labels: {
+        app: 'serviceApp', // this is from the runtime config
+        serviceId: 'with-logger' // this is set for each service
+      }
+    }
+  })
+})


### PR DESCRIPTION
The runtime metrics config is propagated to all services, but the `serviceId` must be added to all the services labels to correctly identify them in prometheus.

This is on v1.x, if OK, the commit will be ported to `main` too