### PR TITLE
Fix ALS when calling inject() on @platformatic/node stackable

### DIFF
--- a/packages/basic/lib/worker/listeners.js
+++ b/packages/basic/lib/worker/listeners.js
@@ -1,5 +1,12 @@
 import { withResolvers } from '@platformatic/utils'
 import { subscribe, tracingChannel, unsubscribe } from 'node:diagnostics_channel'
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const snapshots = new WeakMap()
+
+export function getAsyncLocalStorageSnapshot (server) {
+  return snapshots.get(server)
+}
 
 export function createServerListener (overridePort = true, overrideHost) {
   const { promise, resolve, reject } = withResolvers()
@@ -20,6 +27,7 @@ export function createServerListener (overridePort = true, overrideHost) {
     },
     asyncEnd ({ server }) {
       cancel()
+      snapshots.set(server, AsyncLocalStorage.snapshot())
       resolve(server)
     },
     error ({ error }) {

--- a/packages/node/test/fixtures/node-async-local-storage-inject/package.json
+++ b/packages/node/test/fixtures/node-async-local-storage-inject/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test",
+  "private": true,
+  "workspaces": [
+    "services/*"
+  ],
+  "dependencies": {
+    "@platformatic/runtime": "^2.3.1",
+    "platformatic": "^2.3.1"
+  }
+}

--- a/packages/node/test/fixtures/node-async-local-storage-inject/platformatic.runtime.json
+++ b/packages/node/test/fixtures/node-async-local-storage-inject/platformatic.runtime.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "api",
+  "services": [
+    {
+      "id": "api",
+      "config": "platformatic.application.json",
+      "path": "./services/api"
+    }
+  ],
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/node/test/fixtures/node-async-local-storage-inject/services/api/index.js
+++ b/packages/node/test/fixtures/node-async-local-storage-inject/services/api/index.js
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { createServer } from 'node:http'
+
+const store = new AsyncLocalStorage()
+
+store.run('Hello, World!', () => {
+  const server = createServer((_req, res) => {
+    const value = store.getStore()
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      connection: 'close'
+    })
+
+    res.end(JSON.stringify({
+      value
+    }))
+  })
+
+  server.listen(3000)
+})

--- a/packages/node/test/fixtures/node-async-local-storage-inject/services/api/package.json
+++ b/packages/node/test/fixtures/node-async-local-storage-inject/services/api/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@platformatic/basic": "^2.3.1",
+    "@platformatic/node": "^2.3.1"
+  }
+}

--- a/packages/node/test/fixtures/node-async-local-storage-inject/services/api/platformatic.application.json
+++ b/packages/node/test/fixtures/node-async-local-storage-inject/services/api/platformatic.application.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.0.0.json",
+  "node": {
+    "main": "index.js"
+  }
+}

--- a/packages/node/test/inject.test.js
+++ b/packages/node/test/inject.test.js
@@ -3,11 +3,13 @@ import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import {
+  createRuntime,
   getLogs,
   prepareRuntimeWithServices,
   setFixturesDir,
   updateFile,
-  verifyJSONViaHTTP
+  verifyJSONViaHTTP,
+  verifyJSONViaInject
 } from '../../basic/test/helper.js'
 
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
@@ -103,4 +105,10 @@ test('should inject request via the HTTP port if asked to', async t => {
   await verifyJSONViaHTTP(url, '/frontend/inject', 500, content => {
     ok(content.message.includes('ECONNREFUSED'))
   })
+})
+
+test('should keep AsyncLocalStorage context of entrypoint when injecting', async t => {
+  const { runtime } = await createRuntime(t, 'node-async-local-storage-inject')
+
+  await verifyJSONViaInject(runtime, 'api', 'GET', '/', 200, { value: 'Hello, World!' })
 })


### PR DESCRIPTION
This allows servers found via diagnostics_channel `net.server.listen` events to run injected requests while retaining the asynchronous context captured by the `server.listen(...)` and creating new asynchronous resources as normal http request handle objects would.