### PR TITLE
fix: enable reusePort and getHeapStatistics post node 24 (#4262)

### DIFF
--- a/packages/utils/lib/features.js
+++ b/packages/utils/lib/features.js
@@ -6,9 +6,9 @@ const { satisfies } = require('semver')
 const currentPlatform = platform()
 
 const node = {
-  reusePort: satisfies(process.version, '^22.12.0 || ^23.1.0') && !['win32', 'darwin'].includes(currentPlatform),
+  reusePort: satisfies(process.version, '^22.12.0 || ^23.1.0 || >=24.0.0') && !['win32', 'darwin'].includes(currentPlatform),
   worker: {
-    getHeapStatistics: satisfies(process.version, '^22.16.0')
+    getHeapStatistics: satisfies(process.version, '^22.16.0 || >=24.0.0')
   }
 }
 


### PR DESCRIPTION
Fixes #4262

A bit more cautious approach would be to enable majors manually (in case something will be deprecated/removed), so let me know wdyt. 