### PR TITLE
fix(create-wattpm): differentiate between internal and external packages

### DIFF
--- a/packages/create-wattpm/lib/index.js
+++ b/packages/create-wattpm/lib/index.js
@@ -24,22 +24,25 @@ import resolveModule from 'resolve'
 import { createGitRepository } from './git.js'
 import { findGatewayConfigFile, getUsername, getVersion, say } from './utils.js'
 
-const defaultCapabilities = [
-  '@platformatic/node',
-  '@platformatic/gateway',
-  '@platformatic/next',
-  '@platformatic/vite',
-  '@platformatic/astro',
-  '@platformatic/remix',
-  '@platformatic/nest',
-  '@platformatic/service',
-  '@platformatic/db',
-  '@platformatic/php',
-  '@platformatic/ai-warp',
-  '@platformatic/pg-hooks',
-  '@platformatic/rabbitmq-hooks',
-  '@platformatic/kafka-hooks'
-]
+export const defaultCapabilities = {
+  '@platformatic/node': { id: '@platformatic/node', external: false },
+  '@platformatic/gateway': { id: '@platformatic/gateway', external: false },
+  '@platformatic/next': { id: '@platformatic/next', external: false },
+  '@platformatic/vite': { id: '@platformatic/vite', external: false },
+  '@platformatic/astro': { id: '@platformatic/astro', external: false },
+  '@platformatic/remix': { id: '@platformatic/remix', external: false },
+  '@platformatic/nest': { id: '@platformatic/nest', external: false },
+  '@platformatic/service': { id: '@platformatic/service', external: false },
+  '@platformatic/db': { id: '@platformatic/db', external: false },
+  '@platformatic/php': { id: '@platformatic/php', external: true },
+  '@platformatic/ai-warp': { id: '@platformatic/ai-warp', external: true },
+  '@platformatic/pg-hooks': { id: '@platformatic/pg-hooks', external: true },
+  '@platformatic/rabbitmq-hooks': { id: '@platformatic/rabbitmq-hooks', external: true },
+  '@platformatic/kafka-hooks': { id: '@platformatic/kafka-hooks', external: true }
+}
+
+// Legacy array for backward compatibility - derived from the object above
+export const defaultCapabilitiesList = Object.keys(defaultCapabilities)
 
 export * from './git.js'
 export * from './utils.js'
@@ -95,8 +98,8 @@ async function importOrLocal ({ pkgManager, projectDir, pkg }) {
 
     let version = ''
 
-    if (defaultCapabilities.includes(pkg) || pkg === '@platformatic/runtime') {
-      // Let's find if we are using one of the default capabilities
+    if ((defaultCapabilities[pkg] && !defaultCapabilities[pkg].external) || pkg === '@platformatic/runtime') {
+      // Let's find if we are using one of the internal capabilities
       // If we are, we have to use the "local" version of the package
 
       const meta = await JSON.parse(await readFile(join(import.meta.dirname, '..', 'package.json'), 'utf-8'))
@@ -365,7 +368,7 @@ export async function createApplication (
     await say('Using existing configuration ...')
   }
 
-  const capabilities = Array.from(new Set([...modules, ...defaultCapabilities]))
+  const capabilities = Array.from(new Set([...modules, ...defaultCapabilitiesList]))
 
   const names = generator.existingApplications ?? []
 

--- a/packages/create-wattpm/test/unit/capabilities.test.js
+++ b/packages/create-wattpm/test/unit/capabilities.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+import { equal } from 'node:assert'
+import { test } from 'node:test'
+import { defaultCapabilities } from '../../lib/index.js'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// Helper function to navigate to the repo root
+function getRepoRoot () {
+  // From test/unit/capabilities.test.js to the repo root
+  return join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
+}
+
+test('internal packages should exist in packages directory', async () => {
+  const packagesDir = join(getRepoRoot(), 'packages')
+
+  for (const [pkgName, pkgInfo] of Object.entries(defaultCapabilities)) {
+    if (!pkgInfo.external) {
+      // Internal package - should exist in packages/
+      const packageName = pkgName.replace('@platformatic/', '')
+      const packagePath = join(packagesDir, packageName)
+      equal(existsSync(packagePath), true, `Internal package ${pkgName} should exist at packages/${packageName}`)
+    }
+  }
+})
+
+test('external packages should NOT exist in packages directory', async () => {
+  const packagesDir = join(getRepoRoot(), 'packages')
+
+  for (const [pkgName, pkgInfo] of Object.entries(defaultCapabilities)) {
+    if (pkgInfo.external) {
+      // External package - should NOT exist in packages/
+      const packageName = pkgName.replace('@platformatic/', '')
+      const packagePath = join(packagesDir, packageName)
+      equal(existsSync(packagePath), false, `External package ${pkgName} should NOT exist at packages/${packageName}`)
+    }
+  }
+})


### PR DESCRIPTION
When using npx wattpm create and selecting a capability that is not included in the monorepo the cli fails, because it tries to uses the version of the repo for that "external" package.

See following errorlog for Details

> npx wattpm create
> Need to install the following packages:
> wattpm@3.0.2
> Ok to proceed? (y) Y
> 
> [09:33:58.647] INFO (28659): Running watt-utils create via npx ...
> Hello schemiii, welcome to Watt Utils 3.0.2!
> ? Where would you like to create your project? .
> ? Which package manager do you want to use? npm
> ? Which kind of application do you want to create? @platformatic/pg-hooks
> ⠏ Installing @platformatic/pg-hooks@^3.0.2 using npm ...file:///Users/schemiii/.npm/_npx/12ab8e5ec0e1363e/node_modules/execa/lib/return/final-error.js:6
> 	return new ErrorClass(message, options);
> 	       ^
> 
> ExecaError: Command failed with exit code 1: npm install '@platformatic/pg-hooks@^3.0.2'
> 
> npm error code ETARGET
> npm error notarget No matching version found for @platformatic/pg-hooks@^3.0.2.
> npm error notarget In most cases you or one of your dependencies are requesting
> npm error notarget a package version that doesn't exist.
> ...
> 
> Node.js v22.18.0