### PR TITLE
Add wattpm pprof commands

### DIFF
--- a/packages/control/lib/errors.js
+++ b/packages/control/lib/errors.js
@@ -22,4 +22,8 @@ module.exports = {
   FailedToGetRuntimeAllLogs: createError(`${ERROR_PREFIX}_FAILED_TO_GET_RUNTIME_ALL_LOGS`, 'Failed to get runtime all logs %s.'),
   FailedToGetRuntimeLogIndexes: createError(`${ERROR_PREFIX}_FAILED_TO_GET_HISTORY_LOGS_COUNT`, 'Failed to get history logs count %s.'),
   FailedToGetRuntimeMetrics: createError(`${ERROR_PREFIX}_FAILED_TO_GET_RUNTIME_METRICS`, 'Failed to get runtime metrics %s.'),
+  ProfilingAlreadyStarted: createError(`${ERROR_PREFIX}_PROFILING_ALREADY_STARTED`, 'Profiling is already started for service "%s".'),
+  ProfilingNotStarted: createError(`${ERROR_PREFIX}_PROFILING_NOT_STARTED`, 'Profiling not started for service "%s".'),
+  FailedToStartProfiling: createError(`${ERROR_PREFIX}_FAILED_TO_START_PROFILING`, 'Failed to start profiling for service "%s": %s'),
+  FailedToStopProfiling: createError(`${ERROR_PREFIX}_FAILED_TO_STOP_PROFILING`, 'Failed to stop profiling for service "%s": %s'),
 }

--- a/packages/control/test/pprof.test.mjs
+++ b/packages/control/test/pprof.test.mjs
@@ -1,0 +1,172 @@
+'use strict'
+
+import { safeRemove } from '@platformatic/utils'
+import * as desm from 'desm'
+import assert from 'node:assert'
+import { createHash } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { RuntimeApiClient } from '../index.js'
+import * as errors from '../lib/errors.js'
+import { startRuntime, kill } from './helper.mjs'
+
+function getRuntimeTmpDir (runtimeDir) {
+  const platformaticTmpDir = join(tmpdir(), 'platformatic', 'applications')
+  const runtimeDirHash = createHash('md5').update(runtimeDir).digest('hex')
+  return join(platformaticTmpDir, runtimeDirHash)
+}
+
+const fixturesDir = desm.join(import.meta.url, 'fixtures')
+
+test('should start profiling via RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Start profiling on service-1
+  await runtimeClient.startServiceProfiling(runtime.pid, 'service-1', { intervalMicros: 1000 })
+
+  // Should not throw - successful start
+  assert.ok(true, 'startServiceProfiling should complete successfully')
+
+  // Clean up - stop profiling
+  await runtimeClient.stopServiceProfiling(runtime.pid, 'service-1')
+})
+
+test('should stop profiling and return profile data via RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Start profiling first
+  await runtimeClient.startServiceProfiling(runtime.pid, 'service-1', { intervalMicros: 1000 })
+
+  // Wait a bit for some profile data
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop profiling and get profile data
+  const profileData = await runtimeClient.stopServiceProfiling(runtime.pid, 'service-1')
+
+  // Should return binary profile data (ArrayBuffer)
+  assert.ok(profileData instanceof ArrayBuffer, 'stopServiceProfiling should return an ArrayBuffer')
+  assert.ok(profileData.byteLength > 0, 'Profile data should not be empty')
+})
+
+test('should handle service not found error in RuntimeApiClient for start profiling', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Try to start profiling on non-existent service
+  await assert.rejects(
+    () => runtimeClient.startServiceProfiling(runtime.pid, 'non-existent-service', { intervalMicros: 1000 }),
+    errors.ServiceNotFound,
+    'Should throw ServiceNotFound error for non-existent service'
+  )
+})
+
+test('should handle service not found error in RuntimeApiClient for stop profiling', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Try to stop profiling on non-existent service
+  await assert.rejects(
+    () => runtimeClient.stopServiceProfiling(runtime.pid, 'non-existent-service'),
+    errors.ServiceNotFound,
+    'Should throw ServiceNotFound error for non-existent service'
+  )
+})
+
+test('should handle profiling already started error in RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Start profiling
+  await runtimeClient.startServiceProfiling(runtime.pid, 'service-1', { intervalMicros: 1000 })
+
+  // Try to start profiling again - should throw error
+  await assert.rejects(
+    () => runtimeClient.startServiceProfiling(runtime.pid, 'service-1', { intervalMicros: 1000 }),
+    errors.ProfilingAlreadyStarted,
+    'Should throw ProfilingAlreadyStarted error when profiling is already started'
+  )
+
+  // Clean up - stop profiling
+  await runtimeClient.stopServiceProfiling(runtime.pid, 'service-1')
+})
+
+test('should handle profiling not started error in RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Try to stop profiling when it's not started
+  await assert.rejects(
+    () => runtimeClient.stopServiceProfiling(runtime.pid, 'service-1'),
+    errors.ProfilingNotStarted,
+    'Should throw ProfilingNotStarted error when profiling is not started'
+  )
+})

