### PR TITLE
fix(client-cli): `req` type definition

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -102,7 +102,7 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
 
     interfacesWriter.blankLine()
     const allResponsesName = responsesWriter(capitalizedCamelCaseOperationId, responses, currentFullResponse, interfacesWriter, schema)
-    mainWriter.writeLine(`${camelCaseOperationId}(req?: ${operationRequestName}${isRequestArray ? '[]' : ''}): Promise<${allResponsesName}>;`)
+    mainWriter.writeLine(`${camelCaseOperationId}(req: ${operationRequestName}${isRequestArray ? '[]' : ''}): Promise<${allResponsesName}>;`)
     currentFullResponse = originalFullResponse
     currentFullRequest = originalFullRequest
   }

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -817,7 +817,7 @@ test('openapi client generation from YAML file', async (t) => {
   const typeFile = join(dir, 'movies', 'movies.d.ts')
   const typeData = await readFile(typeFile, 'utf-8')
 
-  equal(match(typeData, 'getMovies(req?: GetMoviesRequest): Promise<GetMoviesResponses>;'), true)
+  equal(match(typeData, 'getMovies(req: GetMoviesRequest): Promise<GetMoviesResponses>;'), true)
 })
 
 test('nested optional parameters are correctly identified', async (t) => {
@@ -889,7 +889,7 @@ test('openapi client generation (javascript) from file with fullRequest, fullRes
 `), true)
     equal(data.includes(`
   export type Full = {
-    postHello(req?: PostHelloRequest): Promise<PostHelloResponses>;
+    postHello(req: PostHelloRequest): Promise<PostHelloResponses>;
   }`), true)
     const implementationFile = join(dir, 'full', 'full.cjs')
     const implementationData = await readFile(implementationFile, 'utf-8')
@@ -956,7 +956,7 @@ test('do not generate implementation file if in platformatic service', async (t)
 `), true)
     equal(data.includes(`
   export type Full = {
-    postHello(req?: PostHelloRequest): Promise<PostHelloResponses>;
+    postHello(req: PostHelloRequest): Promise<PostHelloResponses>;
   }`), true)
   }
 })
@@ -1089,7 +1089,7 @@ test('requestbody as array', async (t) => {
 
   equal(data.includes(`
   export type Movies = {
-    postFoobar(req?: PostFoobarRequest[]): Promise<PostFoobarResponses>;
+    postFoobar(req: PostFoobarRequest[]): Promise<PostFoobarResponses>;
   }
 `), true)
   equal(data.includes('export type PostFoobarRequest = Array<{ \'id\'?: string; \'title\'?: string }>'), true)

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -107,7 +107,7 @@ app.register(movies, {
 });
 
 app.get('/', async (req) => {
-  const res = await req.movies.getMovies()
+  const res = await req.movies.getMovies({})
   return res
 })
 

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -131,10 +131,10 @@ export const getCustomSwagger = async (request) => {
 export interface Sample {
   setBaseUrl(newUrl: string) : void;
   setDefaultHeaders(headers: Object) : void;
-  getCustomSwagger(req?: GetCustomSwaggerRequest): Promise<GetCustomSwaggerResponses>;
-  getRedirect(req?: GetRedirectRequest): Promise<GetRedirectResponses>;
-  getReturnUrl(req?: GetReturnUrlRequest): Promise<GetReturnUrlResponses>;
-  postFoobar(req?: PostFoobarRequest): Promise<PostFoobarResponses>;
+  getCustomSwagger(req: GetCustomSwaggerRequest): Promise<GetCustomSwaggerResponses>;
+  getRedirect(req: GetRedirectRequest): Promise<GetRedirectResponses>;
+  getReturnUrl(req: GetReturnUrlRequest): Promise<GetReturnUrlResponses>;
+  postFoobar(req: PostFoobarRequest): Promise<PostFoobarResponses>;
 }`
 
     const unionTypesTemplate = `export type GetRedirectResponses =
@@ -259,7 +259,7 @@ export const getHello: Api['getHello'] = async (request: Types.GetHelloRequest):
 export interface Api {
   setBaseUrl(newUrl: string) : void;
   setDefaultHeaders(headers: Object) : void;
-  getHello(req?: GetHelloRequest): Promise<GetHelloResponses>;
+  getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`
 
   ok(implementation)
@@ -288,7 +288,7 @@ export const getHello: ACustomName['getHello'] = async (request: Types.GetHelloR
 export interface ACustomName {
   setBaseUrl(newUrl: string) : void;
   setDefaultHeaders(headers: Object) : void;
-  getHello(req?: GetHelloRequest): Promise<GetHelloResponses>;
+  getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`
 
   ok(implementation)


### PR DESCRIPTION
#### Environment:
Any scaffolded up using platformatic with default `Movies` table, then run 
```bash
npx platformatic client http://127.0.0.1:3042/api --frontend --language ts
```
Example: https://github.com/no-treasure/plt-watt-demo/tree/develop/services/frontend/src/api

#### Description:
If we call `getMovies()` but don't specify any arguments, we won't get any error from TS, but it will throw an error:
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'limit')
```
because in `_getMovies()` and `getMovies()` expects that `request: Types.GetMoviesRequest` should be passed, but there will be undefined in this case
```ts
  queryParameters.forEach((qp) => {
//      undefined[qp]
    if (request[qp]) {
      if (Array.isArray(request[qp])) {
        ;(request[qp] as string[]).forEach((p) => {
          searchParams.append(qp, p)
        })
      } else {
        searchParams.append(qp, request[qp]?.toString() || '')
      }
    }
    delete request[qp]
  })
```

#### Solution:
It will be better if every operator will require `request`, so that this does not lead to unexpected behavior.
I see here the second solution, if in generated definitions will be:
```
request: Types.GetMoviesRequest = {}
```
But it should work only for GET requests, bacause other requests may require some fields