### PR TITLE
fix(client-cli): support required props in additionalProperties

### DIFF
--- a/packages/client-cli/lib/get-type.mjs
+++ b/packages/client-cli/lib/get-type.mjs
@@ -72,6 +72,7 @@ export function getType (typeDef, methodType, spec) {
   if (typeDef.type === 'object') {
     const additionalPropsObj = typeDef?.additionalProperties?.properties
     const additionalPropsType = typeDef?.additionalProperties?.type
+    const additionalPropsRequired = typeDef?.additionalProperties?.required
     const objProperties = typeDef.properties || additionalPropsObj
     if (!objProperties || Object.keys(objProperties).length === 0) {
       // Object without properties
@@ -85,6 +86,9 @@ export function getType (typeDef, methodType, spec) {
       let required = false
       if (typeDef.required) {
         required = !!typeDef.required.includes(prop)
+      }
+      if (additionalPropsRequired) {
+        required = required || !!additionalPropsRequired.includes(prop)
       }
       return `'${prop}'${required ? '' : '?'}: ${getType(objProperties[prop], methodType, spec)}`
     })

--- a/packages/client-cli/test/cli-openapi-additional-properties.test.mjs
+++ b/packages/client-cli/test/cli-openapi-additional-properties.test.mjs
@@ -15,8 +15,8 @@ test('export formdata on full request object', async (t) => {
   const data = await readFile(typeFile, 'utf-8')
   equal(data.includes(`
   export type GetSampleResponseOK = {
-    'entities': { 'foo'?: Record<string, { 'id'?: string; 'name'?: string }>; 'bar'?: Record<string, { 'type'?: 'boolean' | 'list'; 'values'?: Array<{ 'id': string; 'isArchived'?: boolean; 'isDefault': boolean; 'value': string }> }>; 'baz'?: Record<string, { 'id'?: string; 'name'?: string }> };
-    'errors': { 'types'?: Record<string, { 'cause'?: unknown; 'type'?: 'notFound' | 'other' }>; 'group': Record<string, { 'cause'?: unknown; 'type'?: 'notFound' | 'other' }> };
+    'entities': { 'foo'?: Record<string, { 'id': string; 'name': string }>; 'bar'?: Record<string, { 'type': 'boolean' | 'list'; 'values': Array<{ 'id': string; 'isArchived'?: boolean; 'isDefault': boolean; 'value': string }> }>; 'baz'?: Record<string, { 'id': string; 'name': string }> };
+    'errors': { 'types'?: Record<string, { 'cause'?: unknown; 'type': 'notFound' | 'other' }>; 'group': Record<string, { 'cause'?: unknown; 'type': 'notFound' | 'other' }> };
     'xyz'?: Record<string, number>;
   }`), true)
 })


### PR DESCRIPTION
# Context

The generated types are not currently checking if the additional props are required.

# Solution

Use the `required` field in `additionalProperties` to correctly generate the type