### PR TITLE
docs: add framework integration guide with strategic cross-references

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -41,7 +41,7 @@ Watt provides a comprehensive set of capabilities:
 - **Database APIs** - Auto-generated REST and GraphQL endpoints from SQL databases (Platformatic DB)
 - **HTTP Services** - Custom application logic and APIs built on Fastify
 - **API Gateways** - Aggregate multiple services into unified endpoints
-- **Framework Integration** - Next.js, Astro, Remix, Vite applications
+- **Framework Integration** - [Next.js, Astro, Remix, Vite applications](/docs/guides/frameworks)
 - **Microservice Orchestration** - Multi-service applications as single deployments
 - **Built-in Authorization** - Role-based access control and JWT authentication
 - **Real-time Features** - WebSocket and GraphQL subscriptions

--- a/docs/getting-started/port-your-app.md
+++ b/docs/getting-started/port-your-app.md
@@ -116,3 +116,4 @@ wattpm start
 
 - [Watt Quick Start](/docs/getting-started/quick-start-watt/)
 - [Full Stack Guide](/docs/getting-started/quick-start-guide)
+- [Framework Integration Guides](/docs/guides/frameworks) - Setup guides for Next.js, Astro, Remix, Vite, and more

--- a/docs/getting-started/quick-start-watt.md
+++ b/docs/getting-started/quick-start-watt.md
@@ -9,8 +9,7 @@ This guide will help you set up and run an application composed of the following
 - [Platformatic Composer](/docs/reference/composer/introduction), to coordinate/expose them all.
 
 :::note
-In this guide, we will use `Next.js` as our frontend framework, but you can also use [Astro](https://astro.build/),
-or [Remix](https://remix.run/). We plan to expand the list of supported frameworks in the future.
+In this guide, we will use `Next.js` as our frontend framework, but Watt supports many more frameworks including Astro, Remix, Vite, and NestJS. See our [Framework Integration Guides](/docs/guides/frameworks) for complete details and setup instructions for all supported frameworks.
 :::
 
 

--- a/docs/guides/frameworks.md
+++ b/docs/guides/frameworks.md
@@ -1,0 +1,92 @@
+# Framework Integration Guides
+
+Watt supports seamless integration with popular frontend frameworks and Node.js runtimes. Each framework integration provides built-in development tools, optimized builds, and deployment-ready configurations.
+
+Choose the framework that best fits your project needs - whether you're building static sites, server-rendered applications, or complex Node.js services.
+
+## Frontend Frameworks
+
+### [Astro](../reference/astro/overview.md)
+Modern static site generator with component hydration and built-in optimizations.
+
+- **[Overview](../reference/astro/overview.md)** - Getting started with Astro integration
+- **[Configuration](../reference/astro/configuration.md)** - Complete configuration reference
+- **[Caching](../reference/astro/caching.md)** - Caching strategies and configuration
+
+### [Next.js](../reference/next/overview.md)
+Full-stack React framework with server-side rendering and app router support.
+
+- **[Overview](../reference/next/overview.md)** - Getting started with Next.js integration
+- **[Configuration](../reference/next/configuration.md)** - Complete configuration reference
+
+### [Remix](../reference/remix/overview.md)
+Full-stack web framework focused on web fundamentals and modern user experience.
+
+- **[Overview](../reference/remix/overview.md)** - Getting started with Remix integration
+- **[Configuration](../reference/remix/configuration.md)** - Complete configuration reference
+- **[Caching](../reference/remix/caching.md)** - Caching strategies and configuration
+
+### [Vite](../reference/vite/overview.md)
+Fast build tool with hot module replacement for modern web projects.
+
+- **[Overview](../reference/vite/overview.md)** - Getting started with Vite integration
+- **[Configuration](../reference/vite/configuration.md)** - Complete configuration reference
+
+## Node.js Runtimes
+
+### [Node.js](../reference/node/overview.md)
+Generic Node.js stackable for custom applications and existing codebases.
+
+- **[Overview](../reference/node/overview.md)** - Getting started with Node.js integration
+- **[Configuration](../reference/node/configuration.md)** - Complete configuration reference
+
+### [NestJS](../reference/nest/overview.md)
+Progressive Node.js framework for building scalable server-side applications.
+
+- **[Overview](../reference/nest/overview.md)** - Getting started with NestJS integration
+- **[Configuration](../reference/nest/configuration.md)** - Complete configuration reference
+
+## Quick Start
+
+To add a framework to your Watt application:
+
+1. **Add the stackable to your configuration:**
+   ```json
+   {
+     "services": [
+       {
+         "id": "frontend",
+         "path": "./frontend",
+         "config": "platformatic.json"
+       }
+     ]
+   }
+   ```
+
+2. **Create framework-specific configuration:**
+   Each framework has its own configuration file with framework-specific options and build settings.
+
+3. **Run your application:**
+   ```bash
+   watt start
+   ```
+
+## Integration Features
+
+All framework integrations provide:
+
+- **Development Mode** - Hot reload and fast refresh during development
+- **Production Builds** - Optimized builds for deployment
+- **Environment Configuration** - Framework-specific environment variable handling
+- **Logging Integration** - Unified logging across all services
+- **Metrics Collection** - Built-in observability and monitoring
+- **TypeScript Support** - Full TypeScript integration where applicable
+
+## Need Help?
+
+- **New to Watt?** Start with the [Watt Quick Start](/docs/getting-started/quick-start-watt) guide
+- **Migrating an existing app?** See [Running Your Project in Watt](/docs/getting-started/port-your-app)
+- **Framework-specific issues?** Check the individual framework reference pages above
+- **Technical details?** Browse the complete [Reference Documentation](../reference/) 
+- **Step-by-step tutorials?** Visit our [Learning Tutorials](../learn/)
+- **Community support?** Join our [Discord Community](https://discord.gg/platformatic)

--- a/docs/reference/watt/overview.md
+++ b/docs/reference/watt/overview.md
@@ -29,6 +29,7 @@ npm install -g wattpm
 
 ## Getting started
 
-For more details, see the [reference](./reference.md).
+- For complete configuration and CLI details, see the [reference](./reference.md)
+- To integrate with frontend frameworks, see the [Framework Integration Guides](/docs/guides/frameworks)
 
 <Issues />

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -56,6 +56,7 @@ const sidebars = {
           label: 'Application Development',
           collapsed: true,
           items: [
+            'guides/frameworks',
             'guides/build-modular-monolith',
             'guides/cache-with-platformatic-watt',
             'guides/generate-frontend-code-to-consume-platformatic-rest-api',


### PR DESCRIPTION
## Summary
Adds a comprehensive framework integration guide that serves as a central hub for all supported framework documentation, with strategic cross-references throughout the documentation to improve discoverability.

## Changes
- **New Guide**: Created `docs/guides/frameworks.md` with links to all framework reference docs
- **Sidebar Integration**: Added frameworks guide to "How-to Guides" → "Application Development" 
- **Cross-References**: Added strategic links from:
  - Overview page (Framework Integration bullet point)
  - Watt Quick Start (framework support section)
  - Port Your App guide (Learn More section)
  - Watt Reference Overview (connecting to practical guides)
- **Content Enhancement**: Improved framework guide introduction and help section

## Supported Frameworks
- **Frontend**: Astro, Next.js, Remix, Vite
- **Node.js Runtimes**: Node.js, NestJS

## Benefits
- Improved discoverability of Watt's framework integration capabilities
- Clear path from overview to specific framework documentation
- Better user journey for migration and new project scenarios
- Strategic placement following Diátaxis framework principles

🤖 Generated with [Claude Code](https://claude.ai/code)