### PR TITLE
feat: proxy root request instead of redirecting it

### DIFF
--- a/packages/composer/lib/proxy.js
+++ b/packages/composer/lib/proxy.js
@@ -60,9 +60,14 @@ module.exports = fp(async function (app, opts) {
               done(err)
               return
             }
+
+            const replyHeaders = result.headers
+            delete replyHeaders['content-length']
+            delete replyHeaders['transfer-encoding']
+
             reply
               .code(result.statusCode)
-              .headers(result.headers)
+              .headers(replyHeaders)
               .send(result.rawPayload)
             done()
           })


### PR DESCRIPTION
Request redirecting doesn't work because composer has no idea what was the original url that came to the application.