### PR TITLE
More DB telemetry attributes

### DIFF
--- a/packages/db/test/helper.js
+++ b/packages/db/test/helper.js
@@ -54,7 +54,7 @@ async function getConnectionInfo (dbType) {
   } else if (dbType === 'mysql') {
     baseConnectionString = 'mysql://root@127.0.0.1/'
   } else if (dbType === 'mysql8') {
-    baseConnectionString = 'mysql://root@localhost:3308/'
+    baseConnectionString = 'mysql://root@127.0.0.1:3308/'
   }
 
   const { db, sql } = await createConnectionPool({
@@ -72,6 +72,7 @@ async function getConnectionInfo (dbType) {
   const testDBName = 'test_db_' + randomUUID().replace(/-/g, '')
 
   await db.query(sql`CREATE DATABASE ${sql.ident(testDBName)};`)
+  connectionInfo.dbname = testDBName
   connectionInfo.connectionString = baseConnectionString + testDBName
 
   return {
@@ -124,9 +125,23 @@ async function buildConfigManager (source, dirname) {
 module.exports.buildConfigManager = buildConfigManager
 
 if (!process.env.DB || process.env.DB === 'postgresql') {
+  module.exports.isPg = true
   module.exports.expectedTelemetryPrefix = 'pg'
-} else if (process.env.DB === 'mariadb' || process.env.DB === 'mysql' || process.env.DB === 'mysql8') {
+  module.exports.expectedPort = 5432
+} else if (process.env.DB === 'mariadb') {
+  module.exports.isMysql = true
   module.exports.expectedTelemetryPrefix = 'mysql'
+  module.exports.expectedPort = '3307'
+} else if (process.env.DB === 'mysql') {
+  module.exports.isMysql = true
+  module.exports.expectedTelemetryPrefix = 'mysql'
+  module.exports.expectedPort = 3306
+} else if (process.env.DB === 'mysql8') {
+  module.exports.isMysql = true
+  module.exports.isMysql8 = true
+  module.exports.expectedTelemetryPrefix = 'mysql'
+  module.exports.expectedPort = '3308'
 } else if (process.env.DB === 'sqlite') {
+  module.exports.isSQLite = true
   module.exports.expectedTelemetryPrefix = 'sqlite'
 }

--- a/packages/sql-mapper/lib/connection-info.js
+++ b/packages/sql-mapper/lib/connection-info.js
@@ -1,0 +1,37 @@
+// The most general way to get the connection info is through the driver.
+// In this way, we don't need to do any assumptions about the connection string
+// (with the exception of SQLite)
+const getConnectionInfo = async (db, connectionString) => {
+  let database, host, port, user
+  if (db.isPg) {
+    const driver = await db._pool.getConnection()
+    const connectionParameters = driver.connection.client.connectionParameters
+    host = connectionParameters.host
+    port = connectionParameters.port
+    database = connectionParameters.database
+    user = connectionParameters.user
+    driver.release()
+  } else if (db.isMySql || db.isMariaDB || db.isMySql8) {
+    const driver = await db._pool.getConnection()
+    const connectionParameters = driver.connection.client.config
+    database = connectionParameters.database
+    host = connectionParameters.host
+    port = connectionParameters.port
+    user = connectionParameters.user
+    driver.release()
+  } else if (db.isSQLite) {
+    database = connectionString?.split('sqlite://')[1]
+  }
+
+  return {
+    database,
+    host,
+    port,
+    user,
+    isPg: db.isPg,
+    isMySql: db.isMySql,
+    isSQLite: db.isSQLite,
+  }
+}
+
+module.exports = { getConnectionInfo }

--- a/packages/sql-mapper/test/helper.js
+++ b/packages/sql-mapper/test/helper.js
@@ -17,22 +17,26 @@ if (!process.env.DB || process.env.DB === 'postgresql') {
   connInfo.connectionString = 'postgres://postgres:postgres@127.0.0.1/postgres'
   module.exports.isPg = true
   module.exports.expectedTelemetryPrefix = 'pg'
+  module.exports.expectedPort = 5432
 } else if (process.env.DB === 'mariadb') {
   connInfo.connectionString = 'mysql://root@127.0.0.1:3307/graph'
   connInfo.poolSize = 10
   module.exports.isMysql = true
   module.exports.expectedTelemetryPrefix = 'mysql'
+  module.exports.expectedPort = 3307
 } else if (process.env.DB === 'mysql') {
   connInfo.connectionString = 'mysql://root@127.0.0.1/graph'
   connInfo.poolSize = 10
   module.exports.isMysql = true
   module.exports.expectedTelemetryPrefix = 'mysql'
+  module.exports.expectedPort = 3306
 } else if (process.env.DB === 'mysql8') {
   connInfo.connectionString = 'mysql://root@127.0.0.1:3308/graph'
   connInfo.poolSize = 10
   module.exports.isMysql = true
   module.exports.isMysql8 = true
   module.exports.expectedTelemetryPrefix = 'mysql'
+  module.exports.expectedPort = 3308
 } else if (process.env.DB === 'sqlite') {
   connInfo.connectionString = 'sqlite://:memory:'
   module.exports.isSQLite = true


### PR DESCRIPTION
We need more span attirbutes when doing DB queries. 
The `pgIntrumentation` sets:

```
      'db.system': 'postgresql',
      'db.name': 'postgres',
      'db.connection_string': 'postgresql://127.0.0.1:5432/postgres',
      'net.peer.name': '127.0.0.1',
      'net.peer.port': 5432,
      'db.user': 'postgres',
      'db.statement': 'SELECT "id", "title"\n FROM "public"."pages"\nLIMIT $1' 
```    
In this PR we set also all these attributes for the supported DBs , with the exception on `db.connection_string` (because it might contain password), and also is not useful for telemetry, given all the other attributes). 