### PR TITLE
fix: skip capability detection for external services without path

### DIFF
--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -339,3 +339,142 @@ test('should manage application config patch', async t => {
     deepStrictEqual(data, { alternate: true })
   }
 })
+
+test('prepareApplication should not perform slow glob for services with url but no path', async t => {
+  const { prepareApplication } = await import('../lib/config.js')
+  const { kMetadata } = await import('@platformatic/foundation')
+  const { mkdir, writeFile, rm } = await import('node:fs/promises')
+
+  // Create a temporary directory with many JS files to simulate a large codebase
+  // This will make the glob operation slow if it runs unnecessarily
+  const tempDir = join(fixturesDir, 'temp-glob-test-' + Date.now())
+  await mkdir(tempDir, { recursive: true })
+
+  // Create subdirectories with many JS files (simulating external services)
+  const numDirs = 20
+  const filesPerDir = 50
+  for (let i = 0; i < numDirs; i++) {
+    const subDir = join(tempDir, `service-${i}`)
+    await mkdir(subDir, { recursive: true })
+    for (let j = 0; j < filesPerDir; j++) {
+      await writeFile(join(subDir, `file-${j}.js`), '// test file')
+    }
+  }
+
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  // Create a minimal config object with metadata pointing to the temp directory
+  // This is the root that would be globbed if the bug exists
+  const config = {
+    [kMetadata]: {
+      root: tempDir,
+      env: {},
+      path: null,
+      module: '@platformatic/runtime'
+    },
+    entrypoint: 'service-with-url',
+    watch: false
+  }
+
+  const defaultWorkers = { static: 1, dynamic: false }
+
+  // Service with url but no path - simulates external service from git
+  // BUG: When path is undefined, importCapabilityAndConfig(undefined) is called
+  // which globs the cwd looking for JS files
+  const application = {
+    id: 'service-with-url',
+    url: 'git@github.com:example/repo.git',
+    gitBranch: 'main'
+    // Note: no 'path' property - this is the problematic case
+  }
+
+  // Measure ONLY the prepareApplication call, not the test setup
+  const startTime = performance.now()
+  const result = await prepareApplication(config, application, defaultWorkers)
+  const elapsed = performance.now() - startTime
+
+  // Verify the application type is set to 'unknown'
+  strictEqual(result.type, 'unknown', 'Application type should be "unknown" when path is missing')
+
+  // Verify other expected properties are set
+  strictEqual(result.entrypoint, true, 'Should be marked as entrypoint')
+  deepStrictEqual(result.dependencies, [], 'Dependencies should default to empty array')
+  strictEqual(result.localUrl, 'http://service-with-url.plt.local', 'localUrl should be set')
+  strictEqual(result.watch, false, 'watch should inherit from config')
+
+  // Services with url but no path should skip capability detection entirely
+  // This means no file operations (glob, readFile, etc.) should be performed
+  // The threshold is 10ms because we're only setting a few properties
+  ok(elapsed < 10, `prepareApplication for url-only service should skip file operations (took ${elapsed.toFixed(2)}ms, expected < 10ms)`)
+})
+
+test('prepareApplication should handle multiple services with url but no path efficiently', async t => {
+  const { prepareApplication } = await import('../lib/config.js')
+  const { kMetadata } = await import('@platformatic/foundation')
+  const { mkdir, writeFile, rm } = await import('node:fs/promises')
+
+  // Create a temporary directory with many JS files
+  const tempDir = join(fixturesDir, 'temp-glob-test-multi-' + Date.now())
+  await mkdir(tempDir, { recursive: true })
+
+  // Create subdirectories with many JS files
+  const numDirs = 30
+  const filesPerDir = 100
+  for (let i = 0; i < numDirs; i++) {
+    const subDir = join(tempDir, `service-${i}`)
+    await mkdir(subDir, { recursive: true })
+    for (let j = 0; j < filesPerDir; j++) {
+      await writeFile(join(subDir, `file-${j}.js`), '// test file')
+    }
+  }
+
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  const config = {
+    [kMetadata]: {
+      root: tempDir,
+      env: {},
+      path: null,
+      module: '@platformatic/runtime'
+    },
+    entrypoint: 'service-1',
+    watch: false
+  }
+
+  const defaultWorkers = { static: 1, dynamic: false }
+
+  // Create multiple services with url but no path (like in watt.json with git repos)
+  const services = []
+  for (let i = 1; i <= 16; i++) {
+    services.push({
+      id: `service-${i}`,
+      url: `git@github.com:example/repo-${i}.git`,
+      gitBranch: 'main'
+    })
+  }
+
+  // Measure ONLY the prepareApplication calls, not the test setup
+  const startTime = performance.now()
+
+  // Process all services
+  const results = []
+  for (const service of services) {
+    results.push(await prepareApplication(config, { ...service }, defaultWorkers))
+  }
+
+  const elapsed = performance.now() - startTime
+
+  // All services should have type 'unknown'
+  for (const result of results) {
+    strictEqual(result.type, 'unknown', `Service ${result.id} should have type "unknown"`)
+  }
+
+  // 16 services with url but no path should complete in under 50ms total
+  // because they should skip capability detection entirely (no file operations)
+  // With the bug, each service would trigger a glob operation on the temp directory
+  ok(elapsed < 50, `Processing 16 url-only services should be fast (took ${elapsed.toFixed(2)}ms, expected < 50ms)`)
+})


### PR DESCRIPTION
## Summary
  - Skip capability detection for external services (those with url but no path) during config transform to avoid
  expensive glob operations
  - External services now get type: 'unknown' during transform; actual capability detection happens later in the
  worker when the path is resolved after git clone
  - Reduces startup time to milliseconds for configurations with multiple external git services

## Problem
  When starting a runtime with a `watt.json` containing services defined with url (git repos) but no path,
  `prepareApplication()` was calling `importCapabilityAndConfig(undefined)` for each service. This triggered:

  1. detectApplicationType(cwd) which falls through to hasJavascriptFiles(cwd)
  **2. A glob of **/*.{js,mjs,cjs,ts,mts,cts} on the entire working directory**
  3. This could easily last 2-3 seconds for each service  

## Solution

  Added an early return in` prepareApplication()` that skips capability detection for services with url but no path:
```
  if (application.url && !application.path) {
    application.type = 'unknown'
  } else {
    // ... existing capability detection
  }
```
  This is safe because:
  - The worker does its own capability detection at startup using the resolved path
  - type: 'unknown' is already an existing fallback pattern in the codebase
