### PR TITLE
DB info API for DB services

### DIFF
--- a/packages/db/lib/stackable.js
+++ b/packages/db/lib/stackable.js
@@ -22,5 +22,16 @@ class DbStackable extends ServiceStackable {
 
     this.configManager.update(config)
   }
+
+  async getDBInfo () {
+    await this.init()
+    await this.app.ready()
+    if (this.app.platformatic.db) {
+      const connectionInfo = this.app.platformatic.db.connectionInfo
+      const dbschema = this.app.platformatic.dbschema
+      return { connectionInfo, dbschema }
+    }
+    return null
+  }
 }
 module.exports = { DbStackable }

--- a/packages/db/test/stackable/get-db-info.test.js
+++ b/packages/db/test/stackable/get-db-info.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { test } = require('node:test')
+const { join } = require('node:path')
+const { buildConfigManager, getConnectionInfo, createBasicPages } = require('../helper')
+const { buildStackable } = require('../..')
+
+test('get DB info via stackable api', async (t) => {
+  const workingDir = join(__dirname, '..', 'fixtures', 'directories')
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+  const { dbname } = connectionInfo
+
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+    },
+    db: {
+      ...connectionInfo,
+      async onDatabaseLoad (db, sql) {
+        await createBasicPages(db, sql)
+      },
+    },
+    plugins: {
+      paths: [join(workingDir, 'routes')],
+    },
+    watch: false,
+    metrics: false,
+  }
+
+  const configManager = await buildConfigManager(config, workingDir)
+  const stackable = await buildStackable({ configManager })
+
+  t.after(async () => {
+    await stackable.stop()
+    await dropTestDB()
+  })
+  await stackable.start()
+
+  const stackableDBInfo = await stackable.getDBInfo()
+
+  assert.deepStrictEqual(stackableDBInfo.connectionInfo, {
+    database: dbname,
+    dbSystem: 'postgresql',
+    host: '127.0.0.1',
+    port: 5432,
+    user: 'postgres',
+    isPg: true,
+    isMySql: undefined,
+    isSQLite: undefined,
+  })
+
+  const tables = []
+  for (const tableInfo of stackableDBInfo.dbschema) {
+    tables.push(tableInfo.table)
+  }
+  assert.deepStrictEqual(tables, ['pages'])
+})

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -13,6 +13,7 @@ module.exports = {
   ServiceNotStartedError: createError(`${ERROR_PREFIX}_SERVICE_NOT_STARTED`, "Service with id '%s' is not started"),
   FailedToRetrieveOpenAPISchemaError: createError(`${ERROR_PREFIX}_FAILED_TO_RETRIEVE_OPENAPI_SCHEMA`, 'Failed to retrieve OpenAPI schema for service with id "%s": %s'),
   FailedToRetrieveGraphQLSchemaError: createError(`${ERROR_PREFIX}_FAILED_TO_RETRIEVE_GRAPHQL_SCHEMA`, 'Failed to retrieve GraphQL schema for service with id "%s": %s'),
+  FailedToRetrieveDBInfoError: createError(`${ERROR_PREFIX}_FAILED_TO_RETRIEVE_DB_INFO`, 'Failed to retrieve DB info for service with id "%s": %s'),
   ApplicationAlreadyStartedError: createError(`${ERROR_PREFIX}_APPLICATION_ALREADY_STARTED`, 'Application is already started'),
   ApplicationNotStartedError: createError(`${ERROR_PREFIX}_APPLICATION_NOT_STARTED`, 'Application has not been started'),
   ConfigPathMustBeStringError: createError(`${ERROR_PREFIX}_CONFIG_PATH_MUST_BE_STRING`, 'Config path must be a string'),

--- a/packages/runtime/lib/management-api.js
+++ b/packages/runtime/lib/management-api.js
@@ -72,6 +72,12 @@ async function managementApiPlugin (app, opts) {
     return runtime.getServiceGraphqlSchema(id)
   })
 
