### PR TITLE
chore: replace prom-client with @platformatic/prom-client

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -60,7 +60,7 @@ Use [environment variable placeholders](../reference/service/configuration.md#en
 ## Custom Metrics
 
 When running an application inside Platformatic, you can register and export custom metrics by accessing the application registry.
-Do to so, access it via `globalThis.platformatic.prometheus.registry`. In order to ensure the maximum compatibility between Platformatic metrics and custom metrics, there is also a `globalThis.platformatic.prometheus.client`, which is the same version of the `prom-client` used by Platformatic internally.
+Do to so, access it via `globalThis.platformatic.prometheus.registry`. In order to ensure the maximum compatibility between Platformatic metrics and custom metrics, there is also a `globalThis.platformatic.prometheus.client`, which uses `@platformatic/prom-client` internally. This is API compatible with the standard `prom-client` package but significantly faster.
 
 Putting everything together, here it is an example of how to register a custom metric:
 

--- a/docs/reference/node/_shared-overview.md
+++ b/docs/reference/node/_shared-overview.md
@@ -118,7 +118,7 @@ const response = await globalThis.platformatic.messaging.send(
 
 Custom metrics can be registered and exported by accessing the same Prometheus registry that the rest of the Platformatic runtime is using via `globalThis.platformatic.prometheus.registry`.
 
-In order to ensure the maximum compatibility the client package (`prom-client`) is available in `globalThis.platformatic.prometheus.client`.
+In order to ensure the maximum compatibility the client package (`@platformatic/prom-client`) is available in `globalThis.platformatic.prometheus.client`. This package is API compatible with the standard `prom-client` package but significantly faster.
 
 Here is an example of how to register a custom metric:
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -34,7 +34,7 @@
     "neostandard": "^0.12.0",
     "openapi-schema-validator": "^12.1.3",
     "pino-test": "^1.0.1",
-    "prom-client": "^15.1.2",
+    "@platformatic/prom-client": "^1.0.0",
     "self-cert": "^2.0.0",
     "single-user-cache": "^1.0.1",
     "split2": "^4.2.0",

--- a/packages/gateway/test/metrics.test.js
+++ b/packages/gateway/test/metrics.test.js
@@ -1,6 +1,6 @@
 import { ok, strictEqual } from 'node:assert'
 import { test } from 'node:test'
-import promClient from 'prom-client'
+import promClient from '@platformatic/prom-client'
 import { initMetrics } from '../lib/metrics.js'
 
 test('initMetrics should return null when prometheus is not provided', async () => {

--- a/packages/globals/lib/index.d.ts
+++ b/packages/globals/lib/index.d.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { type EventEmitter } from 'node:events'
 import { type Level, type Logger } from 'pino'
-import * as Client from 'prom-client'
+import * as Client from '@platformatic/prom-client'
 
 type Optional<T> = T | undefined
 

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "pino": "^9.9.0",
-    "prom-client": "^15.1.3"
+    "@platformatic/prom-client": "^1.0.0"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/metrics/index.js
+++ b/packages/metrics/index.js
@@ -1,9 +1,9 @@
 import collectHttpMetrics from '@platformatic/http-metrics'
 import os from 'node:os'
 import { performance } from 'node:perf_hooks'
-import client from 'prom-client'
+import client from '@platformatic/prom-client'
 
-export * as client from 'prom-client'
+export * as client from '@platformatic/prom-client'
 
 const { eventLoopUtilization } = performance
 const { Registry, Gauge, Counter, collectDefaultMetrics } = client

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "dependencies": {
-    "@platformatic/http-metrics": "^0.2.1",
+    "@platformatic/http-metrics": "^0.3.0",
     "@platformatic/promotel": "^0.1.0",
-    "prom-client": "^15.1.2"
+    "@platformatic/prom-client": "^1.0.0"
   },
   "devDependencies": {
     "cleaner-spec-reporter": "^0.5.0",

--- a/packages/metrics/test/index.test.js
+++ b/packages/metrics/test/index.test.js
@@ -74,8 +74,9 @@ test('httpMetrics creates histogram and summary with collect functions', async (
 test('httpMetrics histogram resets after metric collection', async () => {
   const result = await collectMetrics('test-service', 1, { httpMetrics: true })
 
-  const metricObjects = result.registry._metrics
-  const histogramMetric = metricObjects.http_request_all_duration_seconds
+  // Get the histogram metric using the public API
+  const histogramMetric = result.registry.getSingleMetric('http_request_all_duration_seconds')
+  assert.ok(histogramMetric, 'histogram metric should exist')
 
   histogramMetric.observe({ method: 'GET', telemetry_id: 'test' }, 0.1)
   histogramMetric.observe({ method: 'GET', telemetry_id: 'test' }, 0.2)
@@ -101,8 +102,9 @@ test('httpMetrics histogram resets after metric collection', async () => {
 test('httpMetrics summary resets after metric collection', async () => {
   const result = await collectMetrics('test-service', 1, { httpMetrics: true })
 
-  const metricObjects = result.registry._metrics
-  const summaryMetric = metricObjects.http_request_all_summary_seconds
+  // Get the summary metric using the public API
+  const summaryMetric = result.registry.getSingleMetric('http_request_all_summary_seconds')
+  assert.ok(summaryMetric, 'summary metric should exist')
 
   summaryMetric.observe({ method: 'POST', telemetry_id: 'test' }, 0.15)
   summaryMetric.observe({ method: 'POST', telemetry_id: 'test' }, 0.25)

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -83,7 +83,7 @@
     "minimist": "^1.2.8",
     "pino": "^9.9.0",
     "pino-pretty": "^13.0.0",
-    "prom-client": "^15.1.2",
+    "@platformatic/prom-client": "^1.0.0",
     "semgrator": "^0.3.0",
     "sonic-boom": "^4.2.0",
     "systeminformation": "^5.27.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,6 +818,9 @@ importers:
       '@platformatic/db':
         specifier: workspace:*
         version: link:../db
+      '@platformatic/prom-client':
+        specifier: ^1.0.0
+        version: 1.0.0
       c8:
         specifier: ^10.0.0
         version: 10.1.3
@@ -842,9 +845,6 @@ importers:
       pino-test:
         specifier: ^1.0.1
         version: 1.1.0
-      prom-client:
-        specifier: ^15.1.2
-        version: 15.1.3
       self-cert:
         specifier: ^2.0.0
         version: 2.0.1
@@ -915,12 +915,12 @@ importers:
 
   packages/globals:
     dependencies:
+      '@platformatic/prom-client':
+        specifier: ^1.0.0
+        version: 1.0.0
       pino:
         specifier: ^9.9.0
         version: 9.11.0
-      prom-client:
-        specifier: ^15.1.3
-        version: 15.1.3
     devDependencies:
       '@types/node':
         specifier: ^22.10.6
@@ -969,14 +969,14 @@ importers:
   packages/metrics:
     dependencies:
       '@platformatic/http-metrics':
-        specifier: ^0.2.1
-        version: 0.2.1
+        specifier: ^0.3.0
+        version: 0.3.0
+      '@platformatic/prom-client':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@platformatic/promotel':
         specifier: ^0.1.0
         version: 0.1.0
-      prom-client:
-        specifier: ^15.1.2
-        version: 15.1.3
     devDependencies:
       cleaner-spec-reporter:
         specifier: ^0.5.0
@@ -1294,6 +1294,9 @@ importers:
       '@platformatic/metrics':
         specifier: workspace:*
         version: link:../metrics
+      '@platformatic/prom-client':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@platformatic/telemetry':
         specifier: workspace:*
         version: link:../telemetry
@@ -1339,9 +1342,6 @@ importers:
       pino-pretty:
         specifier: ^13.0.0
         version: 13.1.2
-      prom-client:
-        specifier: ^15.1.2
-        version: 15.1.3
       semgrator:
         specifier: ^0.3.0
         version: 0.3.0
@@ -3989,11 +3989,15 @@ packages:
   '@platformatic/graphql-composer@0.10.1':
     resolution: {integrity: sha512-c10wlGoAOgD8dMP1HyyCOK5qUi9o+TPlMZ1fj0AL8D49aDKZczkMsR6V+rNa4jPrujxWPGQlylJNEgF7HXOGsg==}
 
-  '@platformatic/http-metrics@0.2.1':
-    resolution: {integrity: sha512-Gy3NHUQT250MrJMlwzcSniVc+71DmCN1BpsuJcBlxyDpNacsH9axNonNWSNJqcWg8WOrv7tS6miBql2cugVuAg==}
+  '@platformatic/http-metrics@0.3.0':
+    resolution: {integrity: sha512-e+wQJDCd9v7yKeV4u30ibAe5uGB14k+jDw1w9FqsM3tDgFY0UEHb24hJR9j2bVa6091e+ppGy3L4LhyUR92M0w==}
 
   '@platformatic/openapi-schema-validator@3.0.0':
     resolution: {integrity: sha512-SHEY5v1Q5EliMaIpXdPCye0QkhFVOoHkEqA8v9qkrO1PqvVOcpii1WqEHYrZZB430sEmrHqEWZInt15EUsR7mw==}
+
+  '@platformatic/prom-client@1.0.0':
+    resolution: {integrity: sha512-O7NfmdBWAm1QJ0LMrtcyCSgWmA+FQEiCyRqvouccmyAuydwLxLdmhcTTW3sEmO5f7bRfXpUVVgTtnFbIqEiHyw==}
+    engines: {node: ^20 || ^22 || >=24}
 
   '@platformatic/promotel@0.1.0':
     resolution: {integrity: sha512-PpbXGiGef+zW9LAbD3JP1ehTDhRXXcrBz+cg1fd5kZamMqqf3leXSjOBlagqxaMk8e1M1GggnmB4RxGBvoAcGQ==}
@@ -11973,9 +11977,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@platformatic/http-metrics@0.2.1':
+  '@platformatic/http-metrics@0.3.0':
     dependencies:
-      prom-client: 15.1.3
+      '@platformatic/prom-client': 1.0.0
 
   '@platformatic/openapi-schema-validator@3.0.0':
     dependencies:
@@ -11983,6 +11987,10 @@ snapshots:
       ajv-draft-04: 1.0.0(ajv@8.17.1)
       ajv-formats: 3.0.1(ajv@8.17.1)
       js-yaml: 4.1.0
+
+  '@platformatic/prom-client@1.0.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
 
   '@platformatic/promotel@0.1.0':
     dependencies:


### PR DESCRIPTION
## Summary
Replace all instances of `prom-client` with `@platformatic/prom-client` v1.0.0, which is API compatible but significantly faster.

## Changes
- ✅ Updated dependencies in `packages/metrics`, `packages/gateway`, `packages/globals`, and `packages/runtime`
- ✅ Updated `@platformatic/http-metrics` to v0.3.0 for compatibility
- ✅ Updated imports in JavaScript files (`packages/metrics/index.js`, `packages/gateway/test/metrics.test.js`)
- ✅ Updated TypeScript definitions (`packages/globals/lib/index.d.ts`)
- ✅ Fixed tests to use public API (`registry.getSingleMetric()`) instead of internal APIs (`registry._metrics`)
- ✅ Updated documentation to mention API compatibility and performance benefits

## Test Results
All tests passing: **20/20** tests in the metrics package ✅

## Performance
`@platformatic/prom-client` is API compatible with the standard `prom-client` package but [significantly faster](https://gist.github.com/mcollina/686b6823b6601c496721199e23f2d1b1), providing better performance for metrics collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)