### PR TITLE
fix(runtime): use undici.install() for proper fetch globals

### DIFF
--- a/packages/runtime/fixtures/fetch-globals/platformatic.json
+++ b/packages/runtime/fixtures/fetch-globals/platformatic.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.3.1.json",
+  "entrypoint": "frontend",
+  "watch": false,
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  }
+}

--- a/packages/runtime/fixtures/fetch-globals/services/backend/platformatic.json
+++ b/packages/runtime/fixtures/fetch-globals/services/backend/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.3.1.json",
+  "plugins": {
+    "paths": ["./plugin.js"]
+  }
+}

--- a/packages/runtime/fixtures/fetch-globals/services/backend/plugin.js
+++ b/packages/runtime/fixtures/fetch-globals/services/backend/plugin.js
@@ -1,0 +1,6 @@
+/** @param {import('fastify').FastifyInstance} app */
+export default async function (app) {
+  app.get('/data', async () => {
+    return { message: 'hello from backend' }
+  })
+}

--- a/packages/runtime/fixtures/fetch-globals/services/frontend/platformatic.json
+++ b/packages/runtime/fixtures/fetch-globals/services/frontend/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.3.1.json",
+  "plugins": {
+    "paths": ["./plugin.js"]
+  }
+}

--- a/packages/runtime/fixtures/fetch-globals/services/frontend/plugin.js
+++ b/packages/runtime/fixtures/fetch-globals/services/frontend/plugin.js
@@ -1,0 +1,26 @@
+/** @param {import('fastify').FastifyInstance} app */
+export default async function (app) {
+  // Test fetch with string URL
+  app.get('/fetch-string', async () => {
+    const response = await fetch('http://backend.plt.local/data')
+    const data = await response.json()
+    return { method: 'string', ok: response.ok, data }
+  })
+
+  // Test fetch with Request object
+  app.get('/fetch-request', async () => {
+    const request = new Request('http://backend.plt.local/data')
+    const response = await fetch(request)
+    const data = await response.json()
+    return { method: 'request', ok: response.ok, data }
+  })
+
+  // Test that Request and Response are the undici versions
+  app.get('/check-globals', async () => {
+    return {
+      hasRequest: typeof globalThis.Request === 'function',
+      hasResponse: typeof globalThis.Response === 'function',
+      hasFetch: typeof globalThis.fetch === 'function'
+    }
+  })
+}

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -13,7 +13,7 @@ import { join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { threadId, workerData } from 'node:worker_threads'
 import pino from 'pino'
-import { fetch } from 'undici'
+import { install as installUndiciGlobals } from 'undici'
 import { Controller } from './controller.js'
 import { setDispatcher } from './interceptors.js'
 import { setupITC } from './itc.js'
@@ -137,7 +137,7 @@ async function setupCompileCache (runtimeConfig, applicationConfig, logger) {
 }
 
 async function main () {
-  globalThis.fetch = fetch
+  installUndiciGlobals(globalThis)
   globalThis[kId] = threadId
   globalThis.platformatic = Object.assign(globalThis.platformatic ?? {}, {
     logger: createLogger(),

--- a/packages/runtime/test/fetch-globals.test.js
+++ b/packages/runtime/test/fetch-globals.test.js
@@ -1,0 +1,54 @@
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+test('fetch globals should work with both string URL and Request object', async t => {
+  const configFile = join(fixturesDir, 'fetch-globals', 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.init()
+  const entryUrl = await app.start()
+
+  // Test fetch with string URL
+  {
+    const { statusCode, body } = await request(entryUrl, { path: '/fetch-string' })
+    strictEqual(statusCode, 200)
+
+    const response = await body.json()
+    strictEqual(response.method, 'string')
+    strictEqual(response.ok, true)
+    deepStrictEqual(response.data, { message: 'hello from backend' })
+  }
+
+  // Test fetch with Request object - this was failing before the fix
+  {
+    const { statusCode, body } = await request(entryUrl, { path: '/fetch-request' })
+    strictEqual(statusCode, 200)
+
+    const response = await body.json()
+    strictEqual(response.method, 'request')
+    strictEqual(response.ok, true)
+    deepStrictEqual(response.data, { message: 'hello from backend' })
+  }
+
+  // Verify globals are properly set
+  {
+    const { statusCode, body } = await request(entryUrl, { path: '/check-globals' })
+    strictEqual(statusCode, 200)
+
+    const response = await body.json()
+    deepStrictEqual(response, {
+      hasRequest: true,
+      hasResponse: true,
+      hasFetch: true
+    })
+  }
+})

--- a/packages/tanstack/test/fetch.test.js
+++ b/packages/tanstack/test/fetch.test.js
@@ -1,0 +1,72 @@
+import { ok, strictEqual } from 'node:assert'
+import { cp } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import {
+  buildRuntime,
+  commonFixturesRoot,
+  prepareRuntime,
+  setAdditionalDependencies,
+  setFixturesDir,
+  startRuntime,
+  updateFile
+} from '../../basic/test/helper.js'
+import { additionalDependencies } from './helper.js'
+
+process.setMaxListeners(100)
+setFixturesDir(resolve(import.meta.dirname, './fixtures'))
+setAdditionalDependencies(additionalDependencies)
+
+function decodeHtmlEntities (str) {
+  return str
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+}
+
+test('fetch() should work with string URL and Request object in TanStack app', async t => {
+  const { runtime, root } = await prepareRuntime(t, 'fetch-test', true, null, async (root) => {
+    // Copy backend and composer services from common fixtures
+    for (const type of ['backend', 'composer']) {
+      await cp(resolve(commonFixturesRoot, `${type}-js`), resolve(root, `services/${type}`), {
+        recursive: true
+      })
+    }
+
+    // Update the composer routes to expose frontend at /frontend prefix
+    await updateFile(resolve(root, 'services/composer/routes/root.js'), contents => {
+      return contents.replace('$PREFIX', '/frontend')
+    })
+  })
+
+  // Build the runtime
+  await buildRuntime(root)
+
+  // Start the runtime
+  const url = await startRuntime(t, runtime)
+
+  // Request the page - the loader will execute fetch calls on the server
+  const response = await request(`${url}/frontend/`)
+  strictEqual(response.statusCode, 200, `Expected 200 but got ${response.statusCode}`)
+
+  const html = await response.body.text()
+
+  // The page should render "Hello from v123" if the loader succeeded
+  ok(html.includes('Hello from v'), 'Page should render successfully')
+
+  // Extract the pre tag content which has the JSON results (HTML encoded)
+  const preMatch = html.match(/<pre[^>]*id="fetch-results"[^>]*>([\s\S]*?)<\/pre>/)
+  ok(preMatch, 'Should find fetch-results pre tag')
+
+  const decoded = decodeHtmlEntities(preMatch[1].trim())
+  const fetchResults = JSON.parse(decoded)
+
+  // Test 1: fetch with string URL should work
+  ok(fetchResults.stringUrl?.ok === true, `fetch with string URL should succeed: ${JSON.stringify(fetchResults.stringUrl)}`)
+
+  // Test 2: fetch with Request object should work
+  ok(fetchResults.requestObject?.ok === true, `fetch with Request object should succeed: ${JSON.stringify(fetchResults.requestObject)}`)
+})

--- a/packages/tanstack/test/fixtures/fetch-test/package.json
+++ b/packages/tanstack/test/fixtures/fetch-test/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test",
+  "private": true,
+  "workspaces": [
+    "services/*"
+  ],
+  "devDependencies": {
+    "fastify": "^5.7.0",
+    "typescript": "^5.5.4"
+  },
+  "dependencies": {
+    "@platformatic/runtime": "^3.0.0",
+    "platformatic": "^3.0.0"
+  }
+}

--- a/packages/tanstack/test/fixtures/fetch-test/platformatic.runtime.json
+++ b/packages/tanstack/test/fixtures/fetch-test/platformatic.runtime.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "composer",
+  "services": [
+    {
+      "id": "frontend",
+      "config": "platformatic.application.json",
+      "path": "./services/frontend"
+    },
+    {
+      "id": "backend",
+      "config": "platformatic.json",
+      "path": "./services/backend"
+    },
+    {
+      "id": "composer",
+      "config": "platformatic.json",
+      "path": "./services/composer"
+    }
+  ],
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/tanstack/test/fixtures/fetch-test/services/frontend/package.json
+++ b/packages/tanstack/test/fixtures/fetch-test/services/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "tanstack",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@platformatic/tanstack": "^3.0.0",
+    "@tanstack/react-start": "^1.139.7",
+    "@tanstack/react-router": "^1.139.7",
+    "@vitejs/plugin-react": "^5.1.1",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "vite": "^7.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "vite-tsconfig-paths": "^5.1.4"
+  }
+}

--- a/packages/tanstack/test/fixtures/fetch-test/services/frontend/platformatic.application.json
+++ b/packages/tanstack/test/fixtures/fetch-test/services/frontend/platformatic.application.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/tanstack/3.0.0.json",
+  "application": {
+    "basePath": "/frontend"
+  }
+}

--- a/packages/tanstack/test/fixtures/fetch-test/services/frontend/src/router.tsx
+++ b/packages/tanstack/test/fixtures/fetch-test/services/frontend/src/router.tsx
@@ -1,0 +1,11 @@
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export function getRouter () {
+  const router = createRouter({
+    routeTree,
+    scrollRestoration: true
+  })
+
+  return router
+}

--- a/packages/tanstack/test/fixtures/fetch-test/services/frontend/src/routes/__root.tsx
+++ b/packages/tanstack/test/fixtures/fetch-test/services/frontend/src/routes/__root.tsx
@@ -1,0 +1,34 @@
+import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
+import type { ReactNode } from 'react'
+
+function RootComponent ({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [
+      {
+        charSet: 'utf-8'
+      },
+      {
+        name: 'viewport',
+        content: 'width=device-width, initial-scale=1'
+      },
+      {
+        title: 'TanStack Start Starter'
+      }
+    ]
+  }),
+  component: RootComponent
+})

