### PR TITLE
feat: Add watt configuration for running certain applications only in development mode

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -49,6 +49,7 @@ runtime. Each application object supports the following settings:
   the application. It can be omitted if `url` is provided.
 - **`url`** (**required**, `string`) - The URL of the application remote GIT repository, if it is a remote application. It can be omitted if `path` is provided. You can specify a branch using the URL fragment syntax: `https://github.com/user/repo.git#branch-name`.
 - **`gitBranch`** (`string`) - The branch of the application to resolve. Takes precedence over the branch specified in the URL fragment.
+- **`devOnly`** (`boolean`) - The application will be started only in development mode.
 - **`config`** (`string`) - The configuration file used to start
   the application.
 - **`useHttp`** (`boolean`) - The application will be started on a random HTTP port

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -430,6 +430,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -72,6 +72,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -399,6 +399,7 @@ export interface PlatformaticComposerConfig {
                   body?: string;
                 };
               };
+          healthChecksTimeouts?: number | string;
           plugins?: string[];
           timeout?: number | string;
           /**

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -732,6 +732,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1369,6 +1369,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -749,6 +749,9 @@ export const applications = {
         type: 'boolean',
         default: true
       },
+      devOnly: {
+        type: 'boolean'
+      },
       workers: {
         anyOf: [
           {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1320,6 +1320,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -430,6 +430,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -430,6 +430,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -430,6 +430,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -430,6 +430,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -21,6 +21,7 @@ export type PlatformaticRuntimeConfig = {
         config?: string;
         useHttp?: boolean;
         reuseTcpPorts?: boolean;
+        devOnly?: boolean;
         workers?:
           | number
           | string

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -444,6 +444,7 @@ export class Runtime extends EventEmitter {
 
     const toStart = []
     for (const application of applications) {
+      if (application.devOnly && this.#isProduction) continue
       const workers = application.workers
 
       if ((workers.static > 1 || workers.minimum > 1) && application.entrypoint && !features.node.reusePort) {
@@ -456,22 +457,22 @@ export class Runtime extends EventEmitter {
 
       this.#applications.set(application.id, application)
       setupInvocations.push([application])
-      toStart.push(application.id)
+      toStart.push(application)
     }
 
     await executeInParallel(this.#setupApplication.bind(this), setupInvocations, this.#concurrency)
 
-    for (const application of applications) {
+    for (const application of toStart) {
       this.logger.info(`Added application "${application.id}"${application.entrypoint ? ' (entrypoint)' : ''}.`)
       this.emitAndNotify('application:added', application)
     }
 
     if (start) {
-      await this.startApplications(toStart)
+      await this.startApplications(toStart.map(application => application.id))
     }
 
     const created = []
-    for (const { id } of applications) {
+    for (const { id } of toStart) {
       created.push(await this.getApplicationDetails(id))
     }
 

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -68,6 +68,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {
@@ -360,6 +363,9 @@
             "type": "boolean",
             "default": true
           },
+          "devOnly": {
+            "type": "boolean"
+          },
           "workers": {
             "anyOf": [
               {
@@ -650,6 +656,9 @@
             "type": "boolean",
             "default": true
           },
+          "devOnly": {
+            "type": "boolean"
+          },
           "workers": {
             "anyOf": [
               {
@@ -939,6 +948,9 @@
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
+          },
+          "devOnly": {
+            "type": "boolean"
           },
           "workers": {
             "anyOf": [

--- a/packages/runtime/test/dev-only-applications.test.js
+++ b/packages/runtime/test/dev-only-applications.test.js
@@ -1,0 +1,215 @@
+import { deepStrictEqual, ok } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { prepareApplication } from '../index.js'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+test('should skip devOnly applications when runtime is in production mode', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+
+  // Create runtime in production mode
+  const runtime = await createRuntime(configFile, null, { isProduction: true })
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with devOnly flag
+  const devOnlyApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'dev-only-app',
+    path: './application-1',
+    devOnly: true
+  })
+
+  // Add the application
+  await runtime.addApplications([devOnlyApp], false)
+
+  // Verify the application was NOT added
+  const applicationsIds = runtime.getApplicationsIds()
+  const devOnlyAppExists = applicationsIds.includes('dev-only-app')
+
+  deepStrictEqual(devOnlyAppExists, false, 'devOnly application should not be added in production mode')
+})
+
+test('should include devOnly applications when runtime is in development mode', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+
+  // Create runtime in development mode (default)
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with devOnly flag
+  const devOnlyApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'dev-only-app',
+    path: './application-1',
+    devOnly: true
+  })
+
+  // Add the application
+  await runtime.addApplications([devOnlyApp], false)
+
+  // Verify the application WAS added
+  const applicationsIds = runtime.getApplicationsIds()
+  const devOnlyAppExists = applicationsIds.includes('dev-only-app')
+
+  ok(devOnlyAppExists, 'devOnly application should be added in development mode')
+})
+
+test('should include regular applications in production mode', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+
+  // Create runtime in production mode
+  const runtime = await createRuntime(configFile, null, { isProduction: true })
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare a regular application without devOnly flag
+  const regularApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'regular-app',
+    path: './application-1'
+  })
+
+  // Add the application
+  await runtime.addApplications([regularApp], false)
+
+  // Verify the application WAS added
+  const applicationsIds = runtime.getApplicationsIds()
+  const regularAppExists = applicationsIds.includes('regular-app')
+
+  ok(regularAppExists, 'regular application should be added in production mode')
+})
+
+test('should include application with devOnly: false in production mode', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+
+  // Create runtime in production mode
+  const runtime = await createRuntime(configFile, null, { isProduction: true })
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with devOnly explicitly set to false
+  const app = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'non-dev-only-app',
+    path: './application-1',
+    devOnly: false
+  })
+
+  // Add the application
+  await runtime.addApplications([app], false)
+
+  // Verify the application WAS added
+  const applicationsIds = runtime.getApplicationsIds()
+  const appExists = applicationsIds.includes('non-dev-only-app')
+
+  ok(appExists, 'application with devOnly: false should be added in production mode')
+})
+
+test('should handle mixed devOnly and regular applications in production', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+
+  // Create runtime in production mode
+  const runtime = await createRuntime(configFile, null, { isProduction: true })
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare multiple applications with different devOnly settings
+  const apps = [
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'dev-only-1',
+      path: './application-1',
+      devOnly: true
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'regular-1',
+      path: './application-1'
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'dev-only-2',
+      path: './application-2',
+      devOnly: true
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'regular-2',
+      path: './application-2',
+      devOnly: false
+    })
+  ]
+
+  // Add all applications at once
+  await runtime.addApplications(apps, false)
+
+  // Verify only regular applications were added
+  const applicationsIds = runtime.getApplicationsIds()
+
+  deepStrictEqual(
+    applicationsIds.includes('dev-only-1'),
+    false,
+    'dev-only-1 should not be added in production'
+  )
+
+  ok(
+    applicationsIds.includes('regular-1'),
+    'regular-1 should be added in production'
+  )
+
+  deepStrictEqual(
+    applicationsIds.includes('dev-only-2'),
+    false,
+    'dev-only-2 should not be added in production'
+  )
+
+  ok(
+    applicationsIds.includes('regular-2'),
+    'regular-2 should be added in production'
+  )
+})
+
+test('should use production context property to determine production mode', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+
+  // Create runtime using the 'production' property instead of 'isProduction'
+  const runtime = await createRuntime(configFile, null, { production: true })
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with devOnly flag
+  const devOnlyApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'dev-only-app-2',
+    path: './application-1',
+    devOnly: true
+  })
+
+  // Add the application
+  await runtime.addApplications([devOnlyApp], false)
+
+  // Verify the application was NOT added (production mode)
+  const applicationsIds = runtime.getApplicationsIds()
+  const devOnlyAppExists = applicationsIds.includes('dev-only-app-2')
+
+  deepStrictEqual(devOnlyAppExists, false, 'devOnly application should not be added when context.production is true')
+})

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1058,6 +1058,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -430,6 +430,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -21,6 +21,7 @@ export type PlatformaticRuntimeConfig = {
         config?: string;
         useHttp?: boolean;
         reuseTcpPorts?: boolean;
+        devOnly?: boolean;
         workers?:
           | number
           | string

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -68,6 +68,9 @@
                 "type": "boolean",
                 "default": true
               },
+              "devOnly": {
+                "type": "boolean"
+              },
               "workers": {
                 "anyOf": [
                   {
@@ -360,6 +363,9 @@
             "type": "boolean",
             "default": true
           },
+          "devOnly": {
+            "type": "boolean"
+          },
           "workers": {
             "anyOf": [
               {
@@ -650,6 +656,9 @@
             "type": "boolean",
             "default": true
           },
+          "devOnly": {
+            "type": "boolean"
+          },
           "workers": {
             "anyOf": [
               {
@@ -939,6 +948,9 @@
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
+          },
+          "devOnly": {
+            "type": "boolean"
           },
           "workers": {
             "anyOf": [


### PR DESCRIPTION
This change adds a simple flag to the watt.json configuration to choose to run an application only in development mode.

Changes:
- In the watt.json file, applications can have a `devOnly` property which, if set to true, prevents them from starting in the production environment.

Benefits:
- This allows you to have applications within the watt environment that are then deployed separately in production.