### PR TITLE
feat(client cli): add props optional param

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -598,7 +598,10 @@ export async function command (argv) {
 
     options.fullRequest = options['full-request']
     options.fullResponse = options['full-response']
+
+    // TODO: default value to true in the next semver-major (https://github.com/platformatic/platformatic/issues/3737)
     options.propsOptional = options['props-optional'] ?? false
+
     options.optionalHeaders = options['optional-headers']
       ? options['optional-headers'].split(',').map(h => h.trim())
       : []

--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -58,7 +58,8 @@ async function writeOpenAPIClient (
   language,
   typesComment,
   logger,
-  withCredentials
+  withCredentials,
+  propsOptional
 ) {
   await createDirectory(folder)
 
@@ -78,7 +79,8 @@ async function writeOpenAPIClient (
       fullResponse,
       language,
       logger,
-      withCredentials
+      withCredentials,
+      propsOptional
     })
     await writeFile(join(folder, `${name}-types.d.ts`), types)
     if (generateImplementation) {
@@ -93,7 +95,8 @@ async function writeOpenAPIClient (
       fullRequest,
       optionalHeaders,
       validateResponse,
-      typesComment
+      typesComment,
+      propsOptional
     })
     await writeFile(join(folder, `${name}.d.ts`), types)
     if (generateImplementation) {
@@ -134,7 +137,8 @@ async function downloadAndWriteOpenAPI (
   language,
   urlAuthHeaders,
   typesComment,
-  withCredentials
+  withCredentials,
+  propsOptional
 ) {
   logger.debug(`Trying to download OpenAPI schema from ${url}`)
   let requestOptions
@@ -165,7 +169,8 @@ async function downloadAndWriteOpenAPI (
         language,
         typesComment,
         logger,
-        withCredentials
+        withCredentials,
+        propsOptional
       )
       /* c8 ignore next 3 */
     } catch (err) {
@@ -217,7 +222,8 @@ async function readFromFileAndWrite (
   isFrontend,
   language,
   typesComment,
-  withCredentials
+  withCredentials,
+  propsOptional
 ) {
   logger.info(`Trying to read schema from file ${file}`)
   const text = await readFile(file, 'utf8')
@@ -237,7 +243,8 @@ async function readFromFileAndWrite (
       language,
       typesComment,
       logger,
-      withCredentials
+      withCredentials,
+      propsOptional
     )
     return 'openapi'
   } catch (err) {
@@ -268,7 +275,8 @@ async function downloadAndProcess (options) {
     type,
     urlAuthHeaders,
     typesComment,
-    withCredentials
+    withCredentials,
+    propsOptional
   } = options
 
   let generateImplementation = options.generateImplementation
@@ -304,7 +312,8 @@ async function downloadAndProcess (options) {
           language,
           urlAuthHeaders,
           typesComment,
-          withCredentials
+          withCredentials,
+          propsOptional
         )
       )
       toTry.push(
@@ -324,7 +333,8 @@ async function downloadAndProcess (options) {
           language,
           urlAuthHeaders,
           typesComment,
-          withCredentials
+          withCredentials,
+          propsOptional
         )
       )
     } else if (options.type === 'graphql') {
@@ -351,7 +361,8 @@ async function downloadAndProcess (options) {
           language,
           urlAuthHeaders,
           typesComment,
-          withCredentials
+          withCredentials,
+          propsOptional
         )
       )
       toTry.push(
@@ -374,7 +385,8 @@ async function downloadAndProcess (options) {
           language,
           urlAuthHeaders,
           typesComment,
-          withCredentials
+          withCredentials,
+          propsOptional
         )
       )
       toTry.push(downloadAndWriteGraphQL.bind(null, logger, url, folder, name, generateImplementation, typesOnly))
@@ -397,7 +409,8 @@ async function downloadAndProcess (options) {
         isFrontend,
         language,
         typesComment,
-        withCredentials
+        withCredentials,
+        propsOptional
       )
     )
   }
