### PR TITLE
Do not use global TracerProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ packages/runtime/test/tmp
 
 # Claude Code
 .claude
+packages/*/CLAUDE.md

--- a/packages/basic/test/fixtures/server.js
+++ b/packages/basic/test/fixtures/server.js
@@ -6,7 +6,7 @@ function handler (_, res) {
     connection: 'close'
   })
 
-  const { events, prometheus, itc, clientSpansAls, telemetryReady, ...platformatic } = globalThis.platformatic
+  const { events, prometheus, itc, clientSpansAls, telemetryReady, tracerProvider, ...platformatic } = globalThis.platformatic
 
   res.end(JSON.stringify(platformatic))
 }

--- a/packages/service/lib/capability.js
+++ b/packages/service/lib/capability.js
@@ -41,7 +41,10 @@ export class ServiceCapability extends BaseCapability {
 
     // This must be done before loading the plugins, so they can inspect if the
     // openTelemetry decorator exists and then configure accordingly.
-    if (isKeyEnabled('telemetry', config)) {
+    // Skip manual telemetry plugin if automatic instrumentation is already active
+    // (loaded via --import from node-telemetry.js)
+    const hasAutomaticInstrumentation = !!globalThis.platformatic?.tracerProvider
+    if (isKeyEnabled('telemetry', config) && !hasAutomaticInstrumentation) {
       await this.#app.register(telemetry, config.telemetry)
     }
 

--- a/packages/telemetry/lib/file-span-exporter.js
+++ b/packages/telemetry/lib/file-span-exporter.js
@@ -26,6 +26,14 @@ export class FileSpanExporter {
   }
 
   #exportInfo (span) {
+    // OpenTelemetry 2.0+ resources need to be serialized with their attributes
+    // The resource.attributes property contains a map of attribute values
+    // We need to convert it to the format expected by tests (_rawAttributes array)
+    const resource = {
+      attributes: span.resource?.attributes || {},
+      _rawAttributes: Object.entries(span.resource?.attributes || {})
+    }
+
     return {
       traceId: span.spanContext().traceId,
       // parentId has been removed from otel 2.0, we need to get it from parentSpanContext
@@ -43,7 +51,7 @@ export class FileSpanExporter {
       status: span.status,
       events: span.events,
       links: span.links,
-      resource: span.resource,
+      resource,
       // instrumentationLibrary is deprecated in otel 2.0, we need to use instrumentationScope
       instrumentationScope: span.instrumentationLibrary || span.instrumentationScope
     }

--- a/packages/telemetry/lib/node-telemetry.js
+++ b/packages/telemetry/lib/node-telemetry.js
@@ -1,85 +1,60 @@
+import { context, propagation } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { resourceFromAttributes } from '@opentelemetry/resources'
-import * as opentelemetry from '@opentelemetry/sdk-node'
-import {
-  BatchSpanProcessor,
-  ConsoleSpanExporter,
-  InMemorySpanExporter,
-  SimpleSpanProcessor
-} from '@opentelemetry/sdk-trace-base'
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
-import { abstractLogger } from '@platformatic/foundation'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { readFileSync, statSync } from 'node:fs'
-import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import util from 'node:util'
 import { workerData } from 'node:worker_threads'
-import { FileSpanExporter } from './file-span-exporter.js'
 import { getInstrumentations } from './pluggable-instrumentations.js'
+import { getSpanProcessors } from './span-processors.js'
 
 const debuglog = util.debuglog('@platformatic/telemetry')
-const require = createRequire(import.meta.url)
 
 // See: https://www.npmjs.com/package/@opentelemetry/instrumentation-http
-// When this is fixed we should set this to 'http' and fixe the tests
+// When this is fixed we should set this to 'http' and fix the tests
 // https://github.com/open-telemetry/opentelemetry-js/issues/5103
 process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'http/dup'
+
+// Set up global propagator EARLY for trace context propagation via HTTP headers
+// This must be set before any HTTP operations occur
+propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+
+// Set up global context manager for async context propagation
+// Context manager MUST be global for instrumentations to work
+const contextManager = new AsyncLocalStorageContextManager()
+contextManager.enable()
+context.setGlobalContextManager(contextManager)
 
 const setupNodeHTTPTelemetry = async (opts, applicationDir) => {
   const { applicationName, instrumentations = [] } = opts
   const additionalInstrumentations = await getInstrumentations(instrumentations, applicationDir)
 
-  let exporter = opts.exporter
-  if (!exporter) {
-    abstractLogger.warn('No exporter configured, defaulting to console.')
-    exporter = { type: 'console' }
-  }
-  const exporters = Array.isArray(exporter) ? exporter : [exporter]
-  const spanProcessors = []
-  for (const exporter of exporters) {
-    // Exporter config:
-    // https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_exporter_zipkin.ExporterConfig.html
-    const exporterOptions = { ...exporter.options, applicationName }
-
-    let exporterObj
-    if (exporter.type === 'console') {
-      exporterObj = new ConsoleSpanExporter(exporterOptions)
-    } else if (exporter.type === 'otlp') {
-      const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto')
-      exporterObj = new OTLPTraceExporter(exporterOptions)
-    } else if (exporter.type === 'zipkin') {
-      const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin')
-      exporterObj = new ZipkinExporter(exporterOptions)
-    } else if (exporter.type === 'memory') {
-      exporterObj = new InMemorySpanExporter()
-    } else if (exporter.type === 'file') {
-      exporterObj = new FileSpanExporter(exporterOptions)
-    } else {
-      abstractLogger.warn(`Unknown exporter type: ${exporter.type}, defaulting to console.`)
-      exporterObj = new ConsoleSpanExporter(exporterOptions)
-    }
-
-    let spanProcessor
-    // We use a SimpleSpanProcessor for the console/memory exporters and a BatchSpanProcessor for the others.
-    // , unless "processor" is set to "simple" (used only in tests)
-    if (exporter.processor === 'simple' || ['memory', 'console', 'file'].includes(exporter.type)) {
-      spanProcessor = new SimpleSpanProcessor(exporterObj)
-    } else {
-      spanProcessor = new BatchSpanProcessor(exporterObj)
-    }
-    spanProcessors.push(spanProcessor)
-  }
+  const { spanProcessors } = getSpanProcessors(opts)
 
   const clientSpansAls = new AsyncLocalStorage()
   globalThis.platformatic = globalThis.platformatic || {}
   globalThis.platformatic.clientSpansAls = clientSpansAls
 
-  const sdk = new opentelemetry.NodeSDK({
+  const tracerProvider = new NodeTracerProvider({
     spanProcessors, // https://github.com/open-telemetry/opentelemetry-js/issues/4881#issuecomment-2358059714
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: applicationName
+    })
+  })
+  globalThis.platformatic.tracerProvider = tracerProvider
+
+  // Register instrumentations with our TracerProvider
+  registerInstrumentations({
+    tracerProvider,
     instrumentations: [
       new UndiciInstrumentation({
         responseHook: span => {
@@ -91,18 +66,16 @@ const setupNodeHTTPTelemetry = async (opts, applicationDir) => {
       }),
       new HttpInstrumentation(),
       ...additionalInstrumentations
-    ],
-    resource: resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: applicationName
-    })
+    ]
   })
-  sdk.start()
 
-  process.on('SIGTERM', () => {
-    sdk
-      .shutdown()
-      .then(() => debuglog('Tracing terminated'))
-      .catch(error => debuglog('Error terminating tracing', error))
+  process.on('SIGTERM', async () => {
+    try {
+      await tracerProvider.shutdown()
+      debuglog('Tracing terminated')
+    } catch (error) {
+      debuglog('Error terminating tracing', error)
+    }
   })
 }
 

--- a/packages/telemetry/lib/span-processors.js
+++ b/packages/telemetry/lib/span-processors.js
@@ -1,0 +1,65 @@
+import {
+  BatchSpanProcessor,
+  ConsoleSpanExporter,
+  InMemorySpanExporter,
+  SimpleSpanProcessor
+} from '@opentelemetry/sdk-trace-base'
+import { abstractLogger } from '@platformatic/foundation'
+import { createRequire } from 'node:module'
+import { FileSpanExporter } from './file-span-exporter.js'
+
+const require = createRequire(import.meta.url)
+
+export function getSpanProcessors (opts = {}, logger = abstractLogger) {
+  const { applicationName, version } = opts
+
+  // Set up exporters
+  let exporter = opts.exporter
+  if (!exporter) {
+    logger.warn?.('No exporter configured, defaulting to console.')
+    exporter = { type: 'console' }
+  }
+
+  const exporters = Array.isArray(exporter) ? exporter : [exporter]
+
+  logger.debug?.(
+    `Setting up platformatic telemetry for application: ${applicationName}${version ? ' version: ' + version : ''} with exporter of type ${exporter.type}`
+  )
+
+  const exporterObjs = []
+  const spanProcessors = []
+  for (const exp of exporters) {
+    const exporterOptions = { ...exp.options, applicationName }
+
+    let exporterObj
+    if (exp.type === 'console') {
+      exporterObj = new ConsoleSpanExporter(exporterOptions)
+    } else if (exp.type === 'otlp') {
+      const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto')
+      exporterObj = new OTLPTraceExporter(exporterOptions)
+    } else if (exp.type === 'zipkin') {
+      const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin')
+      exporterObj = new ZipkinExporter(exporterOptions)
+    } else if (exp.type === 'memory') {
+      exporterObj = new InMemorySpanExporter()
+    } else if (exp.type === 'file') {
+      exporterObj = new FileSpanExporter(exporterOptions)
+    } else {
+      logger.warn?.(`Unknown exporter type: ${exp.type}, defaulting to console.`)
+      exporterObj = new ConsoleSpanExporter(exporterOptions)
+    }
+    exporterObjs.push(exporterObj)
+
+    let spanProcessor
+    // We use a SimpleSpanProcessor for the console/memory exporters and a BatchSpanProcessor for the others.
+    // unless "processor" is set to "simple" (used only in tests)
+    if (exp.processor === 'simple' || ['memory', 'console', 'file'].includes(exp.type)) {
+      spanProcessor = new SimpleSpanProcessor(exporterObj)
+    } else {
+      spanProcessor = new BatchSpanProcessor(exporterObj)
+    }
+    spanProcessors.push(spanProcessor)
+  }
+
+  return { exporters: exporterObjs, spanProcessors }
+}


### PR DESCRIPTION
This should prevent our TracerProvider from conflicting with the global TracerProvider, allowing other OpenTelemetry-based Observability products to work correctly without conflicting with our own use.