### PR TITLE
Check README documentation links only on `main` 

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:  # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
Restrict link-check CI workflow to only run on pushes to main branch and manual triggers. So removes pull_request, schedule, and versioned branch triggers.