### PR TITLE
fix: use ITC to collect health metrics for child process workers

### DIFF
--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -625,7 +625,8 @@ export class BaseCapability extends EventEmitter {
             }
           : {},
       telemetryConfig: this.telemetryConfig,
-      compileCache: this.config.compileCache ?? this.runtimeConfig?.compileCache
+      compileCache: this.config.compileCache ?? this.runtimeConfig?.compileCache,
+      resourceLimits: this.context.resourceLimits
     }
   }
 

--- a/packages/basic/lib/worker/child-manager.js
+++ b/packages/basic/lib/worker/child-manager.js
@@ -174,7 +174,22 @@ export class ChildManager extends ITC {
       telemetryInclude = `--import="${pathToFileURL(openTelemetrySetupPath)}"`
     }
 
-    process.env.NODE_OPTIONS = `${telemetryInclude} ${childProcessInclude} ${nodeOptions}`.trim()
+    // Propagate V8 resource limits to the child process via NODE_OPTIONS.
+    // Note: --code-range-size is not allowed in NODE_OPTIONS, only via CLI args.
+    let v8Flags = ''
+    const limits = this.#context.resourceLimits
+    if (limits) {
+      const flags = []
+      if (limits.maxOldGenerationSizeMb > 0) {
+        flags.push(`--max-old-space-size=${limits.maxOldGenerationSizeMb}`)
+      }
+      if (limits.maxYoungGenerationSizeMb > 0) {
+        flags.push(`--max-semi-space-size=${limits.maxYoungGenerationSizeMb}`)
+      }
+      v8Flags = flags.join(' ')
+    }
+
+    process.env.NODE_OPTIONS = `${v8Flags} ${telemetryInclude} ${childProcessInclude} ${nodeOptions}`.trim()
   }
 
   async eject () {

--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -79,7 +79,6 @@ export class ChildProcess extends ITC {
   #metricsRegistry
   #pendingMessages
   #replStream
-  #lastELU
 
   constructor (executable) {
     super({
@@ -417,13 +416,10 @@ export class ChildProcess extends ITC {
 
   #getHealth () {
     const currentELU = performance.eventLoopUtilization()
-    const elu = performance.eventLoopUtilization(currentELU, this.#lastELU).utilization
-    this.#lastELU = currentELU
-
     const { heapUsed, heapTotal } = process.memoryUsage()
 
     return {
-      elu,
+      currentELU,
       heapUsed,
       heapTotal
     }

--- a/packages/basic/test/worker/child-process.test.js
+++ b/packages/basic/test/worker/child-process.test.js
@@ -291,8 +291,8 @@ test('ChildProcess - getHealth should return health metrics', async t => {
   const health = await childManager.send(socket, 'getHealth')
 
   // Verify health metrics structure
-  ok(typeof health.elu === 'number', 'Expected ELU to be a number')
-  ok(health.elu >= 0 && health.elu <= 1, `Expected ELU to be between 0 and 1, got ${health.elu}`)
+  ok(typeof health.currentELU === 'object', 'Expected currentELU to be an object')
+  ok(typeof health.currentELU.utilization === 'number', 'Expected currentELU.utilization to be a number')
   ok(typeof health.heapUsed === 'number', 'Expected heapUsed to be a number')
   ok(health.heapUsed > 0, 'Expected heapUsed to be positive')
   ok(typeof health.heapTotal === 'number', 'Expected heapTotal to be a number')

--- a/packages/runtime/fixtures/child-process-health/entrypoint/index.mjs
+++ b/packages/runtime/fixtures/child-process-health/entrypoint/index.mjs
@@ -1,0 +1,16 @@
+import fastify from 'fastify'
+
+export function create () {
+  const app = fastify({
+    logger: {
+      name: globalThis.platformatic.applicationId,
+      level: globalThis.platformatic?.logLevel ?? 'info'
+    }
+  })
+
+  app.get('/hello', async () => {
+    return { from: 'entrypoint' }
+  })
+
+  return app
+}

--- a/packages/runtime/fixtures/child-process-health/entrypoint/platformatic.json
+++ b/packages/runtime/fixtures/child-process-health/entrypoint/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.6.0.json",
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/child-process-health/package.json
+++ b/packages/runtime/fixtures/child-process-health/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/runtime/fixtures/child-process-health/platformatic.json
+++ b/packages/runtime/fixtures/child-process-health/platformatic.json
@@ -15,6 +15,6 @@
     "interval": 1000,
     "maxELU": 0.95,
     "maxHeapUsed": 0.95,
-    "maxHeapTotal": "1GB"
+    "maxHeapTotal": "512MB"
   }
 }

--- a/packages/runtime/fixtures/child-process-health/platformatic.json
+++ b/packages/runtime/fixtures/child-process-health/platformatic.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.6.0.json",
+  "watch": false,
+  "managementApi": true,
+  "restartOnError": 500,
+  "entrypoint": "entrypoint",
+  "autoload": {
+    "path": "."
+  },
+  "logger": {
+    "level": "error"
+  },
+  "health": {
+    "enabled": true,
+    "interval": 1000,
+    "maxELU": 0.95,
+    "maxHeapUsed": 0.95,
+    "maxHeapTotal": "1GB"
+  }
+}

--- a/packages/runtime/fixtures/child-process-health/subprocess/index.mjs
+++ b/packages/runtime/fixtures/child-process-health/subprocess/index.mjs
@@ -1,0 +1,24 @@
+import fastify from 'fastify'
+
+// Allocate ~50MB of V8 heap memory so health metrics can distinguish
+// this child process from the coordinator worker thread
+const data = []
+for (let i = 0; i < 500000; i++) {
+  data.push({ index: i, value: 'x'.repeat(50) })
+}
+globalThis.__keepAlive = data
+
+const app = fastify({
+  logger: {
+    name: [globalThis.platformatic.applicationId, globalThis.platformatic.workerId]
+      .filter(f => typeof f !== 'undefined')
+      .join(':'),
+    level: globalThis.platformatic?.logLevel ?? 'info'
+  }
+})
+
+app.get('/hello', async () => {
+  return { from: 'subprocess' }
+})
+
+app.listen({ port: 0 })

--- a/packages/runtime/fixtures/child-process-health/subprocess/index.mjs
+++ b/packages/runtime/fixtures/child-process-health/subprocess/index.mjs
@@ -1,4 +1,5 @@
 import fastify from 'fastify'
+import v8 from 'node:v8'
 
 // Allocate ~50MB of V8 heap memory so health metrics can distinguish
 // this child process from the coordinator worker thread
@@ -19,6 +20,11 @@ const app = fastify({
 
 app.get('/hello', async () => {
   return { from: 'subprocess' }
+})
+
+app.get('/heap-limit', async () => {
+  const stats = v8.getHeapStatistics()
+  return { heapSizeLimit: stats.heap_size_limit }
 })
 
 app.listen({ port: 0 })

--- a/packages/runtime/fixtures/child-process-health/subprocess/platformatic.json
+++ b/packages/runtime/fixtures/child-process-health/subprocess/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.6.0.json",
+  "logger": {
+    "level": "error"
+  },
+  "application": {
+    "commands": {
+      "development": "node index.mjs"
+    }
+  }
+}

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -1728,6 +1728,11 @@ export class Runtime extends EventEmitter {
           index,
           count: workersCount
         },
+        resourceLimits: {
+          maxOldGenerationSizeMb,
+          maxYoungGenerationSizeMb,
+          codeRangeSizeMb
+        },
         inspectorOptions,
         dirname: this.#root
       },

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -73,8 +73,6 @@ import {
 
 const kWorkerFile = join(import.meta.dirname, 'worker/main.js')
 const kInspectorOptions = Symbol('plt.runtime.worker.inspectorOptions')
-const kHeapCheckCounter = Symbol('plt.runtime.worker.heapCheckCounter')
-const kLastHeapStats = Symbol('plt.runtime.worker.lastHeapStats')
 
 const MAX_LISTENERS_COUNT = 100
 
@@ -1518,28 +1516,17 @@ export class Runtime extends EventEmitter {
   }
 
   async getWorkerHealth (worker, options = {}) {
-    const currentELU = worker.performance.eventLoopUtilization()
-    const previousELU = options.previousELU
+    // Use ITC to get health from the worker. This correctly forwards to child
+    // processes when the service uses startWithCommand (subprocess mode),
+    // instead of reading the coordinator thread's metrics.
+    const { currentELU, heapUsed, heapTotal } = await sendViaITC(worker, 'getHealth')
 
+    const previousELU = options.previousELU
     let elu = currentELU
     if (previousELU) {
-      elu = worker.performance.eventLoopUtilization(elu, previousELU)
+      elu = performance.eventLoopUtilization(currentELU, previousELU)
     }
 
-    if (!features.node.worker.getHeapStatistics) {
-      return { elu: elu.utilization, currentELU }
-    }
-
-    // Only check heap statistics every 60 health checks (once per minute)
-    const counter = (worker[kHeapCheckCounter] ?? 0) + 1
-    worker[kHeapCheckCounter] = counter >= 60 ? 0 : counter
-
-    if (counter >= 60 || !worker[kLastHeapStats]) {
-      const { used_heap_size: heapUsed, total_heap_size: heapTotal } = await worker.getHeapStatistics()
-      worker[kLastHeapStats] = { heapUsed, heapTotal }
-    }
-
-    const { heapUsed, heapTotal } = worker[kLastHeapStats]
     return { elu: elu.utilization, heapUsed, heapTotal, currentELU }
   }
 

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -72,6 +72,7 @@ export class Controller extends EventEmitter {
       metricsConfig,
       serverConfig,
       worker: workerData?.worker,
+      resourceLimits: workerData?.resourceLimits,
       hasManagementApi: !!runtimeConfig.managementApi,
       fetchApplicationUrl: fetchApplicationUrl.bind(null, applicationConfig)
     }

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -45,7 +45,6 @@ export class Controller extends EventEmitter {
   #fileWatcher
   #debouncedRestart
   #context
-  #lastELU
 
   constructor (runtimeConfig, applicationConfig, workerId, serverConfig, metricsConfig) {
     super()
@@ -59,7 +58,6 @@ export class Controller extends EventEmitter {
     this.#listening = false
     this.capability = null
     this.#fileWatcher = null
-    this.#lastELU = performance.eventLoopUtilization()
 
     this.#context = {
       controller: this,
@@ -261,13 +259,10 @@ export class Controller extends EventEmitter {
 
   async getHealth () {
     const currentELU = performance.eventLoopUtilization()
-    const elu = performance.eventLoopUtilization(currentELU, this.#lastELU).utilization
-    this.#lastELU = currentELU
-
     const { heapUsed, heapTotal } = process.memoryUsage()
 
     return {
-      elu,
+      currentELU,
       heapUsed,
       heapTotal
     }

--- a/packages/runtime/test/health-child-process.test.js
+++ b/packages/runtime/test/health-child-process.test.js
@@ -48,3 +48,32 @@ test('health metrics for child process should reflect subprocess memory, not coo
     'This likely means health metrics are coming from the coordinator thread, not the child process.'
   )
 })
+
+test('child process should have V8 resource limits from health config', { skip: isWindows && 'Skipping on Windows' }, async t => {
+  const configFile = join(fixturesDir, 'child-process-health', 'platformatic.json')
+
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  // The fixture has maxHeapTotal: "512MB". Query the child process's
+  // actual V8 heap limit to verify the flag was propagated.
+  const res = await app.inject('subprocess', { method: 'GET', url: '/heap-limit' })
+  ok(res.statusCode === 200, `Expected 200, got ${res.statusCode}`)
+
+  const { heapSizeLimit } = JSON.parse(res.body)
+
+  // V8 heap_size_limit should be close to 512MB.
+  // V8 adds some overhead so the actual limit may be slightly higher,
+  // but it should be well below the default (~4GB on 64-bit systems).
+  const maxHeapTotal = 512 * 1024 * 1024
+  ok(
+    heapSizeLimit <= maxHeapTotal * 1.5,
+    `V8 heap limit should be close to 512MB, got ${(heapSizeLimit / 1024 / 1024).toFixed(0)}MB. ` +
+    'This likely means --max-old-space-size was not passed to the child process.'
+  )
+})

--- a/packages/runtime/test/health-child-process.test.js
+++ b/packages/runtime/test/health-child-process.test.js
@@ -1,0 +1,50 @@
+import { ok } from 'node:assert'
+import { once } from 'node:events'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+const isWindows = process.platform === 'win32'
+
+// The subprocess fixture allocates ~50MB of V8 heap in the child process.
+// If health metrics are correctly forwarded from the child process, heapUsed
+// should reflect that allocation (~70MB+). If they come from the coordinator
+// worker thread instead (the bug), heapUsed will be ~24MB.
+const HEAP_THRESHOLD = 40 * 1024 * 1024 // 40MB
+
+test('health metrics for child process should reflect subprocess memory, not coordinator thread', { skip: isWindows && 'Skipping on Windows' }, async t => {
+  const configFile = join(fixturesDir, 'child-process-health', 'platformatic.json')
+
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  // Wait for health metrics for the subprocess service
+  let metric
+  while (true) {
+    const [m] = await once(app, 'application:worker:health:metrics')
+    if (m.application === 'subprocess') {
+      metric = m
+      break
+    }
+  }
+
+  ok(metric.currentHealth, 'Should have currentHealth')
+  ok(typeof metric.currentHealth.elu === 'number', 'Should have ELU metric')
+  ok(typeof metric.currentHealth.heapUsed === 'number', 'Should have heapUsed metric')
+  ok(typeof metric.currentHealth.heapTotal === 'number', 'Should have heapTotal metric')
+
+  // This is the key assertion: the child process allocates ~50MB of objects.
+  // If we're reading from the coordinator thread, heapUsed will be ~24MB.
+  // If we're reading from the actual child process, heapUsed will be ~70MB+.
+  ok(
+    metric.currentHealth.heapUsed > HEAP_THRESHOLD,
+    `heapUsed should reflect child process memory (>40MB), got ${(metric.currentHealth.heapUsed / 1024 / 1024).toFixed(1)}MB. ` +
+    'This likely means health metrics are coming from the coordinator thread, not the child process.'
+  )
+})


### PR DESCRIPTION
## Summary

- When a service runs as a child process (via `startWithCommand`), `getWorkerHealth()` was reading ELU and heap metrics from the coordinator worker thread instead of the actual child process
- Health checks, restart-on-unhealthy, and dynamic worker scaling were all based on wrong data (~24MB coordinator heap vs ~135MB actual child process heap in tests)
- Route `getWorkerHealth()` through `sendViaITC` which correctly forwards to child processes via the existing ITC `getHealth` handler
- Both `controller.getHealth()` and `ChildProcess#getHealth()` now return raw `currentELU` so each caller can independently track ELU deltas without interfering with each other
- V8 resource limits (`maxHeapTotal`, `maxYoungGeneration`) are now propagated to child processes via `--max-old-space-size` and `--max-semi-space-size` in `NODE_OPTIONS`
- Note: `--code-range-size` cannot be propagated via `NODE_OPTIONS` (Node.js restriction)

Ref #4728 — may partially address the "invalid table size" OOM crashes in child process mode. The health system was blind to child process memory (monitoring the coordinator thread instead), so `maxHeapUsed` checks never triggered. Additionally, `maxYoungGeneration` was only enforced on the coordinator thread, not the actual child process.

## Test plan

- [x] New test: health metrics for child process reflect subprocess memory (fixture allocates ~50MB, asserts `heapUsed > 40MB` — fails before fix at 23.8MB, passes after at 134.8MB)
- [x] New test: child process V8 heap limit matches configured `maxHeapTotal` (fails before fix at 4288MB default, passes after at ~704MB for 512MB config)
- [x] Existing `health-subprocess.test.js` — 3/3 pass
- [x] Existing `health-signals.test.js` — 3/3 pass
- [x] `basic/test/worker/child-process.test.js` — 12/12 pass (updated for new `currentELU` response shape)
- [x] `scaling-algorithm.test.js` — 12/12 pass
- [x] `worker-scaler-1.test.js` — 15/15 pass (including ELU-based scaling tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)