### PR TITLE
feat(control): add return inject runtime types

### DIFF
--- a/packages/control/index.d.ts
+++ b/packages/control/index.d.ts
@@ -2,6 +2,7 @@ import { ChildProcess } from "node:child_process";
 import BodyReadable from "undici/types/readable";
 import { FastifyError } from "@fastify/error";
 import { Readable } from "node:stream";
+import { HttpHeader } from 'fastify/types/utils'
 import WebSocket from "ws";
 
 declare namespace control {
@@ -122,7 +123,7 @@ declare namespace control {
         headers: object;
         body: unknown;
       }
-    ): Promise<unknown>;
+    ): Promise<{ headers: Record<string, HttpHeader>, statusCode: number, body: unknown }>;
     close(): Promise<void>;
   }
 

--- a/packages/control/index.test-d.ts
+++ b/packages/control/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from 'tsd'
+import { expectAssignable, expectError, expectType } from 'tsd'
 import { errors, Metric, Runtime, RuntimeApiClient, RuntimeServices } from '.'
 import { FastifyError } from '@fastify/error'
 
@@ -13,6 +13,15 @@ expectType<Promise<Metric[]>>(api.getRuntimeMetrics(runtime.pid, {}))
 expectType<Promise<Metric[]>>(api.getRuntimeMetrics(runtime.pid, { format: 'json' }))
 expectType<Promise<string>>(api.getRuntimeMetrics(runtime.pid, { format: 'text' }))
 expectType<Promise<Runtime[]>>(api.getRuntimes())
+
+async () => {
+  const result = await api.injectRuntime(0, '', { body: {}, headers: {}, method: 'PUT', url: '/foo' })
+
+  expectType<unknown>(result.body)
+  expectType<number>(result.statusCode)
+  expectAssignable<Record<string, unknown>>(result.headers)
+  return result
+}
 
 const [service1] = service.services
 expectType<Promise<unknown>>(api.getRuntimeOpenapi(runtime.pid, service1.id))


### PR DESCRIPTION
Add more proper types (and tests) to the `injectRuntime` method used, for instance, [here](https://github.com/platformatic/watt-admin/pull/85)