--- a/packages/runtime/lib/management-api.js
+++ b/packages/runtime/lib/management-api.js
@@ -90,6 +90,23 @@ async function managementApiPlugin (app, opts) {
     await runtime.stopService(id)
   })
 
+  app.post('/services/:id/pprof/start', async (request, reply) => {
+    const { id } = request.params
+    app.log.debug('start profiling', { id })
+
+    const options = request.body || {}
+    await runtime.startServiceProfiling(id, options)
+    reply.code(200).send({})
+  })
+
+  app.post('/services/:id/pprof/stop', async (request, reply) => {
+    const { id } = request.params
+    app.log.debug('stop profiling', { id })
+
+    const profileData = await runtime.stopServiceProfiling(id)
+    reply.type('application/octet-stream').code(200).send(profileData)
+  })
+
   app.all('/services/:id/proxy/*', async (request, reply) => {
     const { id, '*': requestUrl } = request.params
     app.log.debug('proxy request', { id, requestUrl })

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -795,6 +795,18 @@ class Runtime extends EventEmitter {
     return sendViaITC(service, 'getServiceEnv')
   }
 
+  async startServiceProfiling (id, options = {}, ensureStarted = true) {
+    const service = await this.#getServiceById(id, ensureStarted)
+
+    return sendViaITC(service, 'startProfiling', options)
+  }
+
+  async stopServiceProfiling (id, ensureStarted = true) {
+    const service = await this.#getServiceById(id, ensureStarted)
+
+    return sendViaITC(service, 'stopProfiling')
+  }
+
   async getServiceOpenapiSchema (id) {
     const service = await this.#getServiceById(id, true)
 

--- a/packages/runtime/test/management-api/pprof.test.js
+++ b/packages/runtime/test/management-api/pprof.test.js
@@ -1,0 +1,256 @@
+'use strict'
+
+const assert = require('node:assert')
+const { join } = require('node:path')
+const { test } = require('node:test')
+const { Client } = require('undici')
+
+const { buildServer } = require('../..')
+const fixturesDir = join(__dirname, '..', '..', 'fixtures')
+
+test('should start profiling via management API', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await buildServer(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Start profiling on service-1
+  const { statusCode, body } = await client.request({
+    method: 'POST',
+    path: '/api/v1/services/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ intervalMicros: 1000 })
+  })
+
+  assert.strictEqual(statusCode, 200)
+
+  const response = await body.json()
+  // The response might be empty or contain a status message
+  assert.ok(typeof response === 'object' || response === null)
+})
+
+test('should stop profiling and return profile data via management API', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await buildServer(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Start profiling first
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/services/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ intervalMicros: 1000 })
+  })
+
+  // Wait a bit for some profile data
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop profiling and get profile data
+  const { statusCode, body, headers } = await client.request({
+    method: 'POST',
+    path: '/api/v1/services/service-1/pprof/stop'
+  })
+
+  assert.strictEqual(statusCode, 200)
+
+  // Should return binary profile data
+  assert.strictEqual(headers['content-type'], 'application/octet-stream')
+
+  const profileData = await body.arrayBuffer()
+  assert.ok(profileData.byteLength > 0, 'Profile data should not be empty')
+})
+
+test('should handle service not found error when starting profiling', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await buildServer(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Try to start profiling on non-existent service
+  const { body } = await client.request({
+    method: 'POST',
+    path: '/api/v1/services/non-existent/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ intervalMicros: 1000 })
+  })
+
+  const response = await body.json()
+  assert.ok(response.code === 'PLT_RUNTIME_SERVICE_NOT_FOUND')
+})
+
+test('should handle service not found error when stopping profiling', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await buildServer(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Try to stop profiling on non-existent service
+  const { body } = await client.request({
+    method: 'POST',
+    path: '/api/v1/services/non-existent/pprof/stop'
+  })
+
+  const response = await body.json()
+  assert.ok(response.code === 'PLT_RUNTIME_SERVICE_NOT_FOUND')
+})
+
+test('should handle profiling already started error', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await buildServer(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Start profiling
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/services/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ intervalMicros: 1000 })
+  })
+
+  // Try to start profiling again
+  const { body } = await client.request({
+    method: 'POST',
+    path: '/api/v1/services/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ intervalMicros: 1000 })
+  })
+
+  const response = await body.json()
+  assert.ok(response.code === 'PLT_PPROF_PROFILING_ALREADY_STARTED')
+
+  // Clean up - stop profiling
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/services/service-1/pprof/stop'
+  })
+})
+
+test('should handle profiling not started error', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await buildServer(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Try to stop profiling when it's not started
+  const { body } = await client.request({
+    method: 'POST',
+    path: '/api/v1/services/service-1/pprof/stop'
+  })
+
+  const response = await body.json()
+  assert.ok(response.code === 'PLT_PPROF_PROFILING_NOT_STARTED')
+})

