### PR TITLE
fix: set all Undici error response props on UnexpectedCallFailureError

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -13,7 +13,7 @@ const { createHash } = require('node:crypto')
 const validateFunctionCache = {}
 const errors = require('./errors')
 const camelCase = require('camelcase')
-const { FormData } = require('undici')
+const { FormData, errors: { UndiciError } } = require('undici')
 function generateOperationId (path, method, methodMeta, all) {
   let operationId = null
   // use methodMeta.operationId only if it's present AND it is a valid string that can be
@@ -293,8 +293,13 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
     } catch (err) {
       openTelemetry?.setErrorInSpanClient(span, err)
       const requestError = new errors.UnexpectedCallFailureError(err.toString())
-      if (err.statusCode) {
+      if (err instanceof UndiciError) {
+        requestError.status = err.status
         requestError.statusCode = err.statusCode
+        requestError.headers = err.headers
+        requestError.body = err.body
+        requestError.data = err.data
+        requestError.socket = err.socket
       }
       throw requestError
     } finally {

--- a/packages/client/test/openapi.test.js
+++ b/packages/client/test/openapi.test.js
@@ -421,8 +421,17 @@ test('throw on error level response', async t => {
     }),
     (err) => {
       assert.ok(err instanceof errors.UnexpectedCallFailureError)
-      // Persists status code from error response
+
+      // Persists response properties from Undici error
+      assert.equal(err.status, 404)
       assert.equal(err.statusCode, 404)
+      assert.equal(typeof err.headers, 'object')
+      assert.equal(err.headers['content-type'], 'application/json; charset=utf-8')
+      assert.deepEqual(err.body, {
+        error: 'Not Found',
+        message: 'Route GET:/movies-api/movies/100 not found',
+        statusCode: 404
+      })
       return true
     }
   )


### PR DESCRIPTION
Hi, I added the `statusCode` to `UnexpectedCallFailureError` in https://github.com/platformatic/platformatic/pull/3538, fixing a failing test in my project, but neglected to persist all properties from the Undici error which would be the complete fix (as the previously thrown Undici `ResponseStatusCodeError` would have also included the headers and body, for example).