### PR TITLE
feat: add api descriptions from schema to type definitions

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -15,7 +15,7 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
   let currentFullResponse = originalFullResponse
   let currentFullRequest = originalFullRequest
   for (const operation of operations) {
-    const operationId = operation.operation.operationId
+    const { operationId, description, summary } = operation.operation
     const camelCaseOperationId = camelcase(operationId)
     const { parameters, responses, requestBody } = operation.operation
     currentFullRequest = fullRequest || hasDuplicatedParameters(operation.operation)
@@ -101,6 +101,24 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
 
     interfacesWriter.blankLine()
     const allResponsesName = responsesWriter(capitalizedCamelCaseOperationId, responses, currentFullResponse, interfacesWriter, schema)
+    mainWriter.writeLine('/**')
+    if (summary) {
+      for (const line of summary.split('\n')) {
+        mainWriter.writeLine(` * ${line}`)
+      }
+      // Separate summary and description by blank line
+      if (description) {
+        mainWriter.writeLine(' *')
+      }
+    }
+    if (description) {
+      for (const line of description.split('\n')) {
+        mainWriter.writeLine(` * ${line}`)
+      }
+    }
+    mainWriter.writeLine(' * @param req - request parameters object')
+    mainWriter.writeLine(` * @returns the API response${fullResponse ? '' : ' body'}`)
+    mainWriter.writeLine(' */')
     mainWriter.writeLine(`${camelCaseOperationId}(req: ${operationRequestName}${isRequestArray ? '[]' : ''}): Promise<${allResponsesName}>;`)
     currentFullResponse = originalFullResponse
     currentFullRequest = originalFullRequest
@@ -129,12 +147,22 @@ export function writeProperties (writer, blockName, parameters, addedProps, meth
 
 export function writeProperty (writer, key, value, addedProps, required = true, methodType, spec) {
   addedProps.add(key)
+
+  if (value.description) {
+    writer.writeLine('/**')
+    for (const line of value.description.split('\n')) {
+      writer.writeLine(` * ${line}`)
+    }
+    writer.writeLine(' */')
+  }
+
   if (required) {
     writer.quote(key)
   } else {
     writer.quote(key)
     writer.write('?')
   }
+
   writer.write(`: ${getType(value, methodType, spec)};`)
   writer.newLine()
 }

--- a/packages/client-cli/lib/openapi-generator.mjs
+++ b/packages/client-cli/lib/openapi-generator.mjs
@@ -57,7 +57,7 @@ function generateImplementationFromOpenAPI ({ name, fullResponse, fullRequest, v
 function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, optionalHeaders, typesComment, propsOptional }) {
   const camelcasedName = toJavaScriptName(name)
   const capitalizedName = capitalize(camelcasedName)
-  const { paths } = schema
+  const { paths, info } = schema
   const generatedOperationIds = []
 
   const operations = Object.entries(paths).flatMap(([path, methods]) => {
@@ -149,6 +149,23 @@ function generateTypesFromOpenAPI ({ schema, name, fullResponse, fullRequest, op
     writer.blankLine()
 
     writer.write('interface FastifyRequest').block(() => {
+      if (info) {
+        writer.writeLine('/**')
+        writer.conditionalWriteLine(info.title, ` * ${info.title}`)
+        writer.conditionalWriteLine(info.title, ' *')
+        if (info.summary) {
+          for (const line of info.summary.split('\n')) {
+            writer.writeLine(` * ${line}`)
+          }
+          writer.writeLine(' *')
+        }
+        if (info.description) {
+          for (const line of info.description.split('\n')) {
+            writer.writeLine(` * ${line}`)
+          }
+        }
+        writer.writeLine(' */')
+      }
       writer.quote(camelcasedName)
       writer.write(`: ${camelcasedName}.${capitalizedName};`)
       writer.newLine()

--- a/packages/client-cli/lib/responses-writer.mjs
+++ b/packages/client-cli/lib/responses-writer.mjs
@@ -22,7 +22,7 @@ function responsesWriter (operationId, responsesObject, isFullResponse, writer, 
       let isResponseArray
       const responseContentType = getResponseContentType(response)
       if (responseContentType === 'application/json') {
-        writeResponse(typeName, response.content['application/json'].schema)
+        writeResponse(typeName, response.content['application/json'].schema, response.summary, response.description)
       } else if (responseContentType === null) {
         isFullResponse = true
         writer.writeLine(`export type ${typeName} = unknown`)
@@ -58,9 +58,24 @@ function responsesWriter (operationId, responsesObject, isFullResponse, writer, 
   }
   return 'FullResponse<unknown, 200>'
 
-  function writeResponse (typeName, responseSchema) {
+  function writeResponse (typeName, responseSchema, summary, description) {
     if (!responseSchema) {
       return
+    }
+    if (description || summary) {
+      writer.writeLine('/**')
+      if (summary) {
+        for (const line of summary.split('\n')) {
+          writer.writeLine(` * ${line}`)
+        }
+        writer.writeLine(' *')
+      }
+      if (description) {
+        for (const line of description.split('\n')) {
+          writer.writeLine(` * ${line}`)
+        }
+      }
+      writer.writeLine(' */')
     }
     if (responseSchema.type === 'object') {
       writer.write(`export type ${typeName} =`).block(() => {

--- a/packages/client-cli/test/fixtures/client-with-config/openapi.json
+++ b/packages/client-cli/test/fixtures/client-with-config/openapi.json
@@ -1,10 +1,5 @@
 {
   "openapi": "3.0.3",
-  "info": {
-    "title": "FAN TOZZI",
-    "description": "Tozzi Fan!",
-    "version": "1.0.0"
-  },
   "components": {
     "schemas": {
       "Movie": {

--- a/packages/client-cli/test/fixtures/tsdoc-openapi.json
+++ b/packages/client-cli/test/fixtures/tsdoc-openapi.json
@@ -1,0 +1,142 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Movies API",
+    "description": "An API with movies in it",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "Movie": {
+        "title": "Movie",
+        "description": "A Movie",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "description": "The title of the movie",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      }
+    }
+  },
+  "paths": {
+    "/movies/": {
+      "post": {
+        "summary": "Create a movie",
+        "description": "Add a new movie to the movies database",
+        "operationId": "createMovie",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Movie"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              }
+            },
+            "links": {}
+          }
+        }
+      }
+    },
+    "/movies/{id}": {
+      "get": {
+        "summary": "Get a movie",
+        "operationId": "getMovieById",
+        "parameters": [
+          {
+            "description": "The ID of the movie",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              }
+            },
+            "links": {}
+          }
+        }
+      },
+      "put": {
+        "description": "Update the details of a movie",
+        "operationId": "updateMovie",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Movie"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "id",
+                  "title"
+                ]
+              }
+            },
+            "in": "query",
+            "name": "fields",
+            "required": false
+          },
+          {
+            "description": "The ID of the movie",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              }
+            },
+            "links": {}
+          }
+        }
+      },
+    }
+  }
+}

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -136,9 +136,25 @@ export const getCustomSwagger = async (request) => {
 export interface Sample {
   setBaseUrl(newUrl: string) : void;
   setDefaultHeaders(headers: object) : void;
+  /**
+   * @param req - request parameters object
+   * @returns the API response body
+   */
   getCustomSwagger(req: GetCustomSwaggerRequest): Promise<GetCustomSwaggerResponses>;
+  /**
+   * @param req - request parameters object
+   * @returns the API response body
+   */
   getRedirect(req: GetRedirectRequest): Promise<GetRedirectResponses>;
+  /**
+   * @param req - request parameters object
+   * @returns the API response body
+   */
   getReturnUrl(req: GetReturnUrlRequest): Promise<GetReturnUrlResponses>;
+  /**
+   * @param req - request parameters object
+   * @returns the API response body
+   */
   postFoobar(req: PostFoobarRequest): Promise<PostFoobarResponses>;
 }`
 
@@ -264,6 +280,10 @@ export const getHello: Api['getHello'] = async (request: Types.GetHelloRequest):
 export interface Api {
   setBaseUrl(newUrl: string) : void;
   setDefaultHeaders(headers: object) : void;
+  /**
+   * @param req - request parameters object
+   * @returns the API response body
+   */
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`
 
@@ -293,6 +313,10 @@ export const getHello: ACustomName['getHello'] = async (request: Types.GetHelloR
 export interface ACustomName {
   setBaseUrl(newUrl: string) : void;
   setDefaultHeaders(headers: object) : void;
+  /**
+   * @param req - request parameters object
+   * @returns the API response body
+   */
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`
 
@@ -749,6 +773,10 @@ import type * as Types from './client-types'`))
   ok(types.includes(`export interface Client {
   setBaseUrl(newUrl: string) : void;
   setDefaultHeaders(headers: object) : void;
+  /**
+   * @param req - request parameters object
+   * @returns the API response body
+   */
   getHello(req: GetHelloRequest): Promise<GetHelloResponses>;
 }`))
   ok(types.includes("type PlatformaticFrontendClient = Omit<Client, 'setBaseUrl'>"))

--- a/packages/client-cli/test/responses-writer.test.mjs
+++ b/packages/client-cli/test/responses-writer.test.mjs
@@ -43,7 +43,6 @@ test('support multiple responses', async (t) => {
         }
       }
     }
-
   }
 
   const output = responsesWriter('MyOperation', responses, false, writer)
@@ -52,6 +51,67 @@ export type MyOperationResponseOK = {
   'id': number;
   'unfriendly-key'?: string;
 }
+export type MyOperationResponseForbidden = {
+  'message': string;
+}
+export type MyOperationResponses =
+  MyOperationResponseOK
+  | MyOperationResponseForbidden`
+
+  assert.equal(writer.toString().trim(), expected.trim())
+  assert.equal(output, 'MyOperationResponses')
+})
+
+test('tsdoc comment with response description and summary properties', async (t) => {
+  const writer = getWriter()
+  const responses = {
+    200: {
+      description: 'Response description',
+      summary: 'Response summary',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              id: { type: 'number' },
+              'unfriendly-key': { type: 'string' }
+            },
+            required: ['id']
+          }
+        }
+      }
+    },
+    403: {
+      description: 'Response description',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' }
+            },
+            required: ['message']
+          }
+        }
+      }
+    }
+
+  }
+
+  const output = responsesWriter('MyOperation', responses, false, writer)
+  const expected = `
+/**
+ * Response summary
+ *
+ * Response description
+ */
+export type MyOperationResponseOK = {
+  'id': number;
+  'unfriendly-key'?: string;
+}
+/**
+ * Response description
+ */
 export type MyOperationResponseForbidden = {
   'message': string;
 }


### PR DESCRIPTION
Adds tsdoc comments to client-cli generated types, to give you info in your editor what the different APIs do, and what the different request parameters are.

Example

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/129ef4c2-466f-40bc-9503-1a71102063c2) | ![image](https://github.com/user-attachments/assets/9b9a10fd-78b3-4a9b-a66d-74b0635b7bce)  |
| ![image](https://github.com/user-attachments/assets/dcab8af5-d010-4e94-968f-dcb2c35e0ee7)  | ![image](https://github.com/user-attachments/assets/76a9dfc6-6cbb-4612-a7de-f0e0b98afe35)  |
| ![image](https://github.com/user-attachments/assets/ff2df3f5-e774-4fb1-8ae2-1a1ea34ee6c1) | ![image](https://github.com/user-attachments/assets/477a5603-e008-4682-8217-575cf0048846)  |

(Your mileage with your editor may vary!)