--- a/packages/runtime/test/pprof-commands.test.js
+++ b/packages/runtime/test/pprof-commands.test.js
@@ -1,0 +1,149 @@
+'use strict'
+
+const assert = require('node:assert')
+const { join } = require('node:path')
+const { test } = require('node:test')
+
+const { loadConfig } = require('@platformatic/config')
+const { buildServer, platformaticRuntime } = require('..')
+const fixturesDir = join(__dirname, '..', 'fixtures')
+
+test('should start profiling for a service', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Test starting profiling on a service
+  const result = await app.startServiceProfiling('with-logger', { intervalMicros: 1000 })
+
+  // Should not throw and complete successfully
+  // The actual ITC handler in watt-pprof-capture will handle the profiling logic
+  assert.ok(typeof result === 'undefined' || result === null, 'startServiceProfiling should not return a value')
+})
+
+test('should stop profiling for a service and return profile data', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Start profiling first
+  await app.startServiceProfiling('with-logger', { intervalMicros: 1000 })
+
+  // Wait a bit for some profile data to be collected
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop profiling and get the profile data
+  const profileData = await app.stopServiceProfiling('with-logger')
+
+  // Should return binary profile data (Buffer or Uint8Array)
+  assert.ok(Buffer.isBuffer(profileData) || profileData instanceof Uint8Array, 'stopServiceProfiling should return a Buffer or Uint8Array')
+  assert.ok(profileData.length > 0, 'Profile data should not be empty')
+})
+
+test('should throw error when starting profiling on non-existent service', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Try to start profiling on a service that doesn't exist
+  await assert.rejects(
+    () => app.startServiceProfiling('non-existent-service', {}),
+    (err) => {
+      assert.ok(err.message.includes('Service not found') || err.message.includes('non-existent-service'))
+      return true
+    },
+    'Should throw error for non-existent service'
+  )
+})
+
+test('should throw error when stopping profiling on non-existent service', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Try to stop profiling on a service that doesn't exist
+  await assert.rejects(
+    () => app.stopServiceProfiling('non-existent-service'),
+    (err) => {
+      assert.ok(err.message.includes('Service not found') || err.message.includes('non-existent-service'))
+      return true
+    },
+    'Should throw error for non-existent service'
+  )
+})
+
+test('should handle profiling already started error', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Start profiling
+  await app.startServiceProfiling('with-logger', { intervalMicros: 1000 })
+
+  // Try to start profiling again - should throw an error
+  await assert.rejects(
+    () => app.startServiceProfiling('with-logger', { intervalMicros: 1000 }),
+    (err) => {
+      // The error should indicate profiling is already started
+      assert.ok(err.message.includes('already') || err.message.includes('started'))
+      return true
+    },
+    'Should throw error when profiling is already started'
+  )
+
+  // Clean up - stop profiling
+  await app.stopServiceProfiling('with-logger')
+})
+
+test('should handle profiling not started error', async (t) => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const config = await loadConfig({}, ['-c', configFile], platformaticRuntime)
+  const app = await buildServer(config.configManager.current)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Try to stop profiling when it's not started
+  await assert.rejects(
+    () => app.stopServiceProfiling('with-logger'),
+    (err) => {
+      // The error should indicate profiling is not started
+      assert.ok(err.message.includes('not started') || err.message.includes('not running'))
+      return true
+    },
+    'Should throw error when profiling is not started'
+  )
+})

