### PR TITLE
fix: disable signal handlers in test helper

### DIFF
--- a/packages/basic/test/helper.js
+++ b/packages/basic/test/helper.js
@@ -319,6 +319,7 @@ export async function prepareRuntime (t, fixturePath, production, configFile, ad
   process.chdir(root)
   const runtime = await createPlaformaticRuntime(root, configFile, {
     production,
+    setupSignals: false,
     async transform (config, ...args) {
       config = await transform(config, ...args)
       config.logger ??= {}


### PR DESCRIPTION
## Summary
- Add `setupSignals: false` to `prepareRuntime` in test helper to prevent signal handlers from being installed when the runtime is not started

The `prepareRuntime` function creates a Runtime that sets up `closeWithGrace` and `SIGUSR2` signal handlers even when the runtime is never started. These handlers keep the event loop alive and can prevent tests from terminating properly.

## Test plan
- [ ] Run `npm test` in `packages/wattpm-utils` to verify tests complete and terminate
- [ ] Run `npm test` in `packages/basic` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)