### PR TITLE
feat: Refactor composer proxy prefix rules.

### DIFF
--- a/docs/composer/configuration.md
+++ b/docs/composer/configuration.md
@@ -2,13 +2,13 @@ import Issues from '../getting-started/issues.md';
 
 # Configuration
 
-Platformatic Composer can be configured with a [configuration file](#configuration-files) in the different file formats below. The Composer also supports use of environment variables as setting values with [environment variable placeholders](../composer/configuration.md#setting-and-using-env-placeholders). 
+Platformatic Composer can be configured with a [configuration file](#configuration-files) in the different file formats below. The Composer also supports use of environment variables as setting values with [environment variable placeholders](../composer/configuration.md#setting-and-using-env-placeholders).
 
 ## Configuration Files
 
 Platformatic will automatically detect and load configuration files found in the current working directory with the file names listed [here](../file-formats.md#configuration-files).
 
-To specify a configuration file manually, use the [`--config` option](../cli.md#composer) with any `platformatic composer` CLI command. 
+To specify a configuration file manually, use the [`--config` option](../cli.md#composer) with any `platformatic composer` CLI command.
 
 ## Supported File Formats
 
@@ -16,15 +16,16 @@ For detailed information on supported file formats and extensions, visit our [Su
 
 ## Configuration Settings
 
-Configuration file settings are grouped as follows:  
+Configuration file settings are grouped as follows:
 
+- **`basePath`** **(required)**: Configures the [basePath](../service/configuration.md#basePath).
 - **`server`** **(required)**: Configures the [server settings](../service/configuration.md#server)
 - **`composer`**: Specific settings for Platformatic Composer, such as service management and API composition.
 - **`metrics`**: Monitors and records performance [metrics](../service/configuration.md#metrics).
 - **`plugins`**: Manages additional functionality through [plugins](../service/configuration.md#plugins).
 - **`telemetry`**: Handles [telemetry data reporting](../service/configuration.md#telemetry).
 - **`watch`**: Observes file changes for [dynamic updates](../service/configuration.md#watch).
-- **`clients`**: Configures [client-specific](../service/configuration.md#clients) settings. 
+- **`clients`**: Configures [client-specific](../service/configuration.md#clients) settings.
 
 Sensitive data within these settings should use [configuration placeholders](#configuration-placeholders) to ensure security.
 
@@ -33,24 +34,37 @@ Sensitive data within these settings should use [configuration placeholders](#co
 Configure `@platformatic/composer` specific settings such as `services` or `refreshTimeout`:
 
 - **`services`** (`array`, default: `[]`) — is an array of objects that defines
-the services managed by the composer. Each service object supports the following settings:
+  the services managed by the composer. Each service object supports the following settings:
 
-  - **`id`** (**required**, `string`) - A unique identifier for the service. Use a Platformatic Runtime service id if the service is executing inside [Platformatic Runtime context](../runtime/overview.md#platformatic-runtime-context). 
-  - **`origin`** (`string`) - A service origin. Skip this option if the service is executing inside [Platformatic Runtime context](../runtime/overview.md#platformatic-runtime-context). In this case, service `id` will be used instead of origin. 
-  - **`openapi`** (`object`) - The configuration file used to compose [OpenAPI](#openapi) specification. 
-  - **`graphql`** (`object`) - The configuration for the [GraphQL](#graphql) service. 
+  - **`id`** (**required**, `string`) - A unique identifier for the service. Use a Platformatic Runtime service id if the service is executing inside [Platformatic Runtime context](../runtime/overview.md#platformatic-runtime-context).
+  - **`origin`** (`string`) - A service origin. Skip this option if the service is executing inside [Platformatic Runtime context](../runtime/overview.md#platformatic-runtime-context). In this case, service `id` will be used instead of origin.
+  - **`openapi`** (`object`) - The configuration file used to compose [OpenAPI](#openapi) specification.
+  - **`graphql`** (`object`) - The configuration for the [GraphQL](#graphql) service.
   - **`proxy`** (`object` or `false`) - Service proxy configuration. If `false`, the service proxy is disabled.
-    - `prefix` (**required**, `string`) - Service proxy prefix. All service routes will be prefixed with this value.
+
+    - `prefix` (`string`) - Service proxy prefix. All service routes will be prefixed with this value.
+
+    :::note
+    If the prefix is not explictly set, the composer and the service will try to find the best prefix for the service.
+
+    First of all, if the application code used the `platformatic.setBasePath` (which is always available in each service),
+    then the value will become the service prefix.
+
+    The next attempt will be to let the service autodetect its own prefix by using the configuration (as the `basePath` setting for `@platformatic/service`)
+    or by autodetecting the prefix from the host application (like Next.js).
+
+    When none of the criteria above successfully lead to a prefix, the service ID is chosen as last fallback to ensure there are not routing conflicts.
+    :::
 
 - **`openapi`** (`object`) - See the Platformatic Service [openapi](../service/configuration.md#service) option for more details.
-- **`graphql`** (`object`) - Has the Platformatic Service [graphql](../service//configuration.md#service) options, plus 
-  
-  - **`addEntitiesResolvers`** (`boolean`) - Automatically add related entities on GraphQL types, following the services entities configuration. See [graphql-composer entities](https://github.com/platformatic/graphql-composer#composer-entities) for details. 
+- **`graphql`** (`object`) - Has the Platformatic Service [graphql](../service//configuration.md#service) options, plus
+
+  - **`addEntitiesResolvers`** (`boolean`) - Automatically add related entities on GraphQL types, following the services entities configuration. See [graphql-composer entities](https://github.com/platformatic/graphql-composer#composer-entities) for details.
   - **`defaultArgsAdapter`** (`function` or `string`) - The default `argsAdapter` function for the entities, for example for the platformatic db mapped entities queries.
 
   ```js
   graphql: {
-    defaultArgsAdapter: (partialResults) => ({ where: { id: { in: partialResults.map(r => r.id) } } })
+    defaultArgsAdapter: partialResults => ({ where: { id: { in: partialResults.map(r => r.id) } } })
   }
   ```
 
@@ -59,7 +73,9 @@ the services managed by the composer. Each service object supports the following
   ```json
   "defaultArgsAdapter": "where.id.in.$>#id"
   ```
+
   - **`onSubgraphError`** (`function`) - Hook called when an error occurs getting schema from a subgraph. The arguments are:
+
     - `error` (`error`) - The error message
     - `subgraphName` (`string`) - The erroring subgraph
 
@@ -74,14 +90,14 @@ the services managed by the composer. Each service object supports the following
 - **`url`** (`string`) - A path of the route that exposes the OpenAPI specification. If a service is a Platformatic Service or Platformatic DB, use `/documentation/json` as a value. Use this or `file` option to specify the OpenAPI specification.
 - **`file`** (`string`) - A path to the OpenAPI specification file. Use this or `url` option to specify the OpenAPI specification.
 - **`prefix`** (`string`) - A prefix for the OpenAPI specification. All service routes will be prefixed with this value.
-- **`config`** (`string`) - A path to the OpenAPI configuration file. This file is used to customize the [OpenAPI](#openapi-configuration)specification. 
+- **`config`** (`string`) - A path to the OpenAPI configuration file. This file is used to customize the [OpenAPI](#openapi-configuration)specification.
 
 ### OpenAPI Configuration
 
 The OpenAPI configuration file is a JSON file that is used to customize the OpenAPI specification. It supports the following options:
 
 - **`ignore`** (`boolean`) - If `true`, the route will be ignored by the composer.
-If you want to ignore a specific method, use the `ignore` option in the nested method object.
+  If you want to ignore a specific method, use the `ignore` option in the nested method object.
 
   ```json title="Example JSON object"
   {
@@ -99,7 +115,6 @@ If you want to ignore a specific method, use the `ignore` option in the nested m
 
 - **alias** (`string`) - Use it create an alias for the route path. Original route path will be ignored.
 
-
   ```json title="Example JSON object"
   {
     "paths": {
@@ -111,24 +126,24 @@ If you want to ignore a specific method, use the `ignore` option in the nested m
   ```
 
 - **`rename`** (`string`) - Use it to rename composed route response fields.
-Use json schema format to describe the response structure, this only for  `200` response. 
+  Use json schema format to describe the response structure, this only for `200` response.
 
   ```json title="Example JSON object"
   {
     "paths": {
       "/users": {
         "responses": {
-            "200": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": { "rename": "user_id" },
-                  "name": { "rename": "first_name" }
-                }
+          "200": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "rename": "user_id" },
+                "name": { "rename": "first_name" }
               }
             }
           }
+        }
       }
     }
   }
@@ -196,7 +211,7 @@ Use json schema format to describe the response structure, this only for  `200` 
   - **`resolver`** (`object`) - The resolver to retrieve a list of objects - should return a list - and should accept as an arguments a list of primary keys or foreign keys.
     - **`name`** (`string`, **required**) - The name of the resolver.
     - **`argsAdapter (partialResults)`** (`function` or `string`) - The function invoked with a subset of the result of the initial query, where `partialResults` is an array of the parent node. It should return an object to be used as argument for `resolver` query. Can be a function or a [metaline](https://github.com/platformatic/metaline) string.
-  **Default:** if missing, the `defaultArgsAdapter` function will be used; if that is missing too, a [generic one](lib/utils.js#L3) will be used.
+      **Default:** if missing, the `defaultArgsAdapter` function will be used; if that is missing too, a [generic one](lib/utils.js#L3) will be used.
     - **`partialResults`** (`function` or `string`) - The function to adapt the subset of the result to be passed to `argsAdapter` - usually is needed only on resolvers of `fkeys` and `many`. Can be a function or a [metaline](https://github.com/platformatic/metaline) string.
   - **`pkey`** (`string`, **required**) - The primary key field to identify the entity.
   - **`fkeys`** (`array of objects`) an array to describe the foreign keys of the entities, for example `fkeys: [{ type: 'Author', field: 'authorId' }]`.
@@ -217,9 +232,11 @@ Use json schema format to describe the response structure, this only for  `200` 
 ## Configuration References
 
 ### `telemetry`
+
 Telemetry involves the collection and analysis of data generated by the operations of services. See our [telemetry documentation](../service/configuration.md#telemetry) for details on configuring telemetry for Platformatic Service.
 
 ### `watch`
+
 The `watch` functionality helps in monitoring file changes and dynamically updating services. Learn more at Platformatic Service [watch](../service/configuration.md#watch)
 
 ### `clients`
@@ -232,6 +249,6 @@ Environment variable placeholders are used to securely inject runtime configurat
 
 ### PLT_ROOT
 
-The [PLT_ROOT](../service/configuration.md#plt_root) variable is used to configure relative path and is set to the directory containing the Service configuration file. 
+The [PLT_ROOT](../service/configuration.md#plt_root) variable is used to configure relative path and is set to the directory containing the Service configuration file.
 
 <Issues />

--- a/docs/db/configuration.md
+++ b/docs/db/configuration.md
@@ -18,6 +18,7 @@ For detailed information on supported file formats and extensions, please visit 
 
 Configuration file settings are grouped as follows:
 
+- **`basePath`** **(required)**: Configures the [basePath](../service/configuration.md#basePath).
 - **`server`** **(required)**: Configures the [server settings](../service/configuration.md#server)
 - **`composer`**: Specific settings for Platformatic Composer, such as service management and API composition.
 - **`metrics`**: Monitors and records performance [metrics](../service/configuration.md#metrics).

--- a/docs/service/configuration.md
+++ b/docs/service/configuration.md
@@ -19,6 +19,12 @@ For detailed information on supported file formats and extensions, please visit 
 
 Configuration settings containing sensitive data, such as database connection URLs and passwords, should be set using [configuration placeholders](#configuration-placeholders).
 
+### `basePath`
+
+Service proxy basePath when exposing this service in a [composer](../composer/configuration.md) when setting the `proxy` property.
+
+If not specified, the service will be exposed on the service or a value specified in the service code via `platformatic.setBasePath()`.
+
 ### `server`
 
 An object with the following settings:

--- a/packages/astro/index.js
+++ b/packages/astro/index.js
@@ -112,29 +112,14 @@ export class AstroStackable extends BaseStackable {
   }
 
   getMeta () {
-    let composer = { prefix: this.servicePrefix, wantsAbsoluteUrls: true, needsRootRedirect: true }
+    const config = this.subprocessConfig ?? this.#app?.config
 
-    if (this.isProduction) {
-      composer = {
-        tcp: typeof this.url !== 'undefined',
-        url: this.url,
-        prefix: (this.subprocessConfig?.base ?? this.#basePath).replace(/(^\/)|(\/$)/g, ''),
-        wantsAbsoluteUrls: true,
-        needsRootRedirect: true
-      }
-    } else if (this.url) {
-      if (!this.#basePath) {
-        const config = this.subprocessConfig ?? this.#app.config
-        this.#basePath = config.base.replace(/(^\/)|(\/$)/g, '')
-      }
-
-      composer = {
-        tcp: true,
-        url: this.url,
-        prefix: this.#basePath.replace(/(^\/)|(\/$)/g, ''),
-        wantsAbsoluteUrls: true,
-        needsRootRedirect: true
-      }
+    const composer = {
+      tcp: typeof this.url !== 'undefined',
+      url: this.url,
+      prefix: this.basePath ?? config?.base ?? this.#basePath,
+      wantsAbsoluteUrls: true,
+      needsRootRedirect: true
     }
 
     return { composer }

--- a/packages/basic/lib/base.js
+++ b/packages/basic/lib/base.js
@@ -44,7 +44,7 @@ export class BaseStackable {
     this.registerGlobals({
       setOpenapiSchema: this.setOpenapiSchema.bind(this),
       setGraphqlSchema: this.setGraphqlSchema.bind(this),
-      setServicePrefix: this.setServicePrefix.bind(this)
+      setBasePath: this.setBasePath.bind(this)
     })
   }
 
@@ -104,8 +104,8 @@ export class BaseStackable {
     this.graphqlSchema = schema
   }
 
-  setServicePrefix (prefix) {
-    this.servicePrefix = prefix
+  setBasePath (basePath) {
+    this.basePath = basePath
   }
 
   async log ({ message, level }) {

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
+    "test": "npm run lint && borp --concurrency=1 --no-timeout",
+    "coverage": "npm run lint && borp -C -X test -X test/fixtures --concurrency=1 --no-timeout",
     "gen-schema": "node lib/schema.js > schema.json",
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "pnpm run gen-schema && pnpm run gen-types",

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -38,8 +38,6 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@platformatic/composer": "workspace:*",
-    "@platformatic/service": "workspace:*",
     "borp": "^0.17.0",
     "eslint": "9",
     "express": "^4.19.2",

--- a/packages/cli/test/helper.js
+++ b/packages/cli/test/helper.js
@@ -36,6 +36,12 @@ export const internalServicesFiles = [
   'services/backend/dist/routes/root.js'
 ]
 
+function diagnostic (t, message) {
+  if (!process.env.CI) {
+    t.diagnostic(message)
+  }
+}
+
 async function ensureExists (path) {
   const directory = dirname(path)
   const pattern = basename(path)
@@ -389,7 +395,7 @@ export function verifyBuildAndProductionMode (workingDirectory, configurations, 
     if (!skipBuild) {
       test(`configuration "${configuration.name}" - should build and create all required files`, async t => {
         const { id, baseWorkingDirectory } = configuration
-        t.diagnostic(`starting build for ${id}`)
+        diagnostic(t, `starting build for ${id}`)
         configuration.workingDirectory = resolve(baseWorkingDirectory, id)
 
         runtimeConfig = JSON.parse(
@@ -409,7 +415,7 @@ export function verifyBuildAndProductionMode (workingDirectory, configurations, 
     }
 
     test(`configuration "${configuration.name}" - should start in production mode`, async t => {
-      t.diagnostic(`starting production for ${configuration.id}`)
+      diagnostic(t, `starting production for ${configuration.id}`)
       // Start in production mode
       const { url } = await createProductionRuntime(
         t,

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -6,6 +6,7 @@
  */
 
 export interface PlatformaticComposer {
+  basePath?: string;
   server?: {
     hostname?: string;
     port?: number | string;
@@ -148,7 +149,7 @@ export interface PlatformaticComposer {
     };
   };
   composer: {
-    services: {
+    services?: {
       id: string;
       origin?: string;
       openapi?: {
@@ -230,7 +231,7 @@ export interface PlatformaticComposer {
       proxy?:
         | false
         | {
-            prefix: string;
+            prefix?: string;
           };
     }[];
     openapi?: {

--- a/packages/composer/lib/openapi.js
+++ b/packages/composer/lib/openapi.js
@@ -8,16 +8,15 @@ async function composeOpenAPI (app, opts) {
     openapi: {
       info: {
         title: opts.openapi?.title || 'Platformatic Composer',
-        version: opts.openapi?.version || '1.0.0',
-      },
+        version: opts.openapi?.version || '1.0.0'
+      }
     },
     transform: ({ schema, url }) => {
       for (const service of opts.services) {
         if (!service.proxy) continue
 
-        const proxyPrefix = service.proxy.prefix.at(-1) === '/'
-          ? service.proxy.prefix.slice(0, -1)
-          : service.proxy.prefix
+        const prefix = service.proxy.prefix ?? ''
+        const proxyPrefix = prefix.at(-1) === '/' ? prefix.slice(0, -1) : prefix
 
         const proxyUrls = [proxyPrefix + '/', proxyPrefix + '/*']
         if (proxyUrls.includes(url)) {
@@ -27,7 +26,7 @@ async function composeOpenAPI (app, opts) {
         }
       }
       return { schema, url }
-    },
+    }
   })
 
   const { default: scalarTheme } = await import('@platformatic/scalar-theme')
@@ -42,8 +41,8 @@ async function composeOpenAPI (app, opts) {
     logLevel: 'warn',
     routePrefix,
     configuration: {
-      customCss: scalarTheme.theme,
-    },
+      customCss: scalarTheme.theme
+    }
   })
 }
 

--- a/packages/composer/lib/schema.js
+++ b/packages/composer/lib/schema.js
@@ -1,7 +1,8 @@
 #! /usr/bin/env node
 'use strict'
 
-const { metrics, server, plugins, watch, clients, openApiBase, openApiDefs, graphqlBase } = require('@platformatic/service').schemas
+const { metrics, server, plugins, watch, clients, openApiBase, openApiDefs, graphqlBase } =
+  require('@platformatic/service').schemas
 const telemetry = require('@platformatic/telemetry').schema
 const pkg = require('../package.json')
 
@@ -11,13 +12,10 @@ const openApiService = {
     url: { type: 'string' },
     file: { type: 'string', resolvePath: true },
     prefix: { type: 'string' },
-    config: { type: 'string', resolvePath: true },
+    config: { type: 'string', resolvePath: true }
   },
-  anyOf: [
-    { required: ['url'] },
-    { required: ['file'] },
-  ],
-  additionalProperties: false,
+  anyOf: [{ required: ['url'] }, { required: ['file'] }],
+  additionalProperties: false
 }
 
 const entityResolver = {
@@ -25,20 +23,14 @@ const entityResolver = {
   properties: {
     name: { type: 'string' },
     argsAdapter: {
-      anyOf: [
-        { typeof: 'function' },
-        { type: 'string' },
-      ],
+      anyOf: [{ typeof: 'function' }, { type: 'string' }]
     },
     partialResults: {
-      anyOf: [
-        { typeof: 'function' },
-        { type: 'string' },
-      ],
-    },
+      anyOf: [{ typeof: 'function' }, { type: 'string' }]
+    }
   },
   required: ['name'],
-  additionalProperties: false,
+  additionalProperties: false
 }
 
 const entities = {
@@ -59,10 +51,10 @@ const entities = {
               as: { type: 'string' },
               pkey: { type: 'string' },
               subgraph: { type: 'string' },
-              resolver: entityResolver,
+              resolver: entityResolver
             },
-            required: ['type'],
-          },
+            required: ['type']
+          }
         },
         many: {
           type: 'array',
@@ -74,14 +66,14 @@ const entities = {
               as: { type: 'string' },
               pkey: { type: 'string' },
               subgraph: { type: 'string' },
-              resolver: entityResolver,
+              resolver: entityResolver
             },
-            required: ['type', 'fkey', 'resolver'],
-          },
-        },
-      },
-    },
-  },
+            required: ['type', 'fkey', 'resolver']
+          }
+        }
+      }
+    }
+  }
 }
 
 const graphqlService = {
@@ -94,11 +86,11 @@ const graphqlService = {
         name: { type: 'string' },
         graphqlEndpoint: { type: 'string', default: '/graphql' },
         composeEndpoint: { type: 'string', default: '/.well-known/graphql-composition' },
-        entities,
+        entities
       },
-      additionalProperties: false,
-    },
-  ],
+      additionalProperties: false
+    }
+  ]
 }
 
 const graphqlComposerOptions = {
@@ -108,15 +100,12 @@ const graphqlComposerOptions = {
     // TODO support subscriptions, subscriptions: { type: 'boolean', default: false },
     onSubgraphError: { typeof: 'function' },
     defaultArgsAdapter: {
-      oneOf: [
-        { typeof: 'function' },
-        { type: 'string' },
-      ],
+      oneOf: [{ typeof: 'function' }, { type: 'string' }]
     },
     entities,
-    addEntitiesResolvers: { type: 'boolean', default: false },
+    addEntitiesResolvers: { type: 'boolean', default: false }
   },
-  additionalProperties: false,
+  additionalProperties: false
 }
 
 const composer = {
@@ -137,41 +126,41 @@ const composer = {
               {
                 type: 'object',
                 properties: {
-                  prefix: { type: 'string' },
+                  prefix: { type: 'string' }
                 },
-                required: ['prefix'],
-                additionalProperties: false,
-              },
-            ],
-          },
+                required: [],
+                additionalProperties: false
+              }
+            ]
+          }
         },
         required: ['id'],
-        additionalProperties: false,
-      },
+        additionalProperties: false
+      }
     },
     openapi: openApiBase,
     graphql: graphqlComposerOptions,
     addEmptySchema: { type: 'boolean', default: false },
-    refreshTimeout: { type: 'integer', minimum: 0, default: 1000 },
+    refreshTimeout: { type: 'integer', minimum: 0, default: 1000 }
   },
-  required: ['services'],
-  additionalProperties: false,
+  required: [],
+  additionalProperties: false
 }
 
 const types = {
   type: 'object',
   properties: {
     autogenerate: {
-      type: 'boolean',
+      type: 'boolean'
     },
     dir: {
       description: 'The path to the directory the types should be generated in.',
       type: 'string',
       default: 'types',
-      resolvePath: true,
-    },
+      resolvePath: true
+    }
   },
-  additionalProperties: false,
+  additionalProperties: false
 }
 
 const platformaticComposerSchema = {
@@ -180,6 +169,9 @@ const platformaticComposerSchema = {
   title: 'Platformatic Composer',
   type: 'object',
   properties: {
+    basePath: {
+      type: 'string'
+    },
     server,
     composer,
     metrics,
@@ -188,22 +180,26 @@ const platformaticComposerSchema = {
     clients,
     telemetry,
     watch: {
-      anyOf: [watch, {
-        type: 'boolean',
-      }, {
-        type: 'string',
-      }],
+      anyOf: [
+        watch,
+        {
+          type: 'boolean'
+        },
+        {
+          type: 'string'
+        }
+      ]
     },
     $schema: {
-      type: 'string',
+      type: 'string'
     },
     module: {
-      type: 'string',
-    },
+      type: 'string'
+    }
   },
   additionalProperties: false,
   required: ['composer'],
-  $defs: openApiDefs,
+  $defs: openApiDefs
 }
 
 module.exports.schema = platformaticComposerSchema

--- a/packages/composer/lib/stackable.js
+++ b/packages/composer/lib/stackable.js
@@ -43,9 +43,12 @@ class ComposerStackable extends ServiceStackable {
   }
 
   async getMeta () {
+    const serviceMeta = super.getMeta()
+    const composerMeta = this.#meta ? { composer: this.#meta } : undefined
+
     return {
-      ...super.getMeta?.(),
-      composer: this.#meta
+      ...serviceMeta,
+      ...composerMeta
     }
   }
 

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -28,6 +28,7 @@
     "@platformatic/client": "workspace:*",
     "@platformatic/config": "workspace:*",
     "@platformatic/db": "workspace:*",
+    "@platformatic/node": "workspace:*",
     "borp": "^0.17.0",
     "c8": "^10.0.0",
     "dedent": "^1.5.1",

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -28,7 +28,6 @@
     "@platformatic/client": "workspace:*",
     "@platformatic/config": "workspace:*",
     "@platformatic/db": "workspace:*",
-    "@platformatic/node": "workspace:*",
     "borp": "^0.17.0",
     "c8": "^10.0.0",
     "dedent": "^1.5.1",

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -4,6 +4,9 @@
   "title": "Platformatic Composer",
   "type": "object",
   "properties": {
+    "basePath": {
+      "type": "string"
+    },
     "server": {
       "type": "object",
       "properties": {
@@ -718,9 +721,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "prefix"
-                    ],
+                    "required": [],
                     "additionalProperties": false
                   }
                 ]
@@ -990,9 +991,7 @@
           "default": 1000
         }
       },
-      "required": [
-        "services"
-      ],
+      "required": [],
       "additionalProperties": false
     },
     "metrics": {

--- a/packages/composer/test/helper.js
+++ b/packages/composer/test/helper.js
@@ -20,13 +20,15 @@ const { createDirectory, safeRemove } = require('@platformatic/utils')
 const { buildServer: buildRuntime, symbols } = require('../../runtime')
 const { buildServer } = require('..')
 
-setInterval(() => {
-  console.log(why())
-}, 10000).unref()
+if (process.env.WHY === 'true') {
+  setInterval(() => {
+    console.log(why())
+  }, 60000).unref()
+}
 
 const agent = new Agent({
   keepAliveMaxTimeout: 10,
-  keepAliveTimeout: 10,
+  keepAliveTimeout: 10
 })
 
 const tmpBaseDir = resolve(__dirname, '../tmp')
@@ -43,16 +45,16 @@ async function createBasicService (t) {
   const app = fastify({
     logger: false,
     keepAliveTimeout: 10,
-    forceCloseConnections: true,
+    forceCloseConnections: true
   })
 
   await app.register(Swagger, {
     openapi: {
       info: {
         title: 'Test',
-        version: '0.1.0',
-      },
-    },
+        version: '0.1.0'
+      }
+    }
   })
 
   /** Serve spec file in yaml and json */
@@ -73,13 +75,13 @@ async function createBasicService (t) {
       schema: {
         response: {
           204: {
-            type: 'null',
+            type: 'null'
           },
           302: {
-            type: 'null',
-          },
-        },
-      },
+            type: 'null'
+          }
+        }
+      }
     },
     async () => {}
   )
@@ -92,12 +94,12 @@ async function createBasicService (t) {
           200: {
             type: 'object',
             properties: {
-              text: { type: 'string' },
+              text: { type: 'string' }
             },
-            required: ['text'],
-          },
-        },
-      },
+            required: ['text']
+          }
+        }
+      }
     },
     async () => {
       return { text: 'Some text' }
@@ -115,13 +117,13 @@ async function createBasicService (t) {
               nested: {
                 type: 'object',
                 properties: {
-                  text: { type: 'string' },
-                },
-              },
-            },
-          },
-        },
-      },
+                  text: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
     },
     async () => {
       return { nested: { text: 'Some text' } }
@@ -139,16 +141,16 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
   const app = fastify({
     logger: false,
     keepAliveTimeout: 10,
-    forceCloseConnections: true,
+    forceCloseConnections: true
   })
 
   await app.register(Swagger, {
     openapi: {
       info: {
         title: 'Test',
-        version: '0.1.0',
-      },
-    },
+        version: '0.1.0'
+      }
+    }
   })
 
   /** Serve spec file in yaml and json */
@@ -165,7 +167,7 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
   app.decorate('getOpenApiSchema', async () => {
     const { body } = await app.inject({
       method: 'GET',
-      url: '/documentation/json',
+      url: '/documentation/json'
     })
     return JSON.parse(body)
   })
@@ -194,8 +196,8 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
       type: 'object',
       properties: {
         id: { type: 'number' },
-        name: { type: 'string' },
-      },
+        name: { type: 'string' }
+      }
     })
 
     app.get(
@@ -205,10 +207,10 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
           response: {
             200: {
               type: 'array',
-              items: { $ref: entity },
-            },
-          },
-        },
+              items: { $ref: entity }
+            }
+          }
+        }
       },
       async () => {
         return Array.from(storage.values())
@@ -222,13 +224,13 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
           body: {
             type: 'object',
             properties: {
-              name: { type: 'string' },
-            },
+              name: { type: 'string' }
+            }
           },
           response: {
-            200: { $ref: entity },
-          },
-        },
+            200: { $ref: entity }
+          }
+        }
       },
       async req => {
         const entity = req.body
@@ -242,9 +244,9 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
         schema: {
           body: { $ref: entity },
           response: {
-            200: { $ref: entity },
-          },
-        },
+            200: { $ref: entity }
+          }
+        }
       },
       async req => {
         const entity = req.body
@@ -257,9 +259,9 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
       {
         schema: {
           response: {
-            200: { $ref: entity },
-          },
-        },
+            200: { $ref: entity }
+          }
+        }
       },
       async req => {
         return storage.get(parseInt(req.params.id))
@@ -271,9 +273,9 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
       {
         schema: {
           response: {
-            200: { $ref: entity },
-          },
-        },
+            200: { $ref: entity }
+          }
+        }
       },
       async req => {
         const id = req.params.id
@@ -287,9 +289,9 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
       {
         schema: {
           response: {
-            200: { $ref: entity },
-          },
-        },
+            200: { $ref: entity }
+          }
+        }
       },
       async req => {
         const id = req.params.id
@@ -303,9 +305,9 @@ async function createOpenApiService (t, entitiesNames = [], options = {}) {
       {
         schema: {
           response: {
-            200: { $ref: entity },
-          },
-        },
+            200: { $ref: entity }
+          }
+        }
       },
       async req => {
         return storage.delete(parseInt(req.params.id))
@@ -366,13 +368,13 @@ async function createComposer (t, composerConfig, loggerInstance = undefined) {
       hostname: '127.0.0.1',
       port: 0,
       keepAliveTimeout: 10,
-      forceCloseConnections: true,
+      forceCloseConnections: true
     },
     composer: { services: [] },
     plugins: {
-      paths: [],
+      paths: []
     },
-    watch: false,
+    watch: false
   }
 
   const config = Object.assign({}, defaultConfig, composerConfig)
