### PR TITLE
fix: remove default telemetry_id=unknown from metrics

### DIFF
--- a/packages/metrics/index.js
+++ b/packages/metrics/index.js
@@ -287,8 +287,8 @@ export async function collectThreadMetrics (applicationId, workerId, metricsConf
     collectHttpMetrics(registry, {
       customLabels: ['telemetry_id'],
       getCustomLabels: req => {
-        const telemetryId = req.headers?.['x-plt-telemetry-id'] ?? 'unknown'
-        return { telemetry_id: telemetryId }
+        const telemetryId = req.headers?.['x-plt-telemetry-id']
+        return telemetryId ? { telemetry_id: telemetryId } : {}
       },
       histogram: {
         name: 'http_request_all_duration_seconds',
@@ -344,8 +344,8 @@ export async function collectMetrics (applicationId, workerId, metricsConfig = {
     collectHttpMetrics(registry, {
       customLabels: ['telemetry_id'],
       getCustomLabels: req => {
-        const telemetryId = req.headers?.['x-plt-telemetry-id'] ?? 'unknown'
-        return { telemetry_id: telemetryId }
+        const telemetryId = req.headers?.['x-plt-telemetry-id']
+        return telemetryId ? { telemetry_id: telemetryId } : {}
       },
       histogram: {
         name: 'http_request_all_duration_seconds',


### PR DESCRIPTION
## Summary
- Remove the default `telemetry_id=unknown` label from HTTP metrics
- Only include `telemetry_id` label when the `x-plt-telemetry-id` header is actually present in the request

## Test plan
- [x] Existing tests pass (they explicitly set the header)
- [ ] Verify metrics no longer include `telemetry_id=unknown` for requests without the header

🤖 Generated with [Claude Code](https://claude.ai/claude-code)