### PR TITLE
fix(wattpm): properly auto resolve nested package manager

### DIFF
--- a/packages/cli/test/install.test.js
+++ b/packages/cli/test/install.test.js
@@ -51,9 +51,9 @@ test('should install dependencies of application and its services using a specif
   const child = await execa('node', [cliPath, 'install', '-P', 'pnpm'], { cwd: rootDir, env: { NO_COLOR: 'true' } })
 
   ok(child.stdout.includes('Installing dependencies for the application using pnpm ...'))
-  ok(child.stdout.includes('Installing dependencies for the service composer using pnpm ...'))
-  ok(child.stdout.includes('Installing dependencies for the service db using pnpm ...'))
-  ok(child.stdout.includes('Installing dependencies for the service service using pnpm ...'))
+  ok(child.stdout.includes('Installing dependencies for the service composer using npm ...'))
+  ok(child.stdout.includes('Installing dependencies for the service db using npm ...'))
+  ok(child.stdout.includes('Installing dependencies for the service service using npm ...'))
 })
 
 test('should install production dependencies only', async t => {
@@ -70,7 +70,7 @@ test('should install production dependencies only', async t => {
   })
 
   ok(child.stdout.includes('Installing production dependencies for the application using pnpm ...'))
-  ok(child.stdout.includes('Installing production dependencies for the service composer using pnpm ...'))
-  ok(child.stdout.includes('Installing production dependencies for the service db using pnpm ...'))
-  ok(child.stdout.includes('Installing production dependencies for the service service using pnpm ...'))
+  ok(child.stdout.includes('Installing production dependencies for the service composer using npm ...'))
+  ok(child.stdout.includes('Installing production dependencies for the service db using npm ...'))
+  ok(child.stdout.includes('Installing production dependencies for the service service using npm ...'))
 })

--- a/packages/wattpm/lib/utils.js
+++ b/packages/wattpm/lib/utils.js
@@ -99,6 +99,21 @@ export function getPackageManager (root) {
   return 'npm'
 }
 
+export function getPackageArgs (packageManager, production) {
+  const args = ['install']
+  if (production) {
+    switch (packageManager) {
+      case 'pnpm':
+        args.push('--prod')
+        break
+      case 'npm':
+        args.push('--omit=dev')
+        break
+    }
+  }
+  return args
+}
+
 export function getRoot (positionals) {
   let root = process.cwd()
 

--- a/packages/wattpm/test/build.test.js
+++ b/packages/wattpm/test/build.test.js
@@ -71,7 +71,7 @@ test('install - should install dependencies of application and its services usin
   const installProcess = await wattpm('install', rootDir, '-P', 'pnpm')
 
   ok(installProcess.stdout.includes('Installing dependencies for the application using pnpm ...'))
-  ok(installProcess.stdout.includes('Installing dependencies for the service main using pnpm ...'))
+  ok(installProcess.stdout.includes('Installing dependencies for the service main using npm ...'))
 })
 
 test('install - should respect the service package manager, if any', async t => {
@@ -106,5 +106,5 @@ test('install - should install production dependencies only', async t => {
   const installProcess = await wattpm('install', rootDir, '-p', '-P', 'pnpm')
 
   ok(installProcess.stdout.includes('Installing production dependencies for the application using pnpm ...'))
-  ok(installProcess.stdout.includes('Installing production dependencies for the service main using pnpm ...'))
+  ok(installProcess.stdout.includes('Installing production dependencies for the service main using npm ...'))
 })

--- a/packages/wattpm/test/resolve.test.js
+++ b/packages/wattpm/test/resolve.test.js
@@ -160,7 +160,8 @@ test('resolve - should install dependencies using a different package manager', 
   const resolveProcess = await wattpm('resolve', '-P', 'pnpm', rootDir)
 
   ok(resolveProcess.stdout.includes(`Cloning ${repo} into web${sep}resolved`))
-  ok(resolveProcess.stdout.includes('Installing dependencies for the service resolved using pnpm ...'))
+  ok(resolveProcess.stdout.includes('Installing dependencies for the application using pnpm ...'))
+  ok(resolveProcess.stdout.includes('Installing dependencies for the service resolved using npm ...'))
 
   deepStrictEqual(await readFile(resolve(rootDir, 'web/resolved/branch'), 'utf8'), 'main')
 })

--- a/packages/wattpm/test/utils.test.js
+++ b/packages/wattpm/test/utils.test.js
@@ -1,9 +1,16 @@
 import { test } from 'node:test'
-import { strictEqual } from 'node:assert'
-import { getPackageManager } from '../lib/utils.js'
+import { deepEqual, strictEqual } from 'node:assert'
+import { getPackageArgs, getPackageManager } from '../lib/utils.js'
 import { join } from 'node:path'
 import { mkdtemp, rmdir, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+
+test('getPackageArgs - should return the right package args', () => {
+  deepEqual(getPackageArgs(), ['install'], 'no args passed')
+  deepEqual(getPackageArgs('yarn'), ['install'], 'yarn passed, no prod')
+  deepEqual(getPackageArgs('pnpm', true), ['install', '--prod'], 'pnpm passed, prod mode')
+  deepEqual(getPackageArgs('npm', true), ['install', '--omit=dev'], 'npm passed, prod mode')
+})
 
 test('getPackageManager - should return the right package manager, depending on the cases', async () => {
   const tmpDir = await mkdtemp(join(tmpdir(), 'wattpm-tests-'))


### PR DESCRIPTION
Fixes the current setup for main folder and subfolder services:
* add a `getPackageArgs` that will define the `args` to be passed when running `resolve`, and it will be called for the `root` and for the nested services
* fix how we auto-detect package manager for nested services => if available, we check first the service option, then the auto-detection for the service, and finally we default to the root package manager