### PR TITLE
Add heap profiling support

### DIFF
--- a/packages/control/lib/index.js
+++ b/packages/control/lib/index.js
@@ -318,12 +318,16 @@ export class RuntimeApiClient {
     return await body.json()
   }
 
-  async stopApplicationProfiling (pid, applicationId) {
+  async stopApplicationProfiling (pid, applicationId, options = {}) {
     const client = this.#getUndiciClient(pid)
 
     const { statusCode, body } = await client.request({
       path: `/api/v1/applications/${applicationId}/pprof/stop`,
-      method: 'POST'
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(options)
     })
 
     if (statusCode !== 200) {

--- a/packages/control/test/pprof.test.js
+++ b/packages/control/test/pprof.test.js
@@ -169,3 +169,121 @@ test('should handle profiling not started error in RuntimeApiClient', async t =>
     'Should throw ProfilingNotStarted error when profiling is not started'
   )
 })
+
+test('should start heap profiling via RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Start heap profiling on service-1
+  await runtimeClient.startApplicationProfiling(runtime.pid, 'service-1', { intervalMicros: 1000, type: 'heap' })
+
+  // Should not throw - successful start
+  assert.ok(true, 'startApplicationProfiling with heap type should complete successfully')
+
+  // Clean up - stop profiling
+  await runtimeClient.stopApplicationProfiling(runtime.pid, 'service-1', { type: 'heap' })
+})
+
+test('should stop heap profiling and return profile data via RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Start heap profiling first
+  await runtimeClient.startApplicationProfiling(runtime.pid, 'service-1', { intervalMicros: 1000, type: 'heap' })
+
+  // Wait a bit for some profile data
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop profiling and get profile data
+  const profileData = await runtimeClient.stopApplicationProfiling(runtime.pid, 'service-1', { type: 'heap' })
+
+  // Should return binary profile data (ArrayBuffer)
+  assert.ok(profileData instanceof ArrayBuffer, 'stopApplicationProfiling should return an ArrayBuffer')
+  assert.ok(profileData.byteLength > 0, 'Profile data should not be empty')
+})
+
+test('should support concurrent cpu and heap profiling via RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Start CPU profiling
+  await runtimeClient.startApplicationProfiling(runtime.pid, 'service-1', { intervalMicros: 1000, type: 'cpu' })
+
+  // Start heap profiling (should work concurrently)
+  await runtimeClient.startApplicationProfiling(runtime.pid, 'service-1', { intervalMicros: 1000, type: 'heap' })
+
+  // Wait a bit for some profile data
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop both and get profile data
+  const cpuProfileData = await runtimeClient.stopApplicationProfiling(runtime.pid, 'service-1', { type: 'cpu' })
+  const heapProfileData = await runtimeClient.stopApplicationProfiling(runtime.pid, 'service-1', { type: 'heap' })
+
+  // Both should return binary profile data
+  assert.ok(cpuProfileData instanceof ArrayBuffer, 'CPU profile should return an ArrayBuffer')
+  assert.ok(cpuProfileData.byteLength > 0, 'CPU profile data should not be empty')
+  assert.ok(heapProfileData instanceof ArrayBuffer, 'Heap profile should return an ArrayBuffer')
+  assert.ok(heapProfileData.byteLength > 0, 'Heap profile data should not be empty')
+})
+
+test('should handle heap profiling already started error in RuntimeApiClient', async t => {
+  const projectDir = join(fixturesDir, 'runtime-1')
+  const configFile = join(projectDir, 'platformatic.json')
+
+  const runtimeTmpDir = getRuntimeTmpDir(projectDir)
+  await safeRemove(runtimeTmpDir)
+
+  const { runtime } = await startRuntime(configFile)
+  t.after(async () => {
+    await kill(runtime)
+    await safeRemove(runtimeTmpDir)
+  })
+
+  const runtimeClient = new RuntimeApiClient()
+
+  // Start heap profiling
+  await runtimeClient.startApplicationProfiling(runtime.pid, 'service-1', { intervalMicros: 1000, type: 'heap' })
+
+  // Try to start heap profiling again - should throw error
+  await assert.rejects(
+    () => runtimeClient.startApplicationProfiling(runtime.pid, 'service-1', { intervalMicros: 1000, type: 'heap' }),
+    errors.ProfilingAlreadyStarted,
+    'Should throw ProfilingAlreadyStarted error when heap profiling is already started'
+  )
+
+  // Clean up - stop profiling
+  await runtimeClient.stopApplicationProfiling(runtime.pid, 'service-1', { type: 'heap' })
+})

--- a/packages/runtime/lib/management-api.js
+++ b/packages/runtime/lib/management-api.js
@@ -126,7 +126,8 @@ export async function managementApiPlugin (app, opts) {
     const { id } = request.params
     app.log.debug('stop profiling', { id })
 
-    const profileData = await runtime.stopApplicationProfiling(id)
+    const options = request.body || {}
+    const profileData = await runtime.stopApplicationProfiling(id, options)
     reply.type('application/octet-stream').code(200).send(profileData)
   })
 

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -556,11 +556,11 @@ export class Runtime extends EventEmitter {
     return sendViaITC(service, 'startProfiling', options)
   }
 
