### PR TITLE
Platformatic Client: use global dispatcher when throwOnError is true

### DIFF
--- a/packages/client/index.js
+++ b/packages/client/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Agent, request, interceptors } = require('undici')
+const { getGlobalDispatcher, request, interceptors } = require('undici')
 const { join } = require('path')
 const fs = require('fs/promises')
 const kHeaders = Symbol('headers')
@@ -221,7 +221,7 @@ async function buildCallFunction (spec, baseUrl, path, method, methodMeta, throw
 
     if (throwOnError) {
       if (!dispatcher) {
-        dispatcher = new Agent()
+        dispatcher = getGlobalDispatcher()
       }
       dispatcher = dispatcher.compose(interceptors.responseError())
     }


### PR DESCRIPTION
platformatic client will use the global dispatcher unless one is supplied via the dispatcher option, however if throwOnError is set to true, it will create an internal Agent and use that instead. If you're using setGlobalDispatcher() in your code, the client will stop using it when you enable throwOnError.

Making a small change to ensure the client will always use the global dispatcher if a custom dispatcher is not supplied, whether throwOnError is on or off.