### PR TITLE
Always set skipLibCheck: true in generated tsconfig

### DIFF
--- a/packages/generators/lib/base-generator.js
+++ b/packages/generators/lib/base-generator.js
@@ -281,6 +281,7 @@ class BaseGenerator extends FileGenerator {
         incremental: true,
         strict: true,
         outDir: 'dist',
+        skipLibCheck: true,
       },
       watchOptions: {
         watchFile: 'fixedPollingInterval',

--- a/packages/generators/test/base-generator.test.js
+++ b/packages/generators/test/base-generator.test.js
@@ -364,6 +364,7 @@ test('should generate tsConfig file and typescript files', async t => {
       incremental: true,
       strict: true,
       outDir: 'dist',
+      skipLibCheck: true,
     },
     watchOptions: {
       watchFile: 'fixedPollingInterval',


### PR DESCRIPTION
Always set `skipLibCheck: true` in generated `tsconfig.json` to avoid problems.

Source: https://x.com/mattpocockuk/status/1820454283457765645