### PR TITLE
fix(runtime): Do not throw when inspector comes from VS Code

### DIFF
--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -31,7 +31,7 @@ async function restartRuntime (runtime) {
 async function buildRuntime (configManager, env) {
   env = env || process.env
 
-  if (inspector.url()) {
+  if (inspector.url() && !env.VSCODE_INSPECTOR_OPTIONS) {
     throw new errors.NodeInspectorFlagsNotSupportedError()
   }
 


### PR DESCRIPTION
When VS Code starts in debug mode, it adds a [specific environment variable](https://github.com/microsoft/vscode-js-debug/blob/ffa6949c71c8dceb3ec3f50e074065ba4c00fae4/src/targets/node/bootloader/environment.ts#L130).
We should not throw the `NodeInspectorFlagsNotSupportedError` in that case.