### PR TITLE
fix: add validation for application generator in RuntimeGenerator.addApplication

### DIFF
--- a/packages/runtime/lib/generator.js
+++ b/packages/runtime/lib/generator.js
@@ -41,6 +41,10 @@ const NoApplicationNamedError = createError(
   "No application named '%s' has been added to this runtime."
 )
 const NoEntryPointError = createError(`${ERROR_PREFIX}_NO_ENTRYPOINT`, 'No entrypoint had been defined.')
+const InvalidApplicationGeneratorError = createError(
+  `${ERROR_PREFIX}_INVALID_APPLICATION_GENERATOR`,
+  "The application generator '%s' does not have a setRuntime method. Expected a BaseGenerator subclass but got %s."
+)
 
 function getRuntimeBaseEnvVars (config) {
   return {
@@ -66,6 +70,12 @@ export class RuntimeGenerator extends BaseGenerator {
   }
 
   async addApplication (application, name) {
+    // Validate that application has the expected interface
+    if (typeof application?.setRuntime !== 'function') {
+      const constructorName = application?.constructor?.name || typeof application
+      throw new InvalidApplicationGeneratorError(name || 'unknown', constructorName)
+    }
+
     // ensure application config is correct
     const originalConfig = application.config
     const applicationName = name || generateDashedName()

--- a/packages/runtime/test/generator.test.js
+++ b/packages/runtime/test/generator.test.js
@@ -94,6 +94,42 @@ test('RuntimeGenerator - should create a runtime with 2 applications', async () 
   })
 })
 
+test('RuntimeGenerator - should throw an error for invalid application generator', async () => {
+  const rg = new RuntimeGenerator({
+    targetDirectory: '/tmp/runtime'
+  })
+
+  // Test with an object that doesn't have setRuntime method
+  const invalidGenerator = {
+    config: {},
+    reset: () => {},
+    setConfig: () => {}
+  }
+
+  await assert.rejects(
+    async () => rg.addApplication(invalidGenerator, 'invalid-app'),
+    {
+      code: 'PLT_RUNTIME_GEN_INVALID_APPLICATION_GENERATOR',
+      message: /does not have a setRuntime method/
+    }
+  )
+
+  // Test with null/undefined
+  await assert.rejects(
+    async () => rg.addApplication(null, 'null-app'),
+    {
+      code: 'PLT_RUNTIME_GEN_INVALID_APPLICATION_GENERATOR'
+    }
+  )
+
+  await assert.rejects(
+    async () => rg.addApplication(undefined, 'undefined-app'),
+    {
+      code: 'PLT_RUNTIME_GEN_INVALID_APPLICATION_GENERATOR'
+    }
+  )
+})
+
 test('RuntimeGenerator - should have a valid package.json', async () => {
   const rg = new RuntimeGenerator({
     name: 'test-runtime',


### PR DESCRIPTION
## Summary
- Adds validation in `RuntimeGenerator.addApplication` to check if the application has a `setRuntime` method before calling it
- Throws a clear `InvalidApplicationGeneratorError` with the application name and actual type received when validation fails
- Adds test coverage for the new validation

## Context
When `addApplication` is called with an invalid application generator that doesn't have a `setRuntime` method, the error `application.setRuntime is not a function` is thrown without helpful context. This change provides better diagnostics by including the application name and the actual type received.

Refs #4567

## Test plan
- [x] Added unit tests for invalid generator scenarios (object without setRuntime, null, undefined)
- [x] Existing tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)