--- a/packages/tanstack/test/fixtures/fetch-test/services/frontend/src/routes/index.tsx
+++ b/packages/tanstack/test/fixtures/fetch-test/services/frontend/src/routes/index.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+const version = 123
+
+// Loader function to test fetch - runs on the server
+export async function loader () {
+  const results: Record<string, unknown> = {}
+
+  // Test 1: fetch with string URL
+  try {
+    const stringUrlResponse = await fetch('http://backend.plt.local/example')
+    const stringUrlData = await stringUrlResponse.json()
+    results.stringUrl = { ok: stringUrlResponse.ok, data: stringUrlData }
+  } catch (err) {
+    results.stringUrl = { ok: false, error: String(err) }
+  }
+
+  // Test 2: fetch with Request object (tests srvx/undici compatibility)
+  try {
+    const req = new Request('http://backend.plt.local/example')
+    const requestObjectResponse = await fetch(req)
+    const requestObjectData = await requestObjectResponse.json()
+    results.requestObject = { ok: requestObjectResponse.ok, data: requestObjectData }
+  } catch (err) {
+    results.requestObject = { ok: false, error: String(err) }
+  }
+
+  return results
+}
+
+function Home () {
+  const data = Route.useLoaderData()
+
+  return (
+    <div>
+      Hello from v{version}
+      <pre id="fetch-results">{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/')({
+  component: Home,
+  loader
+})

--- a/packages/tanstack/test/fixtures/fetch-test/services/frontend/tsconfig.json
+++ b/packages/tanstack/test/fixtures/fetch-test/services/frontend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "target": "ES2022",
+    "skipLibCheck": true,
+    "strictNullChecks": true
+  }
+}

