### PR TITLE
Actually remove Platformatic DB from the CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,6 @@
     "@platformatic/client-cli": "workspace:*",
     "@platformatic/config": "workspace:*",
     "@platformatic/control": "workspace:*",
-    "@platformatic/db": "workspace:*",
     "@platformatic/frontend-template": "workspace:*",
     "@platformatic/runtime": "workspace:*",
     "@platformatic/utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
       '@platformatic/control':
         specifier: workspace:*
         version: link:../control
-      '@platformatic/db':
-        specifier: workspace:*
-        version: link:../db
       '@platformatic/frontend-template':
         specifier: workspace:*
         version: link:../frontend-template
@@ -236,6 +233,9 @@ importers:
       '@platformatic/composer':
         specifier: workspace:*
         version: link:../composer
+      '@platformatic/db':
+        specifier: workspace:*
+        version: link:../db
       '@platformatic/next':
         specifier: workspace:*
         version: link:../next


### PR DESCRIPTION
This was supposed to happen for the v2 release but it slipped. This is not actually needed at all.