### PR TITLE
chore(control): add metrics types

### DIFF
--- a/packages/control/index.d.ts
+++ b/packages/control/index.d.ts
@@ -24,7 +24,7 @@ declare namespace control {
     platformaticVersion: string
   }
 
-  interface Services {
+  interface Service {
     entrypoint: string,
     production: boolean,
     services: ({
@@ -45,11 +45,34 @@ declare namespace control {
     })[]
   }
 
+  interface MetricValue {
+    value: number,
+    labels: {
+      type?: string,
+      space?: string,
+      version?: string,
+      major?: number,
+      minor?: number,
+      patch?: number,
+      le?: number | string,
+      kind?: string,
+      serviceId: string
+    }
+  }
+  
+  interface Metric {
+    help: string,
+    name: string,
+    type: string,
+    values: MetricValue[],
+    aggregator: string
+  }
+
   export class RuntimeApiClient {
-    getMatchingRuntime(opts: { pid?: string; name?: string }): Promise<Runtime>;
+    getMatchingRuntime(options?: { pid?: string; name?: string }): Promise<Runtime>;
     getRuntimes(): Promise<Runtime[]>;
     getRuntimeMetadata(pid: number): Promise<Runtime>;
-    getRuntimeServices(pid: number): Promise<Services>;
+    getRuntimeServices(pid: number): Promise<Service>;
     getRuntimeConfig(pid: number): Promise<void>;
     getRuntimeServiceConfig(pid: number, serviceId?: string): Promise<void>;
     getRuntimeEnv(pid: number): Promise<void>;
@@ -57,10 +80,10 @@ declare namespace control {
     reloadRuntime(pid: number, options?: object): Promise<ChildProcess>;
     restartRuntime(pid: number): Promise<void>;
     stopRuntime(pid: number): Promise<void>;
-    getRuntimeMetrics(
+    getRuntimeMetrics<T extends { format?: "text" | "json" }>(
       pid: number,
-      options?: { format?: "text" | "json" }
-    ): Promise<unknown>;
+      options?: T
+    ): Promise<T extends { format: "text" } ? string : Metric[]>;
     getRuntimeLiveMetricsStream(pid: number): WebSocketStream;
     getRuntimeLiveLogsStream(
       pid: number,

--- a/packages/control/index.d.ts
+++ b/packages/control/index.d.ts
@@ -24,7 +24,7 @@ declare namespace control {
     platformaticVersion: string
   }
 
-  interface Service {
+  interface RuntimeServices {
     entrypoint: string,
     production: boolean,
     services: ({
@@ -72,7 +72,7 @@ declare namespace control {
     getMatchingRuntime(options?: { pid?: string; name?: string }): Promise<Runtime>;
     getRuntimes(): Promise<Runtime[]>;
     getRuntimeMetadata(pid: number): Promise<Runtime>;
-    getRuntimeServices(pid: number): Promise<Service>;
+    getRuntimeServices(pid: number): Promise<RuntimeServices>;
     getRuntimeConfig(pid: number): Promise<void>;
     getRuntimeServiceConfig(pid: number, serviceId?: string): Promise<void>;
     getRuntimeEnv(pid: number): Promise<void>;

--- a/packages/control/index.test-d.ts
+++ b/packages/control/index.test-d.ts
@@ -1,11 +1,17 @@
 import { expectError, expectType } from 'tsd'
-import { errors, Runtime, RuntimeApiClient, Services } from '.'
+import { errors, Metric, Runtime, RuntimeApiClient, Service } from '.'
 import { FastifyError } from '@fastify/error'
 
 // RuntimeApiClient
 let runtime = {} as Runtime
-let services = {} as Services
+let service = {} as Service
+let metric = {} as Metric
 const api = new RuntimeApiClient()
+expectType<Promise<Runtime>>(api.getMatchingRuntime())
+expectType<Promise<Metric[]>>(api.getRuntimeMetrics(runtime.pid))
+expectType<Promise<Metric[]>>(api.getRuntimeMetrics(runtime.pid, {}))
+expectType<Promise<Metric[]>>(api.getRuntimeMetrics(runtime.pid, { format: 'json' }))
+expectType<Promise<string>>(api.getRuntimeMetrics(runtime.pid, { format: 'text' }))
 expectType<Promise<Runtime[]>>(api.getRuntimes())
 expectType<string[]>(runtime.argv)
 expectType<number>(runtime.uptimeSeconds)
@@ -13,10 +19,12 @@ expectType<string | null>(runtime.packageVersion)
 expectType<Promise<{
   entrypoint: string,
   production: boolean,
-  services: Services['services']
+  services: Service['services']
 }>>(api.getRuntimeServices(45))
-expectType<string>(services.services[0].id)
-expectType<string>(services.services[0].status)
+expectType<string>(service.services[0].id)
+expectType<string>(service.services[0].status)
+expectType<string>(metric.aggregator)
+expectType<string>(metric.values[0].labels.serviceId)
 expectType<Promise<void>>(api.close())
 
 // errors

--- a/packages/control/index.test-d.ts
+++ b/packages/control/index.test-d.ts
@@ -1,10 +1,10 @@
 import { expectError, expectType } from 'tsd'
-import { errors, Metric, Runtime, RuntimeApiClient, Service } from '.'
+import { errors, Metric, Runtime, RuntimeApiClient, RuntimeServices } from '.'
 import { FastifyError } from '@fastify/error'
 
 // RuntimeApiClient
 let runtime = {} as Runtime
-let service = {} as Service
+let service = {} as RuntimeServices
 let metric = {} as Metric
 const api = new RuntimeApiClient()
 expectType<Promise<Runtime>>(api.getMatchingRuntime())
@@ -19,7 +19,7 @@ expectType<string | null>(runtime.packageVersion)
 expectType<Promise<{
   entrypoint: string,
   production: boolean,
-  services: Service['services']
+  services: RuntimeServices['services']
 }>>(api.getRuntimeServices(45))
 expectType<string>(service.services[0].id)
 expectType<string>(service.services[0].status)

--- a/packages/control/lib/runtime-api-client.js
+++ b/packages/control/lib/runtime-api-client.js
@@ -17,7 +17,7 @@ class RuntimeApiClient {
   #undiciClients = new Map()
   #webSockets = new Set()
 
-  async getMatchingRuntime (opts) {
+  async getMatchingRuntime (opts = {}) {
     const runtimes = await this.getRuntimes()
 
     let runtime = null

--- a/packages/control/test/runtime-api.test.mjs
+++ b/packages/control/test/runtime-api.test.mjs
@@ -309,6 +309,18 @@ test('should get runtime live metrics', async t => {
   })
 })
 
+test('should get matching runtime', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => { await kill(runtime) })
+
+  const runtimeClient = new RuntimeApiClient()
+  const { pid, url } = await runtimeClient.getMatchingRuntime()
+  assert.strictEqual(typeof pid, 'number')
+  assert.strictEqual(typeof url, 'string')
+})
+
 function getRuntimeTmpDir (runtimeDir) {
   const platformaticTmpDir = join(tmpdir(), 'platformatic', 'applications')
   const runtimeDirHash = createHash('md5').update(runtimeDir).digest('hex')


### PR DESCRIPTION
This will be useful for instance for [watt-admin](https://github.com/platformatic/watt-admin/pull/8/files#diff-73d0003e548bafddce265b62b5fa08bb66f5243eec635b2388479f4a65bc09a1R9)