### PR TITLE
Controller getDependencies API guard

### DIFF
--- a/packages/runtime/lib/worker/itc.js
+++ b/packages/runtime/lib/worker/itc.js
@@ -213,7 +213,7 @@ export function setupITC (controller, application, dispatcher, sharedContext) {
       },
 
       async getDependencies () {
-        return controller.capability.getDependencies()
+        return controller.capability.getDependencies?.() ?? []
       },
 
       async build () {


### PR DESCRIPTION
If we have a watt.json resolving other external watt, these can be on f a lower version. If so, the `controller.capbility.getDependencies might not exists`, hence the `controller.capability.getDependencies is not a function` error