### PR TITLE
feat: add health check support for child processes

### DIFF
--- a/packages/basic/test/fixtures/health-signals-subprocess.js
+++ b/packages/basic/test/fixtures/health-signals-subprocess.js
@@ -1,0 +1,9 @@
+// Send a health signal immediately after startup
+// The sendHealthSignal function batches signals with a 1000ms timeout
+globalThis.platformatic.sendHealthSignal({
+  type: 'test-signal',
+  data: { test: true }
+}).then(() => {
+  // Exit after signals are sent
+  process.exit(0)
+})

--- a/packages/runtime/lib/worker/itc.js
+++ b/packages/runtime/lib/worker/itc.js
@@ -293,6 +293,19 @@ export function setupITC (controller, application, dispatcher, sharedContext) {
       },
 
       async getHealth () {
+        // Check if running in subprocess mode - forward through ChildManager
+        const childManager = controller.capability?.getChildManager?.()
+        const clientWs = controller.capability?.clientWs
+
+        if (childManager && clientWs) {
+          try {
+            return await childManager.send(clientWs, 'getHealth')
+          } catch (err) {
+            throw new FailedToRetrieveHealthError(application.id, err.message)
+          }
+        }
+
+        // Existing thread implementation
         try {
           return await controller.getHealth()
         } catch (err) {

--- a/packages/runtime/test/health-subprocess.test.js
+++ b/packages/runtime/test/health-subprocess.test.js
@@ -1,0 +1,115 @@
+import { ok, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+const isWindows = process.platform === 'win32'
+
+// Tests for subprocess mode (when capability uses startWithCommand)
+// The custom-metrics fixture has an 'external' service that uses commands config,
+// which spawns a subprocess via startWithCommand()
+
+test('should collect health metrics for subprocess application with commands', { skip: isWindows && 'Skipping on Windows' }, async t => {
+  const configFile = join(fixturesDir, 'custom-metrics', 'platformatic.json')
+
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Collect health metrics events
+  const healthMetrics = []
+  app.on('application:worker:health:metrics', (metrics) => {
+    healthMetrics.push(metrics)
+  })
+
+  await app.start()
+
+  // Wait for health metrics to be collected (should happen within 2 seconds)
+  await sleep(2500)
+
+  // Filter for subprocess service 'external' (which uses commands config)
+  const subprocessMetrics = healthMetrics.filter(m => m.application === 'external')
+
+  ok(subprocessMetrics.length > 0, 'Should have collected health metrics for subprocess application')
+
+  // Verify health metrics structure
+  const metric = subprocessMetrics[0]
+  ok(metric.currentHealth, 'Should have currentHealth')
+  ok(typeof metric.currentHealth.elu === 'number', 'Should have ELU metric')
+  ok(typeof metric.currentHealth.heapUsed === 'number', 'Should have heapUsed metric')
+  ok(typeof metric.currentHealth.heapTotal === 'number', 'Should have heapTotal metric')
+  strictEqual(metric.application, 'external')
+  strictEqual(metric.worker, 0)
+})
+
+test('subprocess health metrics should have valid ELU values', { skip: isWindows && 'Skipping on Windows' }, async t => {
+  const configFile = join(fixturesDir, 'custom-metrics', 'platformatic.json')
+
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Collect multiple health metrics
+  const healthMetrics = []
+  app.on('application:worker:health:metrics', (metrics) => {
+    if (metrics.application === 'external') {
+      healthMetrics.push(metrics)
+    }
+  })
+
+  await app.start()
+
+  // Wait for multiple health checks
+  await sleep(3000)
+
+  ok(healthMetrics.length >= 2, 'Should have at least 2 health metrics')
+
+  // ELU should be between 0 and 1
+  for (const metric of healthMetrics) {
+    const elu = metric.currentHealth.elu
+    ok(elu >= 0 && elu <= 1, `ELU should be between 0 and 1, got ${elu}`)
+  }
+})
+
+test('subprocess health metrics heap values should be reasonable', { skip: isWindows && 'Skipping on Windows' }, async t => {
+  const configFile = join(fixturesDir, 'custom-metrics', 'platformatic.json')
+
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Collect health metrics
+  const healthMetrics = []
+  app.on('application:worker:health:metrics', (metrics) => {
+    if (metrics.application === 'external') {
+      healthMetrics.push(metrics)
+    }
+  })
+
+  await app.start()
+
+  // Wait for health check
+  await sleep(2000)
+
+  ok(healthMetrics.length > 0, 'Should have collected health metrics')
+
+  const metric = healthMetrics[0]
+  const { heapUsed, heapTotal } = metric.currentHealth
+
+  // Heap values should be positive numbers (in bytes)
+  ok(heapUsed > 0, 'heapUsed should be positive')
+  ok(heapTotal > 0, 'heapTotal should be positive')
+  ok(heapUsed <= heapTotal, 'heapUsed should be <= heapTotal')
+
+  // Reasonable bounds (at least 1MB heap, less than 1GB)
+  ok(heapTotal >= 1024 * 1024, 'heapTotal should be at least 1MB')
+  ok(heapTotal <= 1024 * 1024 * 1024, 'heapTotal should be less than 1GB')
+})


### PR DESCRIPTION
## Summary

This extends the existing health check functionality (worker threads only) to also support applications running as child processes (subprocess mode via `startWithCommand`).

### Changes

- Add `getHealth` handler in `ChildProcess` to return ELU and heap metrics
- Add `sendHealthSignals` handler to forward health signals from subprocess to parent
- Initialize `sendHealthSignal` API in `globalThis.platformatic` for subprocesses
- Forward `healthSignals` events from `ChildManager` to runtime ITC
- Detect subprocess mode in runtime worker ITC and forward `getHealth` through `ChildManager`
- Fix `spawn()` to use `process.execPath` instead of PATH lookup to ensure subprocess uses the same Node.js version as the parent

### Architecture

When a capability spawns a child process via `startWithCommand()` (e.g., when custom commands are configured), the health check requests are now forwarded through the `ChildManager` WebSocket-based IPC:

```
Runtime API -> Worker Thread ITC -> ChildManager -> ChildProcess -> Health Metrics
```

The subprocess mode is detected by checking `capability.getChildManager() && capability.clientWs`.

## Test Plan

- [x] Unit tests for `getHealth` handler in `ChildProcess`
- [x] Unit tests for `sendHealthSignal` API availability in subprocess
- [x] Integration tests for subprocess health metrics collection
- [x] Tests verify ELU values are between 0 and 1
- [x] Tests verify heap values are reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)