### PR TITLE
fix: correctly handle nullable properties

### DIFF
--- a/packages/client-cli/test/cli-openapi-nullable-properties.test.mjs
+++ b/packages/client-cli/test/cli-openapi-nullable-properties.test.mjs
@@ -1,0 +1,32 @@
+import { moveToTmpdir } from './helper.js'
+import { test, after } from 'node:test'
+import { equal } from 'node:assert'
+import { join } from 'path'
+import * as desm from 'desm'
+import { execa } from 'execa'
+import { readFile } from 'fs/promises'
+
+test('generate types with nullable properties', async (t) => {
+  const dir = await moveToTmpdir(after)
+
+  const openAPIfile = desm.join(
+    import.meta.url,
+    'fixtures',
+    'nullable-properties-openapi.json'
+  )
+  await execa('node', [
+    desm.join(import.meta.url, '..', 'cli.mjs'),
+    openAPIfile,
+    '--name',
+    'nullable-props',
+    '--full-request',
+    '--full-response',
+  ])
+  const typeFile = join(dir, 'nullable-props', 'nullable-props.d.ts')
+  const data = await readFile(typeFile, 'utf-8')
+  equal(
+    data.includes(`
+  export type GetSampleResponseOK = { 'rowDisplayOptions'?: Array<string> | null; 'columnDisplayOptions'?: Array<string>; 'entities'?: { 'id'?: string; 'name'?: string | null; 'operator'?: '=' | '!=' | null; 'value'?: 'toto' | 'tata' } | null }`),
+    true
+  )
+})

--- a/packages/client-cli/test/fixtures/nullable-properties-openapi.json
+++ b/packages/client-cli/test/fixtures/nullable-properties-openapi.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/sample": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "rowDisplayOptions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true
+                    },
+                    "columnDisplayOptions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": false
+                    },
+                    "entities": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "nullable": false
+                        },
+                        "name": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": ["=", "!="],
+                          "nullable": true
+                        },
+                        "value": {
+                          "type": "string",
+                          "enum": ["toto", "tata"],
+                          "nullable": false
+                        }
+                      },
+                      "type": "object",
+                      "nullable": true
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Context

The property `nullable` is currently not used for `object`, `array` and `enum` when generating the types.

# Solution

Add the check on the nullable property and a test for cases with and without this property