### PR TITLE
fix: add missing `PlatformaticServiceConfig` import

### DIFF
--- a/packages/gateway/index.d.ts
+++ b/packages/gateway/index.d.ts
@@ -4,13 +4,14 @@ import {
   Configuration,
   ServiceCapability,
   Generator as ServiceGenerator,
+  PlatformaticServiceConfig,
   ServerInstance as ServiceServerInstance
 } from '@platformatic/service'
 import { JSONSchemaType } from 'ajv'
 import { FastifyError, FastifyInstance } from 'fastify'
 import type { PlatformaticGatewayConfig } from './config.d.ts'
 
-export { PlatformaticService } from '@platformatic/service'
+export type { PlatformaticServiceConfig } from '@platformatic/service'
 export type { PlatformaticGatewayConfig } from './config.d.ts'
 
 export type GatewayCapability = ServiceCapability<PlatformaticGatewayConfig>


### PR DESCRIPTION
This PR adds missing `PlatformaticServiceConfig` import to typings of `@platformatic/gateway`.

The type is used in the lines below, but is never imported: https://github.com/platformatic/platformatic/blob/146d5af030f62fe085e607e2073539a2d849798f/packages/gateway/index.d.ts#L23-L24

---

There is a related issue in the same file: `PlatformaticService` does not exist in `@platformatic/service`, but `@platformatic/gateway` is trying to export it. After looking around, I guess this must be a typo. Likely `PlatformaticServiceConfig` must be exported instead. Double check, please.