### PR TITLE
#230 (part 1) - Cursor pagination in sql-mapper

### DIFF
--- a/packages/sql-mapper/lib/cursor.js
+++ b/packages/sql-mapper/lib/cursor.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const errors = require('./errors')
+
+function encodeCursor () {} // todo(shcube): api
+function decodeCursor () {} // todo(shcube): api
+// todo(shcube): verify That unique field present
+
+function getCursorFields (cursor, orderBy, inputToFieldMap, fields) {
+  if (!orderBy || orderBy.length === 0) throw new errors.MissingOrderByClauseError()
+  const cursorFields = []
+  for (const [key, value] of Object.entries(cursor)) {
+    const dbField = inputToFieldMap[key]
+    if (!dbField) throw new errors.UnknownFieldError(key)
+    const order = orderBy.find((order) => order.field === key)
+    if (!order) throw new errors.MissingOrderByFieldForCursorError(key)
+    cursorFields.push({
+      dbField,
+      fieldWrap: fields[dbField],
+      value,
+      direction: order.direction,
+    })
+  }
+  return cursorFields
+}
+
+// todo(shcube): remove db prop after test
+function buildCursorCondition (sql, cursor, orderBy, inputToFieldMap, fields, computeCriteriaValue, db) {
+  if (!cursor || Object.keys(cursor).length === 0) return null
+
+  const cursorFields = getCursorFields(cursor, orderBy, inputToFieldMap, fields)
+  const conditions = []
+  const equalityParts = []
+
+  for (const { dbField, fieldWrap, value, direction } of cursorFields) {
+    const operator = direction.toLowerCase() === 'desc' ? '<' : '>'
+    const inequalityPart = sql`${sql.ident(dbField)} ${sql.__dangerous__rawValue(operator)} ${computeCriteriaValue(fieldWrap, value)}`
+    if (equalityParts.length === 0) {
+      conditions.push(inequalityPart)
+    } else {
+      conditions.push(sql`${sql.join(equalityParts, sql` AND `)} AND ${inequalityPart}`)
+    }
+    equalityParts.push(sql`${sql.ident(dbField)} = ${computeCriteriaValue(fieldWrap, value)}`)
+  }
+
+  return sql`(${sql.join(conditions, sql` OR `)})`
+}
+
+module.exports = {
+  buildCursorCondition,
+  encodeCursor,
+  decodeCursor
+}

--- a/packages/sql-mapper/lib/cursor.js
+++ b/packages/sql-mapper/lib/cursor.js
@@ -4,36 +4,52 @@ const errors = require('./errors')
 
 function encodeCursor () {} // todo(shcube): api
 function decodeCursor () {} // todo(shcube): api
-// todo(shcube): verify That unique field present
 
