### PR TITLE
feat(gateway): add configurable pass-through content types for OpenAPI composition

### DIFF
--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -78,6 +78,20 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
 
 - **`addEmptySchema`** (`boolean`) - If true, the gateway will add an empty response schema to the composed OpenAPI specification. Default is `false`.
 
+- **`passthroughContentTypes`** (`array`) - An array of content types that should be passed through without parsing to enable proxying. This is useful for handling multipart forms, binary data, or other content types that need to be forwarded to backend services without modification. Default is `['multipart/form-data', 'application/octet-stream']`.
+
+  ```json title="Example JSON object"
+  {
+    "gateway": {
+      "passthroughContentTypes": [
+        "multipart/form-data",
+        "application/octet-stream",
+        "application/custom-binary"
+      ]
+    }
+  }
+  ```
+
 ### OpenAPI
 
 - **`url`** (`string`) - A path of the route that exposes the OpenAPI specification. If an application is a Platformatic Service or Platformatic DB, use `/documentation/json` as a value. Use this or `file` option to specify the OpenAPI specification.

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -2693,6 +2693,17 @@
           "type": "integer",
           "minimum": 0,
           "default": 1000
+        },
+        "passthroughContentTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "multipart/form-data",
+            "application/octet-stream"
+          ],
+          "description": "Content types that should be passed through without parsing to enable proxying"
         }
       },
       "required": [],

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -366,6 +366,10 @@ export interface PlatformaticGatewayConfig {
     };
     addEmptySchema?: boolean;
     refreshTimeout?: number;
+    /**
+     * Content types that should be passed through without parsing to enable proxying
+     */
+    passthroughContentTypes?: string[];
   };
   types?: {
     autogenerate?: boolean;

--- a/packages/gateway/lib/application.js
+++ b/packages/gateway/lib/application.js
@@ -146,18 +146,15 @@ export async function platformaticGateway (app, capability) {
 
   await app.register(gatewayHook)
 
-  // Add content type parser for multipart form data to enable proxying
-  if (!app.hasContentTypeParser('multipart/form-data')) {
-    app.addContentTypeParser('multipart/form-data', function (req, body, done) {
-      done(null, body)
-    })
-  }
-
-  // Add content type parser for binary content to enable proxying
-  if (!app.hasContentTypeParser('application/octet-stream')) {
-    app.addContentTypeParser('application/octet-stream', function (req, body, done) {
-      done(null, body)
-    })
+  // Register pass-through content type parsers from config
+  const passthroughTypes = config.gateway.passthroughContentTypes ||
+                          ['multipart/form-data', 'application/octet-stream']
+  for (const contentType of passthroughTypes) {
+    if (!app.hasContentTypeParser(contentType)) {
+      app.addContentTypeParser(contentType, function (req, body, done) {
+        done(null, body)
+      })
+    }
   }
 
   let generatedComposedOpenAPI = null

--- a/packages/gateway/lib/application.js
+++ b/packages/gateway/lib/application.js
@@ -153,6 +153,13 @@ export async function platformaticGateway (app, capability) {
     })
   }
 
+  // Add content type parser for binary content to enable proxying
+  if (!app.hasContentTypeParser('application/octet-stream')) {
+    app.addContentTypeParser('application/octet-stream', function (req, body, done) {
+      done(null, body)
+    })
+  }
+
   let generatedComposedOpenAPI = null
   if (hasOpenapiApplications) {
     generatedComposedOpenAPI = await openApiGenerator(app, config.gateway)

--- a/packages/gateway/lib/application.js
+++ b/packages/gateway/lib/application.js
@@ -146,6 +146,13 @@ export async function platformaticGateway (app, capability) {
 
   await app.register(gatewayHook)
 
+  // Add content type parser for multipart form data to enable proxying
+  if (!app.hasContentTypeParser('multipart/form-data')) {
+    app.addContentTypeParser('multipart/form-data', function (req, body, done) {
+      done(null, body)
+    })
+  }
+
   let generatedComposedOpenAPI = null
   if (hasOpenapiApplications) {
     generatedComposedOpenAPI = await openApiGenerator(app, config.gateway)

--- a/packages/gateway/lib/schema.js
+++ b/packages/gateway/lib/schema.js
@@ -181,7 +181,13 @@ export const gateway = {
     openapi: openApiBase,
     graphql: graphqlComposerOptions,
     addEmptySchema: { type: 'boolean', default: false },
-    refreshTimeout: { type: 'integer', minimum: 0, default: 1000 }
+    refreshTimeout: { type: 'integer', minimum: 0, default: 1000 },
+    passthroughContentTypes: {
+      type: 'array',
+      items: { type: 'string' },
+      default: ['multipart/form-data', 'application/octet-stream'],
+      description: 'Content types that should be passed through without parsing to enable proxying'
+    }
   },
   required: [],
   default: {},

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "devDependencies": {
+    "@fastify/multipart": "^9.2.1",
     "@platformatic/db": "workspace:*",
     "c8": "^10.0.0",
     "cleaner-spec-reporter": "^0.5.0",

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1109,6 +1109,17 @@
           "type": "integer",
           "minimum": 0,
           "default": 1000
+        },
+        "passthroughContentTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "multipart/form-data",
+            "application/octet-stream"
+          ],
+          "description": "Content types that should be passed through without parsing to enable proxying"
         }
       },
       "required": [],

--- a/packages/gateway/test/capability/get-config.test.js
+++ b/packages/gateway/test/capability/get-config.test.js
@@ -29,7 +29,8 @@ test('get application config via capability api', async t => {
     gateway: {
       applications: [],
       refreshTimeout: 1000,
-      addEmptySchema: false
+      addEmptySchema: false,
+      passthroughContentTypes: ['multipart/form-data', 'application/octet-stream']
     },
     plugins: {
       paths: [join(import.meta.dirname, '..', 'openapi', 'fixtures', 'plugins', 'custom.js')]

--- a/packages/gateway/test/openapi/routes-composition.test.js
+++ b/packages/gateway/test/openapi/routes-composition.test.js
@@ -672,3 +672,81 @@ test('should proxy binary content in OpenAPI composition', async t => {
   assert.equal(response.contentType, 'application/octet-stream')
   assert.equal(response.bodyLength, binaryData.length)
 })
+
+test('should proxy custom content types via config in OpenAPI composition', async t => {
+  const api = await createBasicApplication(t)
+
+  // Add content type parser for custom content type
+  api.addContentTypeParser('application/custom-type', { parseAs: 'buffer' }, function (req, body, done) {
+    done(null, body)
+  })
+
+  // Add a custom content type endpoint to the test API
+  api.post(
+    '/custom',
+    {
+      schema: {
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' },
+              contentType: { type: 'string' },
+              bodyLength: { type: 'number' }
+            }
+          }
+        }
+      }
+    },
+    async (request, reply) => {
+      return {
+        message: 'Custom content type received',
+        contentType: request.headers['content-type'] || 'unknown',
+        bodyLength: request.body ? request.body.length : 0
+      }
+    }
+  )
+
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      passthroughContentTypes: ['application/custom-type', 'multipart/form-data'],
+      applications: [
+        {
+          id: 'api',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json',
+            prefix: '/api'
+          }
+        }
+      ]
+    }
+  })
+
+  const gatewayOrigin = await gateway.start({ listen: true })
+
+  // Test custom content type through the gateway
+  const customData = Buffer.from('custom content data', 'utf8')
+
+  const { statusCode, body } = await request(gatewayOrigin, {
+    method: 'POST',
+    path: '/api/custom',
+    headers: {
+      'content-type': 'application/custom-type'
+    },
+    body: customData
+  })
+
+  assert.equal(statusCode, 200)
+  const response = JSON.parse(await body.text())
+  assert.equal(response.message, 'Custom content type received')
+  assert.equal(response.contentType, 'application/custom-type')
+  assert.equal(response.bodyLength, customData.length)
+})

