### PR TITLE
feat: set verticalScaler default values back to config

### DIFF
--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -2447,16 +2447,27 @@ export class Runtime extends EventEmitter {
 
     const scalerConfig = this.#config.verticalScaler
 
-    const maxTotalWorkers = scalerConfig.maxTotalWorkers ?? os.cpus().length
-    const maxWorkers = scalerConfig.maxWorkers ?? maxTotalWorkers
-    const minWorkers = scalerConfig.minWorkers ?? 1
-    const cooldown = scalerConfig.cooldownSec ?? 60
-    const scaleUpELU = scalerConfig.scaleUpELU ?? 0.8
-    const scaleDownELU = scalerConfig.scaleDownELU ?? 0.2
-    const minELUDiff = scalerConfig.minELUDiff ?? 0.2
-    const scaleIntervalSec = scalerConfig.scaleIntervalSec ?? 60
-    const timeWindowSec = scalerConfig.timeWindowSec ?? 60
-    const applicationsConfigs = scalerConfig.applications ?? {}
+    scalerConfig.maxTotalWorkers ??= os.cpus().length
+    scalerConfig.maxWorkers ??= scalerConfig.maxTotalWorkers
+    scalerConfig.minWorkers ??= 1
+    scalerConfig.cooldownSec ??= 60
+    scalerConfig.scaleUpELU ??= 0.8
+    scalerConfig.scaleDownELU ??= 0.2
+    scalerConfig.minELUDiff ??= 0.2
+    scalerConfig.scaleIntervalSec ??= 60
+    scalerConfig.timeWindowSec ??= 60
+    scalerConfig.applications ??= {}
+
+    const maxTotalWorkers = scalerConfig.maxTotalWorkers
+    const maxWorkers = scalerConfig.maxWorkers
+    const minWorkers = scalerConfig.minWorkers
+    const cooldown = scalerConfig.cooldownSec
+    const scaleUpELU = scalerConfig.scaleUpELU
+    const scaleDownELU = scalerConfig.scaleDownELU
+    const minELUDiff = scalerConfig.minELUDiff
+    const scaleIntervalSec = scalerConfig.scaleIntervalSec
+    const timeWindowSec = scalerConfig.timeWindowSec
+    const applicationsConfigs = scalerConfig.applications
 
     for (const application of this.#config.applications) {
       if (application.entrypoint && !features.node.reusePort) {
@@ -2484,6 +2495,8 @@ export class Runtime extends EventEmitter {
         app => app.id === applicationId
       )
       if (!application) {
+        delete applicationsConfigs[applicationId]
+
         this.logger.warn(
           `Vertical scaler configuration has a configuration for non-existing application "${applicationId}"`
         )

--- a/packages/runtime/test/vertical-scaler.test.js
+++ b/packages/runtime/test/vertical-scaler.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { test } from 'node:test'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
+import { tmpdir, cpus } from 'node:os'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { mkdtemp, readFile } from 'node:fs/promises'
 import { request } from 'undici'
@@ -242,6 +242,9 @@ test('should not scale an applications when the app maxWorkers is reached', asyn
     'Vertical scaler configuration has a configuration for non-existing application \\"non-existing-app\\"'
   ))
 
+  const maxTotalWorkers = cpus().length
+  const maxWorkers = maxTotalWorkers
+
   const verticalScalerConfig = runtimeConfig?.verticalScaler
   assert.deepStrictEqual(verticalScalerConfig, {
     enabled: true,
@@ -249,8 +252,8 @@ test('should not scale an applications when the app maxWorkers is reached', asyn
       'service-1': { minWorkers: 1, maxWorkers: 1 },
       'service-2': { minWorkers: 1, maxWorkers: 1 }
     },
-    maxTotalWorkers: 12,
-    maxWorkers: 12,
+    maxTotalWorkers,
+    maxWorkers,
     minWorkers: 1,
     minELUDiff: 0.2,
     scaleDownELU: 0.2,

--- a/packages/runtime/test/vertical-scaler.test.js
+++ b/packages/runtime/test/vertical-scaler.test.js
@@ -187,16 +187,19 @@ test('should not scale an applications when the app maxWorkers is reached', asyn
   const tmpDir = await mkdtemp(join(tmpdir(), 'platformatic-'))
   const logsPath = join(tmpDir, 'log.txt')
 
+  let runtimeConfig = null
   const app = await createRuntime(configFile, null, {
     async transform (config, ...args) {
       config = await transform(config, ...args)
       config.verticalScaler = {
         enabled: true,
         applications: {
+          'service-1': { maxWorkers: 1 },
           'service-2': { maxWorkers: 1 },
           'non-existing-app': { maxWorkers: 1 }
         }
       }
+      runtimeConfig = config
       return config
     },
     logsPath
@@ -238,4 +241,22 @@ test('should not scale an applications when the app maxWorkers is reached', asyn
   assert.ok(logs.includes(
     'Vertical scaler configuration has a configuration for non-existing application \\"non-existing-app\\"'
   ))
+
+  const verticalScalerConfig = runtimeConfig?.verticalScaler
+  assert.deepStrictEqual(verticalScalerConfig, {
+    enabled: true,
+    applications: {
+      'service-1': { minWorkers: 1, maxWorkers: 1 },
+      'service-2': { minWorkers: 1, maxWorkers: 1 }
+    },
+    maxTotalWorkers: 12,
+    maxWorkers: 12,
+    minWorkers: 1,
+    minELUDiff: 0.2,
+    scaleDownELU: 0.2,
+    scaleIntervalSec: 60,
+    scaleUpELU: 0.8,
+    timeWindowSec: 60,
+    cooldownSec: 60
+  })
 })


### PR DESCRIPTION
Setting the default params back to config so we can read them later. In the watt-extra for example.