### PR TITLE
fix: save last elu outside of the runtime.getHealth method

### DIFF
--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -55,7 +55,8 @@ export module symbols {
   export declare const kWorkerId: unique symbol
   export declare const kITC: unique symbol
   export declare const kHealthCheckTimer: unique symbol
-  export declare const kLastELU: unique symbol
+  export declare const kLastHealthCheckELU: unique symbol
+  export declare const kLastVerticalScalerELU: unique symbol
   export declare const kWorkerStatus: unique symbol
   export declare const kStderrMarker: string
   export declare const kInterceptors: unique symbol

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -127,3 +127,7 @@ export const MissingPprofCapture = createError(
   `${ERROR_PREFIX}_MISSING_PPROF_CAPTURE`,
   'Please install @platformatic/wattpm-pprof-capture'
 )
+export const GetHeapStatisticUnavailable = createError(
+  `${ERROR_PREFIX}_GET_HEAP_STATISTIC_UNAVAILABLE`,
+  'The getHeapStatistics method is not available in your Node version'
+)

--- a/packages/runtime/lib/worker/symbols.js
+++ b/packages/runtime/lib/worker/symbols.js
@@ -8,7 +8,8 @@ export const kHealthCheckTimer = Symbol.for('plt.runtime.worker.healthCheckTimer
 export const kWorkerStatus = Symbol('plt.runtime.worker.status')
 export const kWorkerStartTime = Symbol.for('plt.runtime.worker.startTime')
 export const kInterceptors = Symbol.for('plt.runtime.worker.interceptors')
-export const kLastELU = Symbol.for('plt.runtime.worker.lastELU')
+export const kLastHealthCheckELU = Symbol.for('plt.runtime.worker.lastHealthCheckELU')
+export const kLastVerticalScalerELU = Symbol.for('plt.runtime.worker.lastVerticalScalerELU')
 
 // This string marker should be safe to use since it belongs to Unicode private area
 export const kStderrMarker = '\ue002'


### PR DESCRIPTION
The problem happens when the `Runtime.#getHealth` is called from multiple different places. Each call overrides the `worker[kLastELU]` value, so the timeout of elu measurements very quickly becomes random.   

It's really hard to write a reasonable test for this, since all behaviour is private.