### PR TITLE
Add string support for `types.autogenerate`

### DIFF
--- a/packages/db/lib/adjust-config.js
+++ b/packages/db/lib/adjust-config.js
@@ -35,4 +35,8 @@ module.exports = async function adjustConfig (configManager) {
       [configManager.current.migrations.table || migrationsTableName]: true,
     }, configManager.current.db.ignore)
   }
+
+  if (configManager.current.types?.autogenerate === 'true') {
+    configManager.current.types.autogenerate = true
+  }
 }

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -383,7 +383,12 @@ const types = {
   type: 'object',
   properties: {
     autogenerate: {
-      type: 'boolean',
+      anyOf: [{
+        type: 'string',
+      }, {
+        type: 'boolean',
+      }],
+      description: 'Should types be auto generated.'
     },
     dir: {
       type: 'string',

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1014,7 +1014,15 @@
       "type": "object",
       "properties": {
         "autogenerate": {
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Should types be auto generated."          
         },
         "dir": {
           "type": "string",


### PR DESCRIPTION
This does two things:

- allows config for `types.autogenerate` to be either `boolean` or `string`
- adds short description for `types.autogenerate`