@@ -385,7 +387,7 @@ async function createComposer (t, composerConfig, loggerInstance = undefined) {
   return app
 }
 
-async function createComposerInRuntime (t, prefix, composerConfig) {
+async function createComposerInRuntime (t, prefix, composerConfig, services) {
   await createDirectory(tmpBaseDir)
   const tmpDir = await mkdtemp(resolve(tmpBaseDir, prefix))
   await createDirectory(resolve(tmpDir, 'composer'))
@@ -400,13 +402,16 @@ async function createComposerInRuntime (t, prefix, composerConfig) {
       $schema: 'https://schemas.platformatic.dev/@platformatic/runtime/1.51.0.json',
       entrypoint: 'composer',
       watch: false,
-      services: [
+      services: (services ?? []).concat([
         {
           id: 'composer',
           path: resolve(tmpDir, 'composer'),
-          config: composerConfigPath,
-        },
-      ],
+          config: composerConfigPath
+        }
+      ]),
+      logger: {
+        level: 'error'
+      }
     }),
     'utf-8'
   )
@@ -418,11 +423,11 @@ async function createComposerInRuntime (t, prefix, composerConfig) {
       plugins: {
         paths: [
           {
-            path: './plugin.js',
-          },
-        ],
+            path: './plugin.js'
+          }
+        ]
       },
