### PR TITLE
fix(client cli): dedicated case for 204 response

### DIFF
--- a/packages/client-cli/lib/responses-writer.mjs
+++ b/packages/client-cli/lib/responses-writer.mjs
@@ -35,9 +35,9 @@ function responsesWriter (operationId, responsesObject, isFullResponse, writer, 
       const isStatusCodeRange = lowerStatusCode === '1xx' || lowerStatusCode === '2xx' || lowerStatusCode === '3xx' || lowerStatusCode === '4xx' || lowerStatusCode === '5xx'
       if (statusCode === '204') {
         if (isFullResponse) {
-          typeName = undefined
+          typeName = 'unknown'
         } else {
-          return 'undefined'
+          return 'unknown'
         }
       }
       if (isResponseArray) typeName = `Array<${typeName}>`

--- a/packages/client-cli/test/responses-writer.test.mjs
+++ b/packages/client-cli/test/responses-writer.test.mjs
@@ -191,7 +191,7 @@ test('support 204 without full response', async () => {
   responsesWriter('FantozziFilini', responses, false, writer)
   assert.equal(writer.toString().trim(), `export type FantozziFiliniResponseNoContent = { 'fantozzi': number; 'filini'?: string }
 export type FantozziFiliniResponses =
-  undefined
+  unknown
 `.trim(), 'result without full response')
 })
 
@@ -217,7 +217,7 @@ test('support 204 with full response', async () => {
   responsesWriter('FiliniFantozzi', responses, true, writer)
   assert.equal(writer.toString().trim(), `export type FiliniFantozziResponseNoContent = { 'filini': number; 'fantozzi'?: string }
 export type FiliniFantozziResponses =
-  FullResponse<undefined, 204>
+  FullResponse<unknown, 204>
 `.trim(), 'result with full response')
 })
 


### PR DESCRIPTION
Add a dedicated and special case for `204` responses to always return `undefined` on the frontend client.