### PR TITLE
feat(client-cli): add @deprecated jsdoc tag to deprecated client methods

### DIFF
--- a/packages/client-cli/lib/openapi-common.mjs
+++ b/packages/client-cli/lib/openapi-common.mjs
@@ -15,7 +15,7 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
   let currentFullResponse = originalFullResponse
   let currentFullRequest = originalFullRequest
   for (const operation of operations) {
-    const { operationId, description, summary } = operation.operation
+    const { operationId, description, summary, deprecated } = operation.operation
     const camelCaseOperationId = camelcase(operationId)
     const { parameters, responses, requestBody } = operation.operation
     currentFullRequest = fullRequest || hasDuplicatedParameters(operation.operation)
@@ -116,6 +116,9 @@ export function writeOperations (interfacesWriter, mainWriter, operations, { ful
         mainWriter.writeLine(` * ${line}`)
       }
     }
+    if (deprecated) {
+      mainWriter.writeLine(' * @deprecated')
+    }
     mainWriter.writeLine(' * @param req - request parameters object')
     mainWriter.writeLine(` * @returns the API response${fullResponse ? '' : ' body'}`)
     mainWriter.writeLine(' */')
@@ -148,10 +151,15 @@ export function writeProperties (writer, blockName, parameters, addedProps, meth
 export function writeProperty (writer, key, value, addedProps, required = true, methodType, spec) {
   addedProps.add(key)
 
-  if (value.description) {
+  if (value.description || value.deprecated) {
     writer.writeLine('/**')
-    for (const line of value.description.split('\n')) {
-      writer.writeLine(` * ${line}`)
+    if (value.description) {
+      for (const line of value.description.split('\n')) {
+        writer.writeLine(` * ${line}`)
+      }
+    }
+    if (value.deprecated) {
+      writer.writeLine(' * @deprecated')
     }
     writer.writeLine(' */')
   }

--- a/packages/client-cli/test/cli-openapi.test.mjs
+++ b/packages/client-cli/test/cli-openapi.test.mjs
@@ -1244,6 +1244,16 @@ test('tsdoc client operation descriptions', async (t) => {
      * @returns the API response body
      */
     updateMovie(req: UpdateMovieRequest): Promise<UpdateMovieResponses>;`))
+
+  // Deprecated method
+  ok(data.includes(`
+    /**
+     * Patch a movie
+     * @deprecated
+     * @param req - request parameters object
+     * @returns the API response body
+     */
+    patchMovie(req: PatchMovieRequest): Promise<PatchMovieResponses>;`))
 })
 
 test('tsdoc client request option descriptions', async (t) => {
@@ -1255,16 +1265,6 @@ test('tsdoc client request option descriptions', async (t) => {
   const data = await readFile(join(dir, 'tsdoc', 'tsdoc.d.ts'), 'utf-8')
 
   // Description on title, not on id, built from requestBody scheme #ref
-  ok(data.includes(`
-  export type CreateMovieRequest = {
-    'id'?: number;
-    /**
-     * The title of the movie
-     */
-    'title': string;
-  }`))
-
-  // Description on title, not on id, built from requestBody schema #ref
   ok(data.includes(`
   export type CreateMovieRequest = {
     'id'?: number;
@@ -1289,6 +1289,24 @@ test('tsdoc client request option descriptions', async (t) => {
     'fields'?: Array<'id' | 'title'>;
     /**
      * The ID of the movie
+     */
+    'id': number;
+    /**
+     * The title of the movie
+     */
+    'title': string;
+  }`))
+
+  // Deprecated fields with and without descriptions
+  ok(data.includes(`
+  export type PatchMovieRequest = {
+    /**
+     * @deprecated
+     */
+    'fields'?: Array<'id' | 'title'>;
+    /**
+     * The ID of the movie
+     * @deprecated
      */
     'id': number;
     /**

--- a/packages/client-cli/test/fixtures/tsdoc-openapi.json
+++ b/packages/client-cli/test/fixtures/tsdoc-openapi.json
@@ -137,6 +137,61 @@
           }
         }
       },
+      "patch": {
+        "summary": "Patch a movie",
+        "operationId": "patchMovie",
+        "deprecated": true,
+        "parameters": [
+          {
+            "deprecated": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "id",
+                  "title"
+                ]
+              }
+            },
+            "in": "query",
+            "name": "fields",
+            "required": false
+          },
+          {
+            "description": "The ID of the movie",
+            "deprecated": true,
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Movie"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              }
+            },
+            "links": {}
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Hi, generated a new client for an API today then after checking their swagger I realised I'd been using deprecated methods (they're greyed out in the UI).

Adding `@deprecated` jsdoc tags to the client types so I can avoid making the same mistake in the future :)

| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/f5e3fe5e-5835-466c-8533-4dc50466fa7e) | ![image](https://github.com/user-attachments/assets/f0113bcc-a4e4-43fa-aada-ecccef147610)    |
| ![image](https://github.com/user-attachments/assets/3bcc6566-a45f-491f-828c-8f7883c0e886) |  ![image](https://github.com/user-attachments/assets/81746b1c-bc94-45c7-b2b2-dce853409e83)  |

(Crosses out deprecated methods, but again your mileage may vary for your editor of choice!)