### PR TITLE
feat: support configuring env and envfile in main config file

### DIFF
--- a/docs/runtime/_shared-configuration.md
+++ b/docs/runtime/_shared-configuration.md
@@ -67,10 +67,19 @@ runtime. Each service object supports the following settings:
   on `127.0.0.1`, and exposed to the other services via that port, on default it is set to `false`. Set it to `true` if you are using [@fastify/express](https://github.com/fastify/fastify-express).
 - **`workers`** (`number`) - The number of workers to start for this service. If the service is the entrypoint or if the runtime is running in development mode this value is ignored and hardcoded to `1`.
 - **`health`** (object): Configures the health check for each worker of the service. It supports all the properties also supported in the runtime [health](#health) property. The values specified here overrides the values specified in the runtime.
+- **`envfile`** (`string`) - The path to an `.env` file to load for the service.
+- **`env`** (`object`) - An object containing environment variables to set for the service.
 
 If this property is present, then the services will not be reordered according to the
 `getBootstrapDependencies` function and they will be started in the order they are defined in
 the configuration file.
+
+### `env`
+
+An object containing environment variables to set for all services in the
+runtime. Any environment variables set in the `env` object will be merged with
+the environment variables set in the `envfile` and `env` properties of each
+service, with service-level environment variables taking precedence.
 
 ### `resolvedServicesBasePath`
 

--- a/docs/runtime/_shared-configuration.md
+++ b/docs/runtime/_shared-configuration.md
@@ -68,7 +68,7 @@ runtime. Each service object supports the following settings:
 - **`workers`** (`number`) - The number of workers to start for this service. If the service is the entrypoint or if the runtime is running in development mode this value is ignored and hardcoded to `1`.
 - **`health`** (object): Configures the health check for each worker of the service. It supports all the properties also supported in the runtime [health](#health) property. The values specified here overrides the values specified in the runtime.
 - **`envfile`** (`string`) - The path to an `.env` file to load for the service.
-- **`env`** (`object`) - An object containing environment variables to set for the service.
+- **`env`** (`object`) - An object containing environment variables to set for the service. Values set here takes precedence over values set in the `envfile`.
 
 If this property is present, then the services will not be reordered according to the
 `getBootstrapDependencies` function and they will be started in the order they are defined in

--- a/packages/runtime/fixtures/env-config/platformatic.json
+++ b/packages/runtime/fixtures/env-config/platformatic.json
@@ -5,7 +5,7 @@
     {
       "id": "hello",
       "path": "services/hello",
-      "envfile": "services/hello/.env",
+      "envfile": "services/hello/test.env",
       "env": {
         "FROM_SERVICE_CONFIG_FILE": "true"
       },

--- a/packages/runtime/fixtures/env-config/platformatic.json
+++ b/packages/runtime/fixtures/env-config/platformatic.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/1.52.0.json",
+  "entrypoint": "hello",
+  "services": [
+    {
+      "id": "hello",
+      "path": "services/hello",
+      "envfile": "services/hello/.env",
+      "env": {
+        "FROM_SERVICE_CONFIG_FILE": "true"
+      },
+      "logger": {
+        "level": "trace"
+      }
+    }
+  ],
+  "env": {
+    "FROM_MAIN_CONFIG_FILE": "true"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 3000,
+    "logger": {
+      "level": "trace"
+    }
+  }
+}

--- a/packages/runtime/fixtures/env-config/platformatic.json
+++ b/packages/runtime/fixtures/env-config/platformatic.json
@@ -7,7 +7,8 @@
       "path": "services/hello",
       "envfile": "services/hello/test.env",
       "env": {
-        "FROM_SERVICE_CONFIG_FILE": "true"
+        "FROM_SERVICE_CONFIG_FILE": "true",
+        "OVERRIDE_TEST": "service-override"
       },
       "logger": {
         "level": "trace"
@@ -15,7 +16,8 @@
     }
   ],
   "env": {
-    "FROM_MAIN_CONFIG_FILE": "true"
+    "FROM_MAIN_CONFIG_FILE": "true",
+    "OVERRIDE_TEST": "top-level"
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/env-config/services/hello/package.json
+++ b/packages/runtime/fixtures/env-config/services/hello/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "server.js"
+}

--- a/packages/runtime/fixtures/env-config/services/hello/server.js
+++ b/packages/runtime/fixtures/env-config/services/hello/server.js
@@ -3,7 +3,8 @@ import { createServer } from 'node:http'
 const {
   FROM_ENV_FILE,
   FROM_MAIN_CONFIG_FILE,
-  FROM_SERVICE_CONFIG_FILE
+  FROM_SERVICE_CONFIG_FILE,
+  OVERRIDE_TEST
 } = process.env
 
 export function build () {
@@ -14,7 +15,8 @@ export function build () {
     res.end(JSON.stringify({
       FROM_ENV_FILE,
       FROM_MAIN_CONFIG_FILE,
-      FROM_SERVICE_CONFIG_FILE
+      FROM_SERVICE_CONFIG_FILE,
+      OVERRIDE_TEST
     }))
   })
 }

--- a/packages/runtime/fixtures/env-config/services/hello/server.js
+++ b/packages/runtime/fixtures/env-config/services/hello/server.js
@@ -1,0 +1,20 @@
+import { createServer } from 'node:http'
+
+const {
+  FROM_ENV_FILE,
+  FROM_MAIN_CONFIG_FILE,
+  FROM_SERVICE_CONFIG_FILE
+} = process.env
+
+export function build () {
+  return createServer((req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'application/json'
+    })
+    res.end(JSON.stringify({
+      FROM_ENV_FILE,
+      FROM_MAIN_CONFIG_FILE,
+      FROM_SERVICE_CONFIG_FILE
+    }))
+  })
+}

