### PR TITLE
Allow wattpm import to work inside the web folder

### DIFF
--- a/packages/wattpm/test/helper.js
+++ b/packages/wattpm/test/helper.js
@@ -69,5 +69,8 @@ export function executeCommand (cmd, ...args) {
 }
 
 export function wattpm (...args) {
-  return executeCommand('node', cliPath, ...args)
+  const res = executeCommand('node', cliPath, ...args)
+  // res.stdout.pipe(process.stdout)
+  // res.stderr.pipe(process.stderr)
+  return res
 }


### PR DESCRIPTION
This PR changes a few things:

1. makes `wattpm import` a bit more noisy, telling the user what's doing
2. add the resolution logic for the "top" `watt.json`, so that it can be run inside a subfolder
3. does not add an entry inside the `web` array if the target folder is inside the autoload directory