### PR TITLE
Load .env of app or services by default

### DIFF
--- a/packages/runtime/fixtures/env-service/platformatic.json
+++ b/packages/runtime/fixtures/env-service/platformatic.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/1.52.0.json",
+  "entrypoint": "hello",
+  "services": [
+    {
+      "id": "hello",
+      "path": "services/hello",
+      "env": {
+        "FROM_SERVICE_CONFIG_FILE": "true",
+        "OVERRIDE_TEST": "service-override"
+      },
+      "logger": {
+        "level": "trace"
+      }
+    }
+  ],
+  "env": {
+    "FROM_MAIN_CONFIG_FILE": "true",
+    "OVERRIDE_TEST": "top-level"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 3000,
+    "logger": {
+      "level": "trace"
+    }
+  }
+}

--- a/packages/runtime/fixtures/env-service/services/hello/.env
+++ b/packages/runtime/fixtures/env-service/services/hello/.env
@@ -1,0 +1,1 @@
+FROM_ENV_FILE=true

--- a/packages/runtime/fixtures/env-service/services/hello/package.json
+++ b/packages/runtime/fixtures/env-service/services/hello/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "server.js"
+}

--- a/packages/runtime/fixtures/env-service/services/hello/server.js
+++ b/packages/runtime/fixtures/env-service/services/hello/server.js
@@ -1,0 +1,22 @@
+import { createServer } from 'node:http'
+
+const {
+  FROM_ENV_FILE,
+  FROM_MAIN_CONFIG_FILE,
+  FROM_SERVICE_CONFIG_FILE,
+  OVERRIDE_TEST
+} = process.env
+
+export function build () {
+  return createServer((req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'application/json'
+    })
+    res.end(JSON.stringify({
+      FROM_ENV_FILE,
+      FROM_MAIN_CONFIG_FILE,
+      FROM_SERVICE_CONFIG_FILE,
+      OVERRIDE_TEST
+    }))
+  })
+}

--- a/packages/runtime/fixtures/env/.env
+++ b/packages/runtime/fixtures/env/.env
@@ -1,0 +1,1 @@
+FROM_ENV_FILE=true

--- a/packages/runtime/fixtures/env/platformatic.json
+++ b/packages/runtime/fixtures/env/platformatic.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/1.52.0.json",
+  "entrypoint": "hello",
+  "services": [
+    {
+      "id": "hello",
+      "path": "services/hello",
+      "env": {
+        "FROM_SERVICE_CONFIG_FILE": "true",
+        "OVERRIDE_TEST": "service-override"
+      },
+      "logger": {
+        "level": "trace"
+      }
+    }
+  ],
+  "env": {
+    "FROM_MAIN_CONFIG_FILE": "true",
+    "OVERRIDE_TEST": "top-level"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 3000,
+    "logger": {
+      "level": "trace"
+    }
+  }
+}

--- a/packages/runtime/fixtures/env/services/hello/package.json
+++ b/packages/runtime/fixtures/env/services/hello/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "server.js"
+}

--- a/packages/runtime/fixtures/env/services/hello/server.js
+++ b/packages/runtime/fixtures/env/services/hello/server.js
@@ -1,0 +1,22 @@
+import { createServer } from 'node:http'
+
+const {
+  FROM_ENV_FILE,
+  FROM_MAIN_CONFIG_FILE,
+  FROM_SERVICE_CONFIG_FILE,
+  OVERRIDE_TEST
+} = process.env
+
+export function build () {
+  return createServer((req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'application/json'
+    })
+    res.end(JSON.stringify({
+      FROM_ENV_FILE,
+      FROM_MAIN_CONFIG_FILE,
+      FROM_SERVICE_CONFIG_FILE,
+      OVERRIDE_TEST
+    }))
+  })
+}

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -29,7 +29,7 @@ async function restartRuntime (runtime) {
 }
 
 async function buildRuntime (configManager, env) {
-  env = env || process.env
+  env = env || configManager.env
 
   if (inspector.url() && !env.VSCODE_INSPECTOR_OPTIONS) {
     throw new errors.NodeInspectorFlagsNotSupportedError()

--- a/packages/runtime/lib/start.js
+++ b/packages/runtime/lib/start.js
@@ -29,7 +29,7 @@ async function restartRuntime (runtime) {
 }
 
 async function buildRuntime (configManager, env) {
-  env = env || configManager.env
+  env = env || Object.assign({}, process.env, configManager.env)
 
   if (inspector.url() && !env.VSCODE_INSPECTOR_OPTIONS) {
     throw new errors.NodeInspectorFlagsNotSupportedError()

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -105,14 +105,18 @@ async function main () {
   const service = workerData.serviceConfig
 
   // Load env file and mixin env vars from service config
+  let envfile
   if (service.envfile) {
-    const envfile = resolve(workerData.dirname, service.envfile)
-    globalThis.platformatic.logger.info({ envfile }, 'Loading envfile...')
-
-    dotenv.config({
-      path: envfile
-    })
+    envfile = resolve(workerData.dirname, service.envfile)
+  } else {
+    envfile = resolve(workerData.serviceConfig.path, '.env')
   }
+
+  globalThis.platformatic.logger.debug({ envfile }, 'Loading envfile...')
+
+  dotenv.config({
+    path: envfile
+  })
 
   if (config.env) {
     Object.assign(process.env, config.env)

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -385,6 +385,35 @@ test('supports configurable envfile location', async t => {
   })
 })
 
+test('supports default envfile location', async t => {
+  const configFile = join(fixturesDir, 'env-service', 'platformatic.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const dirname = config.configManager.dirname
+  const runtimeLogsDir = getRuntimeLogsDir(dirname, process.pid)
+
+  const runtime = new Runtime(config.configManager, runtimeLogsDir, process.env)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.init()
+  await runtime.start()
+
+  const { payload } = await runtime.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  assert.deepStrictEqual(data, {
+    FROM_ENV_FILE: 'true',
+    FROM_MAIN_CONFIG_FILE: 'true',
+    FROM_SERVICE_CONFIG_FILE: 'true',
+    OVERRIDE_TEST: 'service-override'
+  })
+})
+
 test('supports configurable arguments', async t => {
   const configFile = join(fixturesDir, 'custom-argv', 'platformatic.json')
   const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)

--- a/packages/runtime/test/start/custom-environment.test.js
+++ b/packages/runtime/test/start/custom-environment.test.js
@@ -29,3 +29,28 @@ test('can start with a custom environment', async (t) => {
   })
   process.exitCode = 0
 })
+
+test('should pass global .env data to workers', async t => {
+  const configFile = join(fixturesDir, 'env', 'platformatic.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildRuntime(config.configManager)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const { payload } = await app.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  assert.deepStrictEqual(data, {
+    FROM_ENV_FILE: 'true',
+    FROM_MAIN_CONFIG_FILE: 'true',
+    FROM_SERVICE_CONFIG_FILE: 'true',
+    OVERRIDE_TEST: 'service-override'
+  })
+})


### PR DESCRIPTION
I think developers _expects_ that the `.env` of individual services to be loaded, and the `.env` of the root app to be available.

This fixes it.