### PR TITLE
feat(runtime): pass name property to worker threads

### DIFF
--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -1564,7 +1564,8 @@ export class Runtime extends EventEmitter {
         codeRangeSizeMb
       },
       stdout: true,
-      stderr: true
+      stderr: true,
+      name: workerId
     })
 
     this.#handleWorkerStandardStreams(worker, applicationId, index)


### PR DESCRIPTION
## Summary

This PR adds worker thread naming support to improve debugging and observability in the Platformatic runtime.

## Changes

1. **lib/runtime.js**: Added `name: workerId` to the Worker constructor options, enabling each worker thread to be identified by its workerId (format: `applicationId:index`, e.g., `node:0`, `service:1`)

2. **test/multiple-workers/basic.test.js**: Added a unit test that verifies each worker's `threadName` property is correctly set to its workerId

## Benefits

- Improves debugging by making worker threads easier to identify in logs
- Enhances observability in monitoring tools
- Follows Node.js Worker thread naming conventions

## Test Plan

- Added new test case that validates the `threadName` property is set correctly for all workers
- Existing tests continue to pass
- Pre-commit linting checks passed

---

Generated with Claude Code