### PR TITLE
DB opentelemetry support

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -212,7 +212,7 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
     urlToCall.search = queryParser ? queryParser(query) : query.toString()
     urlToCall.pathname = pathToCall
 
-    const { span, telemetryHeaders } = openTelemetry?.startSpanClient(urlToCall.toString(), method, telemetryContext) || { span: null, telemetryHeaders: {} }
+    const { span, telemetryHeaders } = openTelemetry?.startHTTPSpanClient(urlToCall.toString(), method, telemetryContext) || { span: null, telemetryHeaders: {} }
     const telemetryId = openTelemetry?.tracer?.resource?._attributes?.['service.name']
 
     if (this[kGetHeaders]) {
@@ -289,7 +289,7 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
       openTelemetry?.setErrorInSpanClient(span, err)
       throw err
     } finally {
-      openTelemetry?.endSpanClient(span, res)
+      openTelemetry?.endHTTPSpanClient(span, res)
     }
   }
 }
@@ -327,7 +327,7 @@ function isArrayQueryParam ({ schema }) {
 
 // TODO: For some unknown reason c8 is not picking up the coverage for this function
 async function graphql (url, log, headers, query, variables, openTelemetry, telemetryContext) {
-  const { span, telemetryHeaders } = openTelemetry?.startSpanClient(url.toString(), 'POST', telemetryContext) || { span: null, telemetryHeaders: {} }
+  const { span, telemetryHeaders } = openTelemetry?.startHTTPSpanClient(url.toString(), 'POST', telemetryContext) || { span: null, telemetryHeaders: {} }
   const telemetryId = openTelemetry?.tracer?.resource?._attributes?.['service.name']
 
   headers = {
@@ -375,7 +375,7 @@ async function graphql (url, log, headers, query, variables, openTelemetry, tele
     openTelemetry?.setErrorInSpanClient(span, err)
     throw err
   } finally {
-    openTelemetry?.endSpanClient(span, res)
+    openTelemetry?.endHTTPSpanClient(span, res)
   }
 }
 

--- a/packages/composer/lib/openapi-generator.js
+++ b/packages/composer/lib/openapi-generator.js
@@ -102,7 +102,7 @@ async function composeOpenAPI (app, opts) {
 
           const replyOptions = {}
           const onResponse = (request, reply, res) => {
-            app.openTelemetry?.endSpanClient(reply.request.proxedCallSpan, { statusCode: reply.statusCode })
+            app.openTelemetry?.endHTTPSpanClient(reply.request.proxedCallSpan, { statusCode: reply.statusCode })
             if (req.routeOptions.config?.onComposerResponse) {
               req.routeOptions.config?.onComposerResponse(request, reply, res)
             } else {
@@ -112,7 +112,7 @@ async function composeOpenAPI (app, opts) {
           const rewriteRequestHeaders = (request, headers) => {
             const targetUrl = `${origin}${request.url}`
             const context = request.span?.context
-            const { span, telemetryHeaders } = app.openTelemetry?.startSpanClient(targetUrl, request.method, context) || { span: null, telemetryHeaders: {} }
+            const { span, telemetryHeaders } = app.openTelemetry?.startHTTPSpanClient(targetUrl, request.method, context) || { span: null, telemetryHeaders: {} }
             // We need to store the span in a different object
             // to correctly close it in the onResponse hook
             // Note that we have 2 spans:

--- a/packages/composer/lib/proxy.js
+++ b/packages/composer/lib/proxy.js
@@ -37,7 +37,7 @@ module.exports = fp(async function (app, opts) {
         rewriteRequestHeaders: (request, headers) => {
           const targetUrl = `${origin}${request.url}`
           const context = request.span?.context
-          const { span, telemetryHeaders } = app.openTelemetry?.startSpanClient(targetUrl, request.method, context) || { span: null, telemetryHeaders: {} }
+          const { span, telemetryHeaders } = app.openTelemetry?.startHTTPSpanClient(targetUrl, request.method, context) || { span: null, telemetryHeaders: {} }
           // We need to store the span in a different object
           // to correctly close it in the onResponse hook
           // Note that we have 2 spans:
@@ -60,7 +60,7 @@ module.exports = fp(async function (app, opts) {
           return headers
         },
         onResponse: (request, reply, res) => {
-          app.openTelemetry?.endSpanClient(reply.request.proxedCallSpan, { statusCode: reply.statusCode })
+          app.openTelemetry?.endHTTPSpanClient(reply.request.proxedCallSpan, { statusCode: reply.statusCode })
           reply.send(res)
         },
       },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@databases/pg": "^5.5.0",
     "@databases/sql": "^3.3.0",
+    "@opentelemetry/api": "^1.8.0",
     "ajv": "^8.12.0",
     "bindings": "^1.5.0",
     "borp": "^0.17.0",

--- a/packages/db/test/helper.js
+++ b/packages/db/test/helper.js
@@ -122,3 +122,11 @@ async function buildConfigManager (source, dirname) {
 }
 
 module.exports.buildConfigManager = buildConfigManager
+
+if (!process.env.DB || process.env.DB === 'postgresql') {
+  module.exports.expectedTelemetryPrefix = 'pg'
+} else if (process.env.DB === 'mariadb' || process.env.DB === 'mysql' || process.env.DB === 'mysql8') {
+  module.exports.expectedTelemetryPrefix = 'mysql'
+} else if (process.env.DB === 'sqlite') {
+  module.exports.expectedTelemetryPrefix = 'sqlite'
+}

--- a/packages/db/test/telemetry.test.js
+++ b/packages/db/test/telemetry.test.js
@@ -228,7 +228,7 @@ test('should trace a request in a platformatic DB app', async () => {
 test('should trace a request getting DB from the request and running the query manually', async () => {
   const plugin = async (app) => {
     app.get('/custom-pages', async (request, _reply) => {
-      const { db } = request
+      const db = request.getDB()
       const { sql } = app.platformatic
       const pages = await db.query(sql`SELECT id, title FROM pages;`)
       return pages

--- a/packages/db/test/telemetry.test.js
+++ b/packages/db/test/telemetry.test.js
@@ -4,7 +4,8 @@ const assert = require('node:assert/strict')
 const { test } = require('node:test')
 const { request } = require('undici')
 const { buildServer } = require('..')
-const { buildConfigManager, getConnectionInfo, createBasicPages } = require('./helper')
+const { SpanStatusCode, SpanKind } = require('@opentelemetry/api')
+const { buildConfigManager, getConnectionInfo, createBasicPages, expectedTelemetryPrefix } = require('./helper')
 
 const getSpanPerType = (spans, type = 'http') => {
   let attibuteToLookFor
@@ -113,4 +114,190 @@ test('should setup telemetry if configured', async (t) => {
   assert.equal(dbSpan.name, 'pg.query:INSERT INTO public.pages (title)VALUES ($1)RETURNING id, title')
   assert.equal(dbSpan.attributes['db.system'], 'postgresql')
   assert.equal(dbSpan.attributes['db.statement'], 'INSERT INTO public.pages (title)\nVALUES ($1)\nRETURNING id, title')
+})
+
+async function setupDBAppWithTelemetry (telemetryOpts, onDatabaseLoad, plugins, teardown) {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+    },
+    db: {
+      ...connectionInfo,
+      onDatabaseLoad,
+    },
+    telemetry: telemetryOpts,
+  }
+
+  const configManager = await buildConfigManager(config)
+  const app = await buildServer({ configManager })
+  for (const plugin of plugins) {
+    await app.register(plugin)
+  }
+
+  teardown(async () => {
+    await app.close()
+    await dropTestDB()
+    const { exporters } = app.openTelemetry
+    exporters.forEach((exporter) => {
+      if (exporter.constructor.name === 'InMemorySpanExporter') {
+        exporter.reset()
+      }
+    })
+  })
+  return app
+}
+
+async function onDatabaseLoad (db, sql) {
+  await createBasicPages(db, sql)
+}
+
+test('should trace a request in a platformatic DB app', async () => {
+  const app = await setupDBAppWithTelemetry(
+    {
+      serviceName: 'test-service',
+      version: '1.0.0',
+      exporter: {
+        type: 'memory',
+      },
+    },
+    onDatabaseLoad,
+    [],
+    test.after
+  )
+
+  const { exporters } = app.openTelemetry
+  const exporter = exporters[0]
+  exporter.reset() //  we reset to avoid the queies to load all the metadata
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/pages',
+  })
+  console.log('res', res.json())
+  assert.equal(res.statusCode, 200, '/pages status code')
+
+  const finishedSpans = exporter.getFinishedSpans()
+  assert.equal(finishedSpans.length, 2)
+
+  let dbTraceId, dbParentSpanId
+  {
+    // DB query span
+    const span = finishedSpans[0]
+    assert.equal(span.kind, SpanKind.CLIENT) // this is the db client span
+    const expectedName = `${expectedTelemetryPrefix}.query:`
+    const expectedNameRE = new RegExp(`^${expectedName}`)
+    assert.match(span.name, expectedNameRE)
+    assert.match(
+      span.attributes['db.statement'],
+      /^SELECT id, title/
+    )
+    const resource = span.resource
+    assert.deepEqual(resource.attributes['service.name'], 'test-service')
+    assert.deepEqual(resource.attributes['service.version'], '1.0.0')
+    dbTraceId = span.spanContext().traceId
+    dbParentSpanId = span.parentSpanId
+  }
+  {
+    // HTTP request span
+    const span = finishedSpans[1]
+    assert.equal(span.kind, SpanKind.SERVER)
+    assert.equal(span.name, 'GET /pages')
+    assert.equal(span.status.code, SpanStatusCode.OK)
+    assert.equal(span.attributes['http.request.method'], 'GET')
+    assert.equal(span.attributes['url.path'], '/pages')
+    assert.equal(span.attributes['http.response.status_code'], 200)
+    assert.equal(span.attributes['url.scheme'], 'http')
+    const resource = span.resource
+    assert.deepEqual(resource.attributes['service.name'], 'test-service')
+    assert.deepEqual(resource.attributes['service.version'], '1.0.0')
+
+    const spanId = span._spanContext.spanId
+    const traceId = span._spanContext.traceId
+    const parentSpanId = span.parentSpanId
+
+    // Check that the traceId is the same and the http span is the parent of the db span
+    assert.equal(traceId, dbTraceId)
+    assert.equal(dbParentSpanId, spanId) // the db span is the child of the http span
+    assert.ok(!parentSpanId) // the http span has no parent
+  }
+})
+
+test('should trace a request getting DB from the request and running the query manually', async () => {
+  const plugin = async (app) => {
+    app.get('/custom-pages', async (request, _reply) => {
+      const { db } = request
+      const { sql } = app.platformatic
+      const pages = await db.query(sql`SELECT id, title FROM pages;`)
+      return pages
+    })
+  }
+  const app = await setupDBAppWithTelemetry(
+    {
+      serviceName: 'test-service',
+      version: '1.0.0',
+      exporter: {
+        type: 'memory',
+      },
+    },
+    onDatabaseLoad,
+    [plugin],
+    test.after
+  )
+  const { exporters } = app.openTelemetry
+  const exporter = exporters[0]
+  exporter.reset() //  we reset to avoid the queies to load all the metadata
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/custom-pages',
+  })
+  assert.equal(res.statusCode, 200, '/custom-pages status code')
+
+  const finishedSpans = exporter.getFinishedSpans()
+  assert.equal(finishedSpans.length, 2)
+
+  let dbTraceId, dbParentSpanId
+  {
+    // DB query span
+    const span = finishedSpans[0]
+    assert.equal(span.kind, SpanKind.CLIENT) // this is the db client span
+    const expectedName = `${expectedTelemetryPrefix}.query:`
+    const expectedNameRE = new RegExp(`^${expectedName}`)
+    assert.match(span.name, expectedNameRE)
+    assert.match(
+      span.attributes['db.statement'],
+      /^SELECT id, title/
+    )
+    const resource = span.resource
+    assert.deepEqual(resource.attributes['service.name'], 'test-service')
+    assert.deepEqual(resource.attributes['service.version'], '1.0.0')
+    dbTraceId = span.spanContext().traceId
+    dbParentSpanId = span.parentSpanId
+  }
+  {
+    // HTTP request span
+    const span = finishedSpans[1]
+    assert.equal(span.kind, SpanKind.SERVER)
+    assert.equal(span.name, 'GET /custom-pages')
+    assert.equal(span.status.code, SpanStatusCode.OK)
+    assert.equal(span.attributes['http.request.method'], 'GET')
+    assert.equal(span.attributes['url.path'], '/custom-pages')
+    assert.equal(span.attributes['http.response.status_code'], 200)
+    assert.equal(span.attributes['url.scheme'], 'http')
+    const resource = span.resource
+    assert.deepEqual(resource.attributes['service.name'], 'test-service')
+    assert.deepEqual(resource.attributes['service.version'], '1.0.0')
+
+    const spanId = span._spanContext.spanId
+    const traceId = span._spanContext.traceId
+    const parentSpanId = span.parentSpanId
+
+    // Check that the traceId is the same and the http span is the parent of the db span
+    assert.equal(traceId, dbTraceId)
+    assert.equal(dbParentSpanId, spanId) // the db span is the child of the http span
+    assert.ok(!parentSpanId) // the http span has no parent
+  }
 })

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -39,7 +39,7 @@ async function platformaticService (app, opts) {
   }
 
   // This must be done before loading the plugins, so they can inspect if the
-  // openTelemetry decoretor exists and then configure accordingly.
+  // openTelemetry decorator exists and then configure accordingly.
   if (isKeyEnabled('telemetry', config)) {
     await app.register(telemetry, config.telemetry)
   }

--- a/packages/sql-graphql/lib/telemetry.js
+++ b/packages/sql-graphql/lib/telemetry.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const telemetryWrapper = (app, fn, operationType, operationName) => async (...args) => {
-  const { startInternalSpan, endInternalSpan } = app.openTelemetry
+  const { startSpan, endSpan } = app.openTelemetry
   const context = args[2]
   const request = context?.reply?.request
   const document = JSON.stringify(request?.body)
@@ -15,14 +15,14 @@ const telemetryWrapper = (app, fn, operationType, operationName) => async (...ar
   const spanName = `${operationType} ${operationName}`
   const ctx = request.span?.context
 
-  const span = startInternalSpan(spanName, ctx, telemetryAttributes)
+  const span = startSpan(spanName, ctx, telemetryAttributes)
   try {
     const result = await fn(...args)
-    endInternalSpan(span)
+    endSpan(span)
     return result
   // We ignore this because in sqlite it's HARD to have a resolver exception without a schema validation exception first.
   } catch (err) /* istanbul ignore next */ {
-    endInternalSpan(span, err)
+    endSpan(span, err)
     throw err
   }
 }

--- a/packages/sql-mapper/lib/telemetry.js
+++ b/packages/sql-mapper/lib/telemetry.js
@@ -1,0 +1,80 @@
+'use strict'
+
+function wrapQuery (app, db, request) {
+  const { startSpan, endSpan, SpanKind } = app.openTelemetry
+  async function wrappedFunction () {
+    const query = arguments[0]
+
+    let namePrefix, dbSystem
+    if (db.isPg) {
+      namePrefix = 'pg.query:'
+      dbSystem = 'postgresql'
+    } else if (db.isMySql) {
+      namePrefix = 'mysql.query:'
+      dbSystem = 'mysql'
+    } else if (db.isMariaDB) {
+      namePrefix = 'mariadb.query:'
+      dbSystem = 'mysql'
+    } else if (db.isSQLite) {
+      namePrefix = 'sqlite.query:'
+      dbSystem = 'sqlite'
+    } else {
+      namePrefix = 'db.query:'
+      dbSystem = 'unknown'
+    }
+
+    const format = {
+      escapeIdentifier: (str) => (str),
+      formatValue: (value, index) => ({ placeholder: `$${index + 1}`, value }),
+    }
+    const { text: queryText } = query.format(format)
+    const spanName = `${namePrefix}${queryText.replace(/\n|\r/g, '')}`
+
+    const ctx = request.span?.context
+
+    const telemetryAttributes = {
+      'db.statement': queryText,
+      'db.system': dbSystem,
+    }
+
+    let span
+    try {
+      span = startSpan(spanName, ctx, telemetryAttributes, SpanKind.CLIENT)
+      const result = await db.query.apply(db, arguments)
+      endSpan(span)
+      return result
+    } catch (err) /* istanbul ignore next */ {
+      endSpan(span, err)
+      throw err
+    }
+  }
+  return wrappedFunction
+}
+
+function wrapDB (app, db, request) {
+  const newDb = Object.create(db)
+  newDb.query = wrapQuery(app, db, request)
+  newDb.tx = async function wrapTx (func) {
+    return db.tx(async (db) => {
+      const _newDb = Object.create(db)
+      _newDb.query = wrapQuery(app, db, request)
+      return func(_newDb)
+    })
+  }
+  return newDb
+}
+
+const setupTelemetry = app => {
+  // Decorate the request with the wrapped DB.
+  // We need that for the queries written directly using `db`
+  app.addHook('onRequest', async (req, _reply) => {
+    const { db, sql } = app.platformatic
+    req['db'] = wrapDB(app, db, req)
+    req['sql'] = sql // For symmmetry, if we get the DB from the request, we should also get the SQL (even if unchanged)
+  })
+}
+
+module.exports = {
+  setupTelemetry,
+  wrapDB,
+}

--- a/packages/sql-mapper/mapper.js
+++ b/packages/sql-mapper/mapper.js
@@ -8,6 +8,7 @@ const queriesFactory = require('./lib/queries')
 const { areSchemasSupported } = require('./lib/utils')
 const errors = require('./lib/errors')
 const setupCache = require('./lib/cache')
+const { setupTelemetry } = require('./lib/telemetry')
 
 // Ignore the function as it is only used only for MySQL and PostgreSQL
 /* istanbul ignore next */
@@ -273,6 +274,11 @@ async function sqlMapper (app, opts) {
     }
     done()
   })
+
+  // TODO: should we enable db telemetry explicitely with a config?
+  if (app.openTelemetry) {
+    await setupTelemetry(app)
+  }
 }
 
 async function dropTable (db, sql, table) {

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "devDependencies": {
     "@matteo.collina/tspl": "^0.1.1",
+    "@opentelemetry/api": "^1.8.0",
     "borp": "^0.17.0",
     "eslint": "9",
     "fastify": "^4.26.2",

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -27,6 +27,8 @@
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "devDependencies": {
     "@matteo.collina/tspl": "^0.1.1",
+    "@opentelemetry/api": "^1.8.0",
+    "@platformatic/db-core": "workspace:*",
     "borp": "^0.17.0",
     "eslint": "9",
     "fastify": "^4.26.2",
@@ -41,6 +43,7 @@
     "@fastify/error": "^3.4.1",
     "@hapi/topo": "^6.0.2",
     "@matteo.collina/sqlite-pool": "^0.4.0",
+    "@platformatic/telemetry": "workspace:*",
     "@platformatic/utils": "workspace:*",
     "async-cache-dedupe": "^2.1.0",
     "camelcase": "^6.3.0",

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -27,8 +27,6 @@
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "devDependencies": {
     "@matteo.collina/tspl": "^0.1.1",
-    "@opentelemetry/api": "^1.8.0",
-    "@platformatic/db-core": "workspace:*",
     "borp": "^0.17.0",
     "eslint": "9",
     "fastify": "^4.26.2",

--- a/packages/sql-mapper/test/helper.js
+++ b/packages/sql-mapper/test/helper.js
@@ -16,22 +16,27 @@ const connInfo = {
 if (!process.env.DB || process.env.DB === 'postgresql') {
   connInfo.connectionString = 'postgres://postgres:postgres@127.0.0.1/postgres'
   module.exports.isPg = true
+  module.exports.expectedTelemetryPrefix = 'pg'
 } else if (process.env.DB === 'mariadb') {
   connInfo.connectionString = 'mysql://root@127.0.0.1:3307/graph'
   connInfo.poolSize = 10
   module.exports.isMysql = true
+  module.exports.expectedTelemetryPrefix = 'mysql'
 } else if (process.env.DB === 'mysql') {
   connInfo.connectionString = 'mysql://root@127.0.0.1/graph'
   connInfo.poolSize = 10
   module.exports.isMysql = true
+  module.exports.expectedTelemetryPrefix = 'mysql'
 } else if (process.env.DB === 'mysql8') {
   connInfo.connectionString = 'mysql://root@127.0.0.1:3308/graph'
   connInfo.poolSize = 10
   module.exports.isMysql = true
   module.exports.isMysql8 = true
+  module.exports.expectedTelemetryPrefix = 'mysql'
 } else if (process.env.DB === 'sqlite') {
   connInfo.connectionString = 'sqlite://:memory:'
   module.exports.isSQLite = true
+  module.exports.expectedTelemetryPrefix = 'sqlite'
 }
 
 module.exports.connInfo = connInfo

--- a/packages/sql-mapper/test/telemetry.test.js
+++ b/packages/sql-mapper/test/telemetry.test.js
@@ -1,0 +1,198 @@
+'use strict'
+
+const { test } = require('node:test')
+const { deepEqual, equal, match, ok } = require('node:assert')
+const fastify = require('fastify')
+const { SpanStatusCode, SpanKind } = require('@opentelemetry/api')
+const core = require('@platformatic/db-core')
+const { clear, isSQLite, connInfo, expectedTelemetryPrefix } = require('./helper')
+const { telemetry } = require('@platformatic/telemetry')
+
+async function setupDBAppWithTelemetry (telemetryOpts, onDatabaseLoad, plugins, teardown) {
+  const { connectionString } = connInfo
+  const app = fastify()
+  await app.register(telemetry, telemetryOpts)
+  await app.register(core, {
+    connectionString,
+    onDatabaseLoad,
+  })
+  for (const plugin of plugins) {
+    await app.register(plugin)
+  }
+  app.ready()
+  teardown(async () => {
+    await app.close()
+    const { exporters } = app.openTelemetry
+    exporters.forEach((exporter) => {
+      if (exporter.constructor.name === 'InMemorySpanExporter') {
+        exporter.reset()
+      }
+    })
+  })
+  return app
+}
+
+async function createBasicPages (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE pages (
+        id INTEGER PRIMARY KEY,
+        title VARCHAR(42)
+      );`)
+  } else {
+    await db.query(sql`CREATE TABLE pages (
+        id SERIAL PRIMARY KEY,
+        title VARCHAR(255) NOT NULL
+      );`)
+  }
+}
+
+async function onDatabaseLoad (db, sql) {
+  await clear(db, sql)
+  await createBasicPages(db, sql)
+}
+
+test('should trace a request in a platformatic DB app', async () => {
+  const app = await setupDBAppWithTelemetry(
+    {
+      serviceName: 'test-service',
+      version: '1.0.0',
+      exporter: {
+        type: 'memory',
+      },
+    },
+    onDatabaseLoad,
+    [],
+    test.after
+  )
+  const { exporters } = app.openTelemetry
+  const exporter = exporters[0]
+  exporter.reset() //  we reset to avoid the queies to load all the metadata
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/pages',
+  })
+  equal(res.statusCode, 200, '/pages status code')
+
+  const finishedSpans = exporter.getFinishedSpans()
+  equal(finishedSpans.length, 2)
+
+  let dbTraceId, dbParentSpanId
+  {
+    // DB query span
+    const span = finishedSpans[0]
+    equal(span.kind, SpanKind.CLIENT) // this is the db client span
+    const expectedName = `${expectedTelemetryPrefix}.query:`
+    const expectedNameRE = new RegExp(`^${expectedName}`)
+    match(span.name, expectedNameRE)
+    match(
+      span.attributes['db.statement'],
+      /^SELECT id, title/
+    )
+    const resource = span.resource
+    deepEqual(resource.attributes['service.name'], 'test-service')
+    deepEqual(resource.attributes['service.version'], '1.0.0')
+    dbTraceId = span.spanContext().traceId
+    dbParentSpanId = span.parentSpanId
+  }
+  {
+    // HTTP request span
+    const span = finishedSpans[1]
+    equal(span.kind, SpanKind.SERVER)
+    equal(span.name, 'GET /pages')
+    equal(span.status.code, SpanStatusCode.OK)
+    equal(span.attributes['http.request.method'], 'GET')
+    equal(span.attributes['url.path'], '/pages')
+    equal(span.attributes['http.response.status_code'], 200)
+    equal(span.attributes['url.scheme'], 'http')
+    const resource = span.resource
+    deepEqual(resource.attributes['service.name'], 'test-service')
+    deepEqual(resource.attributes['service.version'], '1.0.0')
+
+    const spanId = span._spanContext.spanId
+    const traceId = span._spanContext.traceId
+    const parentSpanId = span.parentSpanId
+
+    // Check that the traceId is the same and the http span is the parent of the db span
+    equal(traceId, dbTraceId)
+    equal(dbParentSpanId, spanId) // the db span is the child of the http span
+    ok(!parentSpanId) // the http span has no parent
+  }
+})
+
+test('should trace a request getting DB from the request and running the query manually', async () => {
+  const plugin = async (app) => {
+    app.get('/custom-pages', async (request, _reply) => {
+      const { db } = request
+      const { sql } = app.platformatic
+      const pages = await db.query(sql`SELECT id, title FROM pages;`)
+      return pages
+    })
+  }
+  const app = await setupDBAppWithTelemetry(
+    {
+      serviceName: 'test-service',
+      version: '1.0.0',
+      exporter: {
+        type: 'memory',
+      },
+    },
+    onDatabaseLoad,
+    [plugin],
+    test.after
+  )
+  const { exporters } = app.openTelemetry
+  const exporter = exporters[0]
+  exporter.reset() //  we reset to avoid the queies to load all the metadata
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/custom-pages',
+  })
+  equal(res.statusCode, 200, '/custom-pages status code')
+
+  const finishedSpans = exporter.getFinishedSpans()
+  equal(finishedSpans.length, 2)
+
+  let dbTraceId, dbParentSpanId
+  {
+    // DB query span
+    const span = finishedSpans[0]
+    equal(span.kind, SpanKind.CLIENT) // this is the db client span
+    const expectedName = `${expectedTelemetryPrefix}.query:`
+    const expectedNameRE = new RegExp(`^${expectedName}`)
+    match(span.name, expectedNameRE)
+    match(
+      span.attributes['db.statement'],
+      /^SELECT id, title/
+    )
+    const resource = span.resource
+    deepEqual(resource.attributes['service.name'], 'test-service')
+    deepEqual(resource.attributes['service.version'], '1.0.0')
+    dbTraceId = span.spanContext().traceId
+    dbParentSpanId = span.parentSpanId
+  }
+  {
+    // HTTP request span
+    const span = finishedSpans[1]
+    equal(span.kind, SpanKind.SERVER)
+    equal(span.name, 'GET /custom-pages')
+    equal(span.status.code, SpanStatusCode.OK)
+    equal(span.attributes['http.request.method'], 'GET')
+    equal(span.attributes['url.path'], '/custom-pages')
+    equal(span.attributes['http.response.status_code'], 200)
+    equal(span.attributes['url.scheme'], 'http')
+    const resource = span.resource
+    deepEqual(resource.attributes['service.name'], 'test-service')
+    deepEqual(resource.attributes['service.version'], '1.0.0')
+
+    const spanId = span._spanContext.spanId
+    const traceId = span._spanContext.traceId
+    const parentSpanId = span.parentSpanId
+
+    // Check that the traceId is the same and the http span is the parent of the db span
+    equal(traceId, dbTraceId)
+    equal(dbParentSpanId, spanId) // the db span is the child of the http span
+    ok(!parentSpanId) // the http span has no parent
+  }
+})

--- a/packages/sql-mapper/test/telemetry.test.js
+++ b/packages/sql-mapper/test/telemetry.test.js
@@ -62,10 +62,13 @@ async function onDatabaseLoad (db, sql) {
 test('should trace a request getting DB from the request and running the query manually', async () => {
   const plugin = async (app) => {
     app.get('/custom-pages', async (request, _reply) => {
-      const { db } = request
-      const { sql } = app.platformatic
-      const pages = await db.query(sql`SELECT id, title FROM pages;`)
-      return pages
+      try {
+        const db = request.getDB()
+        const { sql } = app.platformatic
+        return db.query(sql`SELECT id, title FROM pages;`)
+      } catch (err) {
+        console.error(err)
+      }
     })
   }
   const app = await setupDBAppWithTelemetry(

--- a/packages/sql-mapper/test/telemetry.test.js
+++ b/packages/sql-mapper/test/telemetry.test.js
@@ -4,18 +4,26 @@ const { test } = require('node:test')
 const { deepEqual, equal, match, ok } = require('node:assert')
 const fastify = require('fastify')
 const { SpanStatusCode, SpanKind } = require('@opentelemetry/api')
-const core = require('@platformatic/db-core')
 const { clear, isSQLite, connInfo, expectedTelemetryPrefix } = require('./helper')
 const { telemetry } = require('@platformatic/telemetry')
+const { plugin: mapper } = require('..')
+
+const fakeLogger = {
+  trace: () => {},
+  error: () => {},
+  warn: () => {},
+}
 
 async function setupDBAppWithTelemetry (telemetryOpts, onDatabaseLoad, plugins, teardown) {
   const { connectionString } = connInfo
   const app = fastify()
   await app.register(telemetry, telemetryOpts)
-  await app.register(core, {
+  await app.register(mapper, {
     connectionString,
+    log: fakeLogger,
     onDatabaseLoad,
   })
+
   for (const plugin of plugins) {
     await app.register(plugin)
   }
@@ -50,75 +58,6 @@ async function onDatabaseLoad (db, sql) {
   await clear(db, sql)
   await createBasicPages(db, sql)
 }
-
-test('should trace a request in a platformatic DB app', async () => {
-  const app = await setupDBAppWithTelemetry(
-    {
-      serviceName: 'test-service',
-      version: '1.0.0',
-      exporter: {
-        type: 'memory',
-      },
-    },
-    onDatabaseLoad,
-    [],
-    test.after
-  )
-  const { exporters } = app.openTelemetry
-  const exporter = exporters[0]
-  exporter.reset() //  we reset to avoid the queies to load all the metadata
-
-  const res = await app.inject({
-    method: 'GET',
-    url: '/pages',
-  })
-  equal(res.statusCode, 200, '/pages status code')
-
-  const finishedSpans = exporter.getFinishedSpans()
-  equal(finishedSpans.length, 2)
-
-  let dbTraceId, dbParentSpanId
-  {
-    // DB query span
-    const span = finishedSpans[0]
-    equal(span.kind, SpanKind.CLIENT) // this is the db client span
-    const expectedName = `${expectedTelemetryPrefix}.query:`
-    const expectedNameRE = new RegExp(`^${expectedName}`)
-    match(span.name, expectedNameRE)
-    match(
-      span.attributes['db.statement'],
-      /^SELECT id, title/
-    )
-    const resource = span.resource
-    deepEqual(resource.attributes['service.name'], 'test-service')
-    deepEqual(resource.attributes['service.version'], '1.0.0')
-    dbTraceId = span.spanContext().traceId
-    dbParentSpanId = span.parentSpanId
-  }
-  {
-    // HTTP request span
-    const span = finishedSpans[1]
-    equal(span.kind, SpanKind.SERVER)
-    equal(span.name, 'GET /pages')
-    equal(span.status.code, SpanStatusCode.OK)
-    equal(span.attributes['http.request.method'], 'GET')
-    equal(span.attributes['url.path'], '/pages')
-    equal(span.attributes['http.response.status_code'], 200)
-    equal(span.attributes['url.scheme'], 'http')
-    const resource = span.resource
-    deepEqual(resource.attributes['service.name'], 'test-service')
-    deepEqual(resource.attributes['service.version'], '1.0.0')
-
-    const spanId = span._spanContext.spanId
-    const traceId = span._spanContext.traceId
-    const parentSpanId = span.parentSpanId
-
-    // Check that the traceId is the same and the http span is the parent of the db span
-    equal(traceId, dbTraceId)
-    equal(dbParentSpanId, spanId) // the db span is the child of the http span
-    ok(!parentSpanId) // the http span has no parent
-  }
-})
 
 test('should trace a request getting DB from the request and running the query manually', async () => {
   const plugin = async (app) => {

--- a/packages/telemetry/test/client.test.js
+++ b/packages/telemetry/test/client.test.js
@@ -37,10 +37,10 @@ test('should add the propagation headers correctly, new propagation started', as
     },
   }, handler, test.after)
 
-  const { startSpanClient } = app.openTelemetry
+  const { startHTTPSpanClient } = app.openTelemetry
 
   const url = 'http://localhost:3000/test'
-  const { span, telemetryHeaders } = startSpanClient(url, 'GET')
+  const { span, telemetryHeaders } = startHTTPSpanClient(url, 'GET')
 
   const spanId = span._spanContext.spanId
   const traceId = span._spanContext.traceId
@@ -66,7 +66,7 @@ test('should add the propagation headers correctly, with propagation already sta
     },
   }, handler, test.after)
 
-  const { startSpanClient } = app.openTelemetry
+  const { startHTTPSpanClient } = app.openTelemetry
 
   const url = 'http://localhost:3000/test'
   const incomingHeaders = {
@@ -76,7 +76,7 @@ test('should add the propagation headers correctly, with propagation already sta
   const { propagator } = app.openTelemetry
   const context = propagator.extract(new PlatformaticContext(), { headers: incomingHeaders }, fastifyTextMapGetter)
 
-  const { span, telemetryHeaders } = startSpanClient(url, 'GET', context)
+  const { span, telemetryHeaders } = startHTTPSpanClient(url, 'GET', context)
 
   const spanId2 = span._spanContext.spanId
   const traceId2 = span._spanContext.traceId
@@ -103,14 +103,14 @@ test('should trace a client request', async () => {
     },
   }, handler, test.after)
 
-  const { startSpanClient, endSpanClient } = app.openTelemetry
+  const { startHTTPSpanClient, endHTTPSpanClient } = app.openTelemetry
 
   const url = 'http://localhost:3000/test'
 
   const { propagator } = app.openTelemetry
   const context = propagator.extract(new PlatformaticContext(), { headers: {} }, fastifyTextMapGetter)
 
-  const { span, telemetryHeaders } = startSpanClient(url, 'GET', context)
+  const { span, telemetryHeaders } = startHTTPSpanClient(url, 'GET', context)
   const args = {
     method: 'GET',
     url: '/test',
@@ -120,7 +120,7 @@ test('should trace a client request', async () => {
   }
 
   const response = await app.inject(args)
-  endSpanClient(span, response)
+  endHTTPSpanClient(span, response)
 
   const { exporters } = app.openTelemetry
   const exporter = exporters[0]
@@ -163,20 +163,20 @@ test('should trace a client request failing', async () => {
     },
   }, handler, test.after)
 
-  const { startSpanClient, endSpanClient } = app.openTelemetry
+  const { startHTTPSpanClient, endHTTPSpanClient } = app.openTelemetry
 
   const { propagator } = app.openTelemetry
   const context = propagator.extract(new PlatformaticContext(), { headers: {} }, fastifyTextMapGetter)
 
   const url = 'http://localhost/test'
-  const { span, telemetryHeaders } = startSpanClient(url, 'GET', context)
+  const { span, telemetryHeaders } = startHTTPSpanClient(url, 'GET', context)
   const args = {
     method: 'GET',
     url: '/wrong',
     headers: telemetryHeaders,
   }
   const response = await app.inject(args)
-  endSpanClient(span, response)
+  endHTTPSpanClient(span, response)
 
   const { exporters } = app.openTelemetry
   const exporter = exporters[0]
@@ -213,16 +213,16 @@ test('should trace a client request failing (no HTTP error)', async () => {
     },
   }, handler, test.after)
 
-  const { startSpanClient, endSpanClient, setErrorInSpanClient } = app.openTelemetry
+  const { startHTTPSpanClient, endHTTPSpanClient, setErrorInSpanClient } = app.openTelemetry
 
   const url = 'http://localhost:3000/test'
-  const { span } = startSpanClient(url, 'GET')
+  const { span } = startHTTPSpanClient(url, 'GET')
   try {
     throw new Error('KABOOM!!!')
   } catch (err) {
     setErrorInSpanClient(span, err)
   } finally {
-    endSpanClient(span)
+    endHTTPSpanClient(span)
   }
 
   const { exporters } = app.openTelemetry
@@ -251,10 +251,10 @@ test('should not add the query in span name', async () => {
     },
   }, handler, test.after)
 
-  const { startSpanClient } = app.openTelemetry
+  const { startHTTPSpanClient } = app.openTelemetry
 
   const url = 'http://localhost:3000/test?foo=bar'
-  const { span } = startSpanClient(url, 'GET')
+  const { span } = startHTTPSpanClient(url, 'GET')
   deepEqual(span.name, 'GET http://localhost:3000/test')
 })
 
@@ -276,10 +276,10 @@ test('should ignore the skipped operations', async () => {
     },
   }, handler, test.after)
 
-  const { startSpanClient } = app.openTelemetry
+  const { startHTTPSpanClient } = app.openTelemetry
 
   const url = 'http://localhost:3000/skipme'
-  const ret = startSpanClient(url, 'POST')
+  const ret = startHTTPSpanClient(url, 'POST')
   // no spam should be created
   ok(!ret)
 })

--- a/packages/telemetry/test/internal.test.js
+++ b/packages/telemetry/test/internal.test.js
@@ -24,7 +24,7 @@ test('start and ends an internal span', async () => {
     },
   }, handler, test.after)
 
-  const { startInternalSpan, endInternalSpan } = app.openTelemetry
+  const { startSpan, endSpan } = app.openTelemetry
 
   const incomingHeaders = {
     host: 'test',
@@ -36,11 +36,11 @@ test('start and ends an internal span', async () => {
   const attributes = {
     'test-attribute': 'test-value',
   }
-  const span = startInternalSpan('TEST', context, attributes)
+  const span = startSpan('TEST', context, attributes)
   deepEqual(span._spanContext.traceId, traceId)
   equal(span._ended, false)
   deepEqual(span.attributes, attributes)
-  endInternalSpan(span)
+  endSpan(span)
   equal(span._ended, true)
 
   const { exporters } = app.openTelemetry
@@ -66,12 +66,12 @@ test('start and ends an internal span with no parent context and no attributes',
     },
   }, handler, test.after)
 
-  const { startInternalSpan, endInternalSpan } = app.openTelemetry
+  const { startSpan, endSpan } = app.openTelemetry
 
-  const span = startInternalSpan('TEST')
+  const span = startSpan('TEST')
   equal(span._ended, false)
   deepEqual(span.attributes, {})
-  endInternalSpan(span)
+  endSpan(span)
   equal(span._ended, true)
 
   const { exporters } = app.openTelemetry
@@ -101,7 +101,7 @@ test('start and ends an internal span with error', async () => {
     },
   }, handler, test.after)
 
-  const { startInternalSpan, endInternalSpan } = app.openTelemetry
+  const { startSpan, endSpan } = app.openTelemetry
 
   const incomingHeaders = {
     host: 'test',
@@ -113,12 +113,12 @@ test('start and ends an internal span with error', async () => {
   const attributes = {
     'test-attribute': 'test-value',
   }
-  const span = startInternalSpan('TEST', context, attributes)
+  const span = startSpan('TEST', context, attributes)
   deepEqual(span._spanContext.traceId, traceId)
   deepEqual(span._ended, false)
   deepEqual(span.attributes, attributes)
   const error = new Error('test error')
-  endInternalSpan(span, error)
+  endSpan(span, error)
   deepEqual(span._ended, true)
 
   const { exporters } = app.openTelemetry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -835,6 +835,9 @@ importers:
       '@databases/sql':
         specifier: ^3.3.0
         version: 3.3.0
+      '@opentelemetry/api':
+        specifier: ^1.8.0
+        version: 1.9.0
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
@@ -1785,12 +1788,6 @@ importers:
       '@matteo.collina/tspl':
         specifier: ^0.1.1
         version: 0.1.1
-      '@opentelemetry/api':
-        specifier: ^1.8.0
-        version: 1.9.0
-      '@platformatic/db-core':
-        specifier: workspace:*
-        version: link:../db-core
       borp:
         specifier: ^0.17.0
         version: 0.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1763,6 +1763,9 @@ importers:
       '@matteo.collina/sqlite-pool':
         specifier: ^0.4.0
         version: 0.4.0
+      '@platformatic/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
       '@platformatic/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1782,6 +1785,12 @@ importers:
       '@matteo.collina/tspl':
         specifier: ^0.1.1
         version: 0.1.1
+      '@opentelemetry/api':
+        specifier: ^1.8.0
+        version: 1.9.0
+      '@platformatic/db-core':
+        specifier: workspace:*
+        version: link:../db-core
       borp:
         specifier: ^0.17.0
         version: 0.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1788,6 +1788,9 @@ importers:
       '@matteo.collina/tspl':
         specifier: ^0.1.1
         version: 0.1.1
+      '@opentelemetry/api':
+        specifier: ^1.8.0
+        version: 1.9.0
       borp:
         specifier: ^0.17.0
         version: 0.17.0


### PR DESCRIPTION
Opentelemetry DB span. The `db.query` and `db.tx` functions has been wrapped to create the spans. 
Also, refactored some names, so that `startSpan` and `endSpan` are now generic and not only bound to HTTP. 