-  async stopApplicationProfiling (id, ensureStarted = true) {
+  async stopApplicationProfiling (id, options = {}, ensureStarted = true) {
     const service = await this.#getApplicationById(id, ensureStarted)
     this.#validatePprofCapturePreload()
 
-    return sendViaITC(service, 'stopProfiling')
+    return sendViaITC(service, 'stopProfiling', options)
   }
 
   async updateUndiciInterceptors (undiciConfig) {

--- a/packages/runtime/test/management-api/pprof.test.js
+++ b/packages/runtime/test/management-api/pprof.test.js
@@ -254,3 +254,239 @@ test('should handle profiling not started error', async t => {
   const response = await body.json()
   ok(response.code === 'PLT_PPROF_PROFILING_NOT_STARTED')
 })
+
+test('should start heap profiling via management API', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Start heap profiling on service-1
+  const { statusCode, body } = await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+
+  strictEqual(statusCode, 200)
+
+  const response = await body.json()
+  ok(typeof response === 'object' || response === null)
+
+  // Clean up
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/stop',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+})
+
+test('should stop heap profiling and return profile data via management API', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Start heap profiling first
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+
+  // Wait a bit for some allocations
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop heap profiling and get profile data
+  const { statusCode, body, headers } = await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/stop',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+
+  strictEqual(statusCode, 200)
+
+  // Should return binary profile data
+  strictEqual(headers['content-type'], 'application/octet-stream')
+
+  const profileData = await body.arrayBuffer()
+  ok(profileData.byteLength > 0, 'Heap profile data should not be empty')
+})
+
+test('should support concurrent CPU and heap profiling via management API', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Start CPU profiling
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ intervalMicros: 1000, type: 'cpu' })
+  })
+
+  // Start heap profiling
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+
+  // Wait a bit
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Stop both and get profile data
+  const cpuResponse = await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/stop',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'cpu' })
+  })
+
+  const heapResponse = await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/stop',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+
+  strictEqual(cpuResponse.statusCode, 200)
+  strictEqual(heapResponse.statusCode, 200)
+
+  const cpuProfileData = await cpuResponse.body.arrayBuffer()
+  const heapProfileData = await heapResponse.body.arrayBuffer()
+
+  ok(cpuProfileData.byteLength > 0, 'CPU profile data should not be empty')
+  ok(heapProfileData.byteLength > 0, 'Heap profile data should not be empty')
+})
+
+test('should handle heap profiling already started error', async t => {
+  const projectDir = join(fixturesDir, 'management-api')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await Promise.all([client.close(), app.close()])
+  })
+
+  // Start heap profiling
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+
+  // Try to start heap profiling again
+  const { body } = await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/start',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+
+  const response = await body.json()
+  ok(response.code === 'PLT_PPROF_PROFILING_ALREADY_STARTED')
+
+  // Clean up - stop profiling
+  await client.request({
+    method: 'POST',
+    path: '/api/v1/applications/service-1/pprof/stop',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'heap' })
+  })
+})