--- a/packages/gateway/test/openapi/routes-composition.test.js
+++ b/packages/gateway/test/openapi/routes-composition.test.js
@@ -596,3 +596,79 @@ test('should proxy multipart content in OpenAPI composition', async t => {
   assert.equal(response.parts, 2)
   assert.ok(response.contentType.includes('multipart/form-data'))
 })
+
+test('should proxy binary content in OpenAPI composition', async t => {
+  const api = await createBasicApplication(t)
+
+  api.addContentTypeParser('application/octet-stream', { parseAs: 'buffer' }, function (req, body, done) {
+    done(null, body)
+  })
+
+  // Add a binary endpoint to the test API
+  api.post(
+    '/binary',
+    {
+      schema: {
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' },
+              contentType: { type: 'string' },
+              bodyLength: { type: 'number' }
+            }
+          }
+        }
+      }
+    },
+    async (request, reply) => {
+      return {
+        message: 'Binary content received',
+        contentType: request.headers['content-type'] || 'unknown',
+        bodyLength: request.body ? request.body.length : 0
+      }
+    }
+  )
+
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'api',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json',
+            prefix: '/api'
+          }
+        }
+      ]
+    }
+  })
+
+  const gatewayOrigin = await gateway.start({ listen: true })
+
+  // Test binary content upload through the gateway
+  const binaryData = Buffer.from('test binary content', 'utf8')
+
+  const { statusCode, body } = await request(gatewayOrigin, {
+    method: 'POST',
+    path: '/api/binary',
+    headers: {
+      'content-type': 'application/octet-stream'
+    },
+    body: binaryData
+  })
+
+  assert.equal(statusCode, 200)
+  const response = JSON.parse(await body.text())
+  assert.equal(response.message, 'Binary content received')
+  assert.equal(response.contentType, 'application/octet-stream')
+  assert.equal(response.bodyLength, binaryData.length)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,9 @@ importers:
         specifier: ^7.0.0
         version: 7.11.0
     devDependencies:
+      '@fastify/multipart':
+        specifier: ^9.2.1
+        version: 9.2.1
       '@platformatic/db':
         specifier: workspace:*
         version: link:../db
