### PR TITLE
fix(client cli): frontend generation

### DIFF
--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -286,7 +286,7 @@ async function downloadAndProcess (options) {
     config = configFileNames.find((value, index) => configFilesAccessibility[index])
   }
 
-  if (config) {
+  if (config && !isFrontend) {
     // if config file is found, no implementation is needed because from the 'clients' section
     // of the config file, Platformatic will register automatically the client
     generateImplementation = false
@@ -425,7 +425,7 @@ async function downloadAndProcess (options) {
     throw new Error(`Could not find a valid OpenAPI or GraphQL schema at ${url}`)
   }
 
-  if (config && !typesOnly) {
+  if (config && !typesOnly && !isFrontend) {
     const parse = getParser(config)
     const stringify = getStringifier(config)
     const data = parse(await readFile(config, 'utf8'))

--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -589,11 +589,12 @@ export async function command (argv) {
   }
 
   try {
+    options.isFrontend = !!options.frontend
     if (options['types-only']) {
       options.generateImplementation = false
       options.typesOnly = true
     } else {
-      options.generateImplementation = !options.config
+      options.generateImplementation = options.isFrontend ? true : !options.config
     }
 
     options.fullRequest = options['full-request']
@@ -607,7 +608,6 @@ export async function command (argv) {
       : []
 
     options.validateResponse = options['validate-response']
-    options.isFrontend = !!options.frontend
 
     if (!options.name) {
       options.name = options.isFrontend ? 'api' : 'client'

--- a/packages/client-cli/test/fixtures/client-with-config/openapi.json
+++ b/packages/client-cli/test/fixtures/client-with-config/openapi.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Platformatic DB",
+    "description": "Exposing a SQL database as REST",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "Movie": {
+        "title": "Movie",
+        "description": "A Movie",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      }
+    }
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "operationId": "getHello",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/client-cli/test/fixtures/client-with-config/openapi.json
+++ b/packages/client-cli/test/fixtures/client-with-config/openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "Platformatic DB",
-    "description": "Exposing a SQL database as REST",
+    "title": "FAN TOZZI",
+    "description": "Tozzi Fan!",
     "version": "1.0.0"
   },
   "components": {

--- a/packages/client-cli/test/fixtures/client-with-config/watt.json
+++ b/packages/client-cli/test/fixtures/client-with-config/watt.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schemas.platformatic.dev/wattpm/2.34.0.json",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 3042
+  },
+  "logger": {
+    "level": "info"
+  }
+}

--- a/packages/client-cli/test/fixtures/client-with-config/watt.json
+++ b/packages/client-cli/test/fixtures/client-with-config/watt.json
@@ -6,5 +6,16 @@
   },
   "logger": {
     "level": "info"
+  },
+  "restartOnError": true,
+  "gracefulShutdown": {
+    "runtime": 40000,
+    "service": 20000
+  },
+  "inspectorOptions": {
+    "breakFirstLine": true
+  },
+  "env": {
+    "FOO": "BAR"
   }
 }

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -733,8 +733,24 @@ test('frontend client with config', async (t) => {
   await execa('node', [join(__dirname, '..', 'cli.mjs'), openAPIfile, '--name', 'client', '--language', 'ts', '--frontend', '--config', 'watt.json'])
 
   const implementation = await readFile(join(dir, 'client', 'client.ts'), 'utf-8')
-  ok(implementation.includes("import type { Client } from './client-types'"))
+  ok(implementation.includes(`import type { Client } from './client-types'
+import type * as Types from './client-types'`))
+  ok(implementation.includes(`const _getHello = async (url: string, request: Types.GetHelloRequest): Promise<Types.GetHelloResponses> => {
+  const headers = {
+    ...defaultHeaders
+  }`))
+  ok(implementation.includes(`export const getHello: Client['getHello'] = async (request: Types.GetHelloRequest): Promise<Types.GetHelloResponses> => {
+  return await _getHello(baseUrl, request)
+}`))
 
   const types = await readFile(join(dir, 'client', 'client-types.d.ts'), 'utf-8')
+  ok(types.includes(`export type GetHelloResponses =
+  GetHelloResponseOK`))
+  ok(types.includes(`export interface Client {
+  setBaseUrl(newUrl: string) : void;
+  setDefaultHeaders(headers: Object) : void;
+  getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
+}`))
   ok(types.includes("type PlatformaticFrontendClient = Omit<Client, 'setBaseUrl'>"))
+  ok(types.includes('export default function build(url: string, options?: BuildOptions): PlatformaticFrontendClient'))
 })

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -726,3 +726,15 @@ test('add credentials: include in client implementation from url', async (t) => 
   equal(implementation.includes(expectedGetMethod), true)
   equal(implementation.includes(expectedPostMethod), true)
 })
+
+test('frontend client with config', async (t) => {
+  const dir = await moveToTmpdir(after)
+  const openAPIfile = join(__dirname, 'fixtures', 'client-with-config', 'openapi.json')
+  await execa('node', [join(__dirname, '..', 'cli.mjs'), openAPIfile, '--name', 'client', '--language', 'ts', '--frontend', '--config', 'watt.json'])
+
+  const implementation = await readFile(join(dir, 'client', 'client.ts'), 'utf-8')
+  ok(implementation.includes("import type { Client } from './client-types'"))
+
+  const types = await readFile(join(dir, 'client', 'client-types.d.ts'), 'utf-8')
+  ok(types.includes("type PlatformaticFrontendClient = Omit<Client, 'setBaseUrl'>"))
+})


### PR DESCRIPTION
**Why?**
As of today, when running `platformatic client http://127.0.0.1:3042/documentation/json --frontend --language ts --name client --full` the watt.json is updated with a `clients` section, which is not allowed since we're in a frontend project leveraging `@platformatic/vite`:
![image](https://github.com/user-attachments/assets/8505753c-31d2-4be5-926a-266861e72f9f)

**How?**
We are now checking if it's a front-end project. In this case, we do not update the `config,` and we force the generation of a [client.ts](https://github.com/platformatic/watt-admin/pull/15/files#diff-6e8e03da88f2244788f0fc7d769338e93cb338acafec18857b43655ace35067f)

**QA?**
You can test it by running the `client` command of [this branch](https://github.com/platformatic/watt-admin/pull/15/files#diff-0816cd46d529b043bd6c753c560b74405e043bc40c7b3f9fc9083d16ef23ed46R11)