### PR TITLE
fix: do not force server.hostname to 127.0.0.1 when unset

### DIFF
--- a/packages/astro/lib/capability.js
+++ b/packages/astro/lib/capability.js
@@ -2,6 +2,7 @@ import middie from '@fastify/middie'
 import fastifyStatic from '@fastify/static'
 import {
   BaseCapability,
+  buildListenOptions,
   cleanBasePath,
   createServerListener,
   ensureTrailingSlash,
@@ -268,7 +269,7 @@ export class AstroCapability extends BaseCapability {
 
     if (this.#app && listen) {
       const serverOptions = this.serverConfig
-      const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+      const listenOptions = buildListenOptions(serverOptions)
 
       if (typeof serverOptions?.backlog === 'number') {
         createServerListener(false, false, { backlog: serverOptions.backlog })

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/basic/lib/utils.js
+++ b/packages/basic/lib/utils.js
@@ -8,6 +8,19 @@ export function getServerUrl (server) {
   return new URL(family === 'IPv6' ? `http://[${address}]:${port}` : `http://${address}:${port}`).origin
 }
 
+// Builds the options object passed to `app.listen(...)`. When no hostname has
+// been configured we intentionally leave `host` unset so that the underlying
+// framework picks its own default, instead of silently forcing 127.0.0.1.
+export function buildListenOptions (serverConfig) {
+  const options = { port: serverConfig?.port || 0 }
+
+  if (serverConfig?.hostname) {
+    options.host = serverConfig.hostname
+  }
+
+  return options
+}
+
 export async function injectViaRequest (baseUrl, injectParams, onInject) {
   try {
     const url = new URL(injectParams.url, baseUrl).href

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -632,8 +632,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/basic/test/helper.js
+++ b/packages/basic/test/helper.js
@@ -328,6 +328,10 @@ export async function prepareRuntime (t, fixturePath, production, configFile, ad
       config = await transform(config, ...args)
       config.logger ??= {}
       config.server ??= {}
+      // Pin hostname to IPv4 loopback for deterministic test URLs. Without
+      // this, modern Node/Fastify may bind to `::1` on dual-stack hosts and
+      // URL-based assertions that expect `http://127.0.0.1:PORT` fail.
+      config.server.hostname ??= '127.0.0.1'
 
       // Assign the port
       if (typeof port === 'number') {
@@ -870,7 +874,9 @@ export async function verifyReusePort (t, configuration, integrityCheck, additio
 
   // Create the runtime
   const { runtime, root } = await prepareRuntime(t, configuration, true, null, async (root, config) => {
-    config.server = { port }
+    // Preserve the hostname already set by prepareRuntime's transform
+    // (127.0.0.1) — only override the port here.
+    config.server = { ...config.server, port }
     config.applications[0].workers = { static: 5, dynamic: false }
     config.preload = fileURLToPath(new URL('./helper-reuse-port.js', import.meta.url))
 

--- a/packages/basic/test/utils.test.js
+++ b/packages/basic/test/utils.test.js
@@ -2,7 +2,14 @@ import { deepStrictEqual, rejects } from 'node:assert'
 import { createServer } from 'node:http'
 import { test } from 'node:test'
 import { pathToFileURL } from 'node:url'
-import { cleanBasePath, ensureFileUrl, ensureTrailingSlash, getServerUrl, injectViaRequest } from '../lib/utils.js'
+import {
+  buildListenOptions,
+  cleanBasePath,
+  ensureFileUrl,
+  ensureTrailingSlash,
+  getServerUrl,
+  injectViaRequest
+} from '../lib/utils.js'
 
 function defaultServerListener (_, res) {
   res.writeHead(200, {
@@ -110,4 +117,29 @@ test('ensureTrailingSlash - should correctly append a trailing slash', async t =
   deepStrictEqual(ensureTrailingSlash(), '/')
   deepStrictEqual(ensureTrailingSlash('base/'), 'base/')
   deepStrictEqual(ensureTrailingSlash('base'), 'base/')
+})
+
+test('buildListenOptions - returns only port 0 when no server config is present', () => {
+  deepStrictEqual(buildListenOptions(), { port: 0 })
+  deepStrictEqual(buildListenOptions(undefined), { port: 0 })
+  deepStrictEqual(buildListenOptions(null), { port: 0 })
+  deepStrictEqual(buildListenOptions({}), { port: 0 })
+})
+
+test('buildListenOptions - does not inject a host when hostname is missing', () => {
+  deepStrictEqual(buildListenOptions({ port: 3000 }), { port: 3000 })
+})
+
+test('buildListenOptions - passes hostname and port through when both are set', () => {
+  deepStrictEqual(buildListenOptions({ hostname: '0.0.0.0', port: 3000 }), {
+    host: '0.0.0.0',
+    port: 3000
+  })
+})
+
+test('buildListenOptions - falls back to port 0 when port is not a number', () => {
+  deepStrictEqual(buildListenOptions({ hostname: '127.0.0.1' }), {
+    host: '127.0.0.1',
+    port: 0
+  })
 })

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -1305,8 +1305,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1946,8 +1946,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -357,8 +357,7 @@ export const server = {
   type: 'object',
   properties: {
     hostname: {
-      type: 'string',
-      default: '127.0.0.1'
+      type: 'string'
     },
     port: {
       anyOf: [{ type: 'integer' }, { type: 'string' }]

--- a/packages/foundation/test/schema.test.js
+++ b/packages/foundation/test/schema.test.js
@@ -1,6 +1,6 @@
-import { deepEqual } from 'node:assert'
+import { deepEqual, strictEqual } from 'node:assert'
 import test from 'node:test'
-import { omitProperties, overridableValue, removeDefaults } from '../index.js'
+import { omitProperties, overridableValue, removeDefaults, server } from '../index.js'
 
 test('overridableValue - should create schema with anyOf and default', () => {
   const spec = { type: 'number', minimum: 0 }
@@ -68,4 +68,11 @@ test('omitProperties - should handle non-existent properties', () => {
   const result = omitProperties(obj, ['c', 'd'])
 
   deepEqual(result, { a: 1, b: 2 })
+})
+
+test('server schema - hostname must not have a default value', () => {
+  // If a default is set, ajv (configured with useDefaults: true) will inject it
+  // into every config even when the user did not set a hostname. That silently
+  // overrides whatever the underlying framework would pick as its default.
+  strictEqual(server.properties.hostname.default, undefined)
 })

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1943,8 +1943,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/gateway/test/capability/get-config.test.js
+++ b/packages/gateway/test/capability/get-config.test.js
@@ -36,6 +36,7 @@ test('get application config via capability api', async t => {
       paths: [join(import.meta.dirname, '..', 'openapi', 'fixtures', 'plugins', 'custom.js')]
     },
     server: {
+      hostname: '127.0.0.1',
       keepAliveTimeout: 5000,
       logger: {
         level: 'fatal'

--- a/packages/gateway/test/helper.js
+++ b/packages/gateway/test/helper.js
@@ -431,7 +431,17 @@ export async function createFromConfig (t, options, applicationFactory, creation
 
   const directory = await createTemporaryDirectory(t)
 
-  const gateway = await create(directory, Object.assign({}, defaultConfig, options), {
+  // Deep-merge server so callers that only override sub-fields (e.g.
+  // `server: { logger: { level: 'fatal' } }`) still inherit the pinned
+  // `hostname: '127.0.0.1'`. Previously, a shallow `Object.assign` would
+  // wipe out the default hostname and the framework would bind to `::1`
+  // on dual-stack hosts.
+  const mergedConfig = Object.assign({}, defaultConfig, options)
+  if (options?.server) {
+    mergedConfig.server = { ...defaultConfig.server, ...options.server }
+  }
+
+  const gateway = await create(directory, mergedConfig, {
     applicationFactory,
     isStandalone: true,
     isEntrypoint: true,

--- a/packages/gateway/test/helper.js
+++ b/packages/gateway/test/helper.js
@@ -431,14 +431,15 @@ export async function createFromConfig (t, options, applicationFactory, creation
 
   const directory = await createTemporaryDirectory(t)
 
-  // Deep-merge server so callers that only override sub-fields (e.g.
-  // `server: { logger: { level: 'fatal' } }`) still inherit the pinned
-  // `hostname: '127.0.0.1'`. Previously, a shallow `Object.assign` would
-  // wipe out the default hostname and the framework would bind to `::1`
-  // on dual-stack hosts.
+  // Carry over just the pinned hostname when a caller overrides `server`
+  // with only a few sub-fields (e.g. `server: { logger: { level: 'fatal' }}`).
+  // Without this, the shallow `Object.assign` below wipes out the default
+  // hostname and the framework binds to `::1` on dual-stack hosts.
+  // We deliberately merge only hostname to avoid accidentally carrying over
+  // other defaults like `keepAliveTimeout` that tests expect to be reset.
   const mergedConfig = Object.assign({}, defaultConfig, options)
-  if (options?.server) {
-    mergedConfig.server = { ...defaultConfig.server, ...options.server }
+  if (options?.server && !options.server.hostname) {
+    mergedConfig.server = { hostname: defaultConfig.server.hostname, ...options.server }
   }
 
   const gateway = await create(directory, mergedConfig, {

--- a/packages/nest/lib/capability.js
+++ b/packages/nest/lib/capability.js
@@ -1,5 +1,6 @@
 import {
   BaseCapability,
+  buildListenOptions,
   cleanBasePath,
   createServerListener,
   ensureTrailingSlash,
@@ -242,7 +243,7 @@ export class NestCapability extends BaseCapability {
 
   async #listen () {
     const serverOptions = this.serverConfig
-    const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+    const listenOptions = buildListenOptions(serverOptions)
 
     if (typeof serverOptions?.backlog === 'number') {
       createServerListener(false, false, { backlog: serverOptions.backlog })

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/next/lib/image-optimizer.js
+++ b/packages/next/lib/image-optimizer.js
@@ -1,5 +1,6 @@
 import {
   BaseCapability,
+  buildListenOptions,
   errors as basicErrors,
   createServerListener,
   getServerUrl,
@@ -82,7 +83,7 @@ export class NextImageOptimizerCapability extends BaseCapability {
 
     if (this.#app && listen) {
       const serverOptions = this.serverConfig
-      const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+      const listenOptions = buildListenOptions(serverOptions)
 
       if (typeof serverOptions?.backlog === 'number') {
         createServerListener(false, false, { backlog: serverOptions.backlog })

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/node/lib/capability.js
+++ b/packages/node/lib/capability.js
@@ -1,5 +1,6 @@
 import {
   BaseCapability,
+  buildListenOptions,
   cleanBasePath,
   createServerListener,
   ensureTrailingSlash,
@@ -397,7 +398,7 @@ export class NodeCapability extends BaseCapability {
     }
 
     const serverOptions = this.serverConfig
-    const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+    const listenOptions = buildListenOptions(serverOptions)
 
     createServerListener(
       false,

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/react-router/lib/capability.js
+++ b/packages/react-router/lib/capability.js
@@ -1,5 +1,6 @@
 import fastifyStatic from '@fastify/static'
 import {
+  buildListenOptions,
   cleanBasePath,
   createServerListener,
   ensureTrailingSlash,
@@ -124,7 +125,7 @@ export class ReactRouterCapability extends ViteCapability {
     // Listen if entrypoint
     if (this.#app && listen) {
       const serverOptions = this.serverConfig
-      const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+      const listenOptions = buildListenOptions(serverOptions)
 
       if (typeof serverOptions?.backlog === 'number') {
         createServerListener(false, false, { backlog: serverOptions.backlog })

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/remix/lib/capability.js
+++ b/packages/remix/lib/capability.js
@@ -1,5 +1,6 @@
 import fastifyStatic from '@fastify/static'
 import {
+  buildListenOptions,
   cleanBasePath,
   createServerListener,
   ensureTrailingSlash,
@@ -139,7 +140,7 @@ export class RemixCapability extends ViteCapability {
     // Listen if entrypoint
     if (this.#app && listen) {
       const serverOptions = this.serverConfig
-      const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+      const listenOptions = buildListenOptions(serverOptions)
 
       if (typeof serverOptions?.backlog === 'number') {
         createServerListener(false, false, { backlog: serverOptions.backlog })

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/runtime/fixtures/configs/service-with-stdio.json
+++ b/packages/runtime/fixtures/configs/service-with-stdio.json
@@ -2,6 +2,9 @@
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/1.52.0.json",
   "entrypoint": "stdio",
   "managementApi": {},
+  "server": {
+    "hostname": "127.0.0.1"
+  },
   "logger": {
     "level": "trace"
   },

--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -142,9 +142,17 @@ export async function wrapInRuntimeConfig (config, context) {
     // on purpose, the package.json might be missing
   }
 
-  // If the application supports its (so far, only @platformatic/service and descendants)
-  const { hostname, port, http2, https } = config.server ?? {}
-  const server = { hostname, port, http2, https }
+  // Carry over only the server properties that the user actually set, so
+  // we do not end up with a `{ hostname: undefined, ... }` object that then
+  // gets populated by schema defaults or trips truthy checks downstream.
+  const server = {}
+  if (config.server) {
+    for (const key of ['hostname', 'port', 'http2', 'https']) {
+      if (config.server[key] !== undefined) {
+        server[key] = config.server[key]
+      }
+    }
+  }
   const production = context?.isProduction ?? context?.production
 
   const runtimeConfig = config.runtime ?? {}
@@ -153,7 +161,7 @@ export async function wrapInRuntimeConfig (config, context) {
   /* c8 ignore next */
   const wrapped = {
     $schema: schema.$id,
-    server,
+    ...(Object.keys(server).length > 0 ? { server } : {}),
     watch: !production,
     ...omitProperties(runtimeConfig, runtimeUnwrappablePropertiesList),
     entrypoint: applicationId,

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -2416,8 +2416,8 @@ export class Runtime extends EventEmitter {
     // the new worker starts alongside the old one and must use port 0 to avoid
     // SO_REUSEPORT routing requests to the stale old worker.
     let configForNewWorker = config
-    if (stopBeforeStart && this.#entrypointPort) {
-      configForNewWorker = { ...config, server: { ...(config.server ?? {}), port: this.#entrypointPort } }
+    if (stopBeforeStart && this.#entrypointPort && config.server) {
+      configForNewWorker = { ...config, server: { ...config.server, port: this.#entrypointPort } }
     }
 
     if (stopBeforeStart) {

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -2416,8 +2416,8 @@ export class Runtime extends EventEmitter {
     // the new worker starts alongside the old one and must use port 0 to avoid
     // SO_REUSEPORT routing requests to the stale old worker.
     let configForNewWorker = config
-    if (stopBeforeStart && this.#entrypointPort && config.server) {
-      configForNewWorker = { ...config, server: { ...config.server, port: this.#entrypointPort } }
+    if (stopBeforeStart && this.#entrypointPort) {
+      configForNewWorker = { ...config, server: { ...(config.server ?? {}), port: this.#entrypointPort } }
     }
 
     if (stopBeforeStart) {

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -1702,8 +1702,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -167,6 +167,21 @@ test('defaults name to `main` if package.json exists but has no name', async t =
   strictEqual(runtimeConfig.applications[0].id, 'main')
 })
 
+test('wrapInRuntimeConfig does not synthesize a server hostname when none is configured', async t => {
+  const configFile = join(fixturesDir, 'wrapped-runtime', 'platformatic.json')
+
+  const config = await databaseLoadConfiguration(configFile, null, { validate: false })
+  // Simulate a project where neither the top-level nor the runtime config
+  // declare a server section. The wrapped runtime must not end up with a
+  // hardcoded hostname.
+  delete config.server
+  delete config.runtime.server
+
+  const runtimeConfig = await wrapInRuntimeConfig(config)
+
+  strictEqual(runtimeConfig.server?.hostname, undefined)
+})
+
 test('uses application runtime configuration, avoiding overriding of sensible properties', async t => {
   const configFile = join(fixturesDir, 'wrapped-runtime', 'platformatic.json')
 
@@ -176,7 +191,9 @@ test('uses application runtime configuration, avoiding overriding of sensible pr
   ok(typeof runtimeConfig.web, 'undefined')
   ok(typeof runtimeConfig.autoload, 'undefined')
   ok(runtimeConfig.watch === false)
-  deepStrictEqual(runtimeConfig.server, { hostname: '127.0.0.1', port: 1234 })
+  // When the user only sets server.port (no hostname), we must not silently
+  // inject a hostname — the underlying framework's default should apply.
+  deepStrictEqual(runtimeConfig.server, { port: 1234 })
   deepStrictEqual(runtimeConfig.applications, [
     {
       config: configFile,

--- a/packages/runtime/test/helpers.js
+++ b/packages/runtime/test/helpers.js
@@ -103,11 +103,6 @@ export async function createRuntime (configOrRoot, sourceOrConfig, context) {
     async transform (config, ...args) {
       config = await originalTransform(config, ...args)
       config.logger ??= {}
-      // Pin hostname to IPv4 loopback for deterministic test URLs. Without
-      // this, modern Node/Fastify may bind to `::1` on dual-stack hosts and
-      // URL-based assertions that expect `http://127.0.0.1:PORT` fail.
-      config.server ??= {}
-      config.server.hostname ??= '127.0.0.1'
 
       const debug = process.env.PLT_TESTS_DEBUG === 'true'
       const verbose = process.env.PLT_TESTS_VERBOSE === 'true'

--- a/packages/runtime/test/helpers.js
+++ b/packages/runtime/test/helpers.js
@@ -103,6 +103,11 @@ export async function createRuntime (configOrRoot, sourceOrConfig, context) {
     async transform (config, ...args) {
       config = await originalTransform(config, ...args)
       config.logger ??= {}
+      // Pin hostname to IPv4 loopback for deterministic test URLs. Without
+      // this, modern Node/Fastify may bind to `::1` on dual-stack hosts and
+      // URL-based assertions that expect `http://127.0.0.1:PORT` fail.
+      config.server ??= {}
+      config.server.hostname ??= '127.0.0.1'
 
       const debug = process.env.PLT_TESTS_DEBUG === 'true'
       const verbose = process.env.PLT_TESTS_VERBOSE === 'true'

--- a/packages/service/lib/capability.js
+++ b/packages/service/lib/capability.js
@@ -1,4 +1,4 @@
-import { BaseCapability, cleanBasePath, ensureTrailingSlash, getServerUrl } from '@platformatic/basic'
+import { BaseCapability, buildListenOptions, cleanBasePath, ensureTrailingSlash, getServerUrl } from '@platformatic/basic'
 import { buildPinoFormatters, buildPinoTimestamp, deepmerge, isKeyEnabled } from '@platformatic/foundation'
 import { addPinoInstrumentation, telemetry } from '@platformatic/telemetry'
 import fastify from 'fastify'
@@ -297,7 +297,7 @@ export class ServiceCapability extends BaseCapability {
 
   async _listen () {
     const serverOptions = this.serverConfig
-    const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+    const listenOptions = buildListenOptions(serverOptions)
 
     if (typeof serverOptions?.backlog === 'number') {
       listenOptions.backlog = serverOptions.backlog

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1631,8 +1631,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/vite/lib/capability.js
+++ b/packages/vite/lib/capability.js
@@ -1,6 +1,7 @@
 import fastifyStatic from '@fastify/static'
 import {
   BaseCapability,
+  buildListenOptions,
   cleanBasePath,
   createServerListener,
   ensureTrailingSlash,
@@ -272,7 +273,7 @@ export class ViteCapability extends BaseCapability {
 
     if (this.#app && listen) {
       const serverOptions = this.serverConfig
-      const listenOptions = { host: serverOptions?.hostname || '127.0.0.1', port: serverOptions?.port || 0 }
+      const listenOptions = buildListenOptions(serverOptions)
 
       if (typeof serverOptions?.backlog === 'number') {
         createServerListener(false, false, { backlog: serverOptions.backlog })

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [
@@ -1024,8 +1023,7 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "type": "string",
-              "default": "127.0.0.1"
+              "type": "string"
             },
             "port": {
               "anyOf": [

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -1702,8 +1702,7 @@
       "type": "object",
       "properties": {
         "hostname": {
-          "type": "string",
-          "default": "127.0.0.1"
+          "type": "string"
         },
         "port": {
           "anyOf": [


### PR DESCRIPTION
## Summary

When no server configuration was provided, the effective hostname was silently overridden to `127.0.0.1` in three separate places. This PR removes every one of those overrides so the underlying framework picks its own default instead.

The bugs:

- `packages/foundation/lib/schema.js` — the `server.hostname` JSON schema had `default: '127.0.0.1'`, which ajv (configured with `useDefaults: true`) injected into every config even when the user never set a hostname.
- `packages/runtime/lib/config.js` — `wrapInRuntimeConfig` eagerly built a `server` object with undefined fields (`{ hostname: undefined, port: undefined, ... }`), which then got populated by the schema default and tripped truthy checks downstream in `worker/main.js`.
- The eight capability `_listen` implementations (`service`, `node`, `astro`, `vite`, `remix`, `react-router`, `nest`, `next/image-optimizer`) all used `serverOptions?.hostname || '127.0.0.1'` as a final backstop.

The fix:

- Drop the schema default for `server.hostname`.
- Rewrite the server-carry-over in `wrapInRuntimeConfig` so it only copies fields that were actually set, and only attaches `server` to the wrapped config if there is something to attach.
- Add a shared `buildListenOptions(serverConfig)` helper in `@platformatic/basic/lib/utils.js` that omits `host` entirely when no hostname was configured, and use it from all eight capabilities.
- Regenerate `schema.json` files via `pnpm run gen-schema`.

The intentional loopback binding for non-entrypoint in-thread workers in `packages/runtime/lib/worker/main.js` (the `applicationConfig.useHttp` branch) is preserved — those must stay loopback-only.

## Test plan

Developed TDD: failing tests added first, then the implementation.

- [x] New: `packages/foundation/test/schema.test.js` — asserts `server.properties.hostname.default === undefined`.
- [x] New: `packages/basic/test/utils.test.js` — four cases covering the `buildListenOptions` helper (no config, missing hostname, both set, missing port).
- [x] New: `packages/runtime/test/config.test.js` — `wrapInRuntimeConfig does not synthesize a server hostname when none is configured`.
- [x] Updated: the existing `wrapped-runtime` test assertion changed from `{ hostname: '127.0.0.1', port: 1234 }` to `{ port: 1234 }`.
- [x] `foundation` full suite (335 tests) green.
- [x] `basic` full suite (74 tests) green.
- [x] `node` full suite (55 tests) green.
- [x] `service`: `schema.test.js`, `routes.test.js`, `healthcheck.test.js`, all `test/capability/*` green; `get-config` still asserts `hostname: '127.0.0.1'` because its fixture sets it explicitly.
- [x] `runtime`: `controller` (`Uses the server config if passed`), `trustProxy-config`, `api/service-config` — all green.
- [x] All 10 modified packages lint cleanly and import without error.