### PR TITLE
fix OR WhereCondition type definition

### DIFF
--- a/packages/db-authorization/index.d.ts
+++ b/packages/db-authorization/index.d.ts
@@ -1,6 +1,6 @@
 import {
   type PlatformaticContext,
-  type WhereCondition,
+  type WhereClause,
 } from '@platformatic/sql-mapper'
 import { type FastifyPluginAsync } from 'fastify'
 import { type FastifyUserPluginOptions } from 'fastify-user'
@@ -9,11 +9,11 @@ import { FastifyError } from '@fastify/error'
 export type OperationFunction<T> = (args: {
   user: T,
   ctx: PlatformaticContext,
-  where: WhereCondition
-}) => WhereCondition
+  where: WhereClause
+}) => WhereClause
 
 export interface OperationChecks {
-  checks: Record<string, any> | WhereCondition
+  checks: Record<string, any> | WhereClause
 }
 
 export interface OperationFields {

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -139,7 +139,7 @@ interface Find<EntityFields> {
     /**
      * SQL where condition.
      */
-    where?: WhereCondition,
+    where?: WhereCondition | { or: WhereCondition[] },
     /**
      * List of fields to be returned for each object
      */
@@ -173,7 +173,7 @@ interface Count {
     /**
      * SQL where condition.
      */
-    where?: WhereCondition,
+    where?: WhereCondition | { or: WhereCondition[] },
     /**
      * If present, the entity participates in transaction
      */
@@ -235,7 +235,7 @@ interface Delete<EntityFields> {
     /**
      * SQL where condition.
      */
-    where?: WhereCondition,
+    where?: WhereCondition | { or: WhereCondition[] },
     /**
      * List of fields to be returned for each object
      */
@@ -257,7 +257,7 @@ interface UpdateMany<EntityFields> {
     /**
      * SQL where condition.
      */
-    where: WhereCondition,
+    where?: WhereCondition | { or: WhereCondition[] },
     /**
      * Entity fields to update.
      */

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -69,6 +69,12 @@ export interface DBEntityField {
   autoTimestamp?: boolean
 }
 
+export type WhereClause = {
+  or?: WhereCondition[];
+} | {
+  [columnName: string]: WhereCondition[string];
+}
+
 export interface WhereCondition {
   [columnName: string]: {
     /**
@@ -139,7 +145,7 @@ interface Find<EntityFields> {
     /**
      * SQL where condition.
      */
-    where?: WhereCondition | { or: WhereCondition[] },
+    where?: WhereClause,
     /**
      * List of fields to be returned for each object
      */
@@ -173,7 +179,7 @@ interface Count {
     /**
      * SQL where condition.
      */
-    where?: WhereCondition | { or: WhereCondition[] },
+    where?: WhereClause,
     /**
      * If present, the entity participates in transaction
      */
@@ -235,7 +241,7 @@ interface Delete<EntityFields> {
     /**
      * SQL where condition.
      */
-    where?: WhereCondition | { or: WhereCondition[] },
+    where?: WhereClause,
     /**
      * List of fields to be returned for each object
      */
@@ -257,7 +263,7 @@ interface UpdateMany<EntityFields> {
     /**
      * SQL where condition.
      */
-    where?: WhereCondition | { or: WhereCondition[] },
+    where?: WhereClause,
     /**
      * Entity fields to update.
      */

--- a/packages/sql-mapper/test/types/mapper.test-d.ts
+++ b/packages/sql-mapper/test/types/mapper.test-d.ts
@@ -14,8 +14,8 @@ import {
   createConnectionPool,
   Entities,
   errors,
-  WhereCondition,
   PlatformaticContext,
+  WhereClause,
 } from '../../mapper'
 
 const log = {
@@ -101,7 +101,7 @@ expectType<Partial<EntityFields>[]>(await entity.updateMany({ where: { id: { eq:
 expectType<Partial<EntityFields>[]>(await entity.find({ where: { id: { eq: null } } }))
 expectType<Partial<EntityFields>[]>(await entity.find({ where: { id: { neq: null } } }))
 
-const whereCondition: WhereCondition = {
+const whereCondition: WhereClause = {
   eq: { eq: '' },
   eqNumber: { eq: 1 },
   eqBoolean: { eq: true },
@@ -121,7 +121,12 @@ const whereCondition: WhereCondition = {
   contains: { contains: [] },
   contained: { contained: [] },
   overlaps: { overlaps: [] },
+  or: [
+    { field: { eq: '' } },
+    { field: { eq: null } }
+  ]
 }
+
 await entity.find({ where: whereCondition })
 await entity.delete({ where: whereCondition })
 await entity.count({ where: whereCondition })


### PR DESCRIPTION
@mcollina this commit fix typescript where definition, which did not include the "or" operator.

If you prefer I can rename the existing WhereCondition in SingleWhereCondition and define a new type WhereCondition as `type WhereCondition = SingleWhereCondition | { or: SingleWhereCondition[] }`

Let me know how you prefer to proceed