### PR TITLE
fix: import the `Configuration` type from `@platformatic/foundation`

### DIFF
--- a/packages/gateway/index.d.ts
+++ b/packages/gateway/index.d.ts
@@ -1,7 +1,6 @@
 import { BaseCapability } from '@platformatic/basic'
-import { ConfigurationOptions } from '@platformatic/foundation'
+import { Configuration, ConfigurationOptions } from '@platformatic/foundation'
 import {
-  Configuration,
   ServiceCapability,
   Generator as ServiceGenerator,
   PlatformaticServiceConfig,


### PR DESCRIPTION
Import the `Configuration` type from `@platformatic/foundation`.

Likely a refactoring mistake. `@platformatic/service` has no exported type named `Configuration`.