-      ...composerConfig,
+      ...composerConfig
     }),
     'utf-8'
   )
@@ -456,9 +461,9 @@ async function testEntityRoutes (origin, entitiesRoutes) {
         method: 'POST',
         path: entityRoute,
         headers: {
-          'content-type': 'application/json',
+          'content-type': 'application/json'
         },
-        body: JSON.stringify({ name: 'test' }),
+        body: JSON.stringify({ name: 'test' })
       })
       await body.text()
       assert.equal(statusCode, 200)
@@ -467,7 +472,7 @@ async function testEntityRoutes (origin, entitiesRoutes) {
     {
       const { statusCode, body } = await request(origin, {
         method: 'GET',
-        path: entityRoute,
+        path: entityRoute
       })
       await body.text()
       assert.equal(statusCode, 200)
@@ -478,9 +483,9 @@ async function testEntityRoutes (origin, entitiesRoutes) {
         method: 'PUT',
         path: entityRoute,
         headers: {
-          'content-type': 'application/json',
+          'content-type': 'application/json'
         },
-        body: JSON.stringify({ name: 'test' }),
+        body: JSON.stringify({ name: 'test' })
       })
       await body.text()
       assert.equal(statusCode, 200)
@@ -489,7 +494,7 @@ async function testEntityRoutes (origin, entitiesRoutes) {
     {
       const { statusCode, body } = await request(origin, {
         method: 'GET',
-        path: `${entityRoute}/1`,
+        path: `${entityRoute}/1`
       })
       await body.text()
       assert.equal(statusCode, 200)
@@ -500,9 +505,9 @@ async function testEntityRoutes (origin, entitiesRoutes) {
         method: 'POST',
         path: `${entityRoute}/2`,
         headers: {
-          'content-type': 'application/json',
+          'content-type': 'application/json'
         },
-        body: JSON.stringify({ name: 'test' }),
+        body: JSON.stringify({ name: 'test' })
       })
       await body.text()
       assert.equal(statusCode, 200)
@@ -513,9 +518,9 @@ async function testEntityRoutes (origin, entitiesRoutes) {
         method: 'PUT',
         path: `${entityRoute}/3`,
         headers: {
-          'content-type': 'application/json',
+          'content-type': 'application/json'
         },
-        body: JSON.stringify({ name: 'test' }),
+        body: JSON.stringify({ name: 'test' })
       })
       await body.text()
       assert.equal(statusCode, 200)
@@ -524,7 +529,7 @@ async function testEntityRoutes (origin, entitiesRoutes) {
     {
       const { statusCode, body } = await request(origin, {
         method: 'DELETE',
-        path: `${entityRoute}/4`,
+        path: `${entityRoute}/4`
       })
       await body.text()
       assert.equal(statusCode, 200)
@@ -536,9 +541,9 @@ async function graphqlRequest ({ query, variables, url, host }) {
   const { body, statusCode } = await request(url || host + '/graphql', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ query, variables }),
+    body: JSON.stringify({ query, variables })
   })
 
   const content = await body.json()
@@ -619,7 +624,7 @@ function createLoggerSpy () {
       this._warn = []
       this._error = []
       this._fatal = []
-    },
+    }
   }
 }
 
