### PR TITLE
Regression fix: Reset when we collect latencies

### DIFF
--- a/packages/metrics/index.js
+++ b/packages/metrics/index.js
@@ -33,11 +33,17 @@ async function collectMetrics (serviceId, workerId, metricsConfig = {}, registry
       },
       histogram: {
         name: 'http_request_all_duration_seconds',
-        help: 'request duration in seconds summary for all requests'
+        help: 'request duration in seconds summary for all requests',
+        collect: function () {
+          process.nextTick(() => this.reset())
+        }
       },
       summary: {
         name: 'http_request_all_summary_seconds',
-        help: 'request duration in seconds histogram for all requests'
+        help: 'request duration in seconds histogram for all requests',
+        collect: function () {
+          process.nextTick(() => this.reset())
+        }
       }
     })
   }

--- a/packages/metrics/test/index.test.js
+++ b/packages/metrics/test/index.test.js
@@ -4,6 +4,8 @@ const assert = require('node:assert')
 const { test } = require('node:test')
 const { collectMetrics, client } = require('..')
 
+const nextTick = () => new Promise(resolve => process.nextTick(resolve))
+
 test('returns expected structure', async () => {
   const result = await collectMetrics('test-service', 1, {})
 
@@ -56,4 +58,71 @@ test('workerId is NOT included in labels when negative', async () => {
   const result = await collectMetrics('test-service', -42, { defaultMetrics: true })
   const [{ values }] = await result.registry.getMetricsAsJSON()
   assert.strictEqual(values[0].labels.workerId, undefined)
+})
+
+test('httpMetrics creates histogram and summary with collect functions', async () => {
+  const result = await collectMetrics('test-service', 1, { httpMetrics: true })
+  const metrics = await result.registry.getMetricsAsJSON()
+
+  const histogram = metrics.find(m => m.name === 'http_request_all_duration_seconds')
+  const summary = metrics.find(m => m.name === 'http_request_all_summary_seconds')
+
+  assert.ok(histogram, 'histogram metric should exist')
+  assert.ok(summary, 'summary metric should exist')
+  assert.strictEqual(histogram.help, 'request duration in seconds summary for all requests')
+  assert.strictEqual(summary.help, 'request duration in seconds histogram for all requests')
+})
+
+test('httpMetrics histogram resets after metric collection', async () => {
+  const result = await collectMetrics('test-service', 1, { httpMetrics: true })
+
+  const metricObjects = result.registry._metrics
+  const histogramMetric = metricObjects.http_request_all_duration_seconds
+
+  histogramMetric.observe({ method: 'GET', telemetry_id: 'test' }, 0.1)
+  histogramMetric.observe({ method: 'GET', telemetry_id: 'test' }, 0.2)
+  histogramMetric.observe({ method: 'GET', telemetry_id: 'test' }, 0.3)
+
+  const metricsBefore = await result.registry.getMetricsAsJSON()
+  const histogramBefore = metricsBefore.find(m => m.name === 'http_request_all_duration_seconds')
+  assert.ok(histogramBefore.values.length > 0, 'histogram should have values before collection')
+
+  await result.registry.metrics()
+
+  await nextTick()
+
+  const metricsAfter = await result.registry.getMetricsAsJSON()
+  const histogramAfter = metricsAfter.find(m => m.name === 'http_request_all_duration_seconds')
+
+  const sum = histogramAfter.values.find(v => v.metricName === 'http_request_all_duration_seconds_sum')
+  const count = histogramAfter.values.find(v => v.metricName === 'http_request_all_duration_seconds_count')
+  assert.strictEqual(sum?.value || 0, 0, 'histogram sum should be reset to 0')
+  assert.strictEqual(count?.value || 0, 0, 'histogram count should be reset to 0')
+})
+
+test('httpMetrics summary resets after metric collection', async () => {
+  const result = await collectMetrics('test-service', 1, { httpMetrics: true })
+
+  const metricObjects = result.registry._metrics
+  const summaryMetric = metricObjects.http_request_all_summary_seconds
+
+  summaryMetric.observe({ method: 'POST', telemetry_id: 'test' }, 0.15)
+  summaryMetric.observe({ method: 'POST', telemetry_id: 'test' }, 0.25)
+  summaryMetric.observe({ method: 'POST', telemetry_id: 'test' }, 0.35)
+
+  const metricsBefore = await result.registry.getMetricsAsJSON()
+  const summaryBefore = metricsBefore.find(m => m.name === 'http_request_all_summary_seconds')
+  assert.ok(summaryBefore.values.length > 0, 'summary should have values before collection')
+
+  await result.registry.metrics()
+
+  await nextTick()
+
+  const metricsAfter = await result.registry.getMetricsAsJSON()
+  const summaryAfter = metricsAfter.find(m => m.name === 'http_request_all_summary_seconds')
+
+  const sum = summaryAfter.values.find(v => v.metricName === 'http_request_all_summary_seconds_sum')
+  const count = summaryAfter.values.find(v => v.metricName === 'http_request_all_summary_seconds_count')
+  assert.strictEqual(sum?.value || 0, 0, 'summary sum should be reset to 0')
+  assert.strictEqual(count?.value || 0, 0, 'summary count should be reset to 0')
 })


### PR DESCRIPTION
in https://github.com/platformatic/platformatic/pull/4084 We accidentally removed: https://github.com/platformatic/platformatic/blob/a0aecf2b55b7fe9e8ccb8e520d1c1054a21b26a5/packages/metrics/index.js#L55

(and we didn't have a test to catch it).
Fixed back and added the tests.