### PR TITLE
fix: persist status code from response to UnexpectedCallFailureError

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -292,7 +292,11 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
       return responseBody
     } catch (err) {
       openTelemetry?.setErrorInSpanClient(span, err)
-      throw new errors.UnexpectedCallFailureError(err.toString())
+      const requestError = new errors.UnexpectedCallFailureError(err.toString())
+      if (err.statusCode) {
+        requestError.statusCode = err.statusCode
+      }
+      throw requestError
     } finally {
       openTelemetry?.endHTTPSpanClient(span, res)
     }

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -7,7 +7,6 @@ const { tmpdir } = require('node:os')
 const { test, mock } = require('node:test')
 const { join } = require('node:path')
 const { unlink, mkdtemp, cp } = require('node:fs/promises')
-const { FastifyError } = require('fastify')
 const { buildServer } = require('../../db')
 const { buildOpenAPIClient } = require('..')
 const { safeRemove } = require('@platformatic/utils')
@@ -420,7 +419,12 @@ test('throw on error level response', async t => {
     client.getMovieById({
       id: 100
     }),
-    FastifyError
+    (err) => {
+      assert.ok(err instanceof errors.UnexpectedCallFailureError)
+      // Persists status code from error response
+      assert.equal(err.statusCode, 404)
+      return true
+    }
   )
 })
 


### PR DESCRIPTION
2.16.0 has broken platformatic client for users using `throwOnError: true` as now all errors have a status code of 500 rather than the status code that was in the original error response, so adding a small fix.