### PR TITLE
fix(basic): base capability and typescript tests

### DIFF
--- a/packages/basic/index.d.ts
+++ b/packages/basic/index.d.ts
@@ -22,7 +22,6 @@ export declare const schemaOptions: Partial<Record<string, unknown>>
 
 export class BaseCapability<Config = Record<string, any>, Options = BaseOptions> {
   basePath: string
-  url: string
 
   constructor (
     type: string,


### PR DESCRIPTION
The `url` property is not returned. Also, this PR adds tests with `tsd` to the `basic` package.