### PR TITLE
Add sourceMaps config option

### DIFF
--- a/docs/runtime/_shared-configuration.md
+++ b/docs/runtime/_shared-configuration.md
@@ -70,6 +70,7 @@ runtime. Each service object supports the following settings:
 - **`health`** (object): Configures the health check for each worker of the service. It supports all the properties also supported in the runtime [health](#health) property. The values specified here overrides the values specified in the runtime.
 - **`envfile`** (`string`) - The path to an `.env` file to load for the service.
 - **`env`** (`object`) - An object containing environment variables to set for the service. Values set here takes precedence over values set in the `envfile`.
+- **`sourceMaps`** (`boolean`) - If `true`, source maps are enabled for the service. Default: `false`.
 
 If this property is present, then the services will not be reordered according to the
 `getBootstrapDependencies` function and they will be started in the order they are defined in
@@ -85,6 +86,10 @@ An object containing environment variables to set for all services in the
 runtime. Any environment variables set in the `env` object will be merged with
 the environment variables set in the `envfile` and `env` properties of each
 service, with service-level environment variables taking precedence.
+
+### `sourceMaps`
+
+If `true`, source maps are enabled for all services. Default: `false`. This setting can be overridden at the service level.
 
 ### `resolvedServicesBasePath`
 

--- a/packages/runtime/fixtures/typescript/services/titles/routes/root.ts
+++ b/packages/runtime/fixtures/typescript/services/titles/routes/root.ts
@@ -13,6 +13,11 @@ export default async function (fastify: FastifyInstance, opts: FastifyPluginOpti
     return { hello: fastify.example }
   })
 
+  fastify.get('/source-map-test', async (request, reply) => {
+    const error = new Error('source-map-test')
+    return error.stack
+  })
+
   fastify.get('/titles', async (request, reply) => {
     const movies = await fastify.client.getMovies({})
     const titles = movies.map((movie) => movie.title)

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -862,6 +862,16 @@ class Runtime extends EventEmitter {
     const errorLabel = this.#workerExtendedLabel(serviceId, index, workersCount)
     const health = deepmerge(config.health ?? {}, serviceConfig.health ?? {})
 
+    const execArgv = []
+
+    if (!serviceConfig.isPLTService) {
+      execArgv.push('--require', openTelemetrySetupPath)
+    }
+
+    if ((serviceConfig.sourceMaps ?? config.sourceMaps) === true) {
+      execArgv.push('--enable-source-maps')
+    }
+
     const worker = new Worker(kWorkerFile, {
       workerData: {
         config,
@@ -879,7 +889,7 @@ class Runtime extends EventEmitter {
         runtimeLogsDir: this.#runtimeLogsDir,
         loggingPort
       },
-      execArgv: serviceConfig.isPLTService ? [] : ['--require', openTelemetrySetupPath],
+      execArgv,
       env: this.#env,
       transferList: [loggingPort],
       resourceLimits: {

--- a/packages/runtime/lib/schema.js
+++ b/packages/runtime/lib/schema.js
@@ -56,6 +56,10 @@ const services = {
       env,
       envfile: {
         type: 'string'
+      },
+      sourceMaps: {
+        type: 'boolean',
+        default: false
       }
     }
   }
@@ -332,7 +336,11 @@ const platformaticRuntimeSchema = {
       type: 'string',
       default: 'external'
     },
-    env
+    env,
+    sourceMaps: {
+      type: 'boolean',
+      default: false
+    }
   },
   anyOf: [{ required: ['autoload'] }, { required: ['services'] }, { required: ['web'] }],
   additionalProperties: false,

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -309,6 +309,10 @@
           },
           "envfile": {
             "type": "string"
+          },
+          "sourceMaps": {
+            "type": "boolean",
+            "default": false
           }
         }
       }
@@ -475,6 +479,10 @@
           },
           "envfile": {
             "type": "string"
+          },
+          "sourceMaps": {
+            "type": "boolean",
+            "default": false
           }
         }
       }
@@ -1145,6 +1153,10 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "sourceMaps": {
+      "type": "boolean",
+      "default": false
     }
   },
   "anyOf": [

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const assert = require('node:assert')
+const { readFile, writeFile, cp, mkdtemp } = require('node:fs/promises')
 const { join } = require('node:path')
 const { test } = require('node:test')
+const { safeRemove, createDirectory } = require('@platformatic/utils')
 const { loadConfig } = require('@platformatic/config')
 const { platformaticService } = require('@platformatic/service')
 const { platformaticDB } = require('@platformatic/db')
@@ -382,3 +384,90 @@ test('supports configurable envfile location', async t => {
     OVERRIDE_TEST: 'service-override'
   })
 })
+
+const sourceMapTests = [
+  {
+    title: 'service-level',
+    transform (json) {
+      json.services = [
+        {
+          id: 'movies',
+          path: 'services/movies',
+        },
+        {
+          id: 'titles',
+          path: 'services/titles',
+          sourceMaps: true
+        },
+        {
+          id: 'composer',
+          path: 'services/composer'
+        },
+      ]
+      json.autoload = undefined
+    }
+  },
+  {
+    title: 'top-level',
+    transform (json) {
+      json.sourceMaps = true
+    }
+  }
+]
+
+for (const { title, transform } of sourceMapTests) {
+  test(`supports ${title} sourceMaps configuration`, async t => {
+    const base = join(__dirname, 'tmp')
+    try {
+      await createDirectory(base)
+    } catch { }
+
+    const tmpDir = await mkdtemp(join(base, 'typescript'))
+    const prev = process.cwd()
+    process.chdir(tmpDir)
+    t.after(async () => {
+      process.chdir(prev)
+      await safeRemove(base)
+    })
+
+    const folder = join(fixturesDir, 'typescript')
+    await cp(folder, tmpDir, { recursive: true })
+
+    const { execa } = await import('execa')
+    const cliPath = join(__dirname, '..', 'runtime.mjs')
+    await execa(cliPath, ['compile'])
+
+    const configFile = join(tmpDir, 'platformatic.runtime.json')
+    await editJSON(configFile, transform)
+    const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+    const dirname = config.configManager.dirname
+    const runtimeLogsDir = getRuntimeLogsDir(dirname, process.pid)
+
+    const runtime = new Runtime(config.configManager, runtimeLogsDir, process.env)
+
+    t.after(async () => {
+      await runtime.close()
+    })
+
+    await runtime.init()
+    await runtime.start()
+
+    const res = await runtime.inject('composer', {
+      method: 'GET',
+      url: 'source-map-test'
+    })
+
+    // Should contain ts file in the stack trace
+    assert.match(res.body, /root\.ts/)
+  })
+}
+
+async function editJSON (path, transform) {
+  const input = await readFile(path, 'utf8')
+  const data = JSON.parse(input)
+
+  transform(data)
+
+  const output = JSON.stringify(data, null, 2)
+  await writeFile(path, output, 'utf8')
+}

--- a/packages/wattpm/test/management.test.js
+++ b/packages/wattpm/test/management.test.js
@@ -191,6 +191,7 @@ test('config - should list configuration for an application', async t => {
       path: `${resolve(rootDir, 'web')}`,
       exclude: []
     },
+    sourceMaps: false,
     restartOnError: 5000,
     startTimeout: 30000,
     managementApi: true,


### PR DESCRIPTION
Add support for enabling source maps per-service or globally.

Fixes #3561