@@ -704,5 +709,5 @@ module.exports = {
   createLoggerSpy,
   getRuntimeLogs,
   waitForRestart,
-  checkSchema,
+  checkSchema
 }

--- a/packages/composer/test/proxy.test.js
+++ b/packages/composer/test/proxy.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert/strict')
+const { resolve } = require('node:path')
 const { test } = require('node:test')
 const { request } = require('undici')
 const { default: OpenAPISchemaValidator } = require('openapi-schema-validator')
@@ -8,11 +9,13 @@ const {
   createComposer,
   createOpenApiService,
   testEntityRoutes,
+  createComposerInRuntime,
+  REFRESH_TIMEOUT
 } = require('./helper')
 
 const openApiValidator = new OpenAPISchemaValidator({ version: 3 })
 
-test('should proxy openapi requests', async (t) => {
+test('should proxy openapi requests', async t => {
   const service1 = await createOpenApiService(t, ['users'], { addHeadersSchema: true })
   const service2 = await createOpenApiService(t, ['posts'])
   const service3 = await createOpenApiService(t, ['comments'])
@@ -28,35 +31,35 @@ test('should proxy openapi requests', async (t) => {
           id: 'service1',
           origin: origin1,
           openapi: {
-            url: '/documentation/json',
+            url: '/documentation/json'
           },
           proxy: {
-            prefix: '/internal/service1',
-          },
+            prefix: '/internal/service1'
+          }
         },
         {
           id: 'service2',
           origin: origin2,
           openapi: {
-            url: '/documentation/json',
+            url: '/documentation/json'
           },
           proxy: {
-            prefix: '/internal/service2',
-          },
+            prefix: '/internal/service2'
+          }
         },
         {
           id: 'service3',
           origin: origin3,
           openapi: {
-            url: '/documentation/json',
+            url: '/documentation/json'
           },
           proxy: {
-            prefix: '/',
-          },
-        },
+            prefix: '/'
+          }
+        }
       ],
-      refreshTimeout: 1000,
-    },
+      refreshTimeout: 1000
+    }
   }
 
   const composer = await createComposer(t, config)
@@ -64,7 +67,7 @@ test('should proxy openapi requests', async (t) => {
 
   const { statusCode, body } = await request(composerOrigin, {
     method: 'GET',
-    path: '/documentation/json',
+    path: '/documentation/json'
   })
   assert.equal(statusCode, 200)
 
@@ -73,14 +76,9 @@ test('should proxy openapi requests', async (t) => {
 
   for (const path in openApiSchema.paths) {
     for (const service of config.composer.services) {
-      const proxyPrefix = service.proxy.prefix.at(-1) === '/'
-        ? service.proxy.prefix.slice(0, -1)
-        : service.proxy.prefix
+      const proxyPrefix = service.proxy.prefix.at(-1) === '/' ? service.proxy.prefix.slice(0, -1) : service.proxy.prefix
 
-      if (
-        path === proxyPrefix + '/' ||
-        path === proxyPrefix + '/*'
-      ) {
+      if (path === proxyPrefix + '/' || path === proxyPrefix + '/*') {
         assert.fail('proxy routes should be removed from openapi schema')
       }
     }
@@ -89,7 +87,7 @@ test('should proxy openapi requests', async (t) => {
   {
     const { statusCode, body } = await request(composerOrigin, {
       method: 'GET',
-      path: '/internal/service1/documentation/json',
+      path: '/internal/service1/documentation/json'
     })
     assert.equal(statusCode, 200)
 
@@ -103,7 +101,7 @@ test('should proxy openapi requests', async (t) => {
   {
     const { statusCode, body } = await request(composerOrigin, {
       method: 'GET',
-      path: '/internal/service2/documentation/json',
+      path: '/internal/service2/documentation/json'
     })
     assert.equal(statusCode, 200)
 
@@ -115,10 +113,9 @@ test('should proxy openapi requests', async (t) => {
   }
 
   {
-    // internal service gets the x-forwarded-for and x-forwarded-host headers
     const { statusCode, body } = await request(composerOrigin, {
       method: 'GET',
-      path: '/internal/service1/headers',
+      path: '/internal/service1/headers'
     })
     assert.equal(statusCode, 200)
 
@@ -128,5 +125,310 @@ test('should proxy openapi requests', async (t) => {
     const [expectedForwardedFor] = expectedForwardedHost.split(':')
     assert.equal(returnedHeaders['x-forwarded-host'], expectedForwardedHost)
     assert.equal(returnedHeaders['x-forwarded-for'], expectedForwardedFor)
+  }
+})
+
+test('should proxy openapi requests', async t => {
+  const service1 = await createOpenApiService(t, ['users'], { addHeadersSchema: true })
+  const service2 = await createOpenApiService(t, ['posts'])
+  const service3 = await createOpenApiService(t, ['comments'])
+
+  const origin1 = await service1.listen({ port: 0 })
+  const origin2 = await service2.listen({ port: 0 })
+  const origin3 = await service3.listen({ port: 0 })
+
+  const config = {
+    composer: {
+      services: [
+        {
+          id: 'service1',
+          origin: origin1,
+          openapi: {
+            url: '/documentation/json'
+          },
+          proxy: {
+            prefix: '/internal/service1'
+          }
+        },
+        {
+          id: 'service2',
+          origin: origin2,
+          openapi: {
+            url: '/documentation/json'
+          },
+          proxy: {
+            prefix: '/internal/service2'
+          }
+        },
+        {
+          id: 'service3',
+          origin: origin3,
+          openapi: {
+            url: '/documentation/json'
+          },
+          proxy: {
+            prefix: '/'
+          }
+        }
+      ],
+      refreshTimeout: 1000
+    }
+  }
+
+  const composer = await createComposer(t, config)
+  const composerOrigin = await composer.start()
+
+  const { statusCode, body } = await request(composerOrigin, {
+    method: 'GET',
+    path: '/documentation/json'
+  })
+  assert.equal(statusCode, 200)
+
+  const openApiSchema = await body.json()
+  openApiValidator.validate(openApiSchema)
+
+  for (const path in openApiSchema.paths) {
+    for (const service of config.composer.services) {
+      const proxyPrefix = service.proxy.prefix.at(-1) === '/' ? service.proxy.prefix.slice(0, -1) : service.proxy.prefix
+
+      if (path === proxyPrefix + '/' || path === proxyPrefix + '/*') {
+        assert.fail('proxy routes should be removed from openapi schema')
+      }
+    }
+  }
+
+  {
+    const { statusCode, body } = await request(composerOrigin, {
+      method: 'GET',
+      path: '/internal/service1/documentation/json'
+    })
+    assert.equal(statusCode, 200)
+
+    const openApiSchema = await body.json()
+    openApiValidator.validate(openApiSchema)
+
+    await testEntityRoutes(composerOrigin, ['/users'])
+    await testEntityRoutes(composerOrigin, ['/internal/service1/users'])
+  }
+
+  {
+    const { statusCode, body } = await request(composerOrigin, {
+      method: 'GET',
+      path: '/internal/service2/documentation/json'
+    })
+    assert.equal(statusCode, 200)
+
+    const openApiSchema = await body.json()
+    openApiValidator.validate(openApiSchema)
+
+    await testEntityRoutes(composerOrigin, ['/posts'])
+    await testEntityRoutes(composerOrigin, ['/internal/service2/posts'])
+  }
+
+  {
+    const { statusCode, body } = await request(composerOrigin, {
+      method: 'GET',
+      path: '/internal/service1/headers'
+    })
+    assert.equal(statusCode, 200)
+
+    const returnedHeaders = await body.json()
+
+    const expectedForwardedHost = composerOrigin.replace('http://', '')
+    const [expectedForwardedFor] = expectedForwardedHost.split(':')
+    assert.equal(returnedHeaders['x-forwarded-host'], expectedForwardedHost)
+    assert.equal(returnedHeaders['x-forwarded-for'], expectedForwardedFor)
+  }
+})
+
+test('should proxy a @platformatic/service to its prefix by default', async t => {
+  const runtime = await createComposerInRuntime(
+    t,
+    'composer-default-prefix',
+    {
+      composer: {
+        services: [
+          {
+            id: 'main',
+            proxy: {}
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'main',
+        path: resolve(__dirname, './proxy/fixtures/service')
+      }
+    ]
+  )
+
+  t.after(() => {
+    runtime.close()
+  })
+
+  const address = await runtime.start()
+
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/main/hello'
+    })
+    assert.equal(statusCode, 200)
+
+    const body = await rawBody.json()
+    assert.deepStrictEqual(body, { ok: true })
+  }
+})
+
+test('should proxy a @platformatic/service to the chosen prefix by the user in the configuration', async t => {
+  const runtime = await createComposerInRuntime(
+    t,
+    'composer-prefix-in-conf',
+    {
+      composer: {
+        services: [
+          {
+            id: 'main',
+            proxy: {}
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'main',
+        path: resolve(__dirname, './proxy/fixtures/service'),
+        config: 'platformatic-prefix-in-conf.json'
+      }
+    ]
+  )
+
+  t.after(() => {
+    runtime.close()
+  })
+
+  const address = await runtime.start()
+
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/whatever/hello'
+    })
+    assert.equal(statusCode, 200)
+
+    const body = await rawBody.json()
+    assert.deepStrictEqual(body, { ok: true })
+  }
+})
+
+test('should proxy a @platformatic/service to the chosen prefix by the user in the code', async t => {
+  const runtime = await createComposerInRuntime(
+    t,
+    'composer-prefix-in-code',
+    {
+      composer: {
+        services: [
+          {
+            id: 'main',
+            proxy: {}
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'main',
+        path: resolve(__dirname, './proxy/fixtures/service'),
+        config: 'platformatic-prefix-in-code.json'
+      }
+    ]
+  )
+
+  t.after(() => {
+    runtime.close()
+  })
+
+  const address = await runtime.start()
+
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/from-code/hello'
+    })
+    assert.equal(statusCode, 200)
+
+    const body = await rawBody.json()
+    assert.deepStrictEqual(body, { ok: true })
+  }
+})
+
+test('should proxy all services if none are defined', async t => {
+  const runtime = await createComposerInRuntime(
+    t,
+    'composer-prefix-in-code',
+    {
+      composer: {
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'first',
+        path: resolve(__dirname, './proxy/fixtures/service'),
+        config: 'platformatic.json'
+      },
+      {
+        id: 'second',
+        path: resolve(__dirname, './proxy/fixtures/service'),
+        config: 'platformatic.json'
+      },
+      {
+        id: 'third',
+        path: resolve(__dirname, './proxy/fixtures/node')
+      }
+    ]
+  )
+
+  t.after(() => {
+    runtime.close()
+  })
+
+  const address = await runtime.start()
+
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/first/hello'
+    })
+    assert.equal(statusCode, 200)
+
+    const body = await rawBody.json()
+    assert.deepStrictEqual(body, { ok: true })
+  }
+
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/second/hello'
+    })
+    assert.equal(statusCode, 200)
+
+    const body = await rawBody.json()
+    assert.deepStrictEqual(body, { ok: true })
+  }
+
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/third/hello'
+    })
+    assert.equal(statusCode, 200)
+
+    const body = await rawBody.json()
+    assert.deepStrictEqual(body, { ok: true })
   }
 })

--- a/packages/composer/test/proxy/fixtures/node/index.mjs
+++ b/packages/composer/test/proxy/fixtures/node/index.mjs
@@ -1,0 +1,20 @@
+import { createServer } from 'node:http'
+
+const server = createServer((req, res) => {
+  if (req.url === '/third/hello') {
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      connection: 'close'
+    })
+    res.end(JSON.stringify({ ok: true }))
+  } else {
+    res.writeHead(404, {
+      'content-type': 'application/json',
+      connection: 'close'
+    })
+    res.end(JSON.stringify({ ok: false }))
+  }
+})
+
+// This would likely fail if our code doesn't work
+server.listen(1)

