### PR TITLE
fix: correct allowBuilds YAML syntax in pnpm-workspace.yaml generation

### DIFF
--- a/packages/create-wattpm/lib/index.js
+++ b/packages/create-wattpm/lib/index.js
@@ -520,7 +520,7 @@ export async function createApplication (
     }
 
     if (generator.applications.some(({ application }) => application.module === '@platformatic/db' && application.config.database === 'sqlite')) {
-      content += '\nallowBuilds:\n- better-sqlite3'
+      content += '\nallowBuilds:\n  better-sqlite3'
     }
 
     await writeFile(pnpmWorkspacePath, content)

--- a/packages/create-wattpm/lib/index.js
+++ b/packages/create-wattpm/lib/index.js
@@ -520,7 +520,7 @@ export async function createApplication (
     }
 
     if (generator.applications.some(({ application }) => application.module === '@platformatic/db' && application.config.database === 'sqlite')) {
-      content += '\nallowBuilds:\n  better-sqlite3'
+      content += '\nallowBuilds:\n  better-sqlite3: true'
     }
 
     await writeFile(pnpmWorkspacePath, content)

--- a/packages/create-wattpm/test/cli/db.test.js
+++ b/packages/create-wattpm/test/cli/db.test.js
@@ -36,7 +36,7 @@ test('Creates a Platformatic DB application with no migrations', async t => {
   equal(await isFileAccessible(join(baseProjectDir, 'pnpm-workspace.yaml')), true)
 
   const pnpmWorkspace = await readFile(join(baseProjectDir, 'pnpm-workspace.yaml'), 'utf8')
-  equal(pnpmWorkspace.includes('allowBuilds:\n- better-sqlite3'), true)
+  equal(pnpmWorkspace.includes('allowBuilds:\n  better-sqlite3'), true)
 
   // Here check the generated application
   const applications = await getApplications(join(baseProjectDir, 'web'))

--- a/packages/create-wattpm/test/cli/db.test.js
+++ b/packages/create-wattpm/test/cli/db.test.js
@@ -36,7 +36,7 @@ test('Creates a Platformatic DB application with no migrations', async t => {
   equal(await isFileAccessible(join(baseProjectDir, 'pnpm-workspace.yaml')), true)
 
   const pnpmWorkspace = await readFile(join(baseProjectDir, 'pnpm-workspace.yaml'), 'utf8')
-  equal(pnpmWorkspace.includes('allowBuilds:\n  better-sqlite3'), true)
+  equal(pnpmWorkspace.includes('allowBuilds:\n  better-sqlite3: true'), true)
 
   // Here check the generated application
   const applications = await getApplications(join(baseProjectDir, 'web'))


### PR DESCRIPTION
The `allowBuilds` field in the generated `pnpm-workspace.yaml` used list syntax (`- better-sqlite3`) instead of the correct map key syntax (`  better-sqlite3`), producing invalid YAML.

Fixed in both the generator (`lib/index.js`) and the corresponding test assertion.

Fixes #4679