### PR TITLE
fix(client cli): use proper types

### DIFF
--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -59,6 +59,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
     writer.newLine()
 
     writer.writeLine('type JSON = Record<string, unknown>')
+    writer.writeLine('/* @ts-ignore - potential unused variable */')
     writer.write('function headersToJSON(headers: Headers): JSON ').block(() => {
       writer.writeLine('const output: JSON = {}')
       writer.write('headers.forEach((value, key) => ').inlineBlock(() => {

--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -55,7 +55,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
       'export const setBaseUrl = (newUrl: string) : void => { baseUrl = sanitizeUrl(newUrl) }'
     )
     writer.newLine()
-    writer.writeLine('export const setDefaultHeaders = (headers: Object): void => { defaultHeaders = headers }')
+    writer.writeLine('export const setDefaultHeaders = (headers: object): void => { defaultHeaders = headers }')
     writer.newLine()
 
     writer.writeLine('type JSON = Record<string, unknown>')
@@ -255,7 +255,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
         })
 
         // write default response as fallback
-        writer.write('if (response.headers.get(\'content-type\').startsWith(\'application/json\')) ').block(() => {
+        writer.write('if (response.headers.get(\'content-type\')?.startsWith(\'application/json\')) ').block(() => {
           writer.write('return ').block(() => {
             writer.write('statusCode: response.status')
             if (language === 'ts') {
@@ -265,9 +265,6 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
             }
             writer.writeLine('headers: headersToJSON(response.headers),')
             writer.write('body: await response.json()')
-            if (language === 'ts') {
-              writer.write(' as any')
-            }
           })
         })
         writer.write('return ').block(() => {
@@ -279,9 +276,6 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
           }
           writer.writeLine('headers: headersToJSON(response.headers),')
           writer.write('body: await response.text()')
-          if (language === 'ts') {
-            writer.write(' as any')
-          }
         })
       } else {
         writer.write('if (!response.ok)').block(() => {
@@ -322,7 +316,7 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
   // create factory
   if (language === 'ts') {
     writer.write('type BuildOptions = ').block(() => {
-      writer.writeLine('headers?: Object')
+      writer.writeLine('headers?: object')
     })
   }
 
@@ -389,7 +383,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, propsOptional }
   writer.blankLine()
   writer.write(`export interface ${camelCaseName}`).block(() => {
     writer.writeLine('setBaseUrl(newUrl: string) : void;')
-    writer.writeLine('setDefaultHeaders(headers: Object) : void;')
+    writer.writeLine('setDefaultHeaders(headers: object) : void;')
     writeOperations(interfaces, writer, operations, {
       fullRequest: false, fullResponse, optionalHeaders: [], schema, propsOptional
     })
@@ -397,7 +391,7 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, propsOptional }
 
   writer.writeLine(`type PlatformaticFrontendClient = Omit<${camelCaseName}, 'setBaseUrl'>`)
   writer.write('type BuildOptions = ').block(() => {
-    writer.writeLine('headers?: Object')
+    writer.writeLine('headers?: object')
   })
   writer.writeLine('export default function build(url: string, options?: BuildOptions): PlatformaticFrontendClient')
   return interfaces.toString() + writer.toString()

--- a/packages/client-cli/lib/frontend-openapi-generator.mjs
+++ b/packages/client-cli/lib/frontend-openapi-generator.mjs
@@ -59,7 +59,6 @@ function generateFrontendImplementationFromOpenAPI ({ schema, name, language, fu
     writer.newLine()
 
     writer.writeLine('type JSON = Record<string, unknown>')
-    writer.writeLine('/* @ts-ignore */')
     writer.write('function headersToJSON(headers: Headers): JSON ').block(() => {
       writer.writeLine('const output: JSON = {}')
       writer.write('headers.forEach((value, key) => ').inlineBlock(() => {

--- a/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
+++ b/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
@@ -13,7 +13,7 @@ function sanitizeUrl(url: string) : string {
 }
 export const setBaseUrl = (newUrl: string) : void => { baseUrl = sanitizeUrl(newUrl) }
 
-export const setDefaultHeaders = (headers: Object): void => { defaultHeaders = headers }
+export const setDefaultHeaders = (headers: object): void => { defaultHeaders = headers }
 
 type JSON = Record<string, unknown>
 /* @ts-ignore */
@@ -58,17 +58,17 @@ const _getPkgScopeNameVersion = async (url: string, request: Types.GetPkgScopeNa
       body: await response.json()
     }
   }
-  if (response.headers.get('content-type').startsWith('application/json')) {
+  if (response.headers.get('content-type')?.startsWith('application/json')) {
     return {
       statusCode: response.status as 200 | 202 | 302 | 400 | 404,
       headers: headersToJSON(response.headers),
-      body: await response.json() as any
+      body: await response.json()
     }
   }
   return {
     statusCode: response.status as 200 | 202 | 302 | 400 | 404,
     headers: headersToJSON(response.headers),
-    body: await response.text() as any
+    body: await response.text()
   }
 }
 
@@ -76,7 +76,7 @@ export const getPkgScopeNameVersion: Movies['getPkgScopeNameVersion'] = async (r
   return await _getPkgScopeNameVersion(baseUrl, request)
 }
 type BuildOptions = {
-  headers?: Object
+  headers?: object
 }
 export default function build (url: string, options?: BuildOptions) {
   url = sanitizeUrl(url)

--- a/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
+++ b/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
@@ -16,7 +16,6 @@ export const setBaseUrl = (newUrl: string) : void => { baseUrl = sanitizeUrl(new
 export const setDefaultHeaders = (headers: object): void => { defaultHeaders = headers }
 
 type JSON = Record<string, unknown>
-/* @ts-ignore */
 function headersToJSON(headers: Headers): JSON {
   const output: JSON = {}
   headers.forEach((value, key) => {

--- a/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
+++ b/packages/client-cli/test/expected-generated-code/multiple-responses-movies.ts
@@ -16,6 +16,7 @@ export const setBaseUrl = (newUrl: string) : void => { baseUrl = sanitizeUrl(new
 export const setDefaultHeaders = (headers: object): void => { defaultHeaders = headers }
 
 type JSON = Record<string, unknown>
+/* @ts-ignore - potential unused variable */
 function headersToJSON(headers: Headers): JSON {
   const output: JSON = {}
   headers.forEach((value, key) => {

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -73,7 +73,7 @@ async function _getRedirect (url, request) {
       body: await response.json()
     }
   }
-  if (response.headers.get('content-type').startsWith('application/json')) {
+  if (response.headers.get('content-type')?.startsWith('application/json')) {
     return {
       statusCode: response.status,
       headers: headersToJSON(response.headers),
@@ -109,7 +109,7 @@ export default function build (url, options) {
   const factoryType = `
 type PlatformaticFrontendClient = Omit<Sample, 'setBaseUrl'>
 type BuildOptions = {
-  headers?: Object
+  headers?: object
 }
 export default function build(url: string, options?: BuildOptions): PlatformaticFrontendClient`
 
@@ -135,7 +135,7 @@ export const getCustomSwagger = async (request) => {
     const typesTemplate = `
 export interface Sample {
   setBaseUrl(newUrl: string) : void;
-  setDefaultHeaders(headers: Object) : void;
+  setDefaultHeaders(headers: object) : void;
   getCustomSwagger(req: GetCustomSwaggerRequest): Promise<GetCustomSwaggerResponses>;
   getRedirect(req: GetRedirectRequest): Promise<GetRedirectResponses>;
   getReturnUrl(req: GetReturnUrlRequest): Promise<GetReturnUrlResponses>;
@@ -263,7 +263,7 @@ export const getHello: Api['getHello'] = async (request: Types.GetHelloRequest):
   const typesTemplate = `
 export interface Api {
   setBaseUrl(newUrl: string) : void;
-  setDefaultHeaders(headers: Object) : void;
+  setDefaultHeaders(headers: object) : void;
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`
 
@@ -292,7 +292,7 @@ export const getHello: ACustomName['getHello'] = async (request: Types.GetHelloR
   const typesTemplate = `
 export interface ACustomName {
   setBaseUrl(newUrl: string) : void;
-  setDefaultHeaders(headers: Object) : void;
+  setDefaultHeaders(headers: object) : void;
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`
 
@@ -445,17 +445,17 @@ test('do not add headers to fetch if a get request', async (t) => {
       body: await response.text()
     }
   }
-  if (response.headers.get('content-type').startsWith('application/json')) {
+  if (response.headers.get('content-type')?.startsWith('application/json')) {
     return {
       statusCode: response.status as 200,
       headers: headersToJSON(response.headers),
-      body: await response.json() as any
+      body: await response.json()
     }
   }
   return {
     statusCode: response.status as 200,
     headers: headersToJSON(response.headers),
-    body: await response.text() as any
+    body: await response.text()
   }`), true)
 })
 
@@ -482,17 +482,17 @@ test('support empty response', async (t) => {
       body: await response.text()
     }
   }
-  if (response.headers.get('content-type').startsWith('application/json')) {
+  if (response.headers.get('content-type')?.startsWith('application/json')) {
     return {
       statusCode: response.status as 200,
       headers: headersToJSON(response.headers),
-      body: await response.json() as any
+      body: await response.json()
     }
   }
   return {
     statusCode: response.status as 200,
     headers: headersToJSON(response.headers),
-    body: await response.text() as any
+    body: await response.text()
   }
 `), true)
 
@@ -525,17 +525,17 @@ test('call response.json only for json responses', async (t) => {
       body: await response.text()
     }
   }
-  if (response.headers.get('content-type').startsWith('application/json')) {
+  if (response.headers.get('content-type')?.startsWith('application/json')) {
     return {
       statusCode: response.status as 200,
       headers: headersToJSON(response.headers),
-      body: await response.json() as any
+      body: await response.json()
     }
   }
   return {
     statusCode: response.status as 200,
     headers: headersToJSON(response.headers),
-    body: await response.text() as any
+    body: await response.text()
   }`
 
     equal(implementation.includes(expected), true)
@@ -748,7 +748,7 @@ import type * as Types from './client-types'`))
   GetHelloResponseOK`))
   ok(types.includes(`export interface Client {
   setBaseUrl(newUrl: string) : void;
-  setDefaultHeaders(headers: Object) : void;
+  setDefaultHeaders(headers: object) : void;
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`))
   ok(types.includes("type PlatformaticFrontendClient = Omit<Client, 'setBaseUrl'>"))


### PR DESCRIPTION
- Use a more strict `object` type rather than `Object` (which can wrongly include values such as `number`, `boolean`, `null`, etc.)
- Do not cast `json()` and `text()` return values (since they already have a proper type defined [here](https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts#L3465))
- Use optional chaining when defining header values
- Add comment on `ts-ignore`