### PR TITLE
feat(client-cli): Allow body string

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -184,9 +184,11 @@ export function writeContent (writer, content, spec, addedProps, methodType, wra
       }
 
       if (wrapper) {
-        writer.write(`${wrapper}: `).block(() =>
-          writeObjectProperties(writer, schema, spec, addedProps, methodType)
-        )
+        if (isStructuredType) {
+          writer.write(`${wrapper}: `).block(() => writeObjectProperties(writer, schema, spec, addedProps, methodType))
+        } else {
+          writer.write(`${wrapper}: ${getType(body.schema, methodType, spec)}`)
+        }
       } else {
         writeObjectProperties(writer, schema, spec, addedProps, methodType)
       }

--- a/packages/client-cli/test/cli-openapi-body-string.test.mjs
+++ b/packages/client-cli/test/cli-openapi-body-string.test.mjs
@@ -1,0 +1,38 @@
+import { isFileAccessible } from '../cli.mjs'
+import { moveToTmpdir } from './helper.js'
+import { test, after } from 'node:test'
+import { equal } from 'node:assert'
+import { join } from 'path'
+import * as desm from 'desm'
+import { execa } from 'execa'
+import { promises as fs } from 'fs'
+import { readFile } from 'fs/promises'
+
+test('body-string', async () => {
+  const openapi = desm.join(import.meta.url, 'fixtures', 'body-string', 'openapi.json')
+  const dir = await moveToTmpdir(after)
+
+  const pltServiceConfig = {
+    $schema: 'https://schemas.platformatic.dev/@platformatic/service/1.52.0.json',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+    },
+    plugins: {
+      paths: ['./plugin.js'],
+    },
+  }
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapi, '--name', 'full', '--full'])
+
+  equal(await isFileAccessible(join(dir, 'full', 'full.cjs')), false)
+
+  const typeFile = join(dir, 'full', 'full.d.ts')
+  const data = await readFile(typeFile, 'utf-8')
+  equal(data.includes(`
+  export type PostBodyStringRequest = {
+    body: string
+  }`), true)
+})

--- a/packages/client-cli/test/fixtures/body-string/openapi.json
+++ b/packages/client-cli/test/fixtures/body-string/openapi.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Pippo Baudo service",
+    "description": "Pippo Baudo great API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/body-string": {
+      "post": {
+        "operationId": "postBodyString",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pippo Baudo"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/fixtures/body-string/package.json
+++ b/packages/client-cli/test/fixtures/body-string/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": ">=20.16.0"
+  }
+}

--- a/packages/client-cli/test/fixtures/body-string/platformatic.service.json
+++ b/packages/client-cli/test/fixtures/body-string/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/1.52.0.json",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client-cli/test/fixtures/body-string/plugins/example.js
+++ b/packages/client-cli/test/fixtures/body-string/plugins/example.js
@@ -1,0 +1,6 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify) {
+  fastify.post('/body-string', async ({ body }) => ({ body }))
+}


### PR DESCRIPTION
This will add support to generate types for client that has a `string` as body, instead of an `object`