### PR TITLE
fix: fix call signature of `BaseCapability#getMetrics()`

### DIFF
--- a/packages/basic/index.d.ts
+++ b/packages/basic/index.d.ts
@@ -62,7 +62,7 @@ export class BaseCapability<Config = Record<string, any>, Options = BaseOptions>
       | Promise<{ status: boolean; statusCode?: number; body?: string }>
   ): Promise<void>
   collectMetrics (): Promise<any>
-  getMetrics (options: { format: string }): Promise<string | Array<object>>
+  getMetrics (options?: { format?: string }): Promise<string | Array<object>>
   getMeta (): Promise<object>
   inject (injectParams: string | object): Promise<{
     statusCode: number

--- a/packages/basic/test/types/index.test-d.ts
+++ b/packages/basic/test/types/index.test-d.ts
@@ -104,6 +104,7 @@ expectType<Promise<void>>(capability.setCustomReadinessCheck(() => Promise.resol
 
 // Test metrics methods
 expectType<Promise<any>>(capability.collectMetrics())
+expectType<Promise<string | Array<object>>>(capability.getMetrics())
 expectType<Promise<string | Array<object>>>(capability.getMetrics({ format: 'json' }))
 expectType<Promise<object>>(capability.getMeta())
 


### PR DESCRIPTION
This PR fixes call signature of `BaseCapability#getMetrics()` by adding missing identifier.