### PR TITLE
fix: correctly interpret Record response

### DIFF
--- a/packages/client-cli/lib/responses-writer.mjs
+++ b/packages/client-cli/lib/responses-writer.mjs
@@ -1,7 +1,6 @@
 'use strict'
 import { STATUS_CODES } from 'node:http'
 import { capitalize, classCase, getResponseContentType, getResponseTypes } from './utils.mjs'
-import { writeObjectProperties } from './openapi-common.mjs'
 import { getType } from './get-type.mjs'
 
 function responsesWriter (operationId, responsesObject, isFullResponse, writer, spec) {
@@ -77,13 +76,7 @@ function responsesWriter (operationId, responsesObject, isFullResponse, writer, 
       }
       writer.writeLine(' */')
     }
-    if (responseSchema.type === 'object') {
-      writer.write(`export type ${typeName} =`).block(() => {
-        writeObjectProperties(writer, responseSchema, spec, new Set(), 'res')
-      })
-    } else {
-      writer.writeLine(`export type ${typeName} = ${getType(responseSchema, 'res', spec)}`)
-    }
+    writer.writeLine(`export type ${typeName} = ${getType(responseSchema, 'res', spec)}`)
   }
 }
 

--- a/packages/client-cli/test/cli-openapi-additional-properties.test.mjs
+++ b/packages/client-cli/test/cli-openapi-additional-properties.test.mjs
@@ -14,10 +14,8 @@ test('export formdata on full request object', async (t) => {
   const typeFile = join(dir, 'additional-props', 'additional-props.d.ts')
   const data = await readFile(typeFile, 'utf-8')
   equal(data.includes(`
-  export type GetSampleResponseOK = {
-    'entities': { 'foo'?: Record<string, { 'id': string; 'name': string }>; 'bar'?: Record<string, { 'type': 'boolean' | 'list'; 'values': Array<{ 'id': string; 'isArchived'?: boolean; 'isDefault': boolean; 'value': string }> }>; 'baz'?: Record<string, { 'id': string; 'name': string }> };
-    'errors': { 'types'?: Record<string, { 'cause'?: unknown; 'type': 'notFound' | 'other' }>; 'group': Record<string, { 'cause'?: unknown; 'type': 'notFound' | 'other' }> };
-    'xyz'?: Record<string, number>;
-    'fantozzi'?: { 'carlo'?: string; 'martello'?: number; [key: string]: unknown };
-  }`), true)
+  export type GetSampleResponseOK = { 'entities': { 'foo'?: Record<string, { 'id': string; 'name': string }>; 'bar'?: Record<string, { 'type': 'boolean' | 'list'; 'values': Array<{ 'id': string; 'isArchived'?: boolean; 'isDefault': boolean; 'value': string }> }>; 'baz'?: Record<string, { 'id': string; 'name': string }> }; 'errors': { 'types'?: Record<string, { 'cause'?: unknown; 'type': 'notFound' | 'other' }>; 'group': Record<string, { 'cause'?: unknown; 'type': 'notFound' | 'other' }> }; 'xyz'?: Record<string, number>; 'fantozzi'?: { 'carlo'?: string; 'martello'?: number; [key: string]: unknown } }`), true)
+
+  equal(data.includes(`
+  export type GetAnotherResponseOK = Record<string, { 'description': string }>`), true)
 })

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -830,9 +830,7 @@ test('nested optional parameters are correctly identified', async (t) => {
   const data = await readFile(typeFile, 'utf-8')
 
   equal(data.includes(`
-  export type GetMoviesResponseOK = {
-    'data': { 'foo': string; 'bar'?: string; 'baz'?: { 'nested1'?: string; 'nested2': string } };
-  }
+  export type GetMoviesResponseOK = { 'data'?: { 'foo': string; 'bar'?: string; 'baz'?: { 'nested1'?: string; 'nested2': string } } }
 `), true)
 })
 

--- a/packages/client-cli/test/fixtures/additional-properties-openapi.json
+++ b/packages/client-cli/test/fixtures/additional-properties-openapi.json
@@ -142,6 +142,31 @@
           }
         }
       }
+    },
+    "/another": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["description"],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/client-cli/test/frontend-openapi.test.mjs
+++ b/packages/client-cli/test/frontend-openapi.test.mjs
@@ -48,11 +48,11 @@ test('build basic client from url', async (t) => {
   ok(types.includes("'normalStringReq': string;"))
 
   // Response shouldn't contain `Date` for the same fields as above
-  ok(types.includes("'messageRes': string | null;"))
-  ok(types.includes("'dateTimeRes': string;"))
-  ok(types.includes("'otherDateRes': string;"))
-  ok(types.includes("'nullableDateRes': string | null;"))
-  ok(types.includes("'normalStringRes': string;"))
+  ok(types.includes("'messageRes'?: string | null;"))
+  ok(types.includes("'dateTimeRes'?: string;"))
+  ok(types.includes("'otherDateRes'?: string;"))
+  ok(types.includes("'nullableDateRes'?: string | null;"))
+  ok(types.includes("'normalStringRes'?: string"))
 
   // handle non 200 code endpoint
   const expectedImplementation = `

--- a/packages/client-cli/test/responses-writer.test.mjs
+++ b/packages/client-cli/test/responses-writer.test.mjs
@@ -47,13 +47,8 @@ test('support multiple responses', async (t) => {
 
   const output = responsesWriter('MyOperation', responses, false, writer)
   const expected = `
-export type MyOperationResponseOK = {
-  'id': number;
-  'unfriendly-key'?: string;
-}
-export type MyOperationResponseForbidden = {
-  'message': string;
-}
+export type MyOperationResponseOK = { 'id': number; 'unfriendly-key'?: string }
+export type MyOperationResponseForbidden = { 'message': string }
 export type MyOperationResponses =
   MyOperationResponseOK
   | MyOperationResponseForbidden`
@@ -105,16 +100,11 @@ test('tsdoc comment with response description and summary properties', async (t)
  *
  * Response description
  */
-export type MyOperationResponseOK = {
-  'id': number;
-  'unfriendly-key'?: string;
-}
+export type MyOperationResponseOK = { 'id': number; 'unfriendly-key'?: string }
 /**
  * Response description
  */
-export type MyOperationResponseForbidden = {
-  'message': string;
-}
+export type MyOperationResponseForbidden = { 'message': string }
 export type MyOperationResponses =
   MyOperationResponseOK
   | MyOperationResponseForbidden`
@@ -173,10 +163,7 @@ test('support object', async (t) => {
   }
   responsesWriter('TheOperationId', responses, false, writer)
   assert.equal(writer.toString().trim(), `
-export type TheOperationIdResponseOK = {
-  'id': number;
-  'name'?: string;
-}
+export type TheOperationIdResponseOK = { 'id': number; 'name'?: string }
 export type TheOperationIdResponses =
   TheOperationIdResponseOK
 `.trim())


### PR DESCRIPTION
# Context

When the OpenAPI specs are defined with:
```
"application/json": {
  "schema": {
    "type": "object",
    "additionalProperties": {
      "type": "object",
      "properties": {
        "description": {
          "type": "string"
        }
      },
      "required": ["description"],
      "additionalProperties": false
    }
  }
}
```
the generated types will currently be:
```
export type GetAnotherResponseOK = {
    'type': unknown;
    'properties': unknown;
    'required': unknown;
    'additionalProperties': unknown;
  }
```

# Solution

Make sure that the generated types are `Record<string, { 'description': string }>` by using the `getType` function which is better handling the optional & addition properties than `writeObjectProperties`.