### PR TITLE
feat: add flamegraph generation instruction to pprof stop command

### DIFF
--- a/packages/wattpm/lib/commands/pprof.js
+++ b/packages/wattpm/lib/commands/pprof.js
@@ -102,6 +102,7 @@ export async function pprofStopCommand (logger, args) {
       logger.info(
         `${type.toUpperCase()} profiling stopped for application ${bold(applicationId)}, profile saved to ${bold(filename)}`
       )
+      logger.info(`Run ${bold(`npx @platformatic/flame generate ${filename}`)} to generate the flamegraph`)
     } else {
       // Stop profiling for all applications
       for (const application of runtimeApplications) {
@@ -112,6 +113,7 @@ export async function pprofStopCommand (logger, args) {
           logger.info(
             `${type.toUpperCase()} profiling stopped for application ${bold(application.id)}, profile saved to ${bold(filename)}`
           )
+          logger.info(`Run ${bold(`npx @platformatic/flame generate ${filename}`)} to generate the flamegraph`)
         } catch (error) {
           logger.warn(`Failed to stop profiling for application ${application.id}: ${error.message}`)
         }

--- a/packages/wattpm/test/pprof.test.js
+++ b/packages/wattpm/test/pprof.test.js
@@ -86,6 +86,16 @@ test('pprof stop - should stop profiling and create profile file', async t => {
   const profileFile = profileFiles[0]
   const stats = await stat(join(tempDir, profileFile))
   ok(stats.size > 0, 'Profile file should not be empty')
+
+  // Check that the flamegraph generation instruction is in the output
+  ok(
+    pprofStopProcess.stdout.includes('npx @platformatic/flame generate'),
+    'Should include flamegraph generation instruction'
+  )
+  ok(
+    pprofStopProcess.stdout.includes(profileFile),
+    'Should include the profile filename in the instruction'
+  )
 })
 
 test('pprof start - should start profiling on all services when no service specified', async t => {
@@ -463,6 +473,16 @@ test('pprof stop --type=heap - should stop heap profiling and create profile fil
   const profileFile = profileFiles[0]
   const stats = await stat(join(tempDir, profileFile))
   ok(stats.size > 0, 'Heap profile file should not be empty')
+
+  // Check that the flamegraph generation instruction is in the output
+  ok(
+    pprofStopProcess.stdout.includes('npx @platformatic/flame generate'),
+    'Should include flamegraph generation instruction'
+  )
+  ok(
+    pprofStopProcess.stdout.includes(profileFile),
+    'Should include the profile filename in the instruction'
+  )
 })
 
 test('pprof concurrent cpu and heap profiling', async t => {


### PR DESCRIPTION
## Summary

- Added helpful log message after `wattpm pprof stop` command to instruct users to generate flamegraphs
- The message displays: `Run npx @platformatic/flame generate <filename.pb> to generate the flamegraph`
- Applied to both single application and all applications scenarios
- Works for both CPU and heap profiling types

## Changes

- Updated `lib/commands/pprof.js` to log flamegraph generation instructions after stopping profiling
- Added test assertions in `test/pprof.test.js` to verify the new log message appears in the output

## Test plan

- [x] All existing tests pass
- [x] Added new assertions to verify flamegraph instruction message appears in output
- [x] Tested with both CPU and heap profiling types
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)