### PR TITLE
fix: Do not set a port when dealing with UNIX sockets.

### DIFF
--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -176,6 +176,11 @@ export class ChildProcess extends ITC {
   #setupServer () {
     const subscribers = {
       asyncStart ({ options }) {
+        // Unix socket, do nothing
+        if (options.path) {
+          return
+        }
+
         const port = globalThis.platformatic.port
         const host = globalThis.platformatic.host
 
@@ -189,8 +194,15 @@ export class ChildProcess extends ITC {
       asyncEnd: ({ server }) => {
         tracingChannel('net.server.listen').unsubscribe(subscribers)
 
-        const { family, address, port } = server.address()
-        const url = new URL(family === 'IPv6' ? `http://[${address}]:${port}` : `http://${address}:${port}`).origin
+        const address = server.address()
+
+        // Unix socket, do nothing
+        if (typeof address === 'string') {
+          return
+        }
+
+        const { family, address: host, port } = address
+        const url = new URL(family === 'IPv6' ? `http://[${host}]:${port}` : `http://${host}:${port}`).origin
 
         this.notify('url', url)
       },

--- a/packages/basic/lib/worker/listeners.js
+++ b/packages/basic/lib/worker/listeners.js
@@ -1,14 +1,16 @@
 import { withResolvers } from '@platformatic/utils'
 import { subscribe, tracingChannel, unsubscribe } from 'node:diagnostics_channel'
 
-export function createServerListener (
-  overridePort = true,
-  overrideHost = true
-) {
+export function createServerListener (overridePort = true, overrideHost = true) {
   const { promise, resolve, reject } = withResolvers()
 
   const subscribers = {
     asyncStart ({ options }) {
+      // Unix socket, do nothing
+      if (options.path) {
+        return
+      }
+
       if (overridePort !== false) {
         options.port = typeof overridePort === 'number' ? overridePort : 0
       }


### PR DESCRIPTION
Fixes #3223.

FWIW, there is also an "error" (is not technically an error but it might be confusing) in the user code. In the `apps/express/app/index.ts` he was doing this:

```
app.listen(port, host).on("listening", () => {
  logger.info(
    `Express server is listening on port http://${host}:${port}`
  );
});
```

But since Watt is changing the port, this would be more correct:

```
app.listen(port, host).on("listening", function () {
  logger.info(
    `Express server is listening on port http://${host}:${this.address().port}`
  );
});
```