### PR TITLE
feat: Add enable property to application configuration

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -49,6 +49,7 @@ runtime. Each application object supports the following settings:
   the application. It can be omitted if `url` is provided.
 - **`url`** (**required**, `string`) - The URL of the application remote GIT repository, if it is a remote application. It can be omitted if `path` is provided. You can specify a branch using the URL fragment syntax: `https://github.com/user/repo.git#branch-name`.
 - **`gitBranch`** (`string`) - The branch of the application to resolve. Takes precedence over the branch specified in the URL fragment.
+- **`enable`** (`boolean`) - By default, the application is enabled. If set to false, the application will not start.
 - **`config`** (`string`) - The configuration file used to start
   the application.
 - **`useHttp`** (`boolean`) - The application will be started on a random HTTP port

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -426,6 +426,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -68,6 +68,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -399,6 +399,7 @@ export interface PlatformaticComposerConfig {
                   body?: string;
                 };
               };
+          healthChecksTimeouts?: number | string;
           plugins?: string[];
           timeout?: number | string;
           /**

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -728,6 +728,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1365,6 +1365,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -745,6 +745,9 @@ export const applications = {
       useHttp: {
         type: 'boolean'
       },
+      enable: {
+        type: 'boolean'
+      },
       reuseTcpPorts: {
         type: 'boolean',
         default: true

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1316,6 +1316,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -426,6 +426,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -426,6 +426,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -426,6 +426,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -426,6 +426,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -20,6 +20,7 @@ export type PlatformaticRuntimeConfig = {
         id: string;
         config?: string;
         useHttp?: boolean;
+        enable?: boolean;
         reuseTcpPorts?: boolean;
         workers?:
           | number

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -444,6 +444,7 @@ export class Runtime extends EventEmitter {
 
     const toStart = []
     for (const application of applications) {
+      if (application.enable === false) continue
       const workers = application.workers
 
       if ((workers.static > 1 || workers.minimum > 1) && application.entrypoint && !features.node.reusePort) {
@@ -456,22 +457,22 @@ export class Runtime extends EventEmitter {
 
       this.#applications.set(application.id, application)
       setupInvocations.push([application])
-      toStart.push(application.id)
+      toStart.push(application)
     }
 
     await executeInParallel(this.#setupApplication.bind(this), setupInvocations, this.#concurrency)
 
-    for (const application of applications) {
+    for (const application of toStart) {
       this.logger.info(`Added application "${application.id}"${application.entrypoint ? ' (entrypoint)' : ''}.`)
       this.emitAndNotify('application:added', application)
     }
 
     if (start) {
-      await this.startApplications(toStart)
+      await this.startApplications(toStart.map(application => application.id))
     }
 
     const created = []
-    for (const { id } of applications) {
+    for (const { id } of toStart) {
       created.push(await this.getApplicationDetails(id))
     }
 

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -64,6 +64,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true
@@ -356,6 +359,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "enable": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -646,6 +652,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "enable": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -934,6 +943,9 @@
             "default": "main"
           },
           "useHttp": {
+            "type": "boolean"
+          },
+          "enable": {
             "type": "boolean"
           },
           "reuseTcpPorts": {

--- a/packages/runtime/test/disabled-applications.test.js
+++ b/packages/runtime/test/disabled-applications.test.js
@@ -1,0 +1,309 @@
+import { deepStrictEqual, ok } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { prepareApplication } from '../index.js'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+test('should skip applications with enable: false', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with enable: false
+  const disabledApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'disabled-app',
+    path: './application-1',
+    enable: false
+  })
+
+  // Add the application
+  await runtime.addApplications([disabledApp], false)
+
+  // Verify the application was NOT added
+  const applicationsIds = runtime.getApplicationsIds()
+  const disabledAppExists = applicationsIds.includes('disabled-app')
+
+  deepStrictEqual(disabledAppExists, false, 'disabled application should not be added when enable is false')
+})
+
+test('should include applications with enable: true', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with enable: true
+  const enabledApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'enabled-app',
+    path: './application-1',
+    enable: true
+  })
+
+  // Add the application
+  await runtime.addApplications([enabledApp], false)
+
+  // Verify the application WAS added
+  const applicationsIds = runtime.getApplicationsIds()
+  const enabledAppExists = applicationsIds.includes('enabled-app')
+
+  ok(enabledAppExists, 'application with enable: true should be added')
+})
+
+test('should include applications when enable is not specified (default behavior)', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application without enable property
+  const defaultApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'default-app',
+    path: './application-1'
+  })
+
+  // Add the application
+  await runtime.addApplications([defaultApp], false)
+
+  // Verify the application WAS added
+  const applicationsIds = runtime.getApplicationsIds()
+  const defaultAppExists = applicationsIds.includes('default-app')
+
+  ok(defaultAppExists, 'application without enable property should be added by default')
+})
+
+test('should handle mixed enabled and disabled applications', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare multiple applications with different enable settings
+  const apps = [
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'disabled-1',
+      path: './application-1',
+      enable: false
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'enabled-1',
+      path: './application-1',
+      enable: true
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'disabled-2',
+      path: './application-2',
+      enable: false
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'enabled-2',
+      path: './application-2'
+    })
+  ]
+
+  // Add all applications at once
+  await runtime.addApplications(apps, false)
+
+  // Verify only enabled applications were added
+  const applicationsIds = runtime.getApplicationsIds()
+
+  deepStrictEqual(
+    applicationsIds.includes('disabled-1'),
+    false,
+    'disabled-1 should not be added'
+  )
+
+  ok(
+    applicationsIds.includes('enabled-1'),
+    'enabled-1 should be added'
+  )
+
+  deepStrictEqual(
+    applicationsIds.includes('disabled-2'),
+    false,
+    'disabled-2 should not be added'
+  )
+
+  ok(
+    applicationsIds.includes('enabled-2'),
+    'enabled-2 should be added'
+  )
+})
+
+test('should not add disabled applications even when start is true', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare a disabled application
+  const disabledApp = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'disabled-app-no-start',
+    path: './application-1',
+    enable: false
+  })
+
+  // Add the application with start=true
+  await runtime.addApplications([disabledApp], true)
+
+  // Verify the application was NOT added
+  const applicationsIds = runtime.getApplicationsIds()
+  const disabledAppExists = applicationsIds.includes('disabled-app-no-start')
+
+  deepStrictEqual(disabledAppExists, false, 'disabled application should not be added even when start is true')
+})
+
+test('should treat enable: undefined as enabled (truthy check)', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with enable: undefined
+  const app = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'undefined-enable-app',
+    path: './application-1',
+    enable: undefined
+  })
+
+  // Add the application
+  await runtime.addApplications([app], false)
+
+  // Verify the application WAS added (undefined is not === false)
+  const applicationsIds = runtime.getApplicationsIds()
+  const appExists = applicationsIds.includes('undefined-enable-app')
+
+  ok(appExists, 'application with enable: undefined should be added (not strictly false)')
+})
+
+test('should treat enable: null as enabled (not strictly false)', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with enable: null
+  const app = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'null-enable-app',
+    path: './application-1',
+    enable: null
+  })
+
+  // Add the application
+  await runtime.addApplications([app], false)
+
+  // Verify the application WAS added (null is not === false)
+  const applicationsIds = runtime.getApplicationsIds()
+  const appExists = applicationsIds.includes('null-enable-app')
+
+  ok(appExists, 'application with enable: null should be added (not strictly false)')
+})
+
+test('should treat enable: 0 as enabled (not strictly false)', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare an application with enable: 0
+  const app = await prepareApplication(runtime.getRuntimeConfig(true), {
+    id: 'zero-enable-app',
+    path: './application-1',
+    enable: 0
+  })
+
+  // Add the application
+  await runtime.addApplications([app], false)
+
+  // Verify the application WAS added (0 is not === false)
+  const applicationsIds = runtime.getApplicationsIds()
+  const appExists = applicationsIds.includes('zero-enable-app')
+
+  ok(appExists, 'application with enable: 0 should be added (not strictly false)')
+})
+
+test('should only skip when enable is exactly false (strict equality)', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Prepare applications with various falsy values
+  const apps = [
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'app-false',
+      path: './application-1',
+      enable: false
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'app-empty-string',
+      path: './application-1',
+      enable: ''
+    }),
+    await prepareApplication(runtime.getRuntimeConfig(true), {
+      id: 'app-zero',
+      path: './application-1',
+      enable: 0
+    })
+  ]
+
+  // Add all applications
+  await runtime.addApplications(apps, false)
+
+  const applicationsIds = runtime.getApplicationsIds()
+
+  // Only enable: false should be skipped
+  deepStrictEqual(
+    applicationsIds.includes('app-false'),
+    false,
+    'app with enable: false should not be added'
+  )
+
+  ok(
+    applicationsIds.includes('app-empty-string'),
+    'app with enable: "" should be added (not strictly false)'
+  )
+
+  ok(
+    applicationsIds.includes('app-zero'),
+    'app with enable: 0 should be added (not strictly false)'
+  )
+})

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1054,6 +1054,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -426,6 +426,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -20,6 +20,7 @@ export type PlatformaticRuntimeConfig = {
         id: string;
         config?: string;
         useHttp?: boolean;
+        enable?: boolean;
         reuseTcpPorts?: boolean;
         workers?:
           | number

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -64,6 +64,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "enable": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true
@@ -356,6 +359,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "enable": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -646,6 +652,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "enable": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -934,6 +943,9 @@
             "default": "main"
           },
           "useHttp": {
+            "type": "boolean"
+          },
+          "enable": {
             "type": "boolean"
           },
           "reuseTcpPorts": {


### PR DESCRIPTION
This change adds a simple flag to the watt.json configuration to choose to enable or disable to run an application.

Changes:

In the watt.json file, applications can have a enable property which, if set to false, prevents them from starting.
Benefits:

This allows you to have applications within the watt environment that are started through simple env configuration.