### PR TITLE
Enhancement to the import command

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -8,7 +8,8 @@ import { packageJson, schema } from './lib/schema.js'
 import { importFile } from './lib/utils.js'
 
 const importStackablePackageMarker = '__pltImportStackablePackage.js'
-const configCandidates = [
+
+export const configCandidates = [
   'platformatic.application.json',
   'platformatic.json',
   'watt.json',
@@ -23,7 +24,7 @@ const configCandidates = [
   'watt.toml',
   'platformatic.application.tml',
   'platformatic.tml',
-  'watt.tml',
+  'watt.tml'
 ]
 
 function isImportFailedError (error, pkg) {
@@ -107,7 +108,10 @@ async function buildStackable (opts) {
   const imported = await importStackablePackage(opts, toImport, autodetectDescription)
 
   const serviceRoot = relative(process.cwd(), opts.context.directory)
-  if (!hadConfig && !(existsSync(resolve(serviceRoot, 'platformatic.json') || existsSync(resolve(serviceRoot, 'watt.json'))))) {
+  if (
+    !hadConfig &&
+    !existsSync(resolve(serviceRoot, 'platformatic.json') || existsSync(resolve(serviceRoot, 'watt.json')))
+  ) {
     const logger = pino({
       level: opts.context.serverConfig?.logger?.level ?? 'warn',
       name: opts.context.serviceId

--- a/packages/wattpm/index.js
+++ b/packages/wattpm/index.js
@@ -1,6 +1,4 @@
-import { bgGreen, black, bold } from 'colorette'
-import pino from 'pino'
-import pinoPretty from 'pino-pretty'
+import { bold } from 'colorette'
 import { buildCommand } from './lib/commands/build.js'
 import { devCommand, reloadCommand, restartCommand, startCommand, stopCommand } from './lib/commands/execution.js'
 import { importCommand, resolveCommand } from './lib/commands/external.js'
@@ -10,25 +8,10 @@ import { injectCommand } from './lib/commands/inject.js'
 import { logsCommand } from './lib/commands/logs.js'
 import { configCommand, envCommand, psCommand, servicesCommand } from './lib/commands/management.js'
 import { version } from './lib/schema.js'
-import { overrideFatal, parseArgs, setVerbose } from './lib/utils.js'
+import { createLogger, overrideFatal, parseArgs, setVerbose } from './lib/utils.js'
 
 export async function main () {
-  const logger = pino(
-    {
-      level: 'info',
-      customLevels: {
-        done: 35
-      }
-    },
-    pinoPretty({
-      colorize: true,
-      customPrettifiers: {
-        level (logLevel, _u1, _u2, { label, labelColorized, colors }) {
-          return logLevel === 35 ? bgGreen(black(label)) : labelColorized
-        }
-      }
-    })
-  )
+  const logger = createLogger('info')
 
   overrideFatal(logger)
 

--- a/packages/wattpm/lib/commands/execution.js
+++ b/packages/wattpm/lib/commands/execution.js
@@ -16,20 +16,14 @@ export async function devCommand (logger, args) {
   let runtime = await pltStartCommand(['-c', configurationFile], true, true)
 
   // Add a watcher on the configurationFile so that we can eventually restart the runtime
-  try {
-    const watcher = watch(configurationFile, { persistent: false })
-    // eslint-disable-next-line no-unused-vars
-    for await (const _ of watcher) {
-      runtime.logger.info('The configuration file has changed, reloading the application ...')
-      await runtime.close()
-      runtime = await pltStartCommand(['-c', configurationFile], true, true)
-    }
-  } catch (err) {
-    if (err.name === 'AbortError') {
-      return
-    }
-    throw err
+  const watcher = watch(configurationFile, { persistent: false })
+  // eslint-disable-next-line no-unused-vars
+  for await (const _ of watcher) {
+    runtime.logger.info('The configuration file has changed, reloading the application ...')
+    await runtime.close()
+    runtime = await pltStartCommand(['-c', configurationFile], true, true)
   }
+  /* c8 ignore next */
 }
 
 export async function startCommand (logger, args) {

--- a/packages/wattpm/lib/commands/external.js
+++ b/packages/wattpm/lib/commands/external.js
@@ -216,26 +216,32 @@ export async function importCommand (logger, args) {
   let root
   let rawUrl
 
-  if (positionals.length < 2) {
+  /*
+    No arguments = Fix configuration for existing services.
+    One argument = URL
+    Two arguments = root and URL
+  */
+  if (positionals.length === 0) {
     /* c8 ignore next */
-    return fixConfiguration(logger, positionals[0] ?? '')
+    return fixConfiguration(logger, '')
+  } else if (positionals.length === 1) {
+    root = ''
+    rawUrl = positionals[0]
   } else {
     root = positionals[0]
     rawUrl = positionals[1]
   }
   /* c8 ignore next */
-  root = resolve(process.cwd(), root ?? '')
+  root = resolve(process.cwd(), root)
 
   const configurationFile = await findConfigurationFile(logger, root)
 
   // If the rawUrl exists as local folder, import a local folder, otherwise go for Git.
-  // Try a relative from the root folder or from process.cwd()
-  if (!URL.canParse(rawUrl)) {
-    const local = [resolve(root, rawUrl), resolve(process.cwd(), rawUrl)].find(c => existsSync(c))
+  // Try a relative from the root folder or from process.cwd().
+  const local = [resolve(root, rawUrl), resolve(process.cwd(), rawUrl)].find(c => existsSync(c))
 
-    if (local) {
-      return importLocal(logger, root, configurationFile, local)
-    }
+  if (local) {
+    return importLocal(logger, root, configurationFile, local)
   }
 
   return importURL(logger, root, configurationFile, values, rawUrl)
@@ -324,7 +330,7 @@ export async function resolveCommand (logger, args) {
 
 export const help = {
   import: {
-    usage: 'import [root]',
+    usage: 'import [root] [url]',
     description: 'Imports an external resource as a service',
     args: [
       {
@@ -380,11 +386,11 @@ To change the directory where a service is cloned, you can set the \`path\` prop
 
 After cloning the service, the resolve command will set the relative path to the service in the wattpm configuration file.
 
-Example of the runtime platformatic.json configuration file:
+Example of the runtime \`watt.json\` configuration file:
 
 \`\`\`json
 {
-  "$schema": "https://schemas.platformatic.dev/wattpm/2.0.0.json",
+  "$schema": "https://schemas.platformatic.dev/@platformatic/wattpm/2.0.0.json",
   "entrypoint": "service-1",
   "services": [
     {
@@ -409,11 +415,20 @@ Example of the runtime platformatic.json configuration file:
 
 If not specified, the configuration will be loaded from any of the following, in the current directory.
 
+* \`watt.json\`, or
+* \`platformatic.application.json\`, or
 * \`platformatic.json\`, or
-* \`platformatic.yml\`, or 
-* \`platformatic.tml\`, or 
-* \`platformatic.json\`, or
-* \`platformatic.yml\`, or 
+* \`watt.yaml\`, or
+* \`platformatic.application.yaml\`, or
+* \`platformatic.yaml\`, or
+* \`watt.yml\`, or
+* \`platformatic.application.yml\`, or
+* \`platformatic.yml\`, or
+* \`watt.toml\`, or
+* \`platformatic.application.toml\`, or
+* \`platformatic.toml\`, or
+* \`watt.tml\`, or
+* \`platformatic.application.tml\`, or
 * \`platformatic.tml\`
 
 You can find more details about the configuration format here:

--- a/packages/wattpm/lib/commands/init.js
+++ b/packages/wattpm/lib/commands/init.js
@@ -54,7 +54,7 @@ export async function initCommand (logger, args) {
 
   await writeFile(
     configurationFile,
-    JSON.stringify({ $schema: schema.$id, ...configManager.current }, null, 2),
+    JSON.stringify({ $schema: schema.$id, ...configManager.current, entrypoint: positionals[1] ?? '' }, null, 2),
     'utf-8'
   )
 
@@ -78,12 +78,16 @@ export async function initCommand (logger, args) {
 
 export const help = {
   init: {
-    usage: 'init [root]',
+    usage: 'init [root] [entrypoint]',
     description: 'Creates a new application',
     args: [
       {
         name: 'root',
         description: 'The directory containing the application (default is the current directory)'
+      },
+      {
+        name: 'entrypoint',
+        description: 'The name of the entrypoint service'
       }
     ]
   }

--- a/packages/wattpm/lib/defaults.js
+++ b/packages/wattpm/lib/defaults.js
@@ -21,3 +21,5 @@ export const defaultPackageJson = {
   },
   dependencies: {}
 }
+
+export const defaultServiceJson = {}

--- a/packages/wattpm/lib/schema.js
+++ b/packages/wattpm/lib/schema.js
@@ -1,7 +1,7 @@
 import { schema as runtimeSchema } from '@platformatic/runtime'
 import { readFile } from 'node:fs/promises'
 
-const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url)))
+const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf-8'))
 
 export const version = pkg.version
 

--- a/packages/wattpm/lib/utils.js
+++ b/packages/wattpm/lib/utils.js
@@ -1,15 +1,36 @@
 import { ConfigManager, loadConfig as pltConfigLoadConfig, Store } from '@platformatic/config'
 import { platformaticRuntime, buildRuntime as pltBuildRuntime } from '@platformatic/runtime'
-import { bold } from 'colorette'
+import { bgGreen, black, bold } from 'colorette'
 import { existsSync } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { parseArgs as nodeParseArgs } from 'node:util'
+import pino from 'pino'
+import pinoPretty from 'pino-pretty'
 
 export let verbose = false
 
 export function setVerbose (value) {
   verbose = value
+}
+
+export function createLogger (level) {
+  return pino(
+    {
+      level,
+      customLevels: {
+        done: 35
+      }
+    },
+    pinoPretty({
+      colorize: true,
+      customPrettifiers: {
+        level (logLevel, _u1, _u2, { label, labelColorized, colors }) {
+          return logLevel === 35 ? bgGreen(black(label)) : labelColorized
+        }
+      }
+    })
+  )
 }
 
 export function overrideFatal (logger) {

--- a/packages/wattpm/package.json
+++ b/packages/wattpm/package.json
@@ -34,6 +34,7 @@
     "lib"
   ],
   "dependencies": {
+    "@platformatic/basic": "workspace:*",
     "@platformatic/config": "workspace:*",
     "@platformatic/control": "workspace:*",
     "@platformatic/runtime": "workspace:*",

--- a/packages/wattpm/test/execution.test.js
+++ b/packages/wattpm/test/execution.test.js
@@ -308,7 +308,7 @@ test('reload - should reload an application', async t => {
   process.kill(parseInt(mo[1]), 'SIGINT')
 })
 
-test('reload -should complain when a runtime is not found', async t => {
+test('reload - should complain when a runtime is not found', async t => {
   const logsProcess = await wattpm('reload', 'p-' + Date.now.toString(), { reject: false })
 
   deepStrictEqual(logsProcess.exitCode, 1)

--- a/packages/wattpm/test/external.test.js
+++ b/packages/wattpm/test/external.test.js
@@ -16,7 +16,7 @@ test('import - should import a URL', async t => {
   t.after(() => writeFile(configurationFile, originalFileContents))
 
   process.chdir(rootDir)
-  await wattpm('import', rootDir, 'http://github.com/foo/bar.git')
+  await wattpm('import', 'http://github.com/foo/bar.git')
 
   deepStrictEqual(JSON.parse(await readFile(configurationFile, 'utf-8')), {
     ...JSON.parse(originalFileContents),
@@ -215,7 +215,7 @@ for (const [name, dependency] of Object.entries(autodetect)) {
   })
 }
 
-test('import - when launched without a URL, should fix the configuration of all known services', async t => {
+test('import - when launched without arguments, should fix the configuration of all known services', async t => {
   const rootDir = await resolve(fixturesDir, 'no-dependencies')
   const configurationFile = resolve(rootDir, 'watt.json')
   const originalFileContents = await readFile(configurationFile, 'utf-8')
@@ -231,7 +231,8 @@ test('import - when launched without a URL, should fix the configuration of all 
     ])
   })
 
-  await wattpm('import', rootDir)
+  process.chdir(rootDir)
+  await wattpm('import')
 
   deepStrictEqual(await readFile(configurationFile, 'utf-8'), originalFileContents)
 

--- a/packages/wattpm/test/external.test.js
+++ b/packages/wattpm/test/external.test.js
@@ -1,9 +1,12 @@
 import { safeRemove } from '@platformatic/utils'
 import { deepStrictEqual, ok } from 'node:assert'
-import { readFile, writeFile } from 'node:fs/promises'
-import { resolve, sep } from 'node:path'
+import { existsSync } from 'node:fs'
+import { cp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, join, resolve, sep } from 'node:path'
 import { test } from 'node:test'
-import { fixturesDir, wattpm } from './helper.js'
+import { defaultServiceJson } from '../lib/defaults.js'
+import { version } from '../lib/schema.js'
+import { createTemporaryDirectory, executeCommand, fixturesDir, wattpm } from './helper.js'
 
 test('import - should import a URL', async t => {
   const rootDir = await resolve(fixturesDir, 'main')
@@ -68,6 +71,149 @@ test('import - should import a GitHub repo via HTTP', async t => {
     ]
   })
 })
+
+test('import - should import a local folder with Git and no watt.json', async t => {
+  const rootDir = await resolve(fixturesDir, 'main')
+  const configurationFile = resolve(rootDir, 'watt.json')
+  const originalFileContents = await readFile(configurationFile, 'utf-8')
+
+  const directory = await createTemporaryDirectory(t, 'local-with-git')
+  await cp(resolve(rootDir, 'web/main/index.js'), resolve(directory, 'index.js'))
+  await executeCommand('git', 'init', { cwd: directory })
+  await executeCommand('git', 'remote', 'add', 'origin', 'git@github.com:hello/world.git', { cwd: directory })
+
+  t.after(() => writeFile(configurationFile, originalFileContents))
+
+  await wattpm('import', rootDir, directory)
+
+  deepStrictEqual(JSON.parse(await readFile(configurationFile, 'utf-8')), {
+    ...JSON.parse(originalFileContents),
+    web: [
+      {
+        id: basename(directory),
+        path: directory,
+        url: 'git@github.com:hello/world.git'
+      }
+    ]
+  })
+
+  deepStrictEqual(JSON.parse(await readFile(resolve(directory, 'package.json'), 'utf-8')), {
+    dependencies: {
+      '@platformatic/node': `^${version}`
+    }
+  })
+
+  deepStrictEqual(JSON.parse(await readFile(resolve(directory, 'watt.json'), 'utf-8')), {
+    ...defaultServiceJson,
+    $schema: `https://schemas.platformatic.dev/@platformatic/node/${version}.json`
+  })
+})
+
+test('import - should import a local folder without Git and a watt.json', async t => {
+  const rootDir = await resolve(fixturesDir, 'main')
+  const configurationFile = resolve(rootDir, 'watt.json')
+  const originalFileContents = await readFile(configurationFile, 'utf-8')
+
+  const directory = await createTemporaryDirectory(t, 'local-no-git')
+  await cp(resolve(rootDir, 'web/main/index.js'), resolve(directory, 'index.js'))
+  await writeFile(resolve(directory, 'watt.json'), JSON.stringify({ a: 1 }), 'utf-8')
+
+  t.after(() => writeFile(configurationFile, originalFileContents))
+
+  await wattpm('import', rootDir, directory)
+
+  deepStrictEqual(JSON.parse(await readFile(configurationFile, 'utf-8')), {
+    ...JSON.parse(originalFileContents),
+    web: [
+      {
+        id: basename(directory),
+        path: directory
+      }
+    ]
+  })
+
+  ok(!existsSync(resolve(directory, 'package.json'), 'utf-8'))
+  deepStrictEqual(JSON.parse(await readFile(resolve(directory, 'watt.json'), 'utf-8')), { a: 1 })
+})
+
+test('import - should not modify the root watt.json when importing a folder which is already autoloaded', async t => {
+  const rootDir = await resolve(fixturesDir, 'main')
+  const configurationFile = resolve(rootDir, 'watt.json')
+  const originalFileContents = await readFile(configurationFile, 'utf-8')
+
+  const directory = join('web', basename(await createTemporaryDirectory(t, 'local-with-git')))
+  const absoluteDirectory = resolve(rootDir, directory)
+  await mkdir(absoluteDirectory)
+  await cp(resolve(rootDir, 'web/main/index.js'), resolve(rootDir, directory, 'index.js'))
+
+  t.after(() => writeFile(configurationFile, originalFileContents))
+  t.after(() => safeRemove(absoluteDirectory))
+
+  await wattpm('import', rootDir, directory)
+
+  deepStrictEqual(JSON.parse(await readFile(configurationFile, 'utf-8')), {
+    ...JSON.parse(originalFileContents)
+  })
+
+  deepStrictEqual(JSON.parse(await readFile(resolve(rootDir, directory, 'package.json'), 'utf-8')), {
+    dependencies: {
+      '@platformatic/node': `^${version}`
+    }
+  })
+
+  deepStrictEqual(JSON.parse(await readFile(resolve(rootDir, directory, 'watt.json'), 'utf-8')), {
+    ...defaultServiceJson,
+    $schema: `https://schemas.platformatic.dev/@platformatic/node/${version}.json`
+  })
+})
+
+const autodetect = {
+  astro: 'astro',
+  next: 'next',
+  remix: '@remix-run/dev',
+  vite: 'vite'
+}
+
+for (const [name, dependency] of Object.entries(autodetect)) {
+  test(`import - should correctly autodetect a @platformatic/${name} stackable`, async t => {
+    const rootDir = await resolve(fixturesDir, 'main')
+    const configurationFile = resolve(rootDir, 'watt.json')
+    const originalFileContents = await readFile(configurationFile, 'utf-8')
+
+    const directory = await createTemporaryDirectory(t, `local-${name}`)
+    await writeFile(
+      resolve(directory, 'package.json'),
+      JSON.stringify({ dependencies: { [dependency]: '*' } }),
+      'utf-8'
+    )
+
+    t.after(() => writeFile(configurationFile, originalFileContents))
+
+    await wattpm('import', rootDir, directory)
+
+    deepStrictEqual(JSON.parse(await readFile(configurationFile, 'utf-8')), {
+      ...JSON.parse(originalFileContents),
+      web: [
+        {
+          id: basename(directory),
+          path: directory
+        }
+      ]
+    })
+
+    deepStrictEqual(JSON.parse(await readFile(resolve(directory, 'package.json'), 'utf-8')), {
+      dependencies: {
+        [dependency]: '*',
+        [`@platformatic/${name}`]: `^${version}`
+      }
+    })
+
+    deepStrictEqual(JSON.parse(await readFile(resolve(directory, 'watt.json'), 'utf-8')), {
+      ...defaultServiceJson,
+      $schema: `https://schemas.platformatic.dev/@platformatic/${name}/${version}.json`
+    })
+  })
+}
 
 test('import - should complain when the URL is missing', async t => {
   const importProcess = await wattpm('import', { reject: false })

--- a/packages/wattpm/test/fixtures/no-dependencies/package.json
+++ b/packages/wattpm/test/fixtures/no-dependencies/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "main",
+  "private": true,
+  "scripts": {
+    "dev": "wattpm dev",
+    "build": "wattpm build",
+    "start": "wattpm start"
+  },
+  "dependencies": {
+    "wattpm": "^1.0.0"
+  }
+}

--- a/packages/wattpm/test/fixtures/no-dependencies/watt.json
+++ b/packages/wattpm/test/fixtures/no-dependencies/watt.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schemas.platformatic.dev/wattpm/2.0.0.json",
+  "server": {
+    "hostname": "127.0.0.1"
+  },
+  "logger": {
+    "level": "info"
+  },
+  "entrypoint": "main",
+  "autoload": {
+    "path": "web-1"
+  },
+  "services": [
+    {
+      "id": "third",
+      "path": "web-2/third"
+    }
+  ]
+}

--- a/packages/wattpm/test/fixtures/no-dependencies/web-1/first/index.js
+++ b/packages/wattpm/test/fixtures/no-dependencies/web-1/first/index.js
@@ -1,0 +1,23 @@
+const fastify = require('fastify')
+
+const app = fastify({
+  loggerInstance: globalThis.platformatic?.logger?.child({}, { level: 'trace' })
+})
+
+app.get('/', async () => {
+  return { production: process.env.NODE_ENV === 'production' }
+})
+
+app.get('/version', async () => {
+  return { version: 123 }
+})
+
+app.post('/', async request => {
+  return { body: request.body }
+})
+
+app.log.trace('This is a trace')
+
+app.listen({ port: 1 }).then(() => {
+  app.log.info('Service listening')
+})

--- a/packages/wattpm/test/fixtures/no-dependencies/web-1/second/index.js
+++ b/packages/wattpm/test/fixtures/no-dependencies/web-1/second/index.js
@@ -1,0 +1,23 @@
+const fastify = require('fastify')
+
+const app = fastify({
+  loggerInstance: globalThis.platformatic?.logger?.child({}, { level: 'trace' })
+})
+
+app.get('/', async () => {
+  return { production: process.env.NODE_ENV === 'production' }
+})
+
+app.get('/version', async () => {
+  return { version: 123 }
+})
+
+app.post('/', async request => {
+  return { body: request.body }
+})
+
+app.log.trace('This is a trace')
+
+app.listen({ port: 1 }).then(() => {
+  app.log.info('Service listening')
+})

--- a/packages/wattpm/test/fixtures/no-dependencies/web-2/third/index.js
+++ b/packages/wattpm/test/fixtures/no-dependencies/web-2/third/index.js
@@ -1,0 +1,23 @@
+const fastify = require('fastify')
+
+const app = fastify({
+  loggerInstance: globalThis.platformatic?.logger?.child({}, { level: 'trace' })
+})
+
+app.get('/', async () => {
+  return { production: process.env.NODE_ENV === 'production' }
+})
+
+app.get('/version', async () => {
+  return { version: 123 }
+})
+
+app.post('/', async request => {
+  return { body: request.body }
+})
+
+app.log.trace('This is a trace')
+
+app.listen({ port: 1 }).then(() => {
+  app.log.info('Service listening')
+})

--- a/packages/wattpm/test/helper.js
+++ b/packages/wattpm/test/helper.js
@@ -2,7 +2,7 @@ import { createDirectory, safeRemove } from '@platformatic/utils'
 import { execa } from 'execa'
 import { on } from 'node:events'
 import { existsSync } from 'node:fs'
-import { stat, symlink } from 'node:fs/promises'
+import { mkdir, stat, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -19,6 +19,7 @@ export async function createTemporaryDirectory (t, prefix) {
     await safeRemove(directory)
   })
 
+  await mkdir(directory)
   return directory
 }
 
@@ -61,8 +62,12 @@ export async function waitForStart (stream) {
   return url
 }
 
-export function wattpm (...args) {
+export function executeCommand (cmd, ...args) {
   const options = typeof args.at(-1) === 'object' ? args.pop() : {}
 
-  return execa('node', [cliPath, ...args], { env: { NO_COLOR: 'true' }, ...options })
+  return execa(cmd, args, { env: { NO_COLOR: 'true' }, ...options })
+}
+
+export function wattpm (...args) {
+  return executeCommand('node', cliPath, ...args)
 }

--- a/packages/wattpm/test/init.test.js
+++ b/packages/wattpm/test/init.test.js
@@ -27,13 +27,14 @@ test('init - should create a new application for NPM', async t => {
 
 test('init - should create a new application for PNPM', async t => {
   const directory = await createTemporaryDirectory(t, 'init')
-  await wattpm('init', '-p', 'pnpm', directory)
+  await wattpm('init', '-p', 'pnpm', directory, 'entrypoint')
 
   ok(isDirectory(resolve(directory, 'web')))
 
   deepStrictEqual(JSON.parse(await readFile(resolve(directory, 'watt.json'), 'utf-8')), {
     $schema: schema.$id,
-    ...defaultConfiguration
+    ...defaultConfiguration,
+    entrypoint: 'entrypoint'
   })
 
   deepStrictEqual(JSON.parse(await readFile(resolve(directory, 'package.json'), 'utf-8')), {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2480,6 +2480,9 @@ importers:
 
   packages/wattpm:
     dependencies:
+      '@platformatic/basic':
+        specifier: workspace:*
+        version: link:../basic
       '@platformatic/config':
         specifier: workspace:*
         version: link:../config


### PR DESCRIPTION
The `wattpm import` command now behaves like this:

1. When doing `wattpm import rootDir local/folder/somewhere`, the folder is added in the `services` of the root `watt.json`. If the target folder has no `watt.json`, it also makes sure one exists and that the proper package is installed in `package.json`.
2. When doing `wattpm import rootDir http://...`, the URL is added in `watt.json`.
3. When doing `wattpm import rootDir`, the command scans for all services (autoloaded or explicitly specified in the `watt.json`) and performs the same checks made in 1.