### PR TITLE
chore(control): add runtime and services types

### DIFF
--- a/packages/control/index.d.ts
+++ b/packages/control/index.d.ts
@@ -10,11 +10,46 @@ declare namespace control {
     ws: WebSocket;
   }
 
+  interface Runtime {
+    pid: number,
+    cwd: string,
+    argv: string[],
+    uptimeSeconds: number,
+    execPath: string,
+    nodeVersion: string,
+    projectDir: string,
+    packageName: string | null,
+    packageVersion: string | null,
+    url: string | null,
+    platformaticVersion: string
+  }
+
+  interface Services {
+    entrypoint: string,
+    production: boolean,
+    services: ({
+      id: string;
+      type: string;
+      status: string;
+      version: string;
+      localUrl: string;
+      entrypoint: boolean;
+      dependencies: {
+        id: string;
+        url: string;
+        local: boolean;
+      }[];
+    } | {
+      id: string;
+      status: string;
+    })[]
+  }
+
   export class RuntimeApiClient {
-    getMatchingRuntime(opts: { pid?: string; name?: string }): Promise<unknown>;
-    getRuntimes(): Promise<unknown[]>;
-    getRuntimeMetadata(pid: number): Promise<unknown>;
-    getRuntimeServices(pid: number): Promise<unknown>;
+    getMatchingRuntime(opts: { pid?: string; name?: string }): Promise<Runtime>;
+    getRuntimes(): Promise<Runtime[]>;
+    getRuntimeMetadata(pid: number): Promise<Runtime>;
+    getRuntimeServices(pid: number): Promise<Services>;
     getRuntimeConfig(pid: number): Promise<void>;
     getRuntimeServiceConfig(pid: number, serviceId?: string): Promise<void>;
     getRuntimeEnv(pid: number): Promise<void>;

--- a/packages/control/index.test-d.ts
+++ b/packages/control/index.test-d.ts
@@ -1,10 +1,22 @@
 import { expectError, expectType } from 'tsd'
-import { errors, RuntimeApiClient } from '.'
+import { errors, Runtime, RuntimeApiClient, Services } from '.'
 import { FastifyError } from '@fastify/error'
 
 // RuntimeApiClient
+let runtime = {} as Runtime
+let services = {} as Services
 const api = new RuntimeApiClient()
-expectType<Promise<unknown[]>>(api.getRuntimes())
+expectType<Promise<Runtime[]>>(api.getRuntimes())
+expectType<string[]>(runtime.argv)
+expectType<number>(runtime.uptimeSeconds)
+expectType<string | null>(runtime.packageVersion)
+expectType<Promise<{
+  entrypoint: string,
+  production: boolean,
+  services: Services['services']
+}>>(api.getRuntimeServices(45))
+expectType<string>(services.services[0].id)
+expectType<string>(services.services[0].status)
 expectType<Promise<void>>(api.close())
 
 // errors


### PR DESCRIPTION
Will address [this comment](https://github.com/platformatic/watt-admin/pull/5/files#diff-072c26ea8fdfa78fdf65b9c419df4a7bf068a950d5ef4fa8b65ca53de1ba4cbeR32)