### PR TITLE
fix: move tstyche to dev dependencies

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -54,6 +54,7 @@
     "neostandard": "^0.12.0",
     "pino-abstract-transport": "^2.0.0",
     "split2": "^4.2.0",
+    "tstyche": "^6.2.0",
     "typescript": "^5.5.4",
     "undici-oidc-interceptor": "^0.5.0",
     "why-is-node-running": "^2.2.2"
@@ -89,7 +90,6 @@
     "semgrator": "^0.3.0",
     "sonic-boom": "^4.2.0",
     "systeminformation": "^5.27.11",
-    "tstyche": "^6.2.0",
     "undici": "^7.0.0",
     "undici-thread-interceptor": "^1.3.1",
     "ws": "^8.16.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,9 +1454,6 @@ importers:
       systeminformation:
         specifier: ^5.27.11
         version: 5.31.3
-      tstyche:
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
       undici:
         specifier: ^7.0.0
         version: 7.24.0
@@ -1542,6 +1539,9 @@ importers:
       split2:
         specifier: ^4.2.0
         version: 4.2.0
+      tstyche:
+        specifier: ^6.2.0
+        version: 6.2.0(typescript@5.9.3)
       typescript:
         specifier: ^5.5.4
         version: 5.9.3


### PR DESCRIPTION
This PR moves `tstyche` to dev dependencies.

Currently it is declared in the dependencies list. Sorry, that was my mistake.