### PR TITLE
fix(client-cli): Define form data type on the request

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -144,12 +144,20 @@ export function writeContent (writer, content, spec, addedProps, methodType, wra
   let isStructuredType = false
   if (content) {
     for (const [contentType, body] of Object.entries(content)) {
+      const isFormDataContent = contentType.indexOf('multipart/form-data') === 0
+
       // We ignore all non-JSON endpoints for now
       // TODO: support other content types
       /* c8 ignore next 3 */
-      if (contentType.indexOf('application/json') !== 0 && contentType.indexOf('multipart/form-data') !== 0) {
+      if (contentType.indexOf('application/json') !== 0 && !isFormDataContent) {
         continue
       }
+
+      if (isFormDataContent && wrapper) {
+        writer.write(`${wrapper}: FormData;`)
+        break
+      }
+
       // Response body has no schema that can be processed
       // Should not be possible with well formed OpenAPI
       /* c8 ignore next 3 */

--- a/packages/client-cli/lib/openapi-generator.mjs
+++ b/packages/client-cli/lib/openapi-generator.mjs
@@ -103,6 +103,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
 
   writer.writeLine('import { type FastifyReply, type FastifyPluginAsync } from \'fastify\'')
   writer.writeLine('import { type GetHeadersOptions } from \'@platformatic/client\'')
+  writer.writeLine('import { type FormData } from \'undici\'')
   writer.blankLine()
 
   const pluginName = `${capitalizedName}Plugin`

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -1129,3 +1129,17 @@ test('support formdata', async (t) => {
     'data': { 'description'?: string; 'endDate': string | Date; 'startDate': string | Date };
   }`), true)
 })
+
+test('export formdata on full request object', async (t) => {
+  const dir = await moveToTmpdir(after)
+
+  const openAPIfile = desm.join(import.meta.url, 'fixtures', 'multipart-formdata-openapi.json')
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openAPIfile, '--name', 'movies', '--full-request'])
+  const typeFile = join(dir, 'movies', 'movies.d.ts')
+  const data = await readFile(typeFile, 'utf-8')
+  equal(data.includes("import { type FormData } from 'undici"), true)
+  equal(data.includes(`
+  export type PostSampleRequest = {
+    body: FormData;
+  }`), true)
+})


### PR DESCRIPTION
When we have a `multipart/form-data` content type, we should define it as a request body.