@@ -484,7 +497,7 @@ export async function command (argv) {
     ...options
   } = parseArgs(argv, {
     string: ['name', 'folder', 'runtime', 'optional-headers', 'language', 'type', 'url-auth-headers', 'types-comment'],
-    boolean: ['typescript', 'full-response', 'types-only', 'full-request', 'full', 'frontend', 'validate-response'],
+    boolean: ['typescript', 'full-response', 'types-only', 'full-request', 'full', 'frontend', 'validate-response', 'props-optional'],
     default: {
       typescript: false,
       language: 'js'
@@ -585,6 +598,7 @@ export async function command (argv) {
 
     options.fullRequest = options['full-request']
     options.fullResponse = options['full-response']
+    options.propsOptional = options['props-optional'] ?? false
     options.optionalHeaders = options['optional-headers']
       ? options['optional-headers'].split(',').map(h => h.trim())
       : []

--- a/packages/client-cli/help/help.txt
+++ b/packages/client-cli/help/help.txt
@@ -81,4 +81,4 @@ Options:
 * `--types-only` - Generate only the type file.
 * `--types-comment` - Add a comment at the beginning of the auto generated `.d.ts` type definition.
 * `--with-credentials` - Adds "credentials: 'include'" to all fetch requests (only for frontend clients).
-* `--props-optional` - If `true`, properties will be defined as optional unless they're part of the `required` array. By default this opiton is `false`.
+* `--props-optional` - If `true`, properties will be defined as optional unless they're part of the `required` array. By default this option is `false`.

--- a/packages/client-cli/help/help.txt
+++ b/packages/client-cli/help/help.txt
@@ -81,3 +81,4 @@ Options:
 * `--types-only` - Generate only the type file.
 * `--types-comment` - Add a comment at the beginning of the auto generated `.d.ts` type definition.
 * `--with-credentials` - Adds "credentials: 'include'" to all fetch requests (only for frontend clients).
+* `--props-optional` - If `true`, properties will be defined as optional unless they're part of the `required` array. By default this opiton is `false`.

--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -4,9 +4,9 @@ import { capitalize, getAllResponseCodes, getResponseContentType, getResponseTyp
 import camelcase from 'camelcase'
 import { writeOperations } from '../../client-cli/lib/openapi-common.mjs'
 
-export function processFrontendOpenAPI ({ schema, name, language, fullResponse, logger, withCredentials }) {
+export function processFrontendOpenAPI ({ schema, name, language, fullResponse, logger, withCredentials, propsOptional }) {
   return {
-    types: generateTypesFromOpenAPI({ schema, name, fullResponse }),
+    types: generateTypesFromOpenAPI({ schema, name, fullResponse, propsOptional }),
     implementation: generateFrontendImplementationFromOpenAPI({ schema, name, language, fullResponse, logger, withCredentials })
   }
 }
@@ -349,7 +349,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
   return writer.toString()
 }
 
-function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
+function generateTypesFromOpenAPI ({ schema, name, fullResponse, propsOptional }) {
   const camelCaseName = capitalize(camelcase(name))
   const { paths } = schema
   const generatedOperationIds = []
@@ -391,7 +391,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse }) {
     writer.writeLine('setBaseUrl(newUrl: string) : void;')
     writer.writeLine('setDefaultHeaders(headers: Object) : void;')
     writeOperations(interfaces, writer, operations, {
-      fullRequest: false, fullResponse, optionalHeaders: [], schema
+      fullRequest: false, fullResponse, optionalHeaders: [], schema, propsOptional
     })
   })
 

--- a/packages/client-cli/lib/openapi-generator.mjs
+++ b/packages/client-cli/lib/openapi-generator.mjs
@@ -3,9 +3,9 @@ import { generateOperationId } from '@platformatic/client'
 import { capitalize, toJavaScriptName } from './utils.mjs'
 import { writeOperations } from './openapi-common.mjs'
 
-export function processOpenAPI ({ schema, name, fullResponse, fullRequest, optionalHeaders, validateResponse, typesComment }) {
+export function processOpenAPI ({ schema, name, fullResponse, fullRequest, optionalHeaders, validateResponse, typesComment, propsOptional }) {
   return {
-    types: generateTypesFromOpenAPI({ schema, name, fullResponse, fullRequest, optionalHeaders, typesComment }),
+    types: generateTypesFromOpenAPI({ schema, name, fullResponse, fullRequest, optionalHeaders, typesComment, propsOptional }),
     implementation: generateImplementationFromOpenAPI({ name, fullResponse, fullRequest, validateResponse })
   }
 }
@@ -54,7 +54,7 @@ function generateImplementationFromOpenAPI ({ name, fullResponse, fullRequest, v
   return writer.toString()
 }
 
-function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, optionalHeaders, typesComment }) {
+function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, optionalHeaders, typesComment, propsOptional }) {
   const camelcasedName = toJavaScriptName(name)
   const capitalizedName = capitalize(camelcasedName)
   const { paths } = schema
@@ -120,7 +120,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
     interfaces.blankLine()
     writer.write(`export type ${capitalizedName} =`).block(() => {
       writeOperations(interfaces, writer, operations, {
-        fullRequest, fullResponse, optionalHeaders, schema
+        fullRequest, fullResponse, optionalHeaders, schema, propsOptional
       })
     })
 

--- a/packages/client-cli/test/cli-openapi-optional-body.test.mjs
+++ b/packages/client-cli/test/cli-openapi-optional-body.test.mjs
@@ -26,18 +26,27 @@ test(testName, async (t) => {
 
   await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
 
+  // Checking props-optional param
   await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapi, '--name', testName, '--full', '--props-optional'])
-
   equal(await isFileAccessible(join(dir, testName, `${testName}.cjs`)), false)
 
   const typeFile = join(dir, testName, `${testName}.d.ts`)
   const data = await readFile(typeFile, 'utf-8')
-
   equal(data.includes(`
   export type PostHelloRequest = {
     body: {
       'name'?: string;
       'userId'?: string;
     }
-  }`), true)
+  }`), true, 'properties are optional')
+
+  // Checking default behavior
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapi, '--name', 'defaulted', '--full'])
+  equal((await readFile(join(dir, 'defaulted', 'defaulted.d.ts'), 'utf-8')).includes(`
+  export type PostHelloRequest = {
+    body: {
+      'name': string;
+      'userId': string;
+    }
+  }`), true, 'properties are required')
 })

--- a/packages/client-cli/test/cli-openapi-optional-body.test.mjs
+++ b/packages/client-cli/test/cli-openapi-optional-body.test.mjs
@@ -1,0 +1,43 @@
+import { isFileAccessible } from '../cli.mjs'
+import { moveToTmpdir } from './helper.js'
+import { test, after } from 'node:test'
+import { equal } from 'node:assert'
+import { join } from 'path'
+import * as desm from 'desm'
+import { execa } from 'execa'
+import { promises as fs } from 'fs'
+import { readFile } from 'fs/promises'
+
+const testName = 'optional-body'
+test(testName, async (t) => {
+  const openapi = desm.join(import.meta.url, 'fixtures', testName, 'openapi.json')
+  const dir = await moveToTmpdir(after)
+
+  const pltServiceConfig = {
+    $schema: 'https://schemas.platformatic.dev/@platformatic/service/1.52.0.json',
+    server: {
+      hostname: '127.0.0.1',
+      port: 0
+    },
+    plugins: {
+      paths: ['./plugin.js']
+    }
+  }
+
+  await fs.writeFile('./platformatic.service.json', JSON.stringify(pltServiceConfig, null, 2))
+
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openapi, '--name', testName, '--full', '--props-optional'])
+
+  equal(await isFileAccessible(join(dir, testName, `${testName}.cjs`)), false)
+
+  const typeFile = join(dir, testName, `${testName}.d.ts`)
+  const data = await readFile(typeFile, 'utf-8')
+
+  equal(data.includes(`
+  export type PostHelloRequest = {
+    body: {
+      'name'?: string;
+      'userId'?: string;
+    }
+  }`), true)
+})

--- a/packages/client-cli/test/fixtures/optional-body/openapi.json
+++ b/packages/client-cli/test/fixtures/optional-body/openapi.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "userId": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "operationId": "postHello",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" },
+                    "bar": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/fixtures/optional-body/package.json
+++ b/packages/client-cli/test/fixtures/optional-body/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "platformatic start"
+  },
+  "devDependencies": {
+    "fastify": "^4.21.0"
+  },
+  "dependencies": {
+    "platformatic": "^0.38.1"
+  },
+  "engines": {
+    "node": ">=20.16.0"
+  }
+}

--- a/packages/client-cli/test/fixtures/optional-body/platformatic.service.json
+++ b/packages/client-cli/test/fixtures/optional-body/platformatic.service.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/1.52.0.json",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0",
+    "logger": {
+      "level": "error"
+    }
+  },
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugins",
+        "encapsulate": false
+      }
+    ]
+  }
+}

--- a/packages/client-cli/test/fixtures/optional-body/plugins/example.js
+++ b/packages/client-cli/test/fixtures/optional-body/plugins/example.js
@@ -1,0 +1,6 @@
+/// <reference types="@platformatic/service" />
+'use strict'
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify) {
+  fastify.post('/hello', async ({ body }) => ({ body }))
+}


### PR DESCRIPTION
As of today, if `required` array is missing in the Open API schema, we mark the properties as required.
Even though the correct behavior should be different, I added a new property called `--props-optional` (defaulted to `false`) to update this logic avoiding breaking changes.