### PR TITLE
Check json response with startsWith rather than ===

### DIFF
--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -255,7 +255,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
         })
 
         // write default response as fallback
-        writer.write('if (response.headers.get(\'content-type\') === \'application/json\') ').block(() => {
+        writer.write('if (response.headers.get(\'content-type\').startsWith(\'application/json\')) ').block(() => {
           writer.write('return ').block(() => {
             writer.write('statusCode: response.status')
             if (language === 'ts') {

--- a/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
+++ b/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
@@ -58,7 +58,7 @@ const _getPkgScopeNameVersion = async (url: string, request: Types.GetPkgScopeNa
       body: await response.json()
     }
   }
-  if (response.headers.get('content-type') === 'application/json') {
+  if (response.headers.get('content-type').startsWith('application/json')) {
     return {
       statusCode: response.status as 200 | 202 | 302 | 400 | 404,
       headers: headersToJSON(response.headers),

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -73,7 +73,7 @@ async function _getRedirect (url, request) {
       body: await response.json()
     }
   }
-  if (response.headers.get('content-type') === 'application/json') {
+  if (response.headers.get('content-type').startsWith('application/json')) {
     return {
       statusCode: response.status,
       headers: headersToJSON(response.headers),
@@ -445,7 +445,7 @@ test('do not add headers to fetch if a get request', async (t) => {
       body: await response.text()
     }
   }
-  if (response.headers.get('content-type') === 'application/json') {
+  if (response.headers.get('content-type').startsWith('application/json')) {
     return {
       statusCode: response.status as 200,
       headers: headersToJSON(response.headers),
@@ -482,7 +482,7 @@ test('support empty response', async (t) => {
       body: await response.text()
     }
   }
-  if (response.headers.get('content-type') === 'application/json') {
+  if (response.headers.get('content-type').startsWith('application/json')) {
     return {
       statusCode: response.status as 200,
       headers: headersToJSON(response.headers),
@@ -525,7 +525,7 @@ test('call response.json only for json responses', async (t) => {
       body: await response.text()
     }
   }
-  if (response.headers.get('content-type') === 'application/json') {
+  if (response.headers.get('content-type').startsWith('application/json')) {
     return {
       statusCode: response.status as 200,
       headers: headersToJSON(response.headers),


### PR DESCRIPTION
Valid `content-type` headers can be either `application/json` or `application/json; charset=...` so it's safer to use `startsWith` 