### PR TITLE
Avoid adding the typescript prefix in production mode

### DIFF
--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -300,7 +300,6 @@ export class NodeStackable extends BaseStackable {
 
   async _findEntrypoint () {
     const config = this.configManager.current
-    const outputRoot = resolve(this.root, config.application.outputDirectory)
 
     if (config.node.main) {
       return pathResolve(this.root, config.node.main)
@@ -324,19 +323,7 @@ export class NodeStackable extends BaseStackable {
       }
     }
 
-    let root = this.root
-
-    if (this.isProduction) {
-      const hasCommand = this.configManager.current.application.commands.build
-      const hasBuildScript = await this.#hasBuildScript()
-
-      if (hasCommand || hasBuildScript) {
-        this.verifyOutputDirectory(outputRoot)
-        root = outputRoot
-      }
-    }
-
-    return pathResolve(root, entrypoint)
+    return pathResolve(this.root, entrypoint)
   }
 
   async #hasBuildScript () {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "npm run lint && borp --concurrency=1 --no-timeout",
-    "coverage": "npm run lint && borp -C -X test -X test/fixtures --concurrency=1 --no-timeout",
+    "test": "pnpm run lint && borp --concurrency=1 --no-timeout",
+    "coverage": "pnpm run lint && borp -C -X test -X test/fixtures --concurrency=1 --no-timeout",
     "gen-schema": "node lib/schema.js > schema.json",
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "pnpm run gen-schema && pnpm run gen-types",

--- a/packages/node/test/fixtures/node-with-build-no-main/package.json
+++ b/packages/node/test/fixtures/node-with-build-no-main/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test",
+  "private": true,
+  "workspaces": [
+    "services/*"
+  ],
+  "dependencies": {
+    "@platformatic/runtime": "^2.3.1",
+    "platformatic": "^2.3.1"
+  }
+}

--- a/packages/node/test/fixtures/node-with-build-no-main/platformatic.runtime.json
+++ b/packages/node/test/fixtures/node-with-build-no-main/platformatic.runtime.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "frontend",
+  "services": [
+    {
+      "id": "frontend",
+      "config": "platformatic.application.json",
+      "path": "./services/frontend"
+    }
+  ],
+  "logger": {
+    "level": "trace"
+  }
+}

--- a/packages/node/test/fixtures/node-with-build-no-main/services/frontend/package.json
+++ b/packages/node/test/fixtures/node-with-build-no-main/services/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@platformatic/node": "^2.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/node/test/fixtures/node-with-build-no-main/services/frontend/platformatic.application.json
+++ b/packages/node/test/fixtures/node-with-build-no-main/services/frontend/platformatic.application.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.0.0.json"
+}

--- a/packages/node/test/fixtures/node-with-build-no-main/services/frontend/src/server.ts
+++ b/packages/node/test/fixtures/node-with-build-no-main/services/frontend/src/server.ts
@@ -1,0 +1,11 @@
+import { createServer } from 'node:http'
+
+export function create () {
+  return createServer((req, res) => {
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      connection: 'close'
+    })
+    res.end(JSON.stringify({ production: process.env.NODE_ENV === 'production' }))
+  })
+}

--- a/packages/node/test/fixtures/node-with-build-no-main/services/frontend/tsconfig.json
+++ b/packages/node/test/fixtures/node-with-build-no-main/services/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "lib": ["es2022"],
+    "target": "es2022",
+    "sourceMap": true,
+    "pretty": true,
+    "noEmitOnError": true,
+    "incremental": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "watchOptions": {
+    "watchFile": "fixedPollingInterval",
+    "watchDirectory": "fixedPollingInterval",
+    "fallbackPolling": "dynamicPriority",
+    "synchronousWatchDirectory": true,
+    "excludeDirectories": ["**/node_modules", "dist"]
+  },
+  "exclude": ["**/node_modules", "dist"]
+}

--- a/packages/node/test/production.test.js
+++ b/packages/node/test/production.test.js
@@ -124,6 +124,15 @@ const configurations = [
     prefix: ''
   },
   {
+    id: 'node-with-build-no-main',
+    name: 'Node.js application with (with a build function in development mode when standalone)',
+    files: ['services/frontend/dist/server.js'],
+    only: true,
+    checks: [verifyStandalone],
+    language: 'ts',
+    prefix: ''
+  },
+  {
     only: isCIOnWindows,
     id: 'node-with-build-composer-with-prefix',
     name: 'Node.js application with (with a build function in development mode when exposed in a composer with a prefix)',


### PR DESCRIPTION
This avoids errors such as:

```
[09:49:37.048] ERROR (47574): Failed to start service "noir".
    err: {
      "type": "Error",
      "message": "Cannot find module '/Users/matteo/tmp/eeee/web/noir/dist/dist/server.js' imported from /Users/matteo/tmp/eeee/node_modules/@platformatic/basic/lib/utils.js",
      "stack":
          Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/matteo/tmp/eeee/web/noir/dist/dist/server.js' imported from /Users/matteo/tmp/eeee/node_modules/@platformatic/basic/lib/utils.js
              at finalizeResolution (node:internal/modules/esm/resolve:275:11)
              at moduleResolve (node:internal/modules/esm/resolve:860:10)
              at defaultResolve (node:internal/modules/esm/resolve:984:11)
              at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
              at #cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
              at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)
              at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
              at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:577:36)
              at TracingChannel.tracePromise (node:diagnostics_channel:344:14)
              at ModuleLoader.import (node:internal/modules/esm/loader:576:21)
      "code": "ERR_MODULE_NOT_FOUND"
    }
 ```