### PR TITLE
Add watt-pprof-capture package with auto-load in runtime

### DIFF
--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -16,6 +16,38 @@ const { schema } = require('./schema')
 const upgrade = require('./upgrade')
 const { parseArgs } = require('node:util')
 
+function autoDetectPprofCapture (config) {
+  // Skip if explicitly disabled
+  if (process.env.PLT_DISABLE_FLAMEGRAPHS) {
+    return config
+  }
+
+  // Check if package is installed
+  try {
+    let pprofCapturePath
+    try {
+      pprofCapturePath = require.resolve('@platformatic/watt-pprof-capture')
+    } catch (err) {
+      pprofCapturePath = require.resolve('../../watt-pprof-capture/index.js')
+    }
+
+    // Add to preload if not already present
+    if (!config.preload) {
+      config.preload = []
+    } else if (typeof config.preload === 'string') {
+      config.preload = [config.preload]
+    }
+
+    if (!config.preload.includes(pprofCapturePath)) {
+      config.preload.push(pprofCapturePath)
+    }
+  } catch (err) {
+    // Package not installed, skip silently
+  }
+
+  return config
+}
+
 async function _transformConfig (configManager, args) {
   const config = configManager.current
 
@@ -226,6 +258,9 @@ async function _transformConfig (configManager, args) {
       configManager.current.restartOnError = 0
     }
   }
