### PR TITLE
fix(client cli): do not update watt.json

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -400,6 +400,7 @@ Options:
 * `--types-only` - Generate only the type file.
 * `--types-comment` - Add a comment at the beginning of the auto generated `.d.ts` type definition.
 * `--with-credentials` - Adds "credentials: 'include'" to all fetch requests (only for frontend clients).
+* `--skip-config-update` - If `true`, it will not update the `platformatic|watt` config found in your repo.
 
 
 ### composer

--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -283,7 +283,7 @@ async function downloadAndProcess (options) {
   let config = options.config
   if (!config) {
     const configFilesAccessibility = await Promise.all(configFileNames.map(fileName => isFileAccessible(fileName)))
-    config = configFileNames.find((value, index) => configFilesAccessibility[index])
+    config = configFileNames.find((value, index) => configFilesAccessibility[index] && !value.startsWith('watt'))
   }
 
   if (config && !isFrontend) {

--- a/packages/client-cli/cli.mjs
+++ b/packages/client-cli/cli.mjs
@@ -276,14 +276,15 @@ async function downloadAndProcess (options) {
     urlAuthHeaders,
     typesComment,
     withCredentials,
-    propsOptional
+    propsOptional,
+    skipConfigUpdate
   } = options
 
   let generateImplementation = options.generateImplementation
   let config = options.config
   if (!config) {
     const configFilesAccessibility = await Promise.all(configFileNames.map(fileName => isFileAccessible(fileName)))
-    config = configFileNames.find((value, index) => configFilesAccessibility[index] && !value.startsWith('watt'))
+    config = configFileNames.find((value, index) => configFilesAccessibility[index])
   }
 
   if (config && !isFrontend) {
@@ -425,7 +426,7 @@ async function downloadAndProcess (options) {
     throw new Error(`Could not find a valid OpenAPI or GraphQL schema at ${url}`)
   }
 
-  if (config && !typesOnly && !isFrontend) {
+  if (config && !skipConfigUpdate && !typesOnly && !isFrontend) {
     const parse = getParser(config)
     const stringify = getStringifier(config)
     const data = parse(await readFile(config, 'utf8'))
@@ -497,7 +498,7 @@ export async function command (argv) {
     ...options
   } = parseArgs(argv, {
     string: ['name', 'folder', 'runtime', 'optional-headers', 'language', 'type', 'url-auth-headers', 'types-comment'],
-    boolean: ['typescript', 'full-response', 'types-only', 'full-request', 'full', 'frontend', 'validate-response', 'props-optional'],
+    boolean: ['typescript', 'full-response', 'types-only', 'full-request', 'full', 'frontend', 'validate-response', 'props-optional', 'skip-config-update'],
     default: {
       typescript: false,
       language: 'js'
@@ -616,6 +617,7 @@ export async function command (argv) {
     options.urlAuthHeaders = options['url-auth-headers']
     options.typesComment = options['types-comment']
     options.withCredentials = options['with-credentials']
+    options.skipConfigUpdate = options['skip-config-update']
     await downloadAndProcess({ url, ...options, logger, runtime: options.runtime })
     logger.info(`Client generated successfully into ${options.folder}`)
     logger.info('Check out the docs to know more: https://docs.platformatic.dev/docs/service/overview')

--- a/packages/client-cli/help/help.txt
+++ b/packages/client-cli/help/help.txt
@@ -82,3 +82,5 @@ Options:
 * `--types-comment` - Add a comment at the beginning of the auto generated `.d.ts` type definition.
 * `--with-credentials` - Adds "credentials: 'include'" to all fetch requests (only for frontend clients).
 * `--props-optional` - If `true`, properties will be defined as optional unless they're part of the `required` array. By default this option is `false`.
+* `--skip-config-update` - If `true`, it will not update the `platformatic|watt` config found in your repo.
+

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint",
-    "test": "borp --concurrency=1 --timeout=300000 --pattern test/cli-openapi.test.mjs"
+    "test": "pnpm run lint && borp --concurrency=1 --timeout=300000 && tsd"
   },
   "repository": {
     "type": "git",

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint",
-    "test": "pnpm run lint && borp --concurrency=1 --timeout=300000 && tsd"
+    "test": "borp --concurrency=1 --timeout=300000 --pattern test/cli-openapi.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -1157,26 +1157,7 @@ test('client with watt.json and skipConfigUpdate', async (t) => {
     'client': client.Client;
   }`))
 
-  const wattConfig = await readFile(desm.join(import.meta.url, 'fixtures', 'client-with-config', 'watt.json'), 'utf-8')
-  ok(wattConfig.includes(`{
-  "$schema": "https://schemas.platformatic.dev/wattpm/2.34.0.json",
-  "server": {
-    "hostname": "127.0.0.1",
-    "port": 3042
-  },
-  "logger": {
-    "level": "info"
-  },
-  "restartOnError": true,
-  "gracefulShutdown": {
-    "runtime": 40000,
-    "service": 20000
-  },
-  "inspectorOptions": {
-    "breakFirstLine": true
-  },
-  "env": {
-    "FOO": "BAR"
-  }
-}`), 'watt.json config has not been updated')
+  const wattConfig = JSON.parse(await readFile(desm.join(import.meta.url, 'fixtures', 'client-with-config', 'watt.json'), 'utf-8'))
+  ok('$schema' in wattConfig)
+  ok(!('clients' in wattConfig), 'watt.json config has no clients')
 })

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -1,6 +1,6 @@
 import { request, moveToTmpdir, safeKill } from './helper.js'
 import { test, after } from 'node:test'
-import { equal, deepEqual as same, rejects } from 'node:assert'
+import { ok, equal, deepEqual as same, rejects } from 'node:assert'
 import { match } from '@platformatic/utils'
 import { buildServer } from '@platformatic/runtime'
 import { join } from 'path'
@@ -1141,4 +1141,42 @@ test('export formdata on full request object', async (t) => {
   export type PostSampleRequest = {
     body: FormData;
   }`), true)
+})
+
+test('client with watt.json config', async (t) => {
+  const dir = await moveToTmpdir(after)
+
+  const openAPIfile = desm.join(import.meta.url, 'fixtures', 'client-with-config', 'openapi.json')
+  await execa('node', [desm.join(import.meta.url, '..', 'cli.mjs'), openAPIfile, '--name', 'client', '--full-request'])
+
+  const data = await readFile(join(dir, 'client', 'client.d.ts'), 'utf-8')
+  ok(data.includes("import { type FormData } from 'undici"))
+  ok(data.includes('type ClientPlugin = FastifyPluginAsync<NonNullable<client.ClientOptions>>'))
+  ok(data.includes(`
+  interface FastifyRequest {
+    'client': client.Client;
+  }`))
+
+  const wattConfig = await readFile(desm.join(import.meta.url, 'fixtures', 'client-with-config', 'watt.json'), 'utf-8')
+  ok(wattConfig.includes(`{
+  "$schema": "https://schemas.platformatic.dev/wattpm/2.34.0.json",
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 3042
+  },
+  "logger": {
+    "level": "info"
+  },
+  "restartOnError": true,
+  "gracefulShutdown": {
+    "runtime": 40000,
+    "service": 20000
+  },
+  "inspectorOptions": {
+    "breakFirstLine": true
+  },
+  "env": {
+    "FOO": "BAR"
+  }
+}`), 'watt.json config has not been updated')
 })

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -1143,7 +1143,7 @@ test('export formdata on full request object', async (t) => {
   }`), true)
 })
 
-test('client with watt.json config', async (t) => {
+test('client with watt.json and skipConfigUpdate', async (t) => {
   const dir = await moveToTmpdir(after)
 
   const openAPIfile = desm.join(import.meta.url, 'fixtures', 'client-with-config', 'openapi.json')


### PR DESCRIPTION
When you have a repo with a `watt.json` file and you run the `client-cli`: it updates the `watt.json` by adding a `clients` section (which is invalid as not included in the [schema](https://schemas.platformatic.dev/@platformatic/node/2.35.1.json)).
This PR fixes this bug.