### PR TITLE
fix(globals): add missing utility type

### DIFF
--- a/packages/globals/lib/index.d.ts
+++ b/packages/globals/lib/index.d.ts
@@ -3,6 +3,8 @@ import { type EventEmitter } from 'node:events'
 import { type Level, type Logger } from 'pino'
 import * as Client from 'prom-client'
 
+type Optional<T> = T | undefined;
+
 export type Handler = ((data: any) => any) | ((data: any) => Promise<any>)
 
 export interface InvalidateHttpCacheOptions {


### PR DESCRIPTION
I noticed that when `getGlobal` from `@platformatic/global` is used, it resolves with `any` type in typescript.

It happens because `Optional` utility type is [used](https://github.com/platformatic/platformatic/blob/cfed06c00a8250c0985fb7f979a1413b935090bd/packages/globals/lib/index.d.ts#L77) but doesn't exist in TS standard library ([playground](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAyg9gWwgeQEYCsoF4oG8oCGAXFAHYCuCqEATlAL4DcAUKJFALIEjVqY7IwwAJZxSBADYAeeEj4A+RkA) example). Probably a LLM hallucination since such utility types are often implemented in code bases.

PS
Probably worth to include TS type check in CI?