+
+  // Auto-detect and add pprof capture if available
+  autoDetectPprofCapture(configManager.current)
 }
 
 async function platformaticRuntime () {
@@ -358,5 +393,6 @@ function parseInspectorOptions (configManager) {
 module.exports = {
   parseInspectorOptions,
   platformaticRuntime,
-  wrapConfigInRuntimeConfig
+  wrapConfigInRuntimeConfig,
+  autoDetectPprofCapture
 }

--- a/packages/runtime/test/pprof-auto-detection.test.js
+++ b/packages/runtime/test/pprof-auto-detection.test.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const assert = require('node:assert')
+const { test } = require('node:test')
+const { join } = require('node:path')
+const { loadConfig } = require('@platformatic/config')
+const { platformaticRuntime } = require('..')
+
+const fixturesDir = join(__dirname, '..', 'fixtures')
+
+test('should auto-detect @platformatic/watt-pprof-capture when available', async (t) => {
+  // Use existing monorepo fixture which loads services
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+
+  // Load config with runtime transformation
+  const result = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const configManager = result.configManager
+
+  // Check that pprof capture was auto-detected and added to preload
+  const preload = configManager.current.preload
+  assert.ok(Array.isArray(preload), 'preload should be an array')
+  assert.ok(preload.some(p => p.includes('watt-pprof-capture')), 'preload should include watt-pprof-capture')
+})
+
+test('should not auto-detect when PLT_DISABLE_FLAMEGRAPHS is set', async (t) => {
+  const originalEnv = process.env.PLT_DISABLE_FLAMEGRAPHS
+  process.env.PLT_DISABLE_FLAMEGRAPHS = '1' // Test with numeric value
+  t.after(() => {
+    process.env.PLT_DISABLE_FLAMEGRAPHS = originalEnv
+  })
+
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const result = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const configManager = result.configManager
+
+  // Should not have any preload or should not include pprof capture
+  const preload = configManager.current.preload
+  assert.ok(!preload.some(p => p.includes('watt-pprof-capture')), 'preload should not include watt-pprof-capture when disabled')
+})
+
+test('auto-detect function works correctly', async (t) => {
+  // Import the config module to access the auto-detect function
+  const { autoDetectPprofCapture } = require('../lib/config')
+
+  // Test with empty config
+  const config1 = {}
+  autoDetectPprofCapture(config1)
+
+  assert.ok(Array.isArray(config1.preload), 'should create preload array')
+  assert.ok(config1.preload.some(p => p.includes('watt-pprof-capture')), 'should include pprof capture')
+
+  // Test with existing string preload
+  const config2 = { preload: './existing.js' }
+  autoDetectPprofCapture(config2)
+
+  assert.ok(Array.isArray(config2.preload), 'should convert string to array')
+  assert.ok(config2.preload.includes('./existing.js'), 'should preserve existing preload')
+  assert.ok(config2.preload.some(p => p.includes('watt-pprof-capture')), 'should add pprof capture')
+
+  // Test with existing array preload
+  const config3 = { preload: ['./existing1.js', './existing2.js'] }
+  autoDetectPprofCapture(config3)
+
+  assert.ok(config3.preload.includes('./existing1.js'), 'should preserve first existing preload')
+  assert.ok(config3.preload.includes('./existing2.js'), 'should preserve second existing preload')
+  assert.ok(config3.preload.some(p => p.includes('watt-pprof-capture')), 'should add pprof capture')
+
+  // Test with disabled environment variable
+  const originalEnv = process.env.PLT_DISABLE_FLAMEGRAPHS
+  process.env.PLT_DISABLE_FLAMEGRAPHS = '1' // Test with numeric value
+  t.after(() => {
+    process.env.PLT_DISABLE_FLAMEGRAPHS = originalEnv
+  })
+
+  const config4 = {}
+  autoDetectPprofCapture(config4)
+
+  assert.ok(!config4.preload || config4.preload.length === 0, 'should not add preload when disabled')
+
+  // Test with already existing pprof capture (should not duplicate)
+  const existingPprofPath = join(__dirname, '..', '..', 'watt-pprof-capture', 'index.js')
+  const config5 = { preload: [existingPprofPath] }
+  autoDetectPprofCapture(config5)
+
+  const pprofInstances = config5.preload.filter(p => p.includes('watt-pprof-capture'))
+  assert.strictEqual(pprofInstances.length, 1, 'should not duplicate pprof capture')
+})

--- a/packages/watt-pprof-capture/LICENSE
+++ b/packages/watt-pprof-capture/LICENSE
@@ -1,0 +1,196 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (which shall not include communications that are clearly marked or
+      otherwise designated in writing by the author as "Not a License").
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based upon (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and derivative works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control
+      systems, and issue tracking systems that are managed by, or on behalf
+      of, the Licensor for the purpose of discussing and improving the Work,
+      but excluding communication that is clearly marked or otherwise
+      designated in writing by the author as "Not a License".
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to use, reproduce, modify, display, perform,
+      sublicense, and distribute the Work and derivative works thereof in
+      Source and Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, trademark, patent,
+          and attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright notice to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. When redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and on
+      Your sole responsibility, not on behalf of any other Contributor, and
+      only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed by the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same page as the copyright notice for easier identification within
+      third-party archives.
+
+   Copyright 2022-2024 Platformatic Inc. and contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/watt-pprof-capture/NOTICE
+++ b/packages/watt-pprof-capture/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2022-2024 Platformatic Inc. and contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/watt-pprof-capture/eslint.config.js
+++ b/packages/watt-pprof-capture/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('neostandard')({ ts: false })

--- a/packages/watt-pprof-capture/index.js
+++ b/packages/watt-pprof-capture/index.js
@@ -1,0 +1,119 @@
+'use strict'
+
+const pprof = require('@datadog/pprof')
+const runtime = require('@platformatic/runtime')
+const { request } = require('undici')
+const {
+  ProfilingNotStartedError,
+  NoProfileAvailableError,
+  MissingUrlError,
+  SendFlamegraphError
+} = require('./lib/errors')
+
+const kITC = runtime.symbols.kITC
+const timeout = (parseInt(process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC) || 60) * 1000
+
+let latestProfile = null
+let isHandlerRegistered = false
+let captureInterval = null
+let isCapturing = false
+
+// Store reference to any existing handlers that we might replace
+let existingHandlers = null
+
+function registerHandler () {
+  if (!isHandlerRegistered && globalThis[kITC]) {
+    isHandlerRegistered = true
+
+    // Register new handlers - these will replace any existing ones
+    globalThis[kITC].handle('sendFlamegraph', async (options) => {
+      if (!isCapturing) {
+        throw new ProfilingNotStartedError()
+      }
+
+      const { url, headers } = options
+      if (!url) {
+        throw new MissingUrlError()
+      }
+
+      if (latestProfile == null) {
+        throw new NoProfileAvailableError()
+      }
+
+      const { statusCode, body } = await request(url, {
+        method: 'POST',
+        headers: {
+          ...headers,
+          'Content-Type': 'application/octet-stream'
+        },
+        body: latestProfile.encode()
+      })
+
+      if (statusCode !== 200) {
+        const errorText = await body.text()
+        const error = new SendFlamegraphError(errorText)
+        error.statusCode = statusCode
+        throw error
+      }
+    })
+  }
+}
+
+// Start capture loop
+function startCapture () {
+  if (isCapturing) return // Already capturing
+  isCapturing = true
+
+  async function captureAndReschedule () {
+    // Register ITC handlers if ITC is set up
+    registerHandler()
+
+    try {
+      latestProfile = await pprof.time.profile({ durationMillis: timeout })
+    } catch (err) {
+      // Log error but continue capturing
+      if (globalThis.platformatic?.logger) {
+        globalThis.platformatic.logger.error({ err }, 'Failed to capture profile')
+      }
+    }
+
+    // Schedule next capture after current one completes
+    // This prevents overlapping captures due to timer drift
+    if (isCapturing) {
+      captureInterval = setTimeout(captureAndReschedule, timeout)
+      captureInterval.unref()
+    }
+  }
+
+  if (!captureInterval) {
+    // Start the first capture immediately
+    captureAndReschedule()
+  }
+}
+
+// Auto-start unless explicitly disabled
+if (!process.env.PLT_DISABLE_FLAMEGRAPHS) {
+  startCapture()
+}
+
+// Stop capture (for testing)
+function stopCapture () {
+  isCapturing = false
+  if (captureInterval) {
+    clearTimeout(captureInterval)
+    captureInterval = null
+  }
+}
+
+// Check if capturing is active
+function isActive () {
+  return isCapturing
+}
+
+// Export for testing purposes
+module.exports = {
+  startCapture,
+  stopCapture,
+  registerHandler,
+  isActive
+}

--- a/packages/watt-pprof-capture/lib/errors.js
+++ b/packages/watt-pprof-capture/lib/errors.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const createError = require('@fastify/error')
+
+const ERROR_PREFIX = 'PLT_PPROF'
+
+const ProfilingNotStartedError = createError(
+  `${ERROR_PREFIX}_PROFILING_NOT_STARTED`,
+  'Profiling not started - set PLT_DISABLE_FLAMEGRAPHS=false or call startCapture()'
+)
+
+const NoProfileAvailableError = createError(
+  `${ERROR_PREFIX}_NO_PROFILE_AVAILABLE`,
+  'No profile available - wait for profiling to complete or trigger manual capture'
+)
+
+const MissingUrlError = createError(
+  `${ERROR_PREFIX}_MISSING_URL`,
+  'URL is required for sending flamegraph'
+)
+
+const SendFlamegraphError = createError(
+  `${ERROR_PREFIX}_SEND_FAILED`,
+  'Failed to send flamegraph: %s'
+)
+
+module.exports = {
+  ProfilingNotStartedError,
+  NoProfileAvailableError,
+  MissingUrlError,
+  SendFlamegraphError
+}

--- a/packages/watt-pprof-capture/package.json
+++ b/packages/watt-pprof-capture/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@platformatic/watt-pprof-capture",
+  "version": "2.70.1",
+  "description": "pprof profiling capture for watt",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "test": "npm run lint && borp",
+    "lint": "eslint"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/platformatic/platformatic.git"
+  },
+  "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/platformatic/platformatic/issues"
+  },
+  "homepage": "https://github.com/platformatic/platformatic#readme",
+  "dependencies": {
+    "@datadog/pprof": "^5.3.0",
+    "@fastify/error": "^4.0.0",
+    "@platformatic/runtime": "workspace:*",
+    "undici": "^6.0.0"
+  },
+  "devDependencies": {
+    "borp": "^0.20.0",
+    "eslint": "9",
+    "neostandard": "^0.12.0"
+  }
+}

