### PR TITLE
fix(wattpm): enable yarn auto detect

### DIFF
--- a/packages/wattpm/lib/commands/build.js
+++ b/packages/wattpm/lib/commands/build.js
@@ -8,6 +8,7 @@ import { resolve } from 'node:path'
 import {
   buildRuntime,
   findConfigurationFile,
+  getPackageManager,
   getRoot,
   loadConfigurationFile,
   overrideFatal,
@@ -40,13 +41,8 @@ export async function installDependencies (logger, root, services, production, p
     services = config.services
   }
 
-  /* c8 ignore next 8 */
   if (!packageManager) {
-    if (existsSync(resolve(root, 'pnpm-lock.yaml'))) {
-      packageManager = 'pnpm'
-    } else {
-      packageManager = 'npm'
-    }
+    packageManager = getPackageManager(root)
   }
 
   const args = ['install']

--- a/packages/wattpm/lib/commands/external.js
+++ b/packages/wattpm/lib/commands/external.js
@@ -10,6 +10,7 @@ import { defaultServiceJson } from '../defaults.js'
 import { version } from '../schema.js'
 import {
   findConfigurationFile,
+  getPackageManager,
   getRoot,
   loadConfigurationFile,
   loadRawConfigurationFile,
@@ -253,13 +254,8 @@ export async function resolveServices (
 ) {
   const config = await loadConfigurationFile(logger, configurationFile)
 
-  /* c8 ignore next 8 */
   if (!packageManager) {
-    if (existsSync(resolve(root, 'pnpm-lock.yaml'))) {
-      packageManager = 'pnpm'
-    } else {
-      packageManager = 'npm'
-    }
+    getPackageManager(root)
   }
 
   // The services which might be to be resolved are the one that have a URL and either

--- a/packages/wattpm/lib/utils.js
+++ b/packages/wattpm/lib/utils.js
@@ -10,6 +10,7 @@ import { platformaticRuntime, buildRuntime as pltBuildRuntime } from '@platforma
 import { bgGreen, black, bold } from 'colorette'
 import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
+import { existsSync } from 'node:fs'
 import { parseArgs as nodeParseArgs } from 'node:util'
 import { pino } from 'pino'
 import pinoPretty from 'pino-pretty'
@@ -84,6 +85,18 @@ export function parseArgs (args, options, stopAtFirstPositional = true) {
     unparsed,
     tokens
   }
+}
+
+export function getPackageManager (root) {
+  if (existsSync(resolve(root, 'pnpm-lock.yaml'))) {
+    return 'pnpm'
+  }
+
+  if (existsSync(resolve(root, 'yarn.lock'))) {
+    return 'yarn'
+  }
+
+  return 'npm'
 }
 
 export function getRoot (positionals) {

--- a/packages/wattpm/test/utils.test.js
+++ b/packages/wattpm/test/utils.test.js
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import { strictEqual } from 'node:assert'
+import { getPackageManager } from '../lib/utils.js'
+import { join } from 'node:path'
+import { mkdtemp, rmdir, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+test('getPackageManager - should return the right package manager, depending on the cases', async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'wattpm-tests-'))
+  strictEqual(getPackageManager('wrong'), 'npm', 'path is wrong, default to npm')
+
+  const tmpYarnFile = join(tmpDir, 'yarn.lock')
+  await writeFile(tmpYarnFile, '-')
+  strictEqual(getPackageManager(tmpDir), 'yarn', 'path is correct, and we identify yarn')
+  await unlink(tmpYarnFile)
+
+  const tmpPnpmFile = join(tmpDir, 'pnpm-lock.yaml')
+  await writeFile(tmpPnpmFile, '-')
+  strictEqual(getPackageManager(tmpDir), 'pnpm', 'path is correct, and we identify pnpm')
+  await unlink(tmpPnpmFile)
+
+  strictEqual(getPackageManager(tmpDir), 'npm', 'path is correct, but no file are found, so we default to npm')
+  await rmdir(tmpDir)
+})


### PR DESCRIPTION
Connected to [this issue](https://github.com/platformatic/platformatic/issues/3630), steps done:
* add `yarn` auto-detect for `resolve` command
* have the package manager logic detection in a single place
* add tests to check that logic