--- a/packages/watt-pprof-capture/lib/errors.js
+++ b/packages/watt-pprof-capture/lib/errors.js
@@ -6,17 +6,20 @@ const ERROR_PREFIX = 'PLT_PPROF'
 
 const ProfilingAlreadyStartedError = createError(
   `${ERROR_PREFIX}_PROFILING_ALREADY_STARTED`,
-  'Profiling is already started'
+  'Profiling is already started',
+  400
 )
 
 const ProfilingNotStartedError = createError(
   `${ERROR_PREFIX}_PROFILING_NOT_STARTED`,
-  'Profiling not started - call startProfiling() first'
+  'Profiling not started - call startProfiling() first',
+  400
 )
 
 const NoProfileAvailableError = createError(
   `${ERROR_PREFIX}_NO_PROFILE_AVAILABLE`,
-  'No profile available - wait for profiling to complete or trigger manual capture'
+  'No profile available - wait for profiling to complete or trigger manual capture',
+  400
 )
 
 module.exports = {

--- a/packages/wattpm/index.js
+++ b/packages/wattpm/index.js
@@ -10,6 +10,7 @@ import { logsCommand } from './lib/commands/logs.js'
 import { configCommand, envCommand, psCommand, servicesCommand } from './lib/commands/management.js'
 import { metricsCommand } from './lib/commands/metrics.js'
 import { patchConfigCommand } from './lib/commands/patch-config.js'
+import { pprofCommand } from './lib/commands/pprof.js'
 import { version } from './lib/schema.js'
 import { createLogger, logFatalError, parseArgs, setVerbose } from './lib/utils.js'
 
@@ -109,6 +110,9 @@ export async function main () {
       break
     case 'metrics':
       command = metricsCommand
+      break
+    case 'pprof':
+      command = pprofCommand
       break
     /* c8 ignore next - Just an alias */
     case 'init':

--- a/packages/wattpm/lib/commands/help.js
+++ b/packages/wattpm/lib/commands/help.js
@@ -15,7 +15,8 @@ async function loadCommands () {
     'inject',
     'external',
     'patch-config',
-    'metrics'
+    'metrics',
+    'pprof'
   ]) {
     const category = await import(`./${file}.js`)
     Object.assign(commands, category.help)

--- a/packages/wattpm/lib/commands/pprof.js
+++ b/packages/wattpm/lib/commands/pprof.js
@@ -1,0 +1,144 @@
+import { RuntimeApiClient } from '@platformatic/control'
+import { ensureLoggableError } from '@platformatic/utils'
+import { bold } from 'colorette'
+import { writeFile } from 'node:fs/promises'
+import { getMatchingRuntime, logFatalError, parseArgs } from '../utils.js'
+
+export async function pprofStartCommand (logger, args) {
+  try {
+    const { positionals } = parseArgs(args, {}, false)
+
+    const client = new RuntimeApiClient()
+    const [runtime] = await getMatchingRuntime(client, positionals)
+    const { services: runtimeServices } = await client.getRuntimeServices(runtime.pid)
+
+    // Get service ID from positional argument or use all services
+    const serviceId = positionals[0]
+
+    if (serviceId) {
+      // Start profiling for specific service
+      const service = runtimeServices.find(s => s.id === serviceId)
+      if (!service) {
+        await client.close()
+        return logFatalError(logger, `Service not found: ${serviceId}`)
+      }
+
+      await client.startServiceProfiling(runtime.pid, serviceId, { intervalMicros: 1000 })
+      logger.info(`Profiling started for service ${bold(serviceId)}`)
+    } else {
+      // Start profiling for all services
+      for (const service of runtimeServices) {
+        try {
+          await client.startServiceProfiling(runtime.pid, service.id, { intervalMicros: 1000 })
+          logger.info(`Profiling started for service ${bold(service.id)}`)
+        } catch (error) {
+          logger.warn(`Failed to start profiling for service ${service.id}: ${error.message}`)
+        }
+      }
+    }
+
+    await client.close()
+  } catch (error) {
+    if (error.code === 'PLT_CTR_RUNTIME_NOT_FOUND') {
+      return logFatalError(logger, 'Cannot find a matching runtime.')
+    } else if (error.message && (error.message.includes('Service not found'))) {
+      return logFatalError(logger, error.message)
+    } else {
+      return logFatalError(logger, { error: ensureLoggableError(error) }, `Cannot start profiling: ${error.message}`)
+    }
+  }
+}
+
+export async function pprofStopCommand (logger, args) {
+  try {
+    const { positionals } = parseArgs(args, {}, false)
+
+    const client = new RuntimeApiClient()
+    const [runtime] = await getMatchingRuntime(client, positionals)
+    const { services: runtimeServices } = await client.getRuntimeServices(runtime.pid)
+
+    // Get service ID from positional argument or use all services
+    const serviceId = positionals[0]
+    const timestamp = new Date().toISOString().replace(/:/g, '-').replace(/\./g, '-')
+
+    if (serviceId) {
+      // Stop profiling for specific service
+      const service = runtimeServices.find(s => s.id === serviceId)
+      if (!service) {
+        await client.close()
+        return logFatalError(logger, `Service not found: ${serviceId}`)
+      }
+
+      const profileData = await client.stopServiceProfiling(runtime.pid, serviceId)
+      const filename = `pprof-${serviceId}-${timestamp}.pb`
+      await writeFile(filename, Buffer.from(profileData))
+      logger.info(`Profiling stopped for service ${bold(serviceId)}, profile saved to ${bold(filename)}`)
+    } else {
+      // Stop profiling for all services
+      for (const service of runtimeServices) {
+        try {
+          const profileData = await client.stopServiceProfiling(runtime.pid, service.id)
+          const filename = `pprof-${service.id}-${timestamp}.pb`
+          await writeFile(filename, Buffer.from(profileData))
+          logger.info(`Profiling stopped for service ${bold(service.id)}, profile saved to ${bold(filename)}`)
+        } catch (error) {
+          logger.warn(`Failed to stop profiling for service ${service.id}: ${error.message}`)
+        }
+      }
+    }
+
+    await client.close()
+  } catch (error) {
+    if (error.code === 'PLT_CTR_RUNTIME_NOT_FOUND') {
+      return logFatalError(logger, 'Cannot find a matching runtime.')
+    } else if (error.message && (error.message.includes('Service not found'))) {
+      return logFatalError(logger, error.message)
+    } else {
+      return logFatalError(logger, { error: ensureLoggableError(error) }, `Cannot stop profiling: ${error.message}`)
+    }
+  }
+}
+
+export async function pprofCommand (logger, args) {
+  if (args.length === 0) {
+    // Show help when no subcommand is provided
+    logger.info('Available pprof commands:')
+    logger.info('  pprof start [service] - Start profiling')
+    logger.info('  pprof stop [service]  - Stop profiling and save profile')
+    process.exit(1)
+  }
+
+  const [subcommand, ...restArgs] = args
+
+  switch (subcommand) {
+    case 'start':
+      return pprofStartCommand(logger, restArgs)
+    case 'stop':
+      return pprofStopCommand(logger, restArgs)
+    default:
+      logger.error(`Unknown pprof subcommand: ${subcommand}`)
+      logger.info('Available pprof commands:')
+      logger.info('  pprof start [service] - Start profiling')
+      logger.info('  pprof stop [service]  - Stop profiling and save profile')
+      process.exit(1)
+  }
+}
+
+export const help = {
+  pprof: {
+    usage: 'pprof <start|stop> [service]',
+    description: 'Profile CPU usage of running services',
+    options: [],
+    args: [
+      {
+        name: 'command',
+        description: 'The pprof command to run: start or stop'
+      },
+      {
+        name: 'service',
+        description: 'The service ID to profile (if omitted, profiles all services)'
+      }
+    ],
+    footer: 'Use "pprof start [service]" to start profiling and "pprof stop [service]" to stop and save profile data.'
+  }
+}

--- a/packages/wattpm/test/pprof.test.js
+++ b/packages/wattpm/test/pprof.test.js
@@ -1,0 +1,190 @@
+import { ok, strictEqual } from 'node:assert'
+import { readdir, stat } from 'node:fs/promises'
+import { on } from 'node:events'
+import { test } from 'node:test'
+import split2 from 'split2'
+import { prepareRuntime } from '../../basic/test/helper.js'
+import { wattpm } from './helper.js'
+
+test('pprof start - should start profiling on specific service', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+
+  t.after(() => {
+    startProcess.kill('SIGINT')
+    startProcess.catch(() => {})
+  })
+
+  const startProcess = wattpm('start', rootDir)
+
+  for await (const log of on(startProcess.stdout.pipe(split2()), 'data')) {
+    const parsed = JSON.parse(log.toString())
+
+    if (parsed.msg.startsWith('Platformatic is now listening')) {
+      break
+    }
+  }
+
+  const pprofStartProcess = await wattpm('pprof', 'start', 'main')
+
+  ok(pprofStartProcess.stdout.includes('Profiling started') || pprofStartProcess.stdout.length === 0, 'Should start profiling successfully')
+  strictEqual(pprofStartProcess.exitCode, 0, 'Should exit with code 0')
+
+  // Clean up
+  await wattpm('pprof', 'stop', 'main')
+})
+
+test('pprof stop - should stop profiling and create profile file', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+
+  t.after(() => {
+    startProcess.kill('SIGINT')
+    startProcess.catch(() => {})
+  })
+
+  const startProcess = wattpm('start', rootDir)
+
+  for await (const log of on(startProcess.stdout.pipe(split2()), 'data')) {
+    const parsed = JSON.parse(log.toString())
+
+    if (parsed.msg.startsWith('Platformatic is now listening')) {
+      break
+    }
+  }
+
+  // Start profiling
+  await wattpm('pprof', 'start', 'main')
+
+  // Wait a bit for some profile data
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop profiling and get file
+  const pprofStopProcess = await wattpm('pprof', 'stop', 'main')
+
+  strictEqual(pprofStopProcess.exitCode, 0, 'Should exit with code 0')
+
+  // Check that a profile file was created
+  const files = await readdir(process.cwd())
+  const profileFiles = files.filter(file => file.startsWith('pprof-main-') && file.endsWith('.pb'))
+  ok(profileFiles.length > 0, 'Should create at least one profile file')
+
+  // Check that the file has content
+  const profileFile = profileFiles[0]
+  const stats = await stat(profileFile)
+  ok(stats.size > 0, 'Profile file should not be empty')
+})
+
+test('pprof start - should start profiling on all services when no service specified', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+
+  t.after(() => {
+    startProcess.kill('SIGINT')
+    startProcess.catch(() => {})
+  })
+
+  const startProcess = wattpm('start', rootDir)
+
+  for await (const log of on(startProcess.stdout.pipe(split2()), 'data')) {
+    const parsed = JSON.parse(log.toString())
+
+    if (parsed.msg.startsWith('Platformatic is now listening')) {
+      break
+    }
+  }
+
+  const pprofStartProcess = await wattpm('pprof', 'start')
+
+  ok(pprofStartProcess.stdout.includes('Profiling started') || pprofStartProcess.stdout.length === 0, 'Should start profiling on all services')
+  strictEqual(pprofStartProcess.exitCode, 0, 'Should exit with code 0')
+
+  // Clean up
+  await wattpm('pprof', 'stop')
+})
+
+test('pprof stop - should stop profiling on all services and create multiple profile files', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+
+  t.after(() => {
+    startProcess.kill('SIGINT')
+    startProcess.catch(() => {})
+  })
+
+  const startProcess = wattpm('start', rootDir)
+
+  for await (const log of on(startProcess.stdout.pipe(split2()), 'data')) {
+    const parsed = JSON.parse(log.toString())
+
+    if (parsed.msg.startsWith('Platformatic is now listening')) {
+      break
+    }
+  }
+
+  // Start profiling on all services
+  await wattpm('pprof', 'start')
+
+  // Wait a bit for some profile data
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop profiling and get files
+  const pprofStopProcess = await wattpm('pprof', 'stop')
+
+  strictEqual(pprofStopProcess.exitCode, 0, 'Should exit with code 0')
+
+  // Check that profile files were created
+  const files = await readdir(process.cwd())
+  const profileFiles = files.filter(file => file.startsWith('pprof-') && file.endsWith('.pb'))
+  ok(profileFiles.length > 0, 'Should create at least one profile file')
+})
+
+test('pprof - should handle service not found error', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+
+  t.after(() => {
+    startProcess.kill('SIGINT')
+    startProcess.catch(() => {})
+  })
+
+  const startProcess = wattpm('start', rootDir)
+
+  for await (const log of on(startProcess.stdout.pipe(split2()), 'data')) {
+    const parsed = JSON.parse(log.toString())
+
+    if (parsed.msg.startsWith('Platformatic is now listening')) {
+      break
+    }
+  }
+
+  let error
+  try {
+    await wattpm('pprof', 'start', 'non-existent-service')
+  } catch (e) {
+    error = e
+  }
+
+  ok(error, 'Should throw an error')
+  const errorText = error.stdout + error.stderr
+  ok(errorText.includes('Service not found') || errorText.includes('non-existent-service'), 'Should indicate service not found')
+})
+
+test('pprof - should handle no matching runtime error', async t => {
+  let error
+  try {
+    await wattpm('pprof', 'start')
+  } catch (e) {
+    error = e
+  }
+
+  ok(error, 'Should throw an error')
+  ok(error.stdout.includes('Cannot find a matching runtime') || error.stderr.includes('Cannot find a matching runtime'), 'Should indicate no runtime found')
+})
+
+test('pprof - should show help when no subcommand specified', async t => {
+  let error
+  try {
+    await wattpm('pprof')
+  } catch (e) {
+    error = e
+  }
+
+  ok(error, 'Should show help and exit with error')
+  ok(error.stdout.includes('pprof start') || error.stdout.includes('pprof stop'), 'Should show pprof help')
+})


### PR DESCRIPTION
This adds pprof-calling support to:
- runtime instance
- management API
- control client
- wattpm commands

With that we should have the full flow to trigger profiles via the wattpm CLI.