--- a/packages/tanstack/test/fixtures/fetch-test/services/frontend/vite.config.ts
+++ b/packages/tanstack/test/fixtures/fetch-test/services/frontend/vite.config.ts
@@ -1,0 +1,24 @@
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+import { nitro } from 'nitro/vite'
+import { defineConfig } from 'vite'
+import tsConfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [
+    tsConfigPaths(),
+    tanstackStart(),
+    process.env.NODE_ENV === 'production' &&
+      nitro({
+        preset: 'node-server',
+        output: {
+          dir: 'dist'
+        }
+      }),
+    viteReact()
+  ],
+  // This is needed for GitHub actions due to https://github.com/vitejs/vite/issues/10802
+  resolve: {
+    preserveSymlinks: true
+  }
+})

--- a/packages/tanstack/test/fixtures/fetch-test/tsconfig.json
+++ b/packages/tanstack/test/fixtures/fetch-test/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "lib": ["es2022"],
+    "target": "es2022",
+    "sourceMap": true,
+    "pretty": true,
+    "noEmitOnError": true,
+    "incremental": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "watchOptions": {
+    "watchFile": "fixedPollingInterval",
+    "watchDirectory": "fixedPollingInterval",
+    "fallbackPolling": "dynamicPriority",
+    "synchronousWatchDirectory": true,
+    "excludeDirectories": ["**/node_modules", "dist"]
+  }
+}


### PR DESCRIPTION
## Summary

- Use `undici.install(globalThis)` instead of only setting `globalThis.fetch = undici.fetch`
- This ensures all WHATWG fetch globals (fetch, Request, Response, Headers, etc.) are properly set from undici
- Fixes compatibility issues with libraries like srvx that use `new Request()` with fetch

## Problem

Previously, Watt only set `globalThis.fetch` but not `globalThis.Request` and `globalThis.Response`. When libraries like srvx patched `globalThis.Request`, those patched Request instances weren't recognized by undici's internal `webidl.is.Request()` check, causing:

```
TypeError: Failed to parse URL from [object Request]
```

## Test plan

- [x] Added runtime test (`packages/runtime/test/fetch-globals.test.js`) that verifies fetch works with both string URL and Request object
- [x] Added TanStack test (`packages/tanstack/test/fetch.test.js`) that verifies fetch works in TanStack Start loaders
- [x] Both tests pass locally

🤖 Generated with [Claude Code](https://claude.ai/code)