### PR TITLE
feat(runtime): add active_resources_event_loop metric

### DIFF
--- a/packages/basic/lib/base.js
+++ b/packages/basic/lib/base.js
@@ -506,6 +506,13 @@ export class BaseStackable extends EventEmitter {
     globalThis.platformatic.onHttpStatsSize = (url, val) => {
       httpStatsSizeMetric.set({ dispatcher_stats_url: url }, val)
     }
+
+    const activeResourcesEventLoopMetric = new client.Gauge({
+      name: 'active_resources_event_loop',
+      help: 'Number of active resources keeping the event loop alive',
+      registers: [registry]
+    })
+    globalThis.platformatic.onActiveResourcesEventLoop = (val) => activeResourcesEventLoopMetric.set(val)
   }
 
   async #invalidateHttpCache (opts = {}) {

--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -283,6 +283,13 @@ export class ChildProcess extends ITC {
     globalThis.platformatic.onHttpStatsSize = (url, val) => {
       httpStatsSizeMetric.set({ dispatcher_stats_url: url }, val)
     }
+
+    const activeResourcesEventLoopMetric = new client.Gauge({
+      name: 'active_resources_event_loop',
+      help: 'Number of active resources keeping the event loop alive',
+      registers: [registry]
+    })
+    globalThis.platformatic.onActiveResourcesEventLoop = (val) => activeResourcesEventLoopMetric.set(val)
   }
 
   async #getMetrics ({ format } = {}) {

--- a/packages/runtime/lib/worker/app.js
+++ b/packages/runtime/lib/worker/app.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { getActiveResourcesInfo } = require('node:process')
 const { existsSync } = require('node:fs')
 const { EventEmitter } = require('node:events')
 const { resolve } = require('node:path')
@@ -219,6 +220,7 @@ class PlatformaticApp extends EventEmitter {
         globalThis.platformatic.onHttpStatsSize(url, size || 0)
       }
     }
+    globalThis.platformatic.onActiveResourcesEventLoop(getActiveResourcesInfo().length)
     return this.stackable.getMetrics({ format })
   }
 

--- a/packages/runtime/test/api/metrics.test.js
+++ b/packages/runtime/test/api/metrics.test.js
@@ -85,7 +85,8 @@ test('should get runtime metrics in a json format', async t => {
     'http_client_stats_pending',
     'http_client_stats_queued',
     'http_client_stats_running',
-    'http_client_stats_size'
+    'http_client_stats_size',
+    'active_resources_event_loop'
   ]
 
   const services = ['service-1', 'service-2', 'service-db']
@@ -175,7 +176,8 @@ test('should get runtime metrics in a text format', async t => {
     'http_client_stats_pending',
     'http_client_stats_queued',
     'http_client_stats_running',
-    'http_client_stats_size'
+    'http_client_stats_size',
+    'active_resources_event_loop'
   ]
   for (const metricName of expectedMetricNames) {
     assert.ok(metricsNames.includes(metricName), `Missing metric: ${metricName}`)
@@ -436,39 +438,40 @@ test('should get runtime metrics in a json format without a service call', async
   const summaryMetric = metrics.find(
     (metric) => metric.name === 'http_request_all_summary_seconds'
   )
-  assert.strictEqual(summaryMetric.name, 'http_request_all_summary_seconds')
   assert.strictEqual(summaryMetric.type, 'summary')
   assert.strictEqual(summaryMetric.aggregator, 'sum')
 
   const freeMetric = metrics.find(({ name }) => name === 'http_client_stats_free')
-  assert.strictEqual(freeMetric.name, 'http_client_stats_free')
   assert.strictEqual(freeMetric.type, 'gauge')
   assert.strictEqual(freeMetric.aggregator, 'sum')
 
   const connectedMetric = metrics.find(({ name }) => name === 'http_client_stats_connected')
-  assert.strictEqual(connectedMetric.name, 'http_client_stats_connected')
   assert.strictEqual(connectedMetric.type, 'gauge')
   assert.strictEqual(connectedMetric.aggregator, 'sum')
 
   const pendingMetric = metrics.find(({ name }) => name === 'http_client_stats_pending')
-  assert.strictEqual(pendingMetric.name, 'http_client_stats_pending')
   assert.strictEqual(pendingMetric.type, 'gauge')
   assert.strictEqual(pendingMetric.aggregator, 'sum')
 
   const queuedMetric = metrics.find(({ name }) => name === 'http_client_stats_queued')
-  assert.strictEqual(queuedMetric.name, 'http_client_stats_queued')
   assert.strictEqual(queuedMetric.type, 'gauge')
   assert.strictEqual(queuedMetric.aggregator, 'sum')
 
   const runningMetric = metrics.find(({ name }) => name === 'http_client_stats_running')
-  assert.strictEqual(runningMetric.name, 'http_client_stats_running')
   assert.strictEqual(runningMetric.type, 'gauge')
   assert.strictEqual(runningMetric.aggregator, 'sum')
 
   const sizeMetric = metrics.find(({ name }) => name === 'http_client_stats_size')
-  assert.strictEqual(sizeMetric.name, 'http_client_stats_size')
   assert.strictEqual(sizeMetric.type, 'gauge')
   assert.strictEqual(sizeMetric.aggregator, 'sum')
+
+  const activeMetric = metrics.find(({ name }) => name === 'active_resources_event_loop')
+  assert.strictEqual(activeMetric.type, 'gauge')
+  assert.strictEqual(activeMetric.aggregator, 'sum')
+  const [{ labels: { serviceId, custom_label: label }, value }] = activeMetric.values
+  assert.strictEqual(serviceId, 'service-1')
+  assert.strictEqual(label, 'custom-value')
+  assert.ok(value > 0)
 
   const summaryValues = summaryMetric.values
 

--- a/packages/runtime/test/management-api/metrics.test.js
+++ b/packages/runtime/test/management-api/metrics.test.js
@@ -49,7 +49,8 @@ const expectedMetricNames = [
   'http_client_stats_pending',
   'http_client_stats_queued',
   'http_client_stats_running',
-  'http_client_stats_size'
+  'http_client_stats_size',
+  'active_resources_event_loop'
 ]
 
 test('should get prom metrics from the management api', async t => {

--- a/packages/runtime/test/prom-metrics.test.js
+++ b/packages/runtime/test/prom-metrics.test.js
@@ -160,7 +160,8 @@ test('should start a prometheus server on port 9090', async t => {
     'http_client_stats_pending',
     'http_client_stats_queued',
     'http_client_stats_running',
-    'http_client_stats_size'
+    'http_client_stats_size',
+    'active_resources_event_loop'
   ]
 
   for (const metricName of expectedMetricNames) {

--- a/packages/service/lib/stackable.js
+++ b/packages/service/lib/stackable.js
@@ -356,6 +356,13 @@ class ServiceStackable {
     globalThis.platformatic.onHttpStatsSize = (url, val) => {
       httpStatsSizeMetric.set({ dispatcher_stats_url: url }, val)
     }
+
+    const activeResourcesEventLoopMetric = new client.Gauge({
+      name: 'active_resources_event_loop',
+      help: 'Number of active resources keeping the event loop alive',
+      registers: [registry]
+    })
+    globalThis.platformatic.onActiveResourcesEventLoop = (val) => activeResourcesEventLoopMetric.set(val)
   }
 
   #updateConfig () {


### PR DESCRIPTION
This could be then consumed by `watt-admin`