### PR TITLE
fix(client-cli): Handle empty req/res OpenAPI schema

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -84,11 +84,6 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
       const writeContentOutput = writeContent(bodyWriter, requestBody.content, schema, addedProps, 'req', currentFullRequest ? 'body' : null)
       isRequestArray = writeContentOutput.isArray
       isStructuredType = writeContentOutput.isStructuredType
-    } else {
-      if (bodyWriter.getLength() === 0) {
-        // no body has been written, let's put a fallback 'unknown' value
-        bodyWriter.write('unknown')
-      }
     }
 
     if (isStructuredType || currentFullRequest || !isRequestArray) {

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint",
-    "test": "pnpm run lint && borp --pattern '*/cli-openapi-empty-req-res.test.mjs' --concurrency=1 --timeout=180000 && tsd"
+    "test": "pnpm run lint && borp --concurrency=1 --timeout=180000 && tsd"
   },
   "repository": {
     "type": "git",

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint",
-    "test": "pnpm run lint && borp --concurrency=1 --timeout=180000 && tsd"
+    "test": "pnpm run lint && borp --pattern '*/cli-openapi-empty-req-res.test.mjs' --concurrency=1 --timeout=180000 && tsd"
   },
   "repository": {
     "type": "git",

--- a/packages/client-cli/test/cli-openapi-empty-req-res.test.mjs
+++ b/packages/client-cli/test/cli-openapi-empty-req-res.test.mjs
@@ -1,0 +1,40 @@
+import { isFileAccessible } from '../cli.mjs'
+import { moveToTmpdir } from './helper.js'
+import { test, after } from 'node:test'
+import { equal } from 'node:assert'
+import { join } from 'path'
+import * as desm from 'desm'
+import { execa } from 'execa'
+import { promises as fs } from 'fs'
+import { readFile } from 'fs/promises'
+
+test('empty-req-res', async () => {
+  const openapi = desm.join(import.meta.url, 'fixtures', 'empty-req-res', 'openapi.json')
+  const dir = await moveToTmpdir(after)
+
+  const pltServiceConfig = {
+    $schema: 'https://schemas.platformatic.dev/@platformatic/service/1.52.0.json',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+    },
+    plugins: {
+      paths: ['./plugin.js'],
+    },
+  }
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapi, '--name', 'full', '--validate-response', '--optional-headers', 'headerId', '--full'])
+
+  equal(await isFileAccessible(join(dir, 'full', 'full.cjs')), false)
+
+  const typeFile = join(dir, 'full', 'full.d.ts')
+  const data = await readFile(typeFile, 'utf-8')
+  equal(data.includes(`
+  export type GetHelloRequest = {
+    
+  }
+
+  export type GetHelloResponseOK = unknown`), true)
+})

--- a/packages/client-cli/test/fixtures/empty-req-res/openapi.json
+++ b/packages/client-cli/test/fixtures/empty-req-res/openapi.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "operationId": "getHello",
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/fixtures/empty-req-res/package.json
+++ b/packages/client-cli/test/fixtures/empty-req-res/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": ">=20.16.0"
+  }
+}

--- a/packages/client-cli/test/fixtures/empty-req-res/platformatic.service.json
+++ b/packages/client-cli/test/fixtures/empty-req-res/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/1.52.0.json",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client-cli/test/fixtures/empty-req-res/plugins/example.js
+++ b/packages/client-cli/test/fixtures/empty-req-res/plugins/example.js
@@ -1,0 +1,6 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify) {
+  fastify.get('/hello', async ({ body }) => ({ body }))
+}


### PR DESCRIPTION
With an Open API schema like:
```json
{
"paths": {
    "/hello": {
      "get": {
        "operationId": "getHello",
        "responses": {
          "200": {
            "description": "Default Response"
          }
        }
      }
    }
  }
}
```

We currently return an invalid TS syntax:
```ts
 export type GetHelloRequest = {
    unknown
  }
```

With this fix, will return valid TypeScript code:
```ts
 export type GetHelloRequest = {
  }
```