@@ -2900,6 +2903,9 @@ packages:
   '@fastify/basic-auth@6.2.0':
     resolution: {integrity: sha512-Ao9Jf8TyW8v7p3CPy++c+E3qcCDeWfAlSIfFo0CsKrfvm81i0OCpnobIMwaSSkg/At0rzsLzbJPDWrgNru0G1w==}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@fastify/compress@8.1.0':
     resolution: {integrity: sha512-wX3I5u/SYQXxbqjG7CysvzeaCe4Sv8y13MnvnaGTpqfKkJbTLpwvdIDgqrwp/+UGvXOW7OLDLoTAQCDMJJRjDQ==}
 
@@ -2917,6 +2923,9 @@ packages:
 
   '@fastify/deepmerge@2.0.2':
     resolution: {integrity: sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==}
+
+  '@fastify/deepmerge@3.1.0':
+    resolution: {integrity: sha512-lCVONBQINyNhM6LLezB6+2afusgEYR4G8xenMsfe+AT+iZ7Ca6upM5Ha8UkZuYSnuMw3GWl/BiPXnLMi/gSxuQ==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -2947,6 +2956,9 @@ packages:
 
   '@fastify/middie@9.0.3':
     resolution: {integrity: sha512-7OYovKXp9UKYeVMcjcFLMcSpoMkmcZmfnG+eAvtdiatN35W7c+r9y1dRfpA+pfFVNuHGGqI3W+vDTmjvcfLcMA==}
+
+  '@fastify/multipart@9.2.1':
+    resolution: {integrity: sha512-U4221XDMfzCUtfzsyV1/PkR4MNgKI0158vUUyn/oF2Tl6RxMc+N7XYLr5fZXQiEC+Fmw5zFaTjxsTGTgtDtK+g==}
 
   '@fastify/pre-commit@2.2.0':
     resolution: {integrity: sha512-P/01iODIvntjCGKNGhCttCuW81Fi6RmU+n3uk0m1w5gr2t6gU/t9gyNJ1WalUmQgJBsJnK+CVAxoY4ugqQo03g==}
@@ -10579,6 +10591,8 @@ snapshots:
       '@fastify/error': 4.2.0
       fastify-plugin: 5.0.1
 
+  '@fastify/busboy@3.2.0': {}
+
   '@fastify/compress@8.1.0':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
@@ -10608,6 +10622,8 @@ snapshots:
   '@fastify/deepmerge@1.3.0': {}
 
   '@fastify/deepmerge@2.0.2': {}
+
+  '@fastify/deepmerge@3.1.0': {}
 
   '@fastify/error@4.2.0': {}
 
@@ -10661,6 +10677,14 @@ snapshots:
       fastify-plugin: 5.0.1
       path-to-regexp: 8.3.0
       reusify: 1.1.0
+
+  '@fastify/multipart@9.2.1':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@fastify/deepmerge': 3.1.0
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.0.1
+      secure-json-parse: 4.0.0
 
   '@fastify/pre-commit@2.2.0':
     dependencies:


### PR DESCRIPTION
## Summary

Adds configurable pass-through content types to the gateway for improved OpenAPI composition proxying. This generalizes content type handling by introducing a new `passthroughContentTypes` configuration option that allows specifying which content types should be passed through without parsing.

## Changes

- **Configuration Schema**: Added `passthroughContentTypes` array option to gateway schema with sensible defaults
- **Gateway Application**: Replaced hardcoded multipart/binary parsers with dynamic registration from configuration
- **Generated Files**: Updated `schema.json` and `config.d.ts` with new configuration option
- **Test Coverage**: Added comprehensive test for custom content types via configuration, updated capability tests
- **Documentation**: Added detailed configuration reference with examples and use cases

## Key Features

### Configuration Option
```json
{
  "gateway": {
    "passthroughContentTypes": [
      "multipart/form-data",
      "application/octet-stream",
      "application/custom-binary"
    ]
  }
}
```

### Default Behavior
- **Default content types**: `['multipart/form-data', 'application/octet-stream']`
- **Backward compatibility**: Maintains existing multipart/binary support
- **Flexibility**: Allows adding custom content types as needed

### Implementation Benefits
- **Configurable**: Users can specify which content types to pass through
- **Extensible**: Easy to add new content types without code changes
- **Maintainable**: Centralized configuration instead of hardcoded parsers
- **Tested**: Comprehensive test coverage for custom content type scenarios

## Problem Solved

Previously, the gateway had hardcoded content type parsers for multipart and binary data. This implementation generalizes the approach by:

1. **Making it configurable**: Content types are now specified via configuration
2. **Providing sensible defaults**: Common content types work out of the box
3. **Enabling extensibility**: New content types can be added without code changes
4. **Maintaining compatibility**: Existing functionality continues to work

## Test Plan

- [x] Existing gateway tests pass
- [x] New custom content type test verifies configurable approach
- [x] Updated capability test includes new configuration defaults
- [x] Pre-commit hooks (linting, schema generation) pass
- [x] Documentation updated with comprehensive examples
- [ ] Manual testing with various content types through gateway composition

🤖 Generated with [Claude Code](https://claude.ai/code)