### PR TITLE
feat(config): add disable env loaded option

### DIFF
--- a/packages/config/index.d.ts
+++ b/packages/config/index.d.ts
@@ -35,6 +35,7 @@ export interface IConfigManagerOptions {
   allowToWatch?: string[]
   version?: string
   configVersion?: string
+  disableEnvLoad?: boolean
   upgrade?: (config: any, version: string) => Promise<any> | any
 }
 

--- a/packages/config/lib/manager.js
+++ b/packages/config/lib/manager.js
@@ -28,6 +28,7 @@ class ConfigManager extends EventEmitter {
     this._configVersion = opts.configVersion // requested version
     this._version = opts.version
     this.logger = opts.logger || abstractlogger
+    this.disableEnvLoad = opts.disableEnvLoad
 
     if (this._stackableUpgrade && !this._version) {
       throw new errors.VersionMissingError()
@@ -422,7 +423,7 @@ class ConfigManager extends EventEmitter {
       }
     }
     let env = { ...this._originalEnv }
-    if (dotEnvPath) {
+    if (dotEnvPath && this.disableEnvLoad !== true) {
       const data = await readFile(dotEnvPath, 'utf-8')
       const parsed = dotenv.parse(data)
       env = { ...env, ...parsed }


### PR DESCRIPTION
This option avoids loading `.env` files from `@platformatic/config` when it is set as `true`