--- a/packages/wattpm/lib/commands/pprof.js
+++ b/packages/wattpm/lib/commands/pprof.js
@@ -5,7 +5,15 @@ import { writeFile } from 'node:fs/promises'
 
 export async function pprofStartCommand (logger, args) {
   try {
-    const { positionals } = parseArgs(args, {}, false)
+    const { positionals, values } = parseArgs(args, {
+      type: { type: 'string', short: 't', default: 'cpu' }
+    }, false)
+
+    // Validate profile type
+    const type = values.type
+    if (type !== 'cpu' && type !== 'heap') {
+      return logFatalError(logger, `Invalid profile type: ${type}. Must be 'cpu' or 'heap'.`)
+    }
 
     const client = new RuntimeApiClient()
     const [runtime, remainingPositionals] = await getMatchingRuntime(client, positionals)
@@ -13,6 +21,8 @@ export async function pprofStartCommand (logger, args) {
 
     // Get application ID from positional arguments or use all applications
     const applicationId = remainingPositionals[0]
+
+    const options = { intervalMicros: 1000, type }
 
     if (applicationId) {
       // Start profiling for specific application
@@ -22,14 +32,14 @@ export async function pprofStartCommand (logger, args) {
         return logFatalError(logger, `Application not found: ${applicationId}`)
       }
 
-      await client.startApplicationProfiling(runtime.pid, applicationId, { intervalMicros: 1000 })
-      logger.info(`Profiling started for application ${bold(applicationId)}`)
+      await client.startApplicationProfiling(runtime.pid, applicationId, options)
+      logger.info(`${type.toUpperCase()} profiling started for application ${bold(applicationId)}`)
     } else {
       // Start profiling for all applications
       for (const application of runtimeApplications) {
         try {
-          await client.startApplicationProfiling(runtime.pid, application.id, { intervalMicros: 1000 })
-          logger.info(`Profiling started for application ${bold(application.id)}`)
+          await client.startApplicationProfiling(runtime.pid, application.id, options)
+          logger.info(`${type.toUpperCase()} profiling started for application ${bold(application.id)}`)
         } catch (error) {
           logger.warn(`Failed to start profiling for application ${application.id}: ${error.message}`)
         }
@@ -50,7 +60,15 @@ export async function pprofStartCommand (logger, args) {
 
 export async function pprofStopCommand (logger, args) {
   try {
-    const { positionals } = parseArgs(args, {}, false)
+    const { positionals, values } = parseArgs(args, {
+      type: { type: 'string', short: 't', default: 'cpu' }
+    }, false)
+
+    // Validate profile type
+    const type = values.type
+    if (type !== 'cpu' && type !== 'heap') {
+      return logFatalError(logger, `Invalid profile type: ${type}. Must be 'cpu' or 'heap'.`)
+    }
 
     const client = new RuntimeApiClient()
     const [runtime, remainingPositionals] = await getMatchingRuntime(client, positionals)
@@ -60,6 +78,8 @@ export async function pprofStopCommand (logger, args) {
     const applicationId = remainingPositionals[0]
     const timestamp = new Date().toISOString().replace(/:/g, '-').replace(/\./g, '-')
 
+    const options = { type }
+
     if (applicationId) {
       // Stop profiling for specific application
       const application = runtimeApplications.find(s => s.id === applicationId)
@@ -68,18 +88,18 @@ export async function pprofStopCommand (logger, args) {
         return logFatalError(logger, `Application not found: ${applicationId}`)
       }
 
-      const profileData = await client.stopApplicationProfiling(runtime.pid, applicationId)
-      const filename = `pprof-${applicationId}-${timestamp}.pb`
+      const profileData = await client.stopApplicationProfiling(runtime.pid, applicationId, options)
+      const filename = `pprof-${type}-${applicationId}-${timestamp}.pb`
       await writeFile(filename, Buffer.from(profileData))
-      logger.info(`Profiling stopped for application ${bold(applicationId)}, profile saved to ${bold(filename)}`)
+      logger.info(`${type.toUpperCase()} profiling stopped for application ${bold(applicationId)}, profile saved to ${bold(filename)}`)
     } else {
       // Stop profiling for all applications
       for (const application of runtimeApplications) {
         try {
-          const profileData = await client.stopApplicationProfiling(runtime.pid, application.id)
-          const filename = `pprof-${application.id}-${timestamp}.pb`
+          const profileData = await client.stopApplicationProfiling(runtime.pid, application.id, options)
+          const filename = `pprof-${type}-${application.id}-${timestamp}.pb`
           await writeFile(filename, Buffer.from(profileData))
-          logger.info(`Profiling stopped for application ${bold(application.id)}, profile saved to ${bold(filename)}`)
+          logger.info(`${type.toUpperCase()} profiling stopped for application ${bold(application.id)}, profile saved to ${bold(filename)}`)
         } catch (error) {
           logger.warn(`Failed to stop profiling for application ${application.id}: ${error.message}`)
         }
@@ -113,18 +133,18 @@ export async function pprofCommand (logger, args) {
 
 export const help = {
   pprof: {
-    usage: 'pprof <start|stop> [id] [application]',
-    description: 'Profile CPU usage of running application',
-    options: [],
+    usage: 'pprof <start|stop> [id] [application] [options]',
+    description: 'Profile CPU or heap usage of running application',
+    options: [
+      {
+        name: '--type, -t',
+        description: 'Profile type: "cpu" for CPU wall time (default) or "heap" for heap memory'
+      }
+    ],
     args: [
       {
         name: 'command',
         description: 'The pprof command to run: start or stop'
-      },
-      {
-        name: 'id',
-        description:
-          'The process ID or the name of the application (it can be omitted only if there is a single application running)'
       },
       {
         name: 'id',
@@ -137,6 +157,11 @@ export const help = {
       }
     ],
     footer:
-      'Use "pprof start [application]" to start profiling and "pprof stop [application]" to stop and save profile data.'
+      'Use "pprof start [application]" to start profiling and "pprof stop [application]" to stop and save profile data.\n' +
+      'Examples:\n' +
+      '  wattpm pprof start --type=cpu my-app     # Start CPU profiling\n' +
+      '  wattpm pprof start --type=heap my-app    # Start heap profiling\n' +
+      '  wattpm pprof stop --type=cpu my-app      # Stop CPU profiling\n' +
+      '  wattpm pprof stop --type=heap my-app     # Stop heap profiling'
   }
 }


### PR DESCRIPTION
This adds support to wattpm-pprof-capture to capture heap profiles. It also adds all the necessary machinery to the management API to trigger the profiles within Watt.