### PR TITLE
Add pretest to frontend-template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,11 +544,7 @@ jobs:
       - name: Install Playwright browsers
         run: cd packages/frontend-template && pnpm exec playwright install
       - name: Run Platformatic frontend cli and E2E tests
-        run: |
-          cd packages/frontend-template
-          pnpm run test:prepare
-          pnpm run build
-          pnpm test
+        run: cd packages/frontend-template && pnpm test
 
   ci-rpc:
     needs: setup-node_modules

--- a/packages/frontend-template/package.json
+++ b/packages/frontend-template/package.json
@@ -23,7 +23,8 @@
     "test:prepare": "node test/prepare.mjs",
     "test:cleanup": "rm -rf src/platformatic-generated-code test/e2e/fixtures/db.sqlite",
     "lint": "eslint",
-    "test": "npm run lint && npm run test:e2e && npm run test:types"
+    "test": "npm run lint && npm run test:e2e && npm run test:types",
+    "pretest": "npm run test:prepare && npm run build"
   },
   "dependencies": {
     "@platformatic/client": "workspace:*",


### PR DESCRIPTION
This allows workspace-level pnpm test to work, and simplifies the GitHub Actions workflow yaml.