--- a/packages/runtime/fixtures/env-config/services/hello/test.env
+++ b/packages/runtime/fixtures/env-config/services/hello/test.env
@@ -1,0 +1,1 @@
+FROM_ENV_FILE=true

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -862,49 +862,6 @@ class Runtime extends EventEmitter {
     const errorLabel = this.#workerExtendedLabel(serviceId, index, workersCount)
     const health = deepmerge(config.health ?? {}, serviceConfig.health ?? {})
 
-    const execArgv = []
-    if (!serviceConfig.isPLTService) {
-      execArgv.push('--require', openTelemetrySetupPath)
-    }
-
-    if (serviceConfig.sourceMaps === true || config.sourceMaps === true) {
-      execArgv.push('--enable-source-maps')
-    }
-
-    // console.log('worker spawned', {
-    //   workerData: {
-    //     config,
-    //     serviceConfig: {
-    //       ...serviceConfig,
-    //       isProduction: this.#isProduction
-    //     },
-    //     worker: {
-    //       id: workerId,
-    //       index,
-    //       count: workersCount
-    //     },
-    //     inspectorOptions,
-    //     dirname: this.#configManager.dirname,
-    //     runtimeLogsDir: this.#runtimeLogsDir,
-    //     loggingPort
-    //   },
-    //   execArgv,
-    //   env: this.#env,
-    //   transferList: [loggingPort],
-    //   resourceLimits: {
-    //     maxOldGenerationSizeMb: health.maxHeapTotal
-    //   },
-    //   /*
-    //     Important: always set stdout and stderr to true, so that worker's output is not automatically
-    //     piped to the parent thread. We actually never output the thread output since we replace it
-    //     with PinoWritable, and disabling the piping avoids us to redeclare some internal Node.js methods.
-
-    //     The author of this (Paolo and Matteo) are not proud of the solution. Forgive us.
-    //   */
-    //   stdout: true,
-    //   stderr: true
-    // })
-
     const worker = new Worker(kWorkerFile, {
       workerData: {
         config,
@@ -922,7 +879,7 @@ class Runtime extends EventEmitter {
         runtimeLogsDir: this.#runtimeLogsDir,
         loggingPort
       },
-      execArgv,
+      execArgv: serviceConfig.isPLTService ? [] : ['--require', openTelemetrySetupPath],
       env: this.#env,
       transferList: [loggingPort],
       resourceLimits: {

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -862,6 +862,49 @@ class Runtime extends EventEmitter {
     const errorLabel = this.#workerExtendedLabel(serviceId, index, workersCount)
     const health = deepmerge(config.health ?? {}, serviceConfig.health ?? {})
 
+    const execArgv = []
+    if (!serviceConfig.isPLTService) {
+      execArgv.push('--require', openTelemetrySetupPath)
+    }
+
+    if (serviceConfig.sourceMaps === true || config.sourceMaps === true) {
+      execArgv.push('--enable-source-maps')
+    }
+
+    // console.log('worker spawned', {
+    //   workerData: {
+    //     config,
+    //     serviceConfig: {
+    //       ...serviceConfig,
+    //       isProduction: this.#isProduction
+    //     },
+    //     worker: {
+    //       id: workerId,
+    //       index,
+    //       count: workersCount
+    //     },
+    //     inspectorOptions,
+    //     dirname: this.#configManager.dirname,
+    //     runtimeLogsDir: this.#runtimeLogsDir,
+    //     loggingPort
+    //   },
+    //   execArgv,
+    //   env: this.#env,
+    //   transferList: [loggingPort],
+    //   resourceLimits: {
+    //     maxOldGenerationSizeMb: health.maxHeapTotal
+    //   },
+    //   /*
+    //     Important: always set stdout and stderr to true, so that worker's output is not automatically
+    //     piped to the parent thread. We actually never output the thread output since we replace it
+    //     with PinoWritable, and disabling the piping avoids us to redeclare some internal Node.js methods.
+
+    //     The author of this (Paolo and Matteo) are not proud of the solution. Forgive us.
+    //   */
+    //   stdout: true,
+    //   stderr: true
+    // })
+
     const worker = new Worker(kWorkerFile, {
       workerData: {
         config,
@@ -879,7 +922,7 @@ class Runtime extends EventEmitter {
         runtimeLogsDir: this.#runtimeLogsDir,
         loggingPort
       },
-      execArgv: serviceConfig.isPLTService ? [] : ['--require', openTelemetrySetupPath],
+      execArgv,
       env: this.#env,
       transferList: [loggingPort],
       resourceLimits: {

--- a/packages/runtime/lib/schema.js
+++ b/packages/runtime/lib/schema.js
@@ -6,6 +6,13 @@ const {
   schemaComponents: { server, logger, health }
 } = require('@platformatic/utils')
 
+const env = {
+  type: 'object',
+  additionalProperties: {
+    type: 'string'
+  }
+}
+
 const workers = {
   anyOf: [
     {
@@ -41,7 +48,11 @@ const services = {
         type: 'boolean'
       },
       workers,
-      health: { ...health, default: undefined }
+      health: { ...health, default: undefined },
+      env,
+      envfile: {
+        type: 'string'
+      }
     }
   }
 }
@@ -316,7 +327,8 @@ const platformaticRuntimeSchema = {
     resolvedServicesBasePath: {
       type: 'string',
       default: 'external'
-    }
+    },
+    env
   },
   anyOf: [{ required: ['autoload'] }, { required: ['services'] }, { required: ['web'] }],
   additionalProperties: false,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -77,6 +77,7 @@
     "commist": "^3.2.0",
     "debounce": "^2.0.0",
     "desm": "^1.3.1",
+    "dotenv": "^16.4.5",
     "dotenv-tool": "^0.1.1",
     "es-main": "^1.3.0",
     "fastest-levenshtein": "^1.0.16",

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -296,6 +296,15 @@
               }
             },
             "additionalProperties": false
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "envfile": {
+            "type": "string"
           }
         }
       }
@@ -449,6 +458,15 @@
               }
             },
             "additionalProperties": false
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "envfile": {
+            "type": "string"
           }
         }
       }
@@ -1113,6 +1131,12 @@
     "resolvedServicesBasePath": {
       "type": "string",
       "default": "external"
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "anyOf": [

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -378,6 +378,7 @@ test('supports configurable envfile location', async t => {
   assert.deepStrictEqual(data, {
     FROM_ENV_FILE: 'true',
     FROM_MAIN_CONFIG_FILE: 'true',
-    FROM_SERVICE_CONFIG_FILE: 'true'
+    FROM_SERVICE_CONFIG_FILE: 'true',
+    OVERRIDE_TEST: 'service-override'
   })
 })

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -353,3 +353,31 @@ test('set type on services', async t => {
   assert.strictEqual(serviceApp.type, 'service')
   assert.strictEqual(nodeApp.type, 'nodejs')
 })
+
+test('supports configurable envfile location', async t => {
+  const configFile = join(fixturesDir, 'env-config', 'platformatic.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const dirname = config.configManager.dirname
+  const runtimeLogsDir = getRuntimeLogsDir(dirname, process.pid)
+
+  const runtime = new Runtime(config.configManager, runtimeLogsDir, process.env)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.init()
+  await runtime.start()
+
+  const { payload } = await runtime.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  assert.deepStrictEqual(data, {
+    FROM_ENV_FILE: 'true',
+    FROM_MAIN_CONFIG_FILE: 'true',
+    FROM_SERVICE_CONFIG_FILE: 'true'
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1718,6 +1718,9 @@ importers:
       desm:
         specifier: ^1.3.1
         version: 1.3.1
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.7
       dotenv-tool:
         specifier: ^0.1.1
         version: 0.1.1


### PR DESCRIPTION
Add support for setting `env` object and `envfile` path in services of top-level config file to load env vars into the worker thread for the service when starting up.