### PR TITLE
fix: catch runtime service stop error

### DIFF
--- a/packages/runtime/fixtures/monorepo/serviceAppWithLogger/plugin.js
+++ b/packages/runtime/fixtures/monorepo/serviceAppWithLogger/plugin.js
@@ -7,7 +7,7 @@ module.exports = async function (app) {
   })
 
   let crashOnClose = false
-  app.get('/crash-on-close', async () => {
+  app.get('/crash-on-close', { schema: { hide: true } }, async () => {
     crashOnClose = true
   })
 

--- a/packages/runtime/fixtures/monorepo/serviceAppWithLogger/plugin.js
+++ b/packages/runtime/fixtures/monorepo/serviceAppWithLogger/plugin.js
@@ -5,4 +5,16 @@ module.exports = async function (app) {
   app.get('/', async () => {
     return { hello: 'world' }
   })
+
+  let crashOnClose = false
+  app.get('/crash-on-close', async () => {
+    crashOnClose = true
+  })
+
+  app.addHook('onClose', async () => {
+    if (crashOnClose) {
+      app.log.info('Crashing process on purpose')
+      throw new Error('Crashing process on purpose')
+    }
+  })
 }

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -244,7 +244,11 @@ class Runtime extends EventEmitter {
     this.#startedServices.set(id, false)
 
     // Always send the stop message, it will shut down workers that only had ITC and interceptors setup
-    await Promise.race([sendViaITC(service, 'stop'), sleep(10000, 'timeout', { ref: false })])
+    try {
+      await Promise.race([sendViaITC(service, 'stop'), sleep(10000, 'timeout', { ref: false })])
+    } catch (error) {
+      this.logger.info(`Failed to stop service "${id}". Killing a worker thread.`, error)
+    }
 
     // Wait for the worker thread to finish, we're going to create a new one if the service is ever restarted
     const res = await Promise.race([once(service, 'exit'), sleep(10000, 'timeout', { ref: false })])

--- a/packages/runtime/test/api/stop.4.test.js
+++ b/packages/runtime/test/api/stop.4.test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const assert = require('node:assert')
+const { join } = require('node:path')
+const { test } = require('node:test')
+
+const { loadConfig } = require('@platformatic/config')
+const { buildServer, platformaticRuntime } = require('../..')
+const fixturesDir = join(__dirname, '..', '..', 'fixtures')
+
+test('should kill the thread even if stop fails', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  const { statusCode } = await app.inject('with-logger', {
+    method: 'GET',
+    url: '/crash-on-close',
+  })
+  assert.strictEqual(statusCode, 200)
+
+  // Should not fail and hang
+  await app.close()
+})


### PR DESCRIPTION
Runtime should handle the service stop command error and kill the worker thread anyway.