### PR TITLE
Set telemetry config on nodejs services

### DIFF
--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -373,6 +373,11 @@ export async function buildStackable (opts) {
     dirname: root
   })
   await configManager.parseAndValidate()
+  const config = configManager.current
+  // We need to update the config with the telemetry so the service name
+  // used in telemetry can be retreived using the management API
+  config.telemetry = opts.context.telemetryConfig
+  configManager.update(config)
 
   return new NodeStackable(opts, root, configManager)
 }

--- a/packages/node/test/telemetry.test.js
+++ b/packages/node/test/telemetry.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { createRuntime, setFixturesDir } from '../../basic/test/helper.js'
+import { Client } from 'undici'
+
+process.setMaxListeners(100)
+
+setFixturesDir(resolve(import.meta.dirname, './fixtures'))
+
+test('should set telemtry in config on all the node services', async t => {
+  const { runtime } = await createRuntime(t, 'express-api-with-telemetry')
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:',
+    },
+    {
+      socketPath: runtime.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10,
+    }
+  )
+
+  const { statusCode, body } = await client.request({
+    method: 'GET',
+    path: '/api/v1/services/api/config',
+  })
+
+  assert.strictEqual(statusCode, 200)
+
+  const serviceConfig = await body.json()
+  assert.deepEqual(serviceConfig.telemetry, {
+    serviceName: 'test-service-api',
+    version: '1.0.0',
+    exporter: {
+      type: 'memory'
+    }
+  })
+})


### PR DESCRIPTION
We need this because we user the `serviceName` in telemetry