--- a/packages/composer/test/proxy/fixtures/service/platformatic-prefix-in-code.json
+++ b/packages/composer/test/proxy/fixtures/service/platformatic-prefix-in-code.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "watch": false,
+  "plugins": {
+    "paths": [
+      {
+        "path": "./routes-with-prefix-in-code.js"
+      }
+    ]
+  }
+}

--- a/packages/composer/test/proxy/fixtures/service/platformatic-prefix-in-conf.json
+++ b/packages/composer/test/proxy/fixtures/service/platformatic-prefix-in-conf.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "basePath": "whatever",
+  "watch": false,
+  "plugins": {
+    "paths": [
+      {
+        "path": "./routes.js"
+      }
+    ]
+  }
+}

--- a/packages/composer/test/proxy/fixtures/service/platformatic.json
+++ b/packages/composer/test/proxy/fixtures/service/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "watch": false,
+  "plugins": {
+    "paths": [
+      {
+        "path": "./routes.js"
+      }
+    ]
+  }
+}

--- a/packages/composer/test/proxy/fixtures/service/routes-with-prefix-in-code.js
+++ b/packages/composer/test/proxy/fixtures/service/routes-with-prefix-in-code.js
@@ -1,0 +1,8 @@
+/* globals platformatic */
+platformatic.setBasePath('from-code')
+
+module.exports = async function (app) {
+  app.get('/hello', async () => {
+    return { ok: true }
+  })
+}

--- a/packages/composer/test/proxy/fixtures/service/routes.js
+++ b/packages/composer/test/proxy/fixtures/service/routes.js
@@ -1,0 +1,5 @@
+module.exports = async function (app) {
+  app.get('/hello', async () => {
+    return { ok: true }
+  })
+}

--- a/packages/db-authorization/test/helper.js
+++ b/packages/db-authorization/test/helper.js
@@ -5,9 +5,11 @@ const why = require('why-is-node-running')
 // This file must be required/imported as the first file
 // in the test suite. It sets up the global environment
 // to track the open handles via why-is-node-running.
-setInterval(() => {
-  why()
-}, 20000).unref()
+if (process.env.WHY === 'true') {
+  setInterval(() => {
+    why()
+  }, 60000).unref()
+}
 
 // Needed to work with dates & postgresql
 // See https://node-postgres.com/features/types/
@@ -40,12 +42,10 @@ module.exports.connInfo = connInfo
 module.exports.clear = async function (db, sql) {
   try {
     await db.query(sql`DROP TABLE IF EXISTS pages CASCADE`)
-  } catch (err) {
-  }
+  } catch (err) {}
   try {
     await db.query(sql`DROP TABLE IF EXISTS categories CASCADE`)
-  } catch (err) {
-  }
+  } catch (err) {}
 }
 
 async function createBasicPages (db, sql) {

--- a/packages/db-core/test/helper.js
+++ b/packages/db-core/test/helper.js
@@ -5,9 +5,11 @@ const why = require('why-is-node-running')
 // This file must be required/imported as the first file
 // in the test suite. It sets up the global environment
 // to track the open handles via why-is-node-running.
-setInterval(() => {
-  why()
-}, 10000).unref()
+if (process.env.WHY === 'true') {
+  setInterval(() => {
+    why()
+  }, 60000).unref()
+}
 
 // Needed to work with dates & postgresql
 // See https://node-postgres.com/features/types/
@@ -40,8 +42,7 @@ module.exports.connInfo = connInfo
 module.exports.clear = async function (db, sql) {
   try {
     await db.query(sql`DROP TABLE pages`)
-  } catch (err) {
-  }
+  } catch (err) {}
 }
 
 function buildConfig (options) {
@@ -49,7 +50,7 @@ function buildConfig (options) {
     server: {},
     core: {},
     cli: {},
-    authorization: {},
+    authorization: {}
   }
 
   return Object.assign(base, options)

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -23,6 +23,7 @@ export type CrudOperationAuth =
   | boolean;
 
 export interface PlatformaticDB {
+  basePath?: string;
   server?: {
     hostname?: string;
     port?: number | string;

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -9,240 +9,252 @@ const db = {
   type: 'object',
   properties: {
     connectionString: {
-      type: 'string',
+      type: 'string'
     },
     schema: {
       type: 'array',
       items: {
-        type: 'string',
-      },
+        type: 'string'
+      }
     },
     schemalock: {
-      oneOf: [{
-        type: 'boolean',
-        default: false,
-      }, {
-        type: 'object',
-        properties: {
-          path: {
-            type: 'string',
-            resolvePath: true,
-          },
+      oneOf: [
+        {
+          type: 'boolean',
+          default: false
         },
-      }],
+        {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              resolvePath: true
+            }
+          }
+        }
+      ]
     },
     poolSize: {
-      type: 'integer',
+      type: 'integer'
     },
     idleTimeoutMilliseconds: {
-      type: 'integer',
+      type: 'integer'
     },
     queueTimeoutMilliseconds: {
-      type: 'integer',
+      type: 'integer'
     },
     acquireLockTimeoutMilliseconds: {
-      type: 'integer',
+      type: 'integer'
     },
     autoTimestamp: {
-      oneOf: [{
-        type: 'object',
-        properties: {
-          createdAt: {
-            type: 'string',
-            default: 'created_at',
-          },
-          updatedAt: {
-            type: 'string',
-            default: 'updated_at',
-          },
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            createdAt: {
+              type: 'string',
+              default: 'created_at'
+            },
+            updatedAt: {
+              type: 'string',
+              default: 'updated_at'
+            }
+          }
         },
-      }, {
-        type: 'boolean',
-      }],
+        {
+          type: 'boolean'
+        }
+      ]
     },
     graphql: {
-      anyOf: [{
-        type: 'boolean',
-      }, {
-        type: 'object',
-        properties: {
-          graphiql: {
-            type: 'boolean',
-          },
-          include: {
-            type: 'object',
-            additionalProperties: {
-              type: 'boolean',
-            },
-          },
-          ignore: {
-            type: 'object',
-            additionalProperties: {
-              anyOf: [{
-                type: 'boolean',
-              }, {
-                type: 'object',
-                additionalProperties: {
-                  type: 'boolean',
-                },
-              }],
-            },
-          },
-          subscriptionIgnore: {
-            type: 'array',
-            items: {
-              type: 'string',
-            },
-          },
-          schema: {
-            type: 'string',
-          },
-          schemaPath: {
-            type: 'string',
-            resolvePath: true,
-          },
-          enabled: {
-            anyOf: [
-              { type: 'boolean' },
-              { type: 'string' },
-            ],
-          },
+      anyOf: [
+        {
+          type: 'boolean'
         },
-      }],
+        {
+          type: 'object',
+          properties: {
+            graphiql: {
+              type: 'boolean'
+            },
+            include: {
+              type: 'object',
+              additionalProperties: {
+                type: 'boolean'
+              }
+            },
+            ignore: {
+              type: 'object',
+              additionalProperties: {
+                anyOf: [
+                  {
+                    type: 'boolean'
+                  },
+                  {
+                    type: 'object',
+                    additionalProperties: {
+                      type: 'boolean'
+                    }
+                  }
+                ]
+              }
+            },
+            subscriptionIgnore: {
+              type: 'array',
+              items: {
+                type: 'string'
+              }
+            },
+            schema: {
+              type: 'string'
+            },
+            schemaPath: {
+              type: 'string',
+              resolvePath: true
+            },
+            enabled: {
+              anyOf: [{ type: 'boolean' }, { type: 'string' }]
+            }
+          }
+        }
+      ]
     },
     openapi: {
-      anyOf: [{
-        type: 'boolean',
-      }, {
-        type: 'object',
-        properties: {
-          ...(openApiBase.properties),
-          allowPrimaryKeysInInput: {
-            type: 'boolean',
-            default: true,
-          },
-          include: {
-            type: 'object',
-            additionalProperties: {
-              type: 'boolean',
-            },
-          },
-          ignore: {
-            type: 'object',
-            additionalProperties: {
-              anyOf: [{
-                type: 'boolean',
-              }, {
-                type: 'object',
-                additionalProperties: {
-                  type: 'boolean',
-                },
-              }],
-            },
-          },
-          ignoreRoutes: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                method: { type: 'string' },
-                path: { type: 'string' },
-              },
-              required: ['method', 'path'],
-              additionalProperties: false,
-            },
-          },
-          enabled: {
-            anyOf: [
-              { type: 'boolean' },
-              { type: 'string' },
-            ],
-          },
-          swaggerPrefix: {
-            type: 'string',
-            description: 'Base URL for the OpenAPI Swagger Documentation',
-          },
-          prefix: {
-            type: 'string',
-            description: 'Base URL for generated Platformatic DB routes',
-          },
+      anyOf: [
+        {
+          type: 'boolean'
         },
-        additionalProperties: false,
-      }],
+        {
+          type: 'object',
+          properties: {
+            ...openApiBase.properties,
+            allowPrimaryKeysInInput: {
+              type: 'boolean',
+              default: true
+            },
+            include: {
+              type: 'object',
+              additionalProperties: {
+                type: 'boolean'
+              }
+            },
+            ignore: {
+              type: 'object',
+              additionalProperties: {
+                anyOf: [
+                  {
+                    type: 'boolean'
+                  },
+                  {
+                    type: 'object',
+                    additionalProperties: {
+                      type: 'boolean'
+                    }
+                  }
+                ]
+              }
+            },
+            ignoreRoutes: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  method: { type: 'string' },
+                  path: { type: 'string' }
+                },
+                required: ['method', 'path'],
+                additionalProperties: false
+              }
+            },
+            enabled: {
+              anyOf: [{ type: 'boolean' }, { type: 'string' }]
+            },
+            swaggerPrefix: {
+              type: 'string',
+              description: 'Base URL for the OpenAPI Swagger Documentation'
+            },
+            prefix: {
+              type: 'string',
+              description: 'Base URL for generated Platformatic DB routes'
+            }
+          },
+          additionalProperties: false
+        }
+      ]
     },
     include: {
       type: 'object',
       additionalProperties: {
-        type: 'boolean',
-      },
+        type: 'boolean'
+      }
     },
     ignore: {
       type: 'object',
       // TODO add support for column-level ignore
       additionalProperties: {
-        type: 'boolean',
-      },
+        type: 'boolean'
+      }
     },
     limit: {
       type: 'object',
       properties: {
         default: {
           type: 'integer',
-          default: 10,
+          default: 10
         },
         max: {
           type: 'integer',
-          default: 100,
-        },
-      },
+          default: 100
+        }
+      }
     },
     events: {
-      anyOf: [{
-        type: 'boolean',
-      }, {
-        type: 'object',
-        properties: {
-          connectionString: {
-            type: 'string',
-          },
-          enabled: {
-            anyOf: [
-              { type: 'boolean' },
-              { type: 'string' },
-            ],
-          },
+      anyOf: [
+        {
+          type: 'boolean'
         },
-        additionalProperties: false,
-      }],
+        {
+          type: 'object',
+          properties: {
+            connectionString: {
+              type: 'string'
+            },
+            enabled: {
+              anyOf: [{ type: 'boolean' }, { type: 'string' }]
+            }
+          },
+          additionalProperties: false
+        }
+      ]
     },
     cache: {
-      type: 'boolean',
-    },
+      type: 'boolean'
+    }
   },
