### PR TITLE
feat: add an http.cache.hit attribute

### DIFF
--- a/packages/runtime/lib/worker/http-cache.js
+++ b/packages/runtime/lib/worker/http-cache.js
@@ -132,6 +132,8 @@ const httpCacheInterceptor = (interceptorOpts) => {
       const originOnResponseStart = handler.onResponseStart.bind(handler)
       handler.onResponseStart = (ac, statusCode, headers, statusMessage) => {
         const cacheEntryId = headers[kCacheIdHeader] ?? headers[CACHE_ID_HEADER]
+        const isCacheHit = headers.age !== undefined
+
         if (cacheEntryId) {
           // Setting a cache id header on cache hit
           headers[CACHE_ID_HEADER] = cacheEntryId
@@ -142,6 +144,7 @@ const httpCacheInterceptor = (interceptorOpts) => {
               const { span } = clientSpansAls.getStore()
               if (span) {
                 span.setAttribute('http.cache.id', cacheEntryId)
+                span.setAttribute('http.cache.hit', isCacheHit)
               }
             } catch (err) {
               interceptorOpts.logger.error(err, 'Error setting cache id on span')

--- a/packages/runtime/lib/worker/http-cache.js
+++ b/packages/runtime/lib/worker/http-cache.js
@@ -144,7 +144,7 @@ const httpCacheInterceptor = (interceptorOpts) => {
               const { span } = clientSpansAls.getStore()
               if (span) {
                 span.setAttribute('http.cache.id', cacheEntryId)
-                span.setAttribute('http.cache.hit', isCacheHit)
+                span.setAttribute('http.cache.hit', isCacheHit.toString())
               }
             } catch (err) {
               interceptorOpts.logger.error(err, 'Error setting cache id on span')

--- a/packages/runtime/test/http-cache.test.js
+++ b/packages/runtime/test/http-cache.test.js
@@ -437,14 +437,18 @@ test('should set an opentelemetry attribute', async (t) => {
 
     for (const trace of serverTraces) {
       const cacheIdAttribute = trace.attributes['http.cache.id']
+      const cacheHitAttribute = trace.attributes['http.cache.hit']
       assert.strictEqual(cacheIdAttribute, undefined)
+      assert.strictEqual(cacheHitAttribute, undefined)
     }
 
     let previousCacheIdAttribute = null
     for (const trace of clientTraces) {
       const cacheIdAttribute = trace.attributes['http.cache.id']
+      const cacheHitAttribute = trace.attributes['http.cache.hit']
       assert.ok(cacheIdAttribute)
       assert.notStrictEqual(cacheIdAttribute, previousCacheIdAttribute)
+      assert.strictEqual(cacheHitAttribute, false)
       previousCacheIdAttribute = cacheIdAttribute
     }
 
@@ -473,14 +477,18 @@ test('should set an opentelemetry attribute', async (t) => {
 
     for (const trace of serverTraces) {
       const cacheIdAttribute = trace.attributes['http.cache.id']
+      const cacheHitAttribute = trace.attributes['http.cache.hit']
       assert.strictEqual(cacheIdAttribute, undefined)
+      assert.strictEqual(cacheHitAttribute, undefined)
     }
 
     let previousCacheIdAttribute = null
     for (const trace of clientTraces) {
       const cacheIdAttribute = trace.attributes['http.cache.id']
+      const cacheHitAttribute = trace.attributes['http.cache.hit']
       assert.ok(cacheIdAttribute)
       assert.notStrictEqual(cacheIdAttribute, previousCacheIdAttribute)
+      assert.strictEqual(cacheHitAttribute, true)
       previousCacheIdAttribute = cacheIdAttribute
     }
 

--- a/packages/runtime/test/http-cache.test.js
+++ b/packages/runtime/test/http-cache.test.js
@@ -448,7 +448,7 @@ test('should set an opentelemetry attribute', async (t) => {
       const cacheHitAttribute = trace.attributes['http.cache.hit']
       assert.ok(cacheIdAttribute)
       assert.notStrictEqual(cacheIdAttribute, previousCacheIdAttribute)
-      assert.strictEqual(cacheHitAttribute, false)
+      assert.strictEqual(cacheHitAttribute, 'false')
       previousCacheIdAttribute = cacheIdAttribute
     }
 
@@ -488,7 +488,7 @@ test('should set an opentelemetry attribute', async (t) => {
       const cacheHitAttribute = trace.attributes['http.cache.hit']
       assert.ok(cacheIdAttribute)
       assert.notStrictEqual(cacheIdAttribute, previousCacheIdAttribute)
-      assert.strictEqual(cacheHitAttribute, true)
+      assert.strictEqual(cacheHitAttribute, 'true')
       previousCacheIdAttribute = cacheIdAttribute
     }
 

--- a/packages/runtime/test/http-cache.test.js
+++ b/packages/runtime/test/http-cache.test.js
@@ -426,6 +426,8 @@ test('should set an opentelemetry attribute', async (t) => {
     assert.strictEqual(statusCode, 200, error)
   }
 
+  await sleep(100)
+
   let resultCacheId1 = null
   {
     const traces = await parseNDJson(telemetryFilePath)
@@ -466,6 +468,8 @@ test('should set an opentelemetry attribute', async (t) => {
     const error = await body.text()
     assert.strictEqual(statusCode, 200, error)
   }
+
+  await sleep(100)
 
   {
     const traces = await parseNDJson(telemetryFilePath)

--- a/packages/telemetry/lib/telemetry-config.js
+++ b/packages/telemetry/lib/telemetry-config.js
@@ -284,8 +284,12 @@ function setupTelemetry (opts, logger) {
       })
 
       const httpCacheId = response.headers?.['x-plt-http-cache-id']
+      const isCacheHit = response.headers?.age !== undefined
       if (httpCacheId) {
-        span.setAttributes({ 'http.cache.id': httpCacheId })
+        span.setAttributes({
+          'http.cache.id': httpCacheId,
+          'http.cache.hit': isCacheHit
+        })
       }
 
       span.setStatus(spanStatus)

--- a/packages/telemetry/lib/telemetry-config.js
+++ b/packages/telemetry/lib/telemetry-config.js
@@ -288,7 +288,7 @@ function setupTelemetry (opts, logger) {
       if (httpCacheId) {
         span.setAttributes({
           'http.cache.id': httpCacheId,
-          'http.cache.hit': isCacheHit
+          'http.cache.hit': isCacheHit.toString()
         })
       }
 

--- a/packages/telemetry/lib/thread-interceptor-hooks.js
+++ b/packages/telemetry/lib/thread-interceptor-hooks.js
@@ -99,7 +99,7 @@ const createTelemetryThreadInterceptorHooks = () => {
       if (httpCacheId) {
         span.setAttributes({
           'http.cache.id': httpCacheId,
-          'http.cache.hit': isCacheHit
+          'http.cache.hit': isCacheHit.toString()
         })
       }
 

--- a/packages/telemetry/lib/thread-interceptor-hooks.js
+++ b/packages/telemetry/lib/thread-interceptor-hooks.js
@@ -95,8 +95,12 @@ const createTelemetryThreadInterceptorHooks = () => {
       })
 
       const httpCacheId = res.headers?.['x-plt-http-cache-id']
+      const isCacheHit = res.headers?.age !== undefined
       if (httpCacheId) {
-        span.setAttributes({ 'http.cache.id': httpCacheId })
+        span.setAttributes({
+          'http.cache.id': httpCacheId,
+          'http.cache.hit': isCacheHit
+        })
       }
 
       span.setStatus(spanStatus)


### PR DESCRIPTION
This is needed to understand if the trace is done and not wait for a server span if client request was cached.