### PR TITLE
fix(control): add missing metric type

### DIFF
--- a/packages/control/index.d.ts
+++ b/packages/control/index.d.ts
@@ -48,6 +48,7 @@ declare namespace control {
   interface MetricValue {
     value: number,
     labels: {
+      quantile?: number,
       type?: string,
       space?: string,
       version?: string,

--- a/packages/control/index.test-d.ts
+++ b/packages/control/index.test-d.ts
@@ -26,6 +26,7 @@ expectType<string>(service.services[0].id)
 expectType<string>(service.services[0].status)
 expectType<string>(metric.aggregator)
 expectType<string>(metric.values[0].labels.serviceId)
+expectType<number>(metric.values[0].labels?.quantile)
 expectType<Promise<void>>(api.close())
 
 // errors

--- a/packages/control/index.test-d.ts
+++ b/packages/control/index.test-d.ts
@@ -26,7 +26,7 @@ expectType<string>(service.services[0].id)
 expectType<string>(service.services[0].status)
 expectType<string>(metric.aggregator)
 expectType<string>(metric.values[0].labels.serviceId)
-expectType<number>(metric.values[0].labels?.quantile)
+expectType<number | undefined>(metric.values[0].labels?.quantile)
 expectType<Promise<void>>(api.close())
 
 // errors


### PR DESCRIPTION
Fix for https://github.com/platformatic/watt-admin/pull/24/files#diff-511e34c1ee368c527d7e811a3e07a4dec0bd755bfe568f11e498bfe6fc5ef67bR152