-  required: ['connectionString'],
+  required: ['connectionString']
 }
 
 const sharedAuthorizationRule = {
   role: {
     type: 'string',
-    description: 'the role name to match the rule',
+    description: 'the role name to match the rule'
   },
   defaults: {
     type: 'object',
     description: 'defaults for entity creation',
     additionalProperties: {
-      type: 'string',
-    },
+      type: 'string'
+    }
   },
   find: {
-    $ref: '#/$defs/crud-operation-auth',
+    $ref: '#/$defs/crud-operation-auth'
   },
   save: {
-    $ref: '#/$defs/crud-operation-auth',
+    $ref: '#/$defs/crud-operation-auth'
   },
   delete: {
-    $ref: '#/$defs/crud-operation-auth',
-  },
+    $ref: '#/$defs/crud-operation-auth'
+  }
 }
 
 const authorization = {
@@ -250,95 +262,105 @@ const authorization = {
   properties: {
     adminSecret: {
       type: 'string',
-      description: 'The password should be used to access routes under /_admin prefix and for admin access to REST and GraphQL endpoints with X-PLATFORMATIC-ADMIN-SECRET header.',
+      description:
+        'The password should be used to access routes under /_admin prefix and for admin access to REST and GraphQL endpoints with X-PLATFORMATIC-ADMIN-SECRET header.'
     },
     roleKey: {
       type: 'string',
       description: 'The user metadata key to store user roles',
-      default: 'X-PLATFORMATIC-ROLE',
+      default: 'X-PLATFORMATIC-ROLE'
     },
     rolePath: {
       type: 'string',
-      description: 'The user metadata path to store user roles',
+      description: 'The user metadata path to store user roles'
     },
     anonymousRole: {
       type: 'string',
       description: 'The role name for anonymous users',
-      default: 'anonymous',
+      default: 'anonymous'
     },
     jwt: {
       type: 'object',
       additionalProperties: true,
       properties: {
         secret: {
-          oneOf: [{
-            type: 'string',
-            description: 'the shared secret for JWT',
-          }, {
-            type: 'object',
-            description: 'the JWT secret configuration (see: https://github.com/fastify/fastify-jwt#secret-required)',
-            additionalProperties: true,
-          }],
+          oneOf: [
+            {
+              type: 'string',
+              description: 'the shared secret for JWT'
+            },
+            {
+              type: 'object',
+              description: 'the JWT secret configuration (see: https://github.com/fastify/fastify-jwt#secret-required)',
+              additionalProperties: true
+            }
+          ]
         },
         namespace: {
           type: 'string',
-          description: 'the namespace for JWT custom claims',
+          description: 'the namespace for JWT custom claims'
         },
         jwks: {
-          oneOf: [{
-            type: 'boolean',
-          }, {
-            // shall we replicate here all the options in https://github.com/nearform/get-jwks#options
-            type: 'object',
-            additionalProperties: true,
-          }],
-        },
-      },
+          oneOf: [
+            {
+              type: 'boolean'
+            },
+            {
+              // shall we replicate here all the options in https://github.com/nearform/get-jwks#options
+              type: 'object',
+              additionalProperties: true
+            }
+          ]
+        }
+      }
     },
     webhook: {
       type: 'object',
       properties: {
         url: {
           type: 'string',
-          description: 'the webhook url',
-        },
+          description: 'the webhook url'
+        }
       },
-      additionalProperties: false,
+      additionalProperties: false
     },
     rules: {
       type: 'array',
       items: {
         type: 'object',
-        oneOf: [{
-          type: 'object',
-          properties: {
-            entity: {
-              type: 'string',
-              description: 'the DB entity type to which the rule applies',
-            },
-            ...sharedAuthorizationRule,
-          },
-          required: ['role'],
-          additionalProperties: false,
-        }, {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              description: 'the DB entity types to which the rule applies',
-              items: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              entity: {
                 type: 'string',
+                description: 'the DB entity type to which the rule applies'
               },
+              ...sharedAuthorizationRule
             },
-            ...sharedAuthorizationRule,
+            required: ['role'],
+            additionalProperties: false
           },
-          required: ['role'],
-          additionalProperties: false,
-        }],
-      },
-    },
+          {
+            type: 'object',
+            properties: {
+              entities: {
+                type: 'array',
+                description: 'the DB entity types to which the rule applies',
+                items: {
+                  type: 'string'
+                }
+              },
+              ...sharedAuthorizationRule
+            },
+            required: ['role'],
+            additionalProperties: false
+          }
+        ]
+      }
+    }
   },
-  additionalProperties: false,
+  additionalProperties: false
 }
 
 const migrations = {
@@ -347,56 +369,64 @@ const migrations = {
     dir: {
       type: 'string',
       resolvePath: true,
-      description: 'The path to the directory containing the migrations.',
+      description: 'The path to the directory containing the migrations.'
     },
     table: {
       type: 'string',
       description: 'Table created to track schema version.',
-      default: 'versions',
+      default: 'versions'
     },
     validateChecksums: {
-      type: 'boolean',
+      type: 'boolean'
     },
     autoApply: {
       description: 'Whether to automatically apply migrations when running the migrate command.',
-      anyOf: [{
-        type: 'boolean',
-        default: false,
-      }, {
-        type: 'string',
-      }],
+      anyOf: [
+        {
+          type: 'boolean',
+          default: false
+        },
+        {
+          type: 'string'
+        }
+      ]
     },
     newline: {
       type: 'string',
-      description: 'Force line ending on file when generating checksum. Value should be either CRLF (windows) or LF (unix/mac).',
+      description:
+        'Force line ending on file when generating checksum. Value should be either CRLF (windows) or LF (unix/mac).'
     },
     currentSchema: {
       type: 'string',
-      description: 'For Postgres and MS SQL Server(will ignore for another DBs). Specifies schema to look to when validating `versions` table columns. For Postgres, run\'s `SET search_path = currentSchema` prior to running queries against db.',
-    },
+      description:
+        "For Postgres and MS SQL Server(will ignore for another DBs). Specifies schema to look to when validating `versions` table columns. For Postgres, run's `SET search_path = currentSchema` prior to running queries against db."
+    }
   },
   additionalProperties: false,
-  required: ['dir'],
+  required: ['dir']
 }
 
 const types = {
   type: 'object',
   properties: {
     autogenerate: {
-      anyOf: [{
-        type: 'string',
-      }, {
-        type: 'boolean',
-      }],
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'boolean'
+        }
+      ],
       description: 'Should types be auto generated.'
     },
     dir: {
       type: 'string',
       resolvePath: true,
-      description: 'The path to the directory the types should be generated in.',
-    },
+      description: 'The path to the directory the types should be generated in.'
+    }
   },