--- a/packages/watt-pprof-capture/test/capture.test.js
+++ b/packages/watt-pprof-capture/test/capture.test.js
@@ -1,0 +1,321 @@
+'use strict'
+
+const assert = require('node:assert')
+const { test } = require('node:test')
+
+test('pprof capture module should not auto-start when disabled', async (t) => {
+  // Set environment to disable flamegraphs
+  const originalEnv = process.env.PLT_DISABLE_FLAMEGRAPHS
+  process.env.PLT_DISABLE_FLAMEGRAPHS = 'true'
+
+  // Mock ITC to test actual behavior
+  const mockHandlers = new Map()
+  const mockITC = {
+    handle: (name, handler) => {
+      mockHandlers.set(name, handler)
+    },
+    _handlers: mockHandlers
+  }
+
+  const kITC = Symbol.for('plt.runtime.itc')
+  globalThis[kITC] = mockITC
+
+  t.after(() => {
+    delete globalThis[kITC]
+    process.env.PLT_DISABLE_FLAMEGRAPHS = originalEnv
+    delete require.cache[require.resolve('../index.js')]
+  })
+
+  // Module should load but not auto-start capturing
+  const capture = require('../index.js')
+  assert.strictEqual(capture.isActive(), false, 'Should not auto-start when disabled')
+
+  // Register handlers and test ITC behavior
+  capture.registerHandler()
+  const sendHandler = mockHandlers.get('sendFlamegraph')
+
+  // Should throw because profiling not started
+  try {
+    await sendHandler({
+      url: 'http://example.com/test',
+      headers: { authorization: 'Bearer token' }
+    })
+    assert.fail('Expected ProfilingNotStartedError to be thrown')
+  } catch (error) {
+    assert.strictEqual(error.code, 'PLT_PPROF_PROFILING_NOT_STARTED')
+    assert.ok(error.message.includes('Profiling not started'), 'Should indicate profiling not started')
+  }
+})
+
+test('pprof capture module should auto-start when enabled', async (t) => {
+  // Ensure flamegraphs are enabled
+  const originalEnv = process.env.PLT_DISABLE_FLAMEGRAPHS
+  const originalInterval = process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC
+
+  delete process.env.PLT_DISABLE_FLAMEGRAPHS // Enable auto-start
+  process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC = '1' // Short interval
+
+  // Mock ITC to test actual behavior
+  const mockHandlers = new Map()
+  const mockITC = {
+    handle: (name, handler) => {
+      mockHandlers.set(name, handler)
+    },
+    _handlers: mockHandlers
+  }
+
+  const kITC = Symbol.for('plt.runtime.itc')
+  globalThis[kITC] = mockITC
+
+  t.after(() => {
+    delete globalThis[kITC]
+    if (originalEnv !== undefined) {
+      process.env.PLT_DISABLE_FLAMEGRAPHS = originalEnv
+    } else {
+      delete process.env.PLT_DISABLE_FLAMEGRAPHS
+    }
+    if (originalInterval !== undefined) {
+      process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC = originalInterval
+    } else {
+      delete process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC
+    }
+    delete require.cache[require.resolve('../index.js')]
+  })
+
+  // Module should load and auto-start capturing
+  const capture = require('../index.js')
+  assert.strictEqual(capture.isActive(), true, 'Should auto-start when enabled')
+
+  t.after(() => {
+    capture.stopCapture()
+  })
+})
+
+test('ITC handlers should be registered', async (t) => {
+  const originalEnv = process.env.PLT_DISABLE_FLAMEGRAPHS
+  process.env.PLT_DISABLE_FLAMEGRAPHS = 'true' // Disable auto-start for test
+
+  // Mock global ITC
+  const mockHandlers = new Map()
+  const mockITC = {
+    handle: (name, handler) => {
+      mockHandlers.set(name, handler)
+    },
+    _handlers: mockHandlers
+  }
+
+  const kITC = Symbol.for('plt.runtime.itc')
+  globalThis[kITC] = mockITC
+
+  t.after(() => {
+    delete globalThis[kITC]
+    delete require.cache[require.resolve('../index.js')]
+    if (originalEnv !== undefined) {
+      process.env.PLT_DISABLE_FLAMEGRAPHS = originalEnv
+    } else {
+      delete process.env.PLT_DISABLE_FLAMEGRAPHS
+    }
+  })
+
+  const capture = require('../index.js')
+  capture.registerHandler()
+
+  // Check that handlers are registered
+  assert.ok(mockHandlers.has('sendFlamegraph'))
+})
+
+test('sendFlamegraph handler should work correctly', async (t) => {
+  const originalInterval = process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC
+  const originalDisable = process.env.PLT_DISABLE_FLAMEGRAPHS
+  process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC = '1' // Short timeout for tests
+  process.env.PLT_DISABLE_FLAMEGRAPHS = 'true' // Disable auto-start
+
+  // Mock ITC and setup
+  const mockHandlers = new Map()
+  const mockITC = {
+    handle: (name, handler) => {
+      mockHandlers.set(name, handler)
+    },
+    _handlers: mockHandlers
+  }
+
+  const kITC = Symbol.for('plt.runtime.itc')
+  globalThis[kITC] = mockITC
+
+  t.after(() => {
+    delete globalThis[kITC]
+    delete require.cache[require.resolve('../index.js')]
+    if (originalInterval !== undefined) {
+      process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC = originalInterval
+    } else {
+      delete process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC
+    }
+    if (originalDisable !== undefined) {
+      process.env.PLT_DISABLE_FLAMEGRAPHS = originalDisable
+    } else {
+      delete process.env.PLT_DISABLE_FLAMEGRAPHS
+    }
+  })
+
+  const capture = require('../index.js')
+
+  // Start capturing so we can test the sendFlamegraph behavior
+  capture.startCapture()
+  capture.registerHandler()
+
+  // Get the handler
+  const sendHandler = mockHandlers.get('sendFlamegraph')
+
+  // Test with no profile (profiling started but no profile captured yet)
+  try {
+    await sendHandler({
+      url: 'http://example.com/success',
+      headers: { authorization: 'Bearer token' }
+    })
+    assert.fail('Expected NoProfileAvailableError to be thrown')
+  } catch (error) {
+    assert.strictEqual(error.code, 'PLT_PPROF_NO_PROFILE_AVAILABLE')
+    assert.ok(error.message.includes('No profile available'))
+  }
+
+  // Stop capturing and test different behavior
+  capture.stopCapture()
+
+  try {
+    await sendHandler({
+      url: 'http://example.com/test',
+      headers: { authorization: 'Bearer token' }
+    })
+    assert.fail('Expected ProfilingNotStartedError to be thrown')
+  } catch (error) {
+    assert.strictEqual(error.code, 'PLT_PPROF_PROFILING_NOT_STARTED')
+    assert.ok(error.message.includes('Profiling not started'))
+  }
+})
+
+test('should handle environment variables correctly', async (t) => {
+  const originalInterval = process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC
+  const originalDisable = process.env.PLT_DISABLE_FLAMEGRAPHS
+
+  process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC = '1' // Short timeout for tests
+  delete process.env.PLT_DISABLE_FLAMEGRAPHS // Enable auto-start
+
+  t.after(() => {
+    if (originalInterval !== undefined) {
+      process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC = originalInterval
+    } else {
+      delete process.env.PLT_FLAMEGRAPHS_INTERVAL_SEC
+    }
+    if (originalDisable !== undefined) {
+      process.env.PLT_DISABLE_FLAMEGRAPHS = originalDisable
+    } else {
+      delete process.env.PLT_DISABLE_FLAMEGRAPHS
+    }
+    delete require.cache[require.resolve('../index.js')]
+  })
+
+  // The module should auto-start with custom interval
+  const capture = require('../index.js')
+  assert.strictEqual(capture.isActive(), true, 'Should auto-start when environment allows')
+
+  t.after(() => {
+    capture.stopCapture()
+  })
+})
+
+test('manual startCapture should work and enable ITC handlers', async (t) => {
+  const originalEnv = process.env.PLT_DISABLE_FLAMEGRAPHS
+  process.env.PLT_DISABLE_FLAMEGRAPHS = 'true' // Disable auto-start
+
+  // Mock ITC to test actual behavior
+  const mockHandlers = new Map()
+  const mockITC = {
+    handle: (name, handler) => {
+      mockHandlers.set(name, handler)
+    },
+    _handlers: mockHandlers
+  }
+
+  const kITC = Symbol.for('plt.runtime.itc')
+  globalThis[kITC] = mockITC
+
+  t.after(() => {
+    delete globalThis[kITC]
+    process.env.PLT_DISABLE_FLAMEGRAPHS = originalEnv
+    delete require.cache[require.resolve('../index.js')]
+  })
+
+  // Module should load but not auto-start
+  const capture = require('../index.js')
+  assert.strictEqual(capture.isActive(), false, 'Should not auto-start when disabled')
+
+  // Manually start capture
+  capture.startCapture()
+  assert.strictEqual(capture.isActive(), true, 'Should be active after manual start')
+
+  t.after(() => {
+    capture.stopCapture()
+  })
+
+  // Register handlers and test that they now work
+  capture.registerHandler()
+  const sendHandler = mockHandlers.get('sendFlamegraph')
+
+  // Should now throw "No profile available" instead of "Profiling not started"
+  try {
+    await sendHandler({
+      url: 'http://example.com/test',
+      headers: { authorization: 'Bearer token' }
+    })
+    assert.fail('Expected NoProfileAvailableError to be thrown')
+  } catch (error) {
+    assert.strictEqual(error.code, 'PLT_PPROF_NO_PROFILE_AVAILABLE')
+    assert.ok(error.message.includes('No profile available'), 'Should indicate no profile available, not profiling not started')
+  }
+})
+
+test('should throw MissingUrlError when URL is not provided', async (t) => {
+  const originalEnv = process.env.PLT_DISABLE_FLAMEGRAPHS
+  process.env.PLT_DISABLE_FLAMEGRAPHS = 'true' // Disable auto-start
+
+  // Mock ITC to test actual behavior
+  const mockHandlers = new Map()
+  const mockITC = {
+    handle: (name, handler) => {
+      mockHandlers.set(name, handler)
+    },
+    _handlers: mockHandlers
+  }
+
+  const kITC = Symbol.for('plt.runtime.itc')
+  globalThis[kITC] = mockITC
+
+  t.after(() => {
+    delete globalThis[kITC]
+    process.env.PLT_DISABLE_FLAMEGRAPHS = originalEnv
+    delete require.cache[require.resolve('../index.js')]
+  })
+
+  const capture = require('../index.js')
+
+  // Start capturing and register handlers
+  capture.startCapture()
+
+  t.after(() => {
+    capture.stopCapture()
+  })
+
+  capture.registerHandler()
+  const sendHandler = mockHandlers.get('sendFlamegraph')
+
+  // Should throw MissingUrlError when no URL provided
+  try {
+    await sendHandler({
+      headers: { authorization: 'Bearer token' }
+    })
+    assert.fail('Expected MissingUrlError to be thrown')
+  } catch (error) {
+    assert.strictEqual(error.code, 'PLT_PPROF_MISSING_URL')
+    assert.ok(error.message.includes('URL is required'))
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2668,6 +2668,31 @@ importers:
         specifier: ^8.18.0
         version: 8.18.2
 
+  packages/watt-pprof-capture:
+    dependencies:
+      '@datadog/pprof':
+        specifier: ^5.3.0
+        version: 5.9.0
+      '@platformatic/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+      '@platformatic/utils':
+        specifier: workspace:*
+        version: link:../utils
+      undici:
+        specifier: ^6.0.0
+        version: 6.21.3
+    devDependencies:
+      borp:
+        specifier: ^0.20.0
+        version: 0.20.0
+      eslint:
+        specifier: '9'
+        version: 9.29.0
+      neostandard:
+        specifier: ^0.12.0
+        version: 0.12.1(@typescript-eslint/utils@8.34.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
+
   packages/wattpm:
     dependencies:
       '@platformatic/config':
@@ -3036,6 +3061,10 @@ packages:
 
   '@databases/validate-unicode@1.0.0':
     resolution: {integrity: sha512-dLKqxGcymeVwEb/6c44KjOnzaAafFf0Wxa8xcfEjx/qOl3rdijsKYBAtIGhtVtOlpPf/PFKfgTuFurSPn/3B/g==}
+
+  '@datadog/pprof@5.9.0':
+    resolution: {integrity: sha512-7KretVkHUANWe31u9cGJpxmUkyrXsCD+fmlZQUz/zk9mtQNC4uBIKX53VUFfrVj/bxAhEEIPw5XTYiMc5RJLsw==}
+    engines: {node: '>=16'}
 
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
@@ -6093,6 +6122,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -8439,6 +8472,10 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
+  node-gyp-build@3.9.0:
+    resolution: {integrity: sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==}
+    hasBin: true
+
   node-mock-http@1.0.0:
     resolution: {integrity: sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ==}
 
@@ -8974,6 +9011,9 @@ packages:
 
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+
+  pprof-format@2.1.0:
+    resolution: {integrity: sha512-0+G5bHH0RNr8E5hoZo/zJYsL92MhkZjwrHp3O2IxmY8RJL9ooKeuZ8Tm0ZNBw5sGZ9TiM71sthTjWoR2Vf5/xw==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -11190,6 +11230,14 @@ snapshots:
       better-sqlite3: 11.10.0
 
   '@databases/validate-unicode@1.0.0': {}
+
+  '@datadog/pprof@5.9.0':
+    dependencies:
+      delay: 5.0.0
+      node-gyp-build: 3.9.0
+      p-limit: 3.1.0
+      pprof-format: 2.1.0
+      source-map: 0.7.4
 
   '@emnapi/core@1.4.3':
     dependencies:
@@ -14455,6 +14503,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  delay@5.0.0: {}
+
   delayed-stream@1.0.0: {}
 
   delegates@1.0.0: {}
@@ -17683,6 +17733,8 @@ snapshots:
       detect-libc: 2.0.4
     optional: true
 
+  node-gyp-build@3.9.0: {}
+
   node-mock-http@1.0.0: {}
 
   node-releases@2.0.19: {}
@@ -18263,6 +18315,8 @@ snapshots:
   postgres-interval@3.0.0: {}
 
   postgres-range@1.1.4: {}
+
+  pprof-format@2.1.0: {}
 
   prebuild-install@7.1.3:
     dependencies:


### PR DESCRIPTION
This exposes a `sendFlamegraph` ITC handler to capture and report pprof profiles. Not sure if this is the best structure for what we want from it. I'll dig into it some more tomorrow.