-function getCursorFields (cursor, orderBy, inputToFieldMap, fields) {
+function getCursorFields (cursor, orderBy, inputToFieldMap, fields, primaryKeys) {
   if (!orderBy || orderBy.length === 0) throw new errors.MissingOrderByClauseError()
-  const cursorFields = []
+  let hasUniqueField = false
+  const validCursorFields = new Map()
+
   for (const [key, value] of Object.entries(cursor)) {
     const dbField = inputToFieldMap[key]
     if (!dbField) throw new errors.UnknownFieldError(key)
     const order = orderBy.find((order) => order.field === key)
     if (!order) throw new errors.MissingOrderByFieldForCursorError(key)
-    cursorFields.push({
+    if (primaryKeys.has(dbField)) hasUniqueField = true
+    validCursorFields.set(key, {
       dbField,
-      fieldWrap: fields[dbField],
       value,
       direction: order.direction,
+      fieldWrap: fields[dbField]
     })
+  }
+  if (!hasUniqueField) throw new errors.MissingUniqueFieldInCursorError()
+
+  // Process fields in orderBy order
+  const cursorFields = []
+  for (const order of orderBy) {
+    if (validCursorFields.has(order.field)) {
+      cursorFields.push(validCursorFields.get(order.field))
+    }
   }
   return cursorFields
 }
 
 // todo(shcube): remove db prop after test
-function buildCursorCondition (sql, cursor, orderBy, inputToFieldMap, fields, computeCriteriaValue, db) {
+function buildCursorCondition (sql, cursor, orderBy, inputToFieldMap, fields, computeCriteriaValue, db, primaryKeys, reverse) {
   if (!cursor || Object.keys(cursor).length === 0) return null
 
-  const cursorFields = getCursorFields(cursor, orderBy, inputToFieldMap, fields)
+  const cursorFields = getCursorFields(cursor, orderBy, inputToFieldMap, fields, primaryKeys)
   const conditions = []
   const equalityParts = []
 
   for (const { dbField, fieldWrap, value, direction } of cursorFields) {
-    const operator = direction.toLowerCase() === 'desc' ? '<' : '>'
+    let operator
+    if (reverse) {
+      operator = direction.toLowerCase() === 'desc' ? '>' : '<'
+    } else {
+      operator = direction.toLowerCase() === 'desc' ? '<' : '>'
+    }
     const inequalityPart = sql`${sql.ident(dbField)} ${sql.__dangerous__rawValue(operator)} ${computeCriteriaValue(fieldWrap, value)}`
     if (equalityParts.length === 0) {
       conditions.push(inequalityPart)

--- a/packages/sql-mapper/lib/cursor.js
+++ b/packages/sql-mapper/lib/cursor.js
@@ -5,7 +5,7 @@ const errors = require('./errors')
 function encodeCursor () {} // todo(shcube): api
 function decodeCursor () {} // todo(shcube): api
 
-function getCursorFields (cursor, orderBy, inputToFieldMap, fields, primaryKeys) {
+function sanitizeCursor (cursor, orderBy, inputToFieldMap, fields, primaryKeys) {
   if (!orderBy || orderBy.length === 0) throw new errors.MissingOrderByClauseError()
   let hasUniqueField = false
   const validCursorFields = new Map()
@@ -77,7 +77,7 @@ function buildQuery (cursorFields, sql, computeCriteriaValue, isBackwardPaginati
 
 function buildCursorCondition (sql, cursor, orderBy, inputToFieldMap, fields, computeCriteriaValue, primaryKeys, isBackwardPagination) {
   if (!cursor || Object.keys(cursor).length === 0) return null
-  const cursorFields = getCursorFields(cursor, orderBy, inputToFieldMap, fields, primaryKeys)
+  const cursorFields = sanitizeCursor(cursor, orderBy, inputToFieldMap, fields, primaryKeys)
   const sameSortDirection = cursorFields.every(({ direction }) => direction === cursorFields[0].direction)
   return sameSortDirection ? buildTupleQuery(cursorFields, sql, computeCriteriaValue, isBackwardPagination) : buildQuery(cursorFields, sql, computeCriteriaValue, isBackwardPagination)
 }

--- a/packages/sql-mapper/lib/cursor.js
+++ b/packages/sql-mapper/lib/cursor.js
@@ -2,9 +2,6 @@
 
 const errors = require('./errors')
 
-function encodeCursor () {} // todo(shcube): api
-function decodeCursor () {} // todo(shcube): api
-
 function sanitizeCursor (cursor, orderBy, inputToFieldMap, fields, primaryKeys) {
   if (!orderBy || orderBy.length === 0) throw new errors.MissingOrderByClauseError()
   let hasUniqueField = false
@@ -79,11 +76,11 @@ function buildCursorCondition (sql, cursor, orderBy, inputToFieldMap, fields, co
   if (!cursor || Object.keys(cursor).length === 0) return null
   const cursorFields = sanitizeCursor(cursor, orderBy, inputToFieldMap, fields, primaryKeys)
   const sameSortDirection = cursorFields.every(({ direction }) => direction === cursorFields[0].direction)
-  return sameSortDirection ? buildTupleQuery(cursorFields, sql, computeCriteriaValue, isBackwardPagination) : buildQuery(cursorFields, sql, computeCriteriaValue, isBackwardPagination)
+  return sameSortDirection
+    ? buildTupleQuery(cursorFields, sql, computeCriteriaValue, isBackwardPagination)
+    : buildQuery(cursorFields, sql, computeCriteriaValue, isBackwardPagination)
 }
 
 module.exports = {
   buildCursorCondition,
-  encodeCursor,
-  decodeCursor
 }

--- a/packages/sql-mapper/lib/errors.js
+++ b/packages/sql-mapper/lib/errors.js
@@ -24,5 +24,4 @@ module.exports = {
   MissingOrderByClauseError: createError(`${ERROR_PREFIX}_MISSING_ORDER_BY_CLAUSE`, 'Missing orderBy clause'),
   MissingOrderByFieldForCursorError: createError(`${ERROR_PREFIX}_MISSING_ORDER_BY_FIELD_FOR_CURSOR`, 'Cursor field(s) %s must be included in orderBy'),
   MissingUniqueFieldInCursorError: createError(`${ERROR_PREFIX}_MISSING_UNIQUE_FIELD_IN_CURSOR`, 'Cursor must contain at least one primary key field'),
-  UniqueFieldNotLastInOrderByWhenCursorError: createError(`${ERROR_PREFIX}_UNIQUE_FIELD_NOT_LAST_IN_ORDER_BY_WHEN_CURSOR`, 'When cursor is used, the unique field must be the last in orderBy clause'),
 }

--- a/packages/sql-mapper/lib/errors.js
+++ b/packages/sql-mapper/lib/errors.js
@@ -22,5 +22,7 @@ module.exports = {
   MissingWhereClauseError: createError(`${ERROR_PREFIX}_MISSING_WHERE_CLAUSE`, 'Missing where clause', 400),
   SQLiteOnlySupportsAutoIncrementOnOneColumnError: createError(`${ERROR_PREFIX}_SQLITE_ONLY_SUPPORTS_AUTO_INCREMENT_ON_ONE_COLUMN`, 'SQLite only supports autoIncrement on one column'),
   MissingOrderByClauseError: createError(`${ERROR_PREFIX}_MISSING_ORDER_BY_CLAUSE`, 'Missing orderBy clause'),
-  MissingOrderByFieldForCursorError: createError(`${ERROR_PREFIX}_MISSING_ORDER_BY_FIELD_FOR_CURSOR`, 'Cursor field "%s" must be included in orderBy'),
+  MissingOrderByFieldForCursorError: createError(`${ERROR_PREFIX}_MISSING_ORDER_BY_FIELD_FOR_CURSOR`, 'Cursor field(s) %s must be included in orderBy'),
+  MissingUniqueFieldInCursorError: createError(`${ERROR_PREFIX}_MISSING_UNIQUE_FIELD_IN_CURSOR`, 'Cursor must contain at least one primary key field'),
+  UniqueFieldNotLastInOrderByWhenCursorError: createError(`${ERROR_PREFIX}_UNIQUE_FIELD_NOT_LAST_IN_ORDER_BY_WHEN_CURSOR`, 'When cursor is used, the unique field must be the last in orderBy clause'),
 }

--- a/packages/sql-mapper/lib/errors.js
+++ b/packages/sql-mapper/lib/errors.js
@@ -21,4 +21,6 @@ module.exports = {
   MissingValueForPrimaryKeyError: createError(`${ERROR_PREFIX}_MISSING_VALUE_FOR_PRIMARY_KEY`, 'Missing value for primary key %s'),
   MissingWhereClauseError: createError(`${ERROR_PREFIX}_MISSING_WHERE_CLAUSE`, 'Missing where clause', 400),
   SQLiteOnlySupportsAutoIncrementOnOneColumnError: createError(`${ERROR_PREFIX}_SQLITE_ONLY_SUPPORTS_AUTO_INCREMENT_ON_ONE_COLUMN`, 'SQLite only supports autoIncrement on one column'),
+  MissingOrderByClauseError: createError(`${ERROR_PREFIX}_MISSING_ORDER_BY_CLAUSE`, 'Missing orderBy clause'),
+  MissingOrderByFieldForCursorError: createError(`${ERROR_PREFIX}_MISSING_ORDER_BY_FIELD_FOR_CURSOR`, 'Cursor field "%s" must be included in orderBy'),
 }

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -140,6 +140,10 @@ export interface WhereCondition {
   }
 }
 
+export type Cursor = {
+  [columnName: string]: string | number | boolean | null,
+}
+
 interface Find<EntityFields> {
   (options?: {
     /**
@@ -167,6 +171,10 @@ interface Find<EntityFields> {
      * @default true
      */
     paginate?: boolean,
+    /**
+     * Cursor to paginate the results.
+     */
+    cursor?: Cursor,
     /**
      * If present, the entity participates in transaction
      */

--- a/packages/sql-mapper/mapper.d.ts
+++ b/packages/sql-mapper/mapper.d.ts
@@ -176,6 +176,11 @@ interface Find<EntityFields> {
      */
     cursor?: Cursor,
     /**
+      * If set to false, the previous page will be fetched in cursor pagination.
+     * @default true
+     */
+    nextPage?: boolean,
+    /**
      * If present, the entity participates in transaction
      */
     tx?: Database

--- a/packages/sql-mapper/test/cursor.test.js
+++ b/packages/sql-mapper/test/cursor.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const { test } = require('node:test')
-const { equal, deepEqual } = require('node:assert')
+const { equal, deepEqual, ifError } = require('node:assert')
 const { connect } = require('..')
 const { clear, connInfo, isSQLite } = require('./helper')
+const errors = require('../lib/errors')
 
 const fakeLogger = {
   trace: () => {},
@@ -46,9 +47,10 @@ test('single field cursor pagination', async () => {
     { title: 'Third Article', content: 'Content 3', timestamp: '2025-01-03 10:00:00' },
     { title: 'Fourth Article', content: 'Content 4', timestamp: '2025-01-04 10:00:00' },
     { title: 'Fifth Article', content: 'Content 5', timestamp: '2025-01-05 10:00:00' },
-    { title: 'Sixth Article', content: 'Content 6', timestamp: '2025-01-05 11:00:00' },
+    { title: 'Sixth Article', content: 'Content 6', timestamp: '2025-01-05 13:00:00' },
     { title: 'Seventh Article', content: 'Content 7', timestamp: '2025-01-05 12:00:00' },
-    { title: 'Eighth Article', content: 'Content 8', timestamp: '2025-01-05 13:00:00' }
+    { title: 'Eighth Article', content: 'Content 8', timestamp: '2025-01-05 11:00:00' },
+    { title: 'Ninth Article', content: 'Content 9', timestamp: '2025-01-05 10:00:00' },
   ]
   await entity.insert({
     inputs: articles,
@@ -57,19 +59,206 @@ test('single field cursor pagination', async () => {
   const firstPage = await entity.find({
     limit: 3,
     orderBy: [{ field: 'id', direction: 'asc' }],
-    fields: ['id', 'title']
   })
   deepEqual(firstPage.map(p => p.id), ['1', '2', '3'], 'First page contains correct IDs')
-  equal(firstPage.length, 3, 'First page has correct number of items')
 
-  const cursor = { id: firstPage[firstPage.length - 1].id }
   const secondPage = await entity.find({
     limit: 3,
-    cursor,
-    orderBy: [{ field: 'id', direction: 'asc' }],
-    fields: ['id', 'title']
+    cursor: { id: firstPage.at(-1).id },
+    orderBy: [{ field: 'id', direction: 'asc' }]
+  })
+  deepEqual(secondPage.map(p => p.id), ['4', '5', '6'], 'Second page contains correct IDs')
+
+  const secondPageWithOffset = await entity.find({
+    limit: 3,
+    offset: 1,
+    cursor: { id: firstPage.at(-1).id },
+    orderBy: [{ field: 'id', direction: 'asc' }]
+  })
+  deepEqual(secondPageWithOffset.map(p => p.id), ['5', '6', '7'], 'Page with offset contains correct IDs')
+
+  // not all orderBy fields have to be in cursor (but all cursor fields must be in orderBy)
+  const oppositePage = await entity.find({
+    limit: 3,
+    cursor: { id: secondPage.at(-1).id },
+    orderBy: [{ field: 'timestamp', direction: 'desc' }, { field: 'id', direction: 'asc' }]
+  })
+  deepEqual(oppositePage.map(p => p.id), ['7', '8', '9'], 'Opposite timestamp page contains correct IDs')
+
+  const previousPage = await entity.find({
+    limit: 3,
+    nextPage: false,
+    cursor: { id: oppositePage.at(0).id },
+    orderBy: [{ field: 'id', direction: 'asc' }]
+  })
+  deepEqual(previousPage.map(p => p.id), ['4', '5', '6'], 'Previous page contains correct IDs')
+
+  try {
+    await entity.find({
+      limit: 3,
+      cursor: { id: firstPage.at(-1).id },
+      orderBy: [{ field: 'timestamp', direction: 'asc' }]
+    })
+    ifError('Expected to throw when cursor field is not listed in orderBy')
+  } catch (e) {
+    equal(e.code, new errors.MissingOrderByFieldForCursorError('id').code)
+  }
+
+  try {
+    await entity.find({
+      limit: 3,
+      cursor: { unknown_field: firstPage.at(-1).id },
+      orderBy: [{ field: 'id', direction: 'asc' }]
+    })
+    ifError('Expected to throw when unknown field provided in cursor')
+  } catch (e) {
+    equal(e.code, new errors.UnknownFieldError('unknown_field').code)
+  }
+
+  try {
+    await entity.find({
+      limit: 3,
+      cursor: { id: firstPage.at(-1).id },
+    })
+    ifError('Expected to throw when no orderBy')
+  } catch (e) {
+    equal(e.code, new errors.MissingOrderByClauseError().code)
+  }
+
+  try {
+    await entity.find({
+      limit: 3,
+      cursor: { timestamp: firstPage.at(-1).timestamp },
+      orderBy: [{ field: 'timestamp', direction: 'asc' }]
+    })
+    ifError('Expected to throw when cursor does not contain unique field')
+  } catch (e) {
+    equal(e.code, new errors.MissingUniqueFieldInCursorError().code)
+  }
+})
+
+test('multiple field cursor pagination', async () => {
+  const mapper = await connect({
+    ...connInfo,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      test.after(async () => {
+        await clear(db, sql)
+        db.dispose()
+      })
+      await clear(db, sql)
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE articles (
+          id INTEGER PRIMARY KEY,
+          timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+          title VARCHAR(100),
+          content TEXT
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE articles (
+          id SERIAL PRIMARY KEY,
+          timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          title VARCHAR(100),
+          content TEXT
+        );`)
+      }
+    },
   })
 
+  const entity = mapper.entities.article
+  await entity.insert({
+    inputs: [
+      { title: 'First Article', content: 'Content 1', timestamp: '2025-01-01 10:00:00' },
+      { title: 'Second Article', content: 'Content 2', timestamp: '2025-01-02 10:00:00' },
+      { title: 'Third Article', content: 'Content 3', timestamp: '2025-01-02 11:00:00' },
+      { title: 'Fourth Article', content: 'Content 4', timestamp: '2025-01-03 10:00:00' },
+      { title: 'Fifth Article', content: 'Content 5', timestamp: '2025-01-03 11:00:00' },
+      { title: 'Sixth Article', content: 'Content 6', timestamp: '2025-01-03 12:00:00' },
+      { title: 'Seventh Article', content: 'Content 7', timestamp: '2025-01-04 13:00:00' },
+      { title: 'Eighth Article', content: 'Content 8', timestamp: '2025-01-04 13:00:00' },
+      { title: 'Ninth Article', content: 'Content 9', timestamp: '2025-01-04 13:00:00' },
+    ],
+  })
+
+  const firstPage = await entity.find({
+    limit: 3,
+    orderBy: [{ field: 'timestamp', direction: 'asc' }, { field: 'id', direction: 'asc' }],
+  })
+  deepEqual(firstPage.map(p => p.id), ['1', '2', '3'], 'First page contains correct IDs')
+
+  const secondPage = await entity.find({
+    limit: 3,
+    cursor: { timestamp: firstPage.at(-1).timestamp, id: firstPage.at(-1).id },
+    orderBy: [{ field: 'timestamp', direction: 'asc' }, { field: 'id', direction: 'asc' }]
+  })
   deepEqual(secondPage.map(p => p.id), ['4', '5', '6'], 'Second page contains correct IDs')
-  equal(secondPage.length, 3, 'Second page has correct number of items')
+
+  // todo(shcube): previous page compound case
+})
+
+test('articles with same timestamp are correctly ordered by id', async () => {
+  const mapper = await connect({
+    ...connInfo,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      test.after(async () => {
+        await clear(db, sql)
+        db.dispose()
+      })
+      await clear(db, sql)
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE articles (
+          id INTEGER PRIMARY KEY,
+          timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+          title VARCHAR(100),
+          content TEXT
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE articles (
+          id SERIAL PRIMARY KEY,
+          timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          title VARCHAR(100),
+          content TEXT
+        );`)
+      }
+    },
+  })
+
+  const entity = mapper.entities.article
+  const ts = '2025-01-05 13:00:00'
+  const normalArticles = [
+    { title: 'First Article', content: 'Content 1', timestamp: '2025-01-01 10:00:00' },
+    { title: 'Second Article', content: 'Content 2', timestamp: '2025-01-02 10:00:00' },
+    { title: 'Third Article', content: 'Content 3', timestamp: '2025-01-02 11:00:00' },
+    { title: 'Fourth Article', content: 'Content 4', timestamp: '2025-01-03 10:00:00' },
+    { title: 'Fifth Article', content: 'Content 5', timestamp: '2025-01-03 11:00:00' },
+    { title: 'Sixth Article', content: 'Content 6', timestamp: '2025-01-03 12:00:00' },
+  ]
+  const sameTsArticles = [
+    { title: 'Seventh Article', content: 'Content 7', timestamp: ts },
+    { title: 'Eighth Article', content: 'Content 8', timestamp: ts },
+    { title: 'Ninth Article', content: 'Content 9', timestamp: ts },
+  ]
+  await entity.insert({
+    inputs: [
+      ...normalArticles,
+      ...sameTsArticles
+    ],
+  })
+
+  const firstTwoSameTs = await entity.find({
+    limit: 2,
+    where: { timestamp: { eq: ts } },
+    orderBy: [{ field: 'timestamp', direction: 'asc' }, { field: 'id', direction: 'asc' }],
+  })
+
+  const lastWithCursor = await entity.find({
+    cursor: {
+      id: firstTwoSameTs.at(-1).id,
+      timestamp: firstTwoSameTs.at(-1).timestamp,
+    },
+    orderBy: [{ field: 'timestamp', direction: 'asc' }, { field: 'id', direction: 'asc' }],
+  })
+
+  deepEqual(lastWithCursor.map(p => p.id), ['9'], 'Cursor pagination correctly follows tie-breaker order')
 })

--- a/packages/sql-mapper/test/cursor.test.js
+++ b/packages/sql-mapper/test/cursor.test.js
@@ -12,7 +12,7 @@ const fakeLogger = {
   warn: () => {},
 }
 
-test('single field cursor pagination', async () => {
+test('single field cursor pagination', async (test) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,
@@ -137,7 +137,7 @@ test('single field cursor pagination', async () => {
   }
 })
 
-test('compound cursor: simple pagination', async () => {
+test('compound cursor: simple pagination', async (test) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,
@@ -202,7 +202,7 @@ test('compound cursor: simple pagination', async () => {
   }
 })
 
-test('compound cursor: several rows have same timestamp', async () => {
+test('compound cursor: several rows have same timestamp', async (test) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,
@@ -269,7 +269,7 @@ test('compound cursor: several rows have same timestamp', async () => {
   deepEqual(lastWithCursor.map(p => p.id), ['9'], 'Cursor pagination correctly follows tie-breaker order')
 })
 
-test('compound cursor: backward pagination with same direction', async () => {
+test('compound cursor: backward pagination with same direction', async (test) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,
@@ -327,7 +327,7 @@ test('compound cursor: backward pagination with same direction', async () => {
   deepEqual(previousPage.map(p => p.id), ['1', '2', '3'], 'Previous page contains correct IDs')
 })
 
-test('compound cursor: mixed directions', async () => {
+test('compound cursor: mixed directions', async (test) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,
@@ -394,7 +394,7 @@ test('compound cursor: mixed directions', async () => {
   deepEqual(previousPage.map(p => p.id), ['1', '2', '3'], 'Previous page with mixed directions contains correct IDs')
 })
 
-test('compound cursor: four or more fields', async () => {
+test('compound cursor: four or more fields', async (test) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,
@@ -480,7 +480,7 @@ test('compound cursor: four or more fields', async () => {
   deepEqual(previousPage.map(p => p.id), ['4', '3', '2'], 'Previous page with three fields contains correct IDs')
 })
 
-test('compound cursor: where clause', async () => {
+test('compound cursor: where clause', async (test) => {
   const mapper = await connect({
     ...connInfo,
     log: fakeLogger,

--- a/packages/sql-mapper/test/cursor.test.js
+++ b/packages/sql-mapper/test/cursor.test.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const { test } = require('node:test')
+const { equal, deepEqual } = require('node:assert')
+const { connect } = require('..')
+const { clear, connInfo, isSQLite } = require('./helper')
+
+const fakeLogger = {
+  trace: () => {},
+  error: () => {},
+  warn: () => {},
+}
+
+test('single field cursor pagination', async () => {
+  const mapper = await connect({
+    ...connInfo,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      test.after(async () => {
+        await clear(db, sql)
+        db.dispose()
+      })
+      await clear(db, sql)
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE articles (
+          id INTEGER PRIMARY KEY,
+          timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+          title VARCHAR(100),
+          content TEXT
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE articles (
+          id SERIAL PRIMARY KEY,
+          timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          title VARCHAR(100),
+          content TEXT
+        );`)
+      }
+    },
+  })
+
+  const entity = mapper.entities.article
+  const articles = [
+    { title: 'First Article', content: 'Content 1', timestamp: '2025-01-01 10:00:00' },
+    { title: 'Second Article', content: 'Content 2', timestamp: '2025-01-02 10:00:00' },
+    { title: 'Third Article', content: 'Content 3', timestamp: '2025-01-03 10:00:00' },
+    { title: 'Fourth Article', content: 'Content 4', timestamp: '2025-01-04 10:00:00' },
+    { title: 'Fifth Article', content: 'Content 5', timestamp: '2025-01-05 10:00:00' },
+    { title: 'Sixth Article', content: 'Content 6', timestamp: '2025-01-05 11:00:00' },
+    { title: 'Seventh Article', content: 'Content 7', timestamp: '2025-01-05 12:00:00' },
+    { title: 'Eighth Article', content: 'Content 8', timestamp: '2025-01-05 13:00:00' }
+  ]
+  await entity.insert({
+    inputs: articles,
+  })
+
+  const firstPage = await entity.find({
+    limit: 3,
+    orderBy: [{ field: 'id', direction: 'asc' }],
+    fields: ['id', 'title']
+  })
+  deepEqual(firstPage.map(p => p.id), ['1', '2', '3'], 'First page contains correct IDs')
+  equal(firstPage.length, 3, 'First page has correct number of items')
+
+  const cursor = { id: firstPage[firstPage.length - 1].id }
+  const secondPage = await entity.find({
+    limit: 3,
+    cursor,
+    orderBy: [{ field: 'id', direction: 'asc' }],
+    fields: ['id', 'title']
+  })
+
+  deepEqual(secondPage.map(p => p.id), ['4', '5', '6'], 'Second page contains correct IDs')
+  equal(secondPage.length, 3, 'Second page has correct number of items')
+})


### PR DESCRIPTION
 ### Part 1 of #230
 ###  Cursor pagination in sql-mapper
 
 I've decided to divide issue #230 into several PRs (if its ok). This one contains changes for the sql-mapper module. 

* Adds the multi-column cursor to sql-mapper. 
* Cursor respects the order of `orderBy` fields when generating conditions
*  `where` and `orderBy` clauses can be used with cursor
* Forward and backward pagination is supported using `nextPage` key
* Generates short SQL tuple comparison when all sort directions match and falls back to compound query when mixed directions used


### Additional context:
[Support multi-column cursors](https://github.com/prisma/prisma/issues/19159)