### PR TITLE
fix(sql-openapi): skip ignored entities

### DIFF
--- a/packages/sql-openapi/index.js
+++ b/packages/sql-openapi/index.js
@@ -99,6 +99,10 @@ async function setupOpenAPI (app, opts) {
         sourceEntity: relation.entityName,
         relation
       }
+      if (!targetEntity) {
+        app.log.warn(`Entity "${entity.singularName}" has a reverse relation to unknown entity "${targetEntityName}". Skipped.`)
+        continue
+      }
       /* istanbul ignore next */
       targetEntity.reverseRelationships = targetEntity.reverseRelationships || []
       targetEntity.reverseRelationships.push(reverseRelationship)

--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -12,6 +12,10 @@ function getEntityLinksForEntity (app, entity) {
   for (const relation of entity.relations) {
     const ownField = camelcase(relation.column_name)
     const relatedEntity = app.platformatic.entities[relation.foreignEntityName]
+    if (!relatedEntity) {
+      app.log.warn(`Entity "${entity.singularName}" has a foreign relation to unknown entity "${relation.foreignEntityName}". Skipped.`)
+      continue
+    }
     const relatedEntityPrimaryKeyCamelcase = camelcase(relatedEntity.primaryKeys.values().next().value)
     const relatedEntityPrimaryKeyCamelcaseCapitalized = capitalize(relatedEntityPrimaryKeyCamelcase)
     const getEntityById = `Get${relatedEntity.name}By${relatedEntityPrimaryKeyCamelcaseCapitalized}`
@@ -148,6 +152,10 @@ export async function entityPlugin (app, opts) {
   for (const reverseRelationship of entity.reverseRelationships) {
     const targetEntityName = reverseRelationship.relation.entityName
     const targetEntity = app.platformatic.entities[targetEntityName]
+    if (!targetEntity) {
+      app.log.warn(`Entity "${entity.singularName}" has a reverse relation to unknown entity "${targetEntityName}". Skipped.`)
+      continue
+    }
     const targetForeignKeyCamelcase = camelcase(reverseRelationship.relation.column_name)
     const targetEntitySchema = {
       $ref: targetEntity.name + '#'
@@ -275,6 +283,10 @@ export async function entityPlugin (app, opts) {
   for (const relation of entity.relations) {
     const targetEntityName = relation.foreignEntityName
     const targetEntity = app.platformatic.entities[targetEntityName]
+    if (!targetEntity) {
+      app.log.warn(`Entity "${entity.singularName}" has a foreign relation to unknown entity "${targetEntityName}". Skipped.`)
+      continue
+    }
     const targetForeignKeyCamelcase = camelcase(relation.foreign_column_name)
     const targetColumnCamelcase = camelcase(relation.column_name)
     // In this case, we navigate the relationship so we MUST use the column_name otherwise we will fail in case of recursive relationships


### PR DESCRIPTION
Watt openapi and db can be configured to ignore entities. When entity ignored by db then it's not registered as platformatic.entities, so it needs to be ignored by sql-openapi as relation as well.

## Config example

```json
 "db": {
   // ...
    "openapi": {
      "include": {
        "item": true // this generates routes for 1 table and all related tables that was not included in db
      },
      "ignore": {
        "item": {
          "gameItemId": true,
           // ...
        }
      }
    },
    "include": {
      "items": true // this generates only 1 table
    },
    "limit": {
      "max": 100
    },
    "schemalock": true
  },
```

## Logs example

```sh
[19:56:48.803] WARN (db/90844): Entity "item" has a reverse relation to unknown entity "game". Skipped.
[19:56:48.803] WARN (db/90844): Entity "item" has a reverse relation to unknown entity "itemCollection". Skipped.
[19:56:48.803] WARN (db/90844): Entity "item" has a reverse relation to unknown entity "itemRarity". Skipped.
[19:56:48.803] WARN (db/90844): Entity "item" has a reverse relation to unknown entity "itemSeason". Skipped.
[19:56:48.803] WARN (db/90844): Entity "item" has a reverse relation to unknown entity "nft". Skipped.
[19:56:48.810] WARN (db/90844): Entity "item" has a foreign relation to unknown entity "game". Skipped.
[19:56:48.810] WARN (db/90844): Entity "item" has a foreign relation to unknown entity "itemCollection". Skipped.
[19:56:48.810] WARN (db/90844): Entity "item" has a foreign relation to unknown entity "itemRarity". Skipped.
[19:56:48.810] WARN (db/90844): Entity "item" has a foreign relation to unknown entity "itemSeason". Skipped.
[19:56:48.810] WARN (db/90844): Entity "item" has a foreign relation to unknown entity "nft". Skipped.
[19:56:48.864] WARN (db/90844): Entity "item" has a target relation to unknown entity "game". Skipped.
[19:56:48.864] WARN (db/90844): Entity "item" has a target relation to unknown entity "itemCollection". Skipped.
[19:56:48.864] WARN (db/90844): Entity "item" has a target relation to unknown entity "itemRarity". Skipped.
[19:56:48.864] WARN (db/90844): Entity "item" has a target relation to unknown entity "itemSeason". Skipped.
[19:56:48.864] WARN (db/90844): Entity "item" has a target relation to unknown entity "nft". Skipped.
```

## Note

I guess the real fix is ​​configuration-based filtering. However, the logging is a bit better than:

```
[20:04:48.988] ERROR (91093): Failed to start application "db": Cannot read properties of undefined (reading 'reverseRelationships')
    err: {
      "type": "TypeError",
      "message": "Cannot read properties of undefined (reading 'reverseRelationships')",
      "stack":
          TypeError: Cannot read properties of undefined (reading 'reverseRelationships')
              at setupOpenAPI (file:///Users/xyz/projects/project/node_modules/@platformatic/sql-openapi/index.js:107:56)
    }
```