+  app.get('/services/:id/db-info', async request => {
+    const { id } = request.params
+    app.log.debug('get db info', { id })
+    return runtime.getServiceDBInfo(id)
+  })
+
   app.post('/services/:id/start', async request => {
     const { id } = request.params
     app.log.debug('start service', { id })

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -507,6 +507,12 @@ class Runtime extends EventEmitter {
     return sendViaITC(service, 'getServiceGraphQLSchema')
   }
 
+  async getServiceDBInfo (id) {
+    const service = await this.#getServiceById(id, true)
+
+    return sendViaITC(service, 'getServiceDBInfo')
+  }
+
   async getMetrics (format = 'json') {
     let metrics = null
 

--- a/packages/runtime/lib/worker/default-stackable.js
+++ b/packages/runtime/lib/worker/default-stackable.js
@@ -12,6 +12,7 @@ const defaultStackable = {
   getInfo: () => null,
   getDispatchFunc: () => null,
   getOpenapiSchema: () => null,
+  getDBInfo: () => null,
   getGraphqlSchema: () => null,
   getMetrics: () => null,
   inject: () => {

--- a/packages/runtime/lib/worker/itc.js
+++ b/packages/runtime/lib/worker/itc.js
@@ -110,6 +110,14 @@ function setupITC (app, service, dispatcher) {
     }
   })
 
+  itc.handle('getServiceDBInfo', async () => {
+    try {
+      return app.stackable.getDBInfo()
+    } catch (err) {
+      throw new errors.FailedToRetrieveDBInfoError(service.id, err.message)
+    }
+  })
+
   itc.handle('getMetrics', async format => {
     return app.stackable.getMetrics({ format })
   })

--- a/packages/runtime/test/api/dbinfo.test.js
+++ b/packages/runtime/test/api/dbinfo.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const assert = require('node:assert')
+const { join } = require('node:path')
+const { test } = require('node:test')
+
+const { loadConfig } = require('@platformatic/config')
+const { buildServer, platformaticRuntime } = require('../..')
+const fixturesDir = join(__dirname, '..', '..', 'fixtures')
+
+test('should get db info for db services in runtime schema', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const dbInfo = await app.getServiceDBInfo('db-app')
+  const database = join(fixturesDir, 'monorepo', 'dbApp', 'db.sqlite')
+  assert.deepStrictEqual(dbInfo, {
+    connectionInfo: {
+      database,
+      host: undefined,
+      port: undefined,
+      user: undefined,
+      isPg: undefined,
+      isMySql: undefined,
+      isSQLite: true,
+      dbSystem: 'sqlite',
+    },
+    dbschema: [],
+  })
+})
+
+test('should get null if not db', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const dbInfo = await app.getServiceDBInfo('with-logger')
+  console.log('dbInfo', dbInfo)
+  assert.deepStrictEqual(dbInfo, null)
+})

--- a/packages/runtime/test/management-api/service-dbinfo.test.js
+++ b/packages/runtime/test/management-api/service-dbinfo.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const assert = require('node:assert')
+const { join } = require('node:path')
+const { test } = require('node:test')
+const { Client } = require('undici')
+
+const { buildServer } = require('../..')
+const fixturesDir = join(__dirname, '..', '..', 'fixtures')
+
+test('should get service db info', async (t) => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await buildServer(configFile)
+
+  await app.start()
+
+  const client = new Client({
+    hostname: 'localhost',
+    protocol: 'http:',
+  }, {
+    socketPath: app.getManagementApiUrl(),
+    keepAliveTimeout: 10,
+    keepAliveMaxTimeout: 10,
+  })
+
+  t.after(async () => {
+    await Promise.all([
+      client.close(),
+      app.close(),
+    ])
+  })
+
+  const { statusCode, body } = await client.request({
+    method: 'GET',
+    path: '/api/v1/services/service-db/db-info',
+  })
+
+  assert.strictEqual(statusCode, 200)
+
+  const dbInfo = await body.json()
+
+  const database = join(fixturesDir, 'management-api', 'services', 'service-db', 'db.sqlite')
+
+  assert.deepStrictEqual(dbInfo.connectionInfo, {
+    database,
+    isSQLite: true,
+    dbSystem: 'sqlite',
+  })
+
+  const tables = dbInfo.dbschema.map(table => table.table)
+  assert.deepStrictEqual(tables, ['versions', 'movies'])
+
+  {
+    // Must return null if not a db service
+    const { statusCode, body } = await client.request({
+      method: 'GET',
+      path: '/api/v1/services/service-1/db-info',
+    })
+    assert.strictEqual(statusCode, 200)
+    const dbInfo = await body.json()
+    assert.strictEqual(dbInfo, null)
+  }
+})

--- a/packages/sql-mapper/lib/connection-info.js
+++ b/packages/sql-mapper/lib/connection-info.js
@@ -3,6 +3,7 @@
 // (with the exception of SQLite)
 const getConnectionInfo = async (db, connectionString) => {
   let database, host, port, user
+  let dbSystem = 'unknown'
   if (db.isPg) {
     const driver = await db._pool.getConnection()
     const connectionParameters = driver.connection.client.connectionParameters
@@ -10,6 +11,7 @@ const getConnectionInfo = async (db, connectionString) => {
     port = connectionParameters.port
     database = connectionParameters.database
     user = connectionParameters.user
+    dbSystem = 'postgresql'
     driver.release()
   } else if (db.isMySql || db.isMariaDB || db.isMySql8) {
     const driver = await db._pool.getConnection()
@@ -18,8 +20,10 @@ const getConnectionInfo = async (db, connectionString) => {
     host = connectionParameters.host
     port = connectionParameters.port
     user = connectionParameters.user
+    dbSystem = 'mysql'
     driver.release()
   } else if (db.isSQLite) {
+    dbSystem = 'sqlite'
     database = connectionString?.split('sqlite://')[1]
   }
 
@@ -31,6 +35,7 @@ const getConnectionInfo = async (db, connectionString) => {
     isPg: db.isPg,
     isMySql: db.isMySql,
     isSQLite: db.isSQLite,
+    dbSystem,
   }
 }
 

--- a/packages/sql-mapper/lib/telemetry.js
+++ b/packages/sql-mapper/lib/telemetry.js
@@ -6,19 +6,15 @@ function wrapQuery (app, db, request) {
     const query = arguments[0]
     const connectionInfo = db.connectionInfo
 
-    let namePrefix, dbSystem
+    let namePrefix
     if (connectionInfo.isPg) {
       namePrefix = 'pg.query:'
-      dbSystem = 'postgresql'
     } else if (connectionInfo.isMySql) {
       namePrefix = 'mysql.query:'
-      dbSystem = 'mysql'
     } else if (connectionInfo.isSQLite) {
       namePrefix = 'sqlite.query:'
-      dbSystem = 'sqlite'
     } else {
       namePrefix = 'db.query:'
-      dbSystem = 'unknown'
     }
 
     const format = {
@@ -33,7 +29,7 @@ function wrapQuery (app, db, request) {
 
     const ctx = request.span?.context
 
-    const { database, host, port, user } = connectionInfo
+    const { database, host, port, user, dbSystem } = connectionInfo
     const telemetryAttributes = {
       'db.statement': queryText,
       'db.system': dbSystem,


### PR DESCRIPTION
This is a management API that can be used for DB services to extract:
- connection info 
- `dbschema` (as created by `sqlmapper`) 