### PR TITLE
Added admin command

### DIFF
--- a/packages/wattpm/index.js
+++ b/packages/wattpm/index.js
@@ -9,6 +9,7 @@ import { logsCommand } from './lib/commands/logs.js'
 import { configCommand, envCommand, psCommand, servicesCommand } from './lib/commands/management.js'
 import { metricsCommand } from './lib/commands/metrics.js'
 import { patchConfigCommand } from './lib/commands/patch-config.js'
+import { adminCommand } from './lib/commands/admin.js'
 import { version } from './lib/schema.js'
 import { createLogger, overrideFatal, parseArgs, setVerbose } from './lib/utils.js'
 
@@ -110,6 +111,9 @@ export async function main () {
       break
     case 'metrics':
       command = metricsCommand
+      break
+    case 'admin':
+      command = adminCommand
       break
     default:
       logger.fatal(

--- a/packages/wattpm/lib/commands/admin.js
+++ b/packages/wattpm/lib/commands/admin.js
@@ -1,0 +1,37 @@
+import { spawn } from 'node:child_process'
+import { parseArgs } from '../utils.js'
+
+export function adminCommand (logger, args) {
+  logger.info('Running watt-admin via npx')
+  const {
+    values: { latest },
+  } = parseArgs(
+    args,
+    {
+      latest: {
+        type: 'boolean',
+        short: 'l'
+      },
+    },
+    false
+  )
+  const modifier = latest ? '@latest' : ''
+  const proc = spawn('npx', ['-y', '@platformatic/watt-admin' + modifier], { stdio: 'inherit' })
+
+  proc.on('exit', (code) => {
+    process.exit(code)
+  })
+}
+
+export const help = {
+  admin: {
+    usage: 'admin',
+    description: 'Start the admin interface',
+    options: [
+      {
+        usage: '-l --latest',
+        description: 'Use the latest version of @platformatic/watt-admin from',
+      },
+    ]
+  },
+}


### PR DESCRIPTION
This adds the `wattpm admin` command that defers to npx.

I didn't add tests because I don't want to add a module mocking system right now (and deal with the complexity of ESM loaders).
The code is simple enough.