### PR TITLE
Security: Role path traversal can throw and cause request-level denial of service

### DIFF
--- a/packages/db-authorization/lib/utils.js
+++ b/packages/db-authorization/lib/utils.js
@@ -18,6 +18,10 @@ export function getRoles (request, roleKey, anonymousRole, isRolePath = false) {
     const roleKeys = roleKey.split('.')
     rolesRaw = user
     for (const key of roleKeys) {
+      if (rolesRaw === null || rolesRaw === undefined || typeof rolesRaw !== 'object') {
+        rolesRaw = undefined
+        break
+      }
       rolesRaw = rolesRaw[key]
     }
   } else {
@@ -25,9 +29,9 @@ export function getRoles (request, roleKey, anonymousRole, isRolePath = false) {
   }
 
   if (typeof rolesRaw === 'string') {
-    output = rolesRaw.split(',')
+    output = rolesRaw.split(',').map(role => role.trim()).filter(Boolean)
   } else if (Array.isArray(rolesRaw)) {
-    output = rolesRaw
+    output = rolesRaw.filter(role => typeof role === 'string').map(role => role.trim()).filter(Boolean)
   }
   if (output.length === 0) {
     output.push(anonymousRole)


### PR DESCRIPTION
## Summary

Security: Role path traversal can throw and cause request-level denial of service

## Problem

**Severity**: `Medium` | **File**: `packages/db-authorization/lib/utils.js:L13`

In `getRoles`, when `isRolePath` is true, nested property access is performed with `rolesRaw = rolesRaw[key]` without null/type checks. A malformed or unexpected `request.user` payload can trigger `TypeError` (e.g., accessing property of `undefined`), potentially causing 500 responses and allowing repeated request-based DoS against protected endpoints.

## Solution

Harden nested traversal using safe checks (e.g., optional chaining or guarded loop): stop traversal when `rolesRaw` is null/undefined/non-object and fall back to anonymous role. Also normalize and validate extracted role values before use.

## Changes

- `packages/db-authorization/lib/utils.js` (modified)