### PR TITLE
Fix updateMany missing permission in db package config file

### DIFF
--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -249,6 +249,9 @@ const sharedAuthorizationRule = {
   find: {
     $ref: '#/$defs/crud-operation-auth'
   },
+  updateMany: {
+    $ref: '#/$defs/crud-operation-auth'
+  },
   save: {
     $ref: '#/$defs/crud-operation-auth'
   },


### PR DESCRIPTION
In custom plugin, using platformaticContext, updateMany method always results in PLT_DB_AUTH_UNAUTHORIZED response. That because of `rule.updateMany` always `undefined` at the following check https://github.com/platformatic/platformatic/blob/11d986537c657e4d4bbd3fb4fcdfbc7301e1c8a2/packages/db-authorization/index.js#L285 

Adding updateMany rules to JSON config cause config validation fail as additional props not allowed in rule object.

I updated [db config schema](https://github.com/platformatic/platformatic/blob/11d986537c657e4d4bbd3fb4fcdfbc7301e1c8a2/packages/db/lib/schema.js), adding updateMany as available rule