-  additionalProperties: false,
+  additionalProperties: false
 }
 
 const platformaticDBschema = {
@@ -405,15 +435,18 @@ const platformaticDBschema = {
   title: 'Platformatic DB',
   type: 'object',
   properties: {
+    basePath: {
+      type: 'string'
+    },
     server: {
       ...server,
       properties: {
         ...server.properties,
         pluginTimeout: {
           ...server.properties.pluginTimeout,
-          default: 60 * 1000,
-        },
-      },
+          default: 60 * 1000
+        }
+      }
     },
     db,
     authorization,
@@ -424,69 +457,76 @@ const platformaticDBschema = {
     telemetry,
     clients,
     watch: {
-      anyOf: [watch, {
-        type: 'boolean',
-      }, {
-        type: 'string',
-      }],
+      anyOf: [
+        watch,
+        {
+          type: 'boolean'
+        },
+        {
+          type: 'string'
+        }
+      ]
     },
     $schema: {
-      type: 'string',
+      type: 'string'
     },
     module: {
-      type: 'string',
-    },
+      type: 'string'
+    }
   },
   additionalProperties: false,
   required: ['db'],
   $defs: {
     ...openApiDefs,
     'crud-operation-auth': {
-      oneOf: [{
-        type: 'object',
-        description: 'CRUD operation authorization config',
-        properties: {
-          checks: {
-            description: 'checks for the operation',
-            type: 'object',
-            additionalProperties: {
-              if: {
-                type: 'object',
-              },
-              then: {
-                type: 'object',
-                properties: {
-                  eq: { type: 'string' },
-                  in: { type: 'string' },
-                  nin: { type: 'string' },
-                  nen: { type: 'string' },
-                  gt: { type: 'string' },
-                  gte: { type: 'string' },
-                  lt: { type: 'string' },
-                  lte: { type: 'string' },
+      oneOf: [
+        {
+          type: 'object',
+          description: 'CRUD operation authorization config',
+          properties: {
+            checks: {
+              description: 'checks for the operation',
+              type: 'object',
+              additionalProperties: {
+                if: {
+                  type: 'object'
                 },
-                additionalProperties: false,
-              },
-              else: {
-                type: 'string',
-              },
+                then: {
+                  type: 'object',
+                  properties: {
+                    eq: { type: 'string' },
+                    in: { type: 'string' },
+                    nin: { type: 'string' },
+                    nen: { type: 'string' },
+                    gt: { type: 'string' },
+                    gte: { type: 'string' },
+                    lt: { type: 'string' },
+                    lte: { type: 'string' }
+                  },
+                  additionalProperties: false
+                },
+                else: {
+                  type: 'string'
+                }
+              }
             },
+            fields: {
+              type: 'array',
+              description: 'array of enabled field for the operation',
+              items: {
+                type: 'string'
+              }
+            }
           },
-          fields: {
-            type: 'array',
-            description: 'array of enabled field for the operation',
-            items: {
-              type: 'string',
-            },
-          },
+          additionalProperties: false
         },
-        additionalProperties: false,
-      }, {
-        type: 'boolean',
-        description: 'true if enabled (with not authorization constraints enabled)',
-      }],
-    },
-  },
+        {
+          type: 'boolean',
+          description: 'true if enabled (with not authorization constraints enabled)'
+        }
+      ]
+    }
+  }
 }
 
 module.exports.schema = platformaticDBschema

--- a/packages/db/lib/stackable.js
+++ b/packages/db/lib/stackable.js
@@ -27,6 +27,8 @@ class DbStackable extends ServiceStackable {
     await this.init()
     await this.app.ready()
 
+    const serviceMeta = await super.getMeta()
+
     const config = this.configManager.current
 
     const dbConfig = config.db
@@ -34,12 +36,14 @@ class DbStackable extends ServiceStackable {
 
     if (connectionString) {
       return {
+        ...serviceMeta,
         db: {
           connectionStrings: [connectionString]
         }
       }
     }
-    return {}
+
+    return serviceMeta
   }
 }
 module.exports = { DbStackable }

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -4,6 +4,9 @@
   "title": "Platformatic DB",
   "type": "object",
   "properties": {
+    "basePath": {
+      "type": "string"
+    },
     "server": {
       "type": "object",
       "properties": {

--- a/packages/db/test/helper.js
+++ b/packages/db/test/helper.js
@@ -14,7 +14,7 @@ const { platformaticDB, ConfigManager } = require('..')
 // to track the open handles via why-is-node-running.
 setInterval(() => {
   why()
-}, 20000).unref()
+}, 60000).unref()
 
 const agent = new Agent({
   keepAliveTimeout: 10,

--- a/packages/db/test/stackable/get-meta.test.js
+++ b/packages/db/test/stackable/get-meta.test.js
@@ -6,7 +6,7 @@ const { join } = require('node:path')
 const { buildConfigManager, getConnectionInfo, createBasicPages } = require('../helper')
 const { buildStackable } = require('../..')
 
-test('get meta info via stackable api', async (t) => {
+test('get meta info via stackable api', async t => {
   const workingDir = join(__dirname, '..', 'fixtures', 'directories')
   const { connectionInfo, dropTestDB } = await getConnectionInfo()
   const { dbname } = connectionInfo
@@ -14,19 +14,19 @@ test('get meta info via stackable api', async (t) => {
   const config = {
     server: {
       hostname: '127.0.0.1',
-      port: 0,
+      port: 0
     },
     db: {
       ...connectionInfo,
       async onDatabaseLoad (db, sql) {
         await createBasicPages(db, sql)
-      },
+      }
     },
     plugins: {
-      paths: [join(workingDir, 'routes')],
+      paths: [join(workingDir, 'routes')]
     },
     watch: false,
-    metrics: false,
+    metrics: false
   }
 
   const configManager = await buildConfigManager(config, workingDir)
@@ -40,9 +40,14 @@ test('get meta info via stackable api', async (t) => {
 
   const meta = await stackable.getMeta()
   const expected = {
+    composer: {
+      needsRootRedirect: false,
+      prefix: undefined,
+      wantsAbsoluteUrls: false
+    },
     db: {
       connectionStrings: [`postgres://postgres:postgres@127.0.0.1/${dbname}`]
-    },
+    }
   }
 
   assert.deepStrictEqual(meta, expected)

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -102,16 +102,11 @@ export class NextStackable extends BaseStackable {
   }
 
   getMeta () {
-    let composer = { prefix: this.servicePrefix, wantsAbsoluteUrls: true, needsRootRedirect: false }
+    const composer = { prefix: this.basePath ?? this.#basePath, wantsAbsoluteUrls: true, needsRootRedirect: false }
 
     if (this.url) {
-      composer = {
-        tcp: true,
-        url: this.url,
-        prefix: this.#basePath ?? this.servicePrefix,
-        wantsAbsoluteUrls: true,
-        needsRootRedirect: false
-      }
+      composer.tcp = true
+      composer.url = this.url
     }
 
     return { composer }
@@ -155,7 +150,7 @@ export class NextStackable extends BaseStackable {
     const { nextDev } = await importFile(pathResolve(this.#next, './dist/cli/next-dev.js'))
 
     this.#manager.on('config', config => {
-      this.#basePath = config.basePath.replace(/(^\/)|(\/$)/g, '')
+      this.#basePath = config.basePath
     })
 
     try {
@@ -207,7 +202,7 @@ export class NextStackable extends BaseStackable {
 
       // Since we are in the same process
       process.once('plt:next:config', config => {
-        this.#basePath = config.basePath.replace(/(^\/)|(\/$)/g, '')
+        this.#basePath = config.basePath
       })
 
       this.#manager.register()

--- a/packages/next/test/fixtures/composer-with-external-proxy/services/composer/platformatic.json
+++ b/packages/next/test/fixtures/composer-with-external-proxy/services/composer/platformatic.json
@@ -12,7 +12,7 @@
       {
         "id": "frontend",
         "proxy": {
-          "prefix": "/frontend"
+          "prefix": "/external-proxy/frontend"
         }
       }
     ]

--- a/packages/next/test/fixtures/composer-with-external-proxy/services/external-proxy/proxy.js
+++ b/packages/next/test/fixtures/composer-with-external-proxy/services/external-proxy/proxy.js
@@ -5,10 +5,10 @@ module.exports = async function (fastify, opts) {
     base: 'http://composer.plt.local',
     globalAgent: true
   })
-  
+
   fastify.get('/external-proxy/*', async (req, reply) => {
     const newUrl = req.raw.url.replace('/external-proxy', '')
-    reply.from(newUrl)
+    reply.from(newUrl.startsWith('/frontend') ? req.raw.url : newUrl)
     return reply
   })
 }

--- a/packages/next/test/production.test.js
+++ b/packages/next/test/production.test.js
@@ -31,13 +31,9 @@ const configurations = [
   {
     only: isCIOnWindows,
     id: 'composer-with-external-proxy',
-    name: 'Next.js (in composer with prefix)',
+    name: 'Next.js (in composer with external procy)',
     files: [...nextFiles, ...internalServicesFiles],
-    checks: [
-      verifyFrontendOnPrefixWithProxy,
-      verifyPlatformaticComposerWithProxy,
-      verifyPlatformaticServiceWithProxy
-    ]
+    checks: [verifyFrontendOnPrefixWithProxy, verifyPlatformaticComposerWithProxy, verifyPlatformaticServiceWithProxy]
   },
   {
     id: 'composer-without-prefix',

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -221,8 +221,10 @@ export class NodeStackable extends BaseStackable {
 
   getMeta () {
     const config = this.configManager.current
+    const basePath = ensureTrailingSlash(cleanBasePath(this.basePath ?? config.application?.basePath))
+
     let composer = {
-      prefix: this.servicePrefix,
+      prefix: basePath,
       wantsAbsoluteUrls: this._getWantsAbsoluteUrls(),
       needsRootRedirect: true
     }
@@ -231,9 +233,7 @@ export class NodeStackable extends BaseStackable {
       composer = {
         tcp: true,
         url: this.url,
-        prefix: config.application?.basePath
-          ? ensureTrailingSlash(cleanBasePath(config.application?.basePath))
-          : this.servicePrefix,
+        prefix: basePath,
         wantsAbsoluteUrls: this._getWantsAbsoluteUrls(),
         needsRootRedirect: true
       }

--- a/packages/node/test/fixtures/express-no-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/express-no-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,6 +1,6 @@
 import express from 'express'
 
-globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+globalThis.platformatic?.setBasePath('/nested/base/dir')
 
 const app = express()
 

--- a/packages/node/test/fixtures/express-with-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/express-with-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,7 +1,7 @@
 import express from 'express'
 
 export function build () {
-  globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+  globalThis.platformatic?.setBasePath('/nested/base/dir')
 
   const app = express()
 

--- a/packages/node/test/fixtures/fastify-no-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/fastify-no-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,6 +1,6 @@
 import fastify from 'fastify'
 
-globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+globalThis.platformatic?.setBasePath('/nested/base/dir')
 
 const app = fastify({
   loggerInstance: globalThis.platformatic?.logger?.child({}, { level: globalThis.platformatic?.logLevel ?? 'info' })

--- a/packages/node/test/fixtures/fastify-with-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/fastify-with-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,7 +1,7 @@
 import fastify from 'fastify'
 
 export function build () {
-  globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+  globalThis.platformatic?.setBasePath('/nested/base/dir')
 
   const app = fastify({
     loggerInstance: globalThis.platformatic?.logger?.child({}, { level: globalThis.platformatic?.logLevel ?? 'info' })

--- a/packages/node/test/fixtures/koa-no-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/koa-no-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,6 +1,6 @@
 import Koa from 'koa'
 
-globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+globalThis.platformatic?.setBasePath('/nested/base/dir')
 
 const app = new Koa()
 

--- a/packages/node/test/fixtures/koa-with-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/koa-with-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,7 +1,7 @@
 import Koa from 'koa'
 
 export function build () {
-  globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+  globalThis.platformatic?.setBasePath('/nested/base/dir')
 
   const app = new Koa()
 

--- a/packages/node/test/fixtures/node-no-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/node-no-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,6 +1,6 @@
 import { createServer } from 'node:http'
 
-globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+globalThis.platformatic?.setBasePath('/nested/base/dir')
 
 const server = createServer((req, res) => {
   if (req.url === '/nested/base/dir/') {

--- a/packages/node/test/fixtures/node-no-configuration-composer-autodetect-prefix/services/frontend/index.mjs
+++ b/packages/node/test/fixtures/node-no-configuration-composer-autodetect-prefix/services/frontend/index.mjs
@@ -1,6 +1,6 @@
 import { createServer } from 'node:http'
 
-globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+globalThis.platformatic?.setBasePath('/nested/base/dir')
 
 const server = createServer((req, res) => {
   if (req.url === '/') {

--- a/packages/node/test/fixtures/node-no-configuration-composer-with-prefix/services/composer/platformatic.json
+++ b/packages/node/test/fixtures/node-no-configuration-composer-with-prefix/services/composer/platformatic.json
@@ -10,7 +10,10 @@
         }
       },
       {
-        "id": "frontend"
+        "id": "frontend",
+        "proxy": {
+          "prefix": "/frontend"
+        }
       }
     ]
   },

--- a/packages/node/test/fixtures/node-with-build-composer-autodetect-prefix/services/frontend/index.js
+++ b/packages/node/test/fixtures/node-with-build-composer-autodetect-prefix/services/frontend/index.js
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http'
 
 export function build () {
-  globalThis.platformatic?.setServicePrefix('/nested/base/dir')
+  globalThis.platformatic?.setBasePath('/nested/base/dir')
 
   return createServer((req, res) => {
     if (req.url === '/nested/base/dir/') {

--- a/packages/remix/index.js
+++ b/packages/remix/index.js
@@ -150,7 +150,7 @@ export class RemixStackable extends ViteStackable {
       composer: {
         tcp: typeof this.url !== 'undefined',
         url: this.url,
-        prefix: this.#basePath,
+        prefix: this.basePath ?? this.#basePath,
         wantsAbsoluteUrls: true,
         needsRootRedirect: true
       }

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -813,7 +813,8 @@ class Runtime extends EventEmitter {
       name: id + '-runtime',
       port: service,
       handlers: {
-        getServiceMeta: this.getServiceMeta.bind(this)
+        getServiceMeta: this.getServiceMeta.bind(this),
+        getServices: this.getServices.bind(this)
       }
     })
     service[kITC].listen()

--- a/packages/runtime/test/api/meta.test.js
+++ b/packages/runtime/test/api/meta.test.js
@@ -20,6 +20,11 @@ test('should get meta for db services in runtime schema', async t => {
   const dbMeta = await app.getServiceMeta('db-app')
   const database = join(fixturesDir, 'monorepo', 'dbApp', 'db.sqlite')
   assert.deepStrictEqual(dbMeta, {
+    composer: {
+      needsRootRedirect: false,
+      prefix: 'db-app',
+      wantsAbsoluteUrls: false
+    },
     db: {
       connectionStrings: [`sqlite://${database}`]
     }

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -6,6 +6,7 @@
  */
 
 export interface PlatformaticService {
+  basePath?: string;
   server?: {
     hostname?: string;
     port?: number | string;

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -334,6 +334,9 @@ const platformaticServiceSchema = {
   title: 'Platformatic Service',
   type: 'object',
   properties: {
+    basePath: {
+      type: 'string'
+    },
     server,
     plugins,
     metrics,

--- a/packages/service/lib/stackable.js
+++ b/packages/service/lib/stackable.js
@@ -28,6 +28,13 @@ class ServiceStackable {
     })
 
     this.#updateConfig()
+
+    // Setup globals
+    this.registerGlobals({
+      setOpenapiSchema: this.setOpenapiSchema.bind(this),
+      setGraphqlSchema: this.setGraphqlSchema.bind(this),
+      setBasePath: this.setBasePath.bind(this)
+    })
   }
 
   async init () {
@@ -104,6 +111,18 @@ class ServiceStackable {
     return this.configManager.env
   }
 
+  getMeta () {
+    const config = this.configManager.current
+
+    return {
+      composer: {
+        prefix: config.basePath ?? this.basePath ?? this.context?.serviceId,
+        wantsAbsoluteUrls: false,
+        needsRootRedirect: false
+      }
+    }
+  }
+
   async getWatchConfig () {
     const config = this.configManager.current
 
@@ -164,6 +183,22 @@ class ServiceStackable {
   async updateContext (context) {
     this.context = { ...this.context, ...context }
     this.#updateConfig()
+  }
+
+  setOpenapiSchema (schema) {
+    this.openapiSchema = schema
+  }
+
+  setGraphqlSchema (schema) {
+    this.graphqlSchema = schema
+  }
+
+  setBasePath (basePath) {
+    this.basePath = basePath
+  }
+
+  registerGlobals (globals) {
+    globalThis.platformatic = Object.assign(globalThis.platformatic ?? {}, globals)
   }
 
   #setHttpMetrics () {

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -4,6 +4,9 @@
   "title": "Platformatic Service",
   "type": "object",
   "properties": {
+    "basePath": {
+      "type": "string"
+    },
     "server": {
       "type": "object",
       "properties": {

--- a/packages/service/test/helper.js
+++ b/packages/service/test/helper.js
@@ -2,10 +2,12 @@
 
 const why = require('why-is-node-running')
 
-setInterval(() => {
-  console.log('why is node running?')
-  why()
-}, 1000 * 60 * 40).unref() // 1 minute
+if (process.env.WHY === 'true') {
+  setInterval(() => {
+    console.log('why is node running?')
+    why()
+  }, 60000).unref()
+}
 
 const { Agent, setGlobalDispatcher } = require('undici')
 
@@ -13,15 +15,15 @@ const agent = new Agent({
   keepAliveTimeout: 10,
   keepAliveMaxTimeout: 10,
   tls: {
-    rejectUnauthorized: false,
-  },
+    rejectUnauthorized: false
+  }
 })
 
 setGlobalDispatcher(agent)
 
 function buildConfig (options) {
   const base = {
-    server: {},
+    server: {}
   }
 
   return Object.assign(base, options)

--- a/packages/sql-graphql/test/helper.js
+++ b/packages/sql-graphql/test/helper.js
@@ -3,10 +3,12 @@
 const why = require('why-is-node-running')
 const { dropAllTables } = require('@platformatic/sql-mapper')
 
-setInterval(() => {
-  console.log('why is node running?')
-  why()
-}, 1000 * 30).unref() // 30 seconds
+if (process.env.WHY === 'true') {
+  setInterval(() => {
+    console.log('why is node running?')
+    why()
+  }, 60000).unref()
+}
 
 // Needed to work with dates & postgresql
 // See https://node-postgres.com/features/types/
@@ -43,31 +45,25 @@ module.exports.clear = async function (db, sql) {
 
   try {
     await db.query(sql`DROP TYPE custom_enum`)
-  } catch (err) {
-  }
+  } catch (err) {}
 
   try {
     await db.query(sql`DROP TYPE simple_enum`)
-  } catch (err) {
-  }
+  } catch (err) {}
 
   try {
     await db.query(sql`DROP SCHEMA test4`)
-  } catch (err) {
-  }
+  } catch (err) {}
 
   try {
     await db.query(sql`DROP SCHEMA test3`)
-  } catch (err) {
-  }
+  } catch (err) {}
 
   try {
     await db.query(sql`DROP SCHEMA test2`)
-  } catch (err) {
-  }
+  } catch (err) {}
 
   try {
     await db.query(sql`DROP SCHEMA test1`)
-  } catch (err) {
-  }
+  } catch (err) {}
 }

--- a/packages/sql-json-schema-mapper/test/helper.js
+++ b/packages/sql-json-schema-mapper/test/helper.js
@@ -2,10 +2,12 @@
 
 const why = require('why-is-node-running')
 
-setInterval(() => {
-  console.log('why is node running?')
-  why()
-}, 1000 * 30).unref() // 30 seconds
+if (process.env.WHY === 'true') {
+  setInterval(() => {
+    console.log('why is node running?')
+    why()
+  }, 60000).unref()
+}
 
 // Needed to work with dates & postgresql
 // See https://node-postgres.com/features/types/
@@ -39,51 +41,41 @@ module.exports.connInfo = connInfo
 module.exports.clear = async function (db, sql) {
   try {
     await db.query(sql`DROP TABLE pages`)
-  } catch (err) {
-  }
+  } catch (err) {}
 
   try {
     await db.query(sql`DROP TABLE categories`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP TABLE posts`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP TABLE simple_types`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP TABLE owners`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP TABLE users`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP TABLE versions`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP TABLE graphs`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP Type pagetype`)
-  } catch {
-  }
+  } catch {}
 
   try {
     await db.query(sql`DROP TABLE generated_test`)
-  } catch {
-  }
+  } catch {}
 }

--- a/packages/sql-openapi/test/helper.js
+++ b/packages/sql-openapi/test/helper.js
@@ -3,11 +3,12 @@
 const why = require('why-is-node-running')
 const { dropAllTables } = require('@platformatic/sql-mapper')
 
-setInterval(() => {
-  console.log('why is node running?')
-  why()
-}, 1000 * 30).unref() // 30 seconds
-
+if (process.env.WHY === 'true') {
+  setInterval(() => {
+    console.log('why is node running?')
+    why()
+  }, 60000).unref()
+}
 // Needed to work with dates & postgresql
 // See https://node-postgres.com/features/types/
 process.env.TZ = 'UTC'
@@ -66,10 +67,8 @@ module.exports.clear = async function (db, sql) {
 
   try {
     await db.query(sql`DROP SCHEMA test2`)
-  } catch (err) {
-  }
+  } catch (err) {}
   try {
     await db.query(sql`DROP SCHEMA test1`)
-  } catch (err) {
-  }
+  } catch (err) {}
 }

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -125,29 +125,14 @@ export class ViteStackable extends BaseStackable {
   }
 
   getMeta () {
-    let composer = { prefix: this.servicePrefix, wantsAbsoluteUrls: true, needsRootRedirect: true }
+    const config = this.subprocessConfig ?? this.#app?.config
 
-    if (this.isProduction) {
-      composer = {
-        tcp: typeof this.url !== 'undefined',
-        url: this.url,
-        prefix: (this.subprocessConfig?.base ?? this.#basePath).replace(/(^\/)|(\/$)/g, ''),
-        wantsAbsoluteUrls: true,
-        needsRootRedirect: true
-      }
-    } else if (this.url) {
-      if (!this.#basePath) {
-        const config = this.subprocessConfig ?? this.#app.config
-        this.#basePath = config.base.replace(/(^\/)|(\/$)/g, '')
-      }
-
-      composer = {
-        tcp: true,
-        url: this.url,
-        prefix: this.#basePath.replace(/(^\/)|(\/$)/g, ''),
-        wantsAbsoluteUrls: true,
-        needsRootRedirect: true
-      }
+    const composer = {
+      tcp: typeof this.url !== 'undefined',
+      url: this.url,
+      prefix: this.basePath ?? config?.base ?? this.#basePath,
+      wantsAbsoluteUrls: true,
+      needsRootRedirect: true
     }
 
     return { composer }
@@ -370,20 +355,16 @@ export class ViteSSRStackable extends NodeStackable {
   getMeta () {
     let composer = { prefix: this.servicePrefix, wantsAbsoluteUrls: true, needsRootRedirect: true }
 
-    if (this.url) {
-      if (!this.#basePath) {
-        const application = this._getApplication()
-        const config = application.vite.devServer?.config ?? application.vite.config.vite
-        this.#basePath = (config.base ?? '').replace(/(^\/)|(\/$)/g, '')
-      }
+    const vite = this._getApplication()?.vite
+    const config = vite?.devServer?.config ?? vite?.config.vite
+    const applicationBasePath = config?.base
 
-      composer = {
-        tcp: true,
-        url: this.url,
-        prefix: this.#basePath ?? this.servicePrefix,
-        wantsAbsoluteUrls: true,
-        needsRootRedirect: true
-      }
+    composer = {
+      tcp: typeof this.url !== 'undefined',
+      url: this.url,
+      prefix: this.basePath ?? applicationBasePath ?? this.#basePath,
+      wantsAbsoluteUrls: true,
+      needsRootRedirect: true
     }
 
     return { composer }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,6 +569,9 @@ importers:
       '@platformatic/db':
         specifier: workspace:*
         version: link:../db
+      '@platformatic/node':
+        specifier: workspace:*
+        version: link:../node
       borp:
         specifier: ^0.17.0
         version: 0.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,12 +118,6 @@ importers:
         specifier: ^8.18.0
         version: 8.18.0
     devDependencies:
-      '@platformatic/composer':
-        specifier: workspace:*
-        version: link:../composer
-      '@platformatic/service':
-        specifier: workspace:*
-        version: link:../service
       borp:
         specifier: ^0.17.0
         version: 0.17.0
@@ -569,9 +563,6 @@ importers:
       '@platformatic/db':
         specifier: workspace:*
         version: link:../db
-      '@platformatic/node':
-        specifier: workspace:*
-        version: link:../node
       borp:
         specifier: ^0.17.0
         version: 0.17.0


### PR DESCRIPTION
This PR refactors the composer and stackable proxy prefix rules. The first matching rule below determines the service prefix:

1. If there is `proxy.prefix` set in the `platformatic.composer.json` then it is the service prefix.
2. If the user used `platformatic.setBasePath` then that becomes the services prefix.
3. The stackable autodetects the prefix from the hosted application (like Next.js)
4. The stackable autodetects the prefix from the configuration file.
5. As fallback rule, the `service.id` is ultimately chosen as service prefix.