### PR TITLE
fix(db): support pgvector vector columns

### DIFF
--- a/docker-compose-apple-silicon.yml
+++ b/docker-compose-apple-silicon.yml
@@ -3,7 +3,7 @@ services:
   postgresql:
     ports:
       - '127.0.0.1:5432:5432'
-    image: 'arm64v8/postgres:17-alpine'
+    image: 'pgvector/pgvector:pg17-trixie'
     environment:
       - POSTGRES_PASSWORD=postgres
   mariadb:

--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -3,7 +3,7 @@ services:
   postgresql:
     ports:
       - "127.0.0.1:5432:5432"
-    image: "postgres:17-alpine"
+    image: "pgvector/pgvector:pg17-trixie"
     environment:
       - POSTGRES_PASSWORD=postgres
   mariadb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   postgresql:
     ports:
       - '127.0.0.1:5432:5432'
-    image: 'postgres:17-alpine'
+    image: 'pgvector/pgvector:pg17-trixie'
     environment:
       - POSTGRES_PASSWORD=postgres
   mariadb:

--- a/packages/sql-graphql/lib/utils.js
+++ b/packages/sql-graphql/lib/utils.js
@@ -61,6 +61,8 @@ export function sqlTypeToGraphQL (sqlType) {
       return GraphQLJSONObject
     case 'jsonb':
       return GraphQLJSONObject
+    case 'vector':
+      return new graphql.GraphQLList(graphql.GraphQLFloat)
     default:
       return graphql.GraphQLString
   }

--- a/packages/sql-graphql/test/vector.test.js
+++ b/packages/sql-graphql/test/vector.test.js
@@ -1,0 +1,132 @@
+import sqlMapper from '@platformatic/sql-mapper'
+import fastify from 'fastify'
+import { equal, deepEqual as same, ok } from 'node:assert'
+import { test } from 'node:test'
+import { printSchema } from 'graphql'
+import sqlGraphQL from '../index.js'
+import { clear, connInfo, isPg } from './helper.js'
+
+test('[PG] vector fields are exposed as float lists', { skip: !isPg }, async t => {
+  const seedApp = fastify()
+  t.after(async () => {
+    try {
+      await seedApp.close()
+    } catch {}
+  })
+
+  seedApp.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      await db.query(sql`DROP TABLE IF EXISTS embeddings`)
+      await db.query(sql`CREATE TABLE embeddings (
+        id SERIAL PRIMARY KEY,
+        embedding TEXT NOT NULL
+      );`)
+    }
+  })
+
+  await seedApp.ready()
+
+  const dbschema = structuredClone(seedApp.platformatic.dbschema)
+  const embeddings = dbschema.find(table => table.table === 'embeddings')
+  embeddings.columns.find(column => column.column_name === 'embedding').udt_name = 'vector'
+
+  await seedApp.close()
+
+  const app = fastify()
+  t.after(() => app.close())
+
+  app.register(sqlMapper, {
+    ...connInfo,
+    dbschema
+  })
+  app.register(sqlGraphQL)
+
+  await app.ready()
+
+  ok(printSchema(app.graphql.schema).includes('embedding: [Float]'))
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          mutation {
+            saveEmbedding(input: { embedding: [1, 2.5, 3] }) {
+              id
+              embedding
+            }
+          }
+        `
+      }
+    })
+
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      data: {
+        saveEmbedding: {
+          id: 1,
+          embedding: [1, 2.5, 3]
+        }
+      }
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            getEmbeddingById(id: 1) {
+              id
+              embedding
+            }
+          }
+        `
+      }
+    })
+
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      data: {
+        getEmbeddingById: {
+          id: 1,
+          embedding: [1, 2.5, 3]
+        }
+      }
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            embeddings(where: { embedding: { eq: [1, 2.5, 3] } }) {
+              id
+              embedding
+            }
+          }
+        `
+      }
+    })
+
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      data: {
+        embeddings: [
+          {
+            id: 1,
+            embedding: [1, 2.5, 3]
+          }
+        ]
+      }
+    })
+  }
+})

--- a/packages/sql-graphql/test/vector.test.js
+++ b/packages/sql-graphql/test/vector.test.js
@@ -1,4 +1,4 @@
-import sqlMapper from '@platformatic/sql-mapper'
+import sqlMapper, { createConnectionPool } from '@platformatic/sql-mapper'
 import fastify from 'fastify'
 import { equal, deepEqual as same, ok } from 'node:assert'
 import { test } from 'node:test'
@@ -6,40 +6,54 @@ import { printSchema } from 'graphql'
 import sqlGraphQL from '../index.js'
 import { clear, connInfo, isPg } from './helper.js'
 
-test('[PG] vector fields are exposed as float lists', { skip: !isPg }, async t => {
-  const seedApp = fastify()
-  t.after(async () => {
-    try {
-      await seedApp.close()
-    } catch {}
+const fakeLogger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {}
+}
+
+async function ensureVectorExtension (t) {
+  const { db, sql } = await createConnectionPool({
+    log: fakeLogger,
+    connectionString: connInfo.connectionString,
+    poolSize: 1
   })
 
-  seedApp.register(sqlMapper, {
-    ...connInfo,
-    async onDatabaseLoad (db, sql) {
-      await clear(db, sql)
-      await db.query(sql`DROP TABLE IF EXISTS embeddings`)
-      await db.query(sql`CREATE TABLE embeddings (
-        id SERIAL PRIMARY KEY,
-        embedding TEXT NOT NULL
-      );`)
+  try {
+    const rows = await db.query(sql`SELECT 1 FROM pg_available_extensions WHERE name = 'vector'`)
+    if (rows.length === 0) {
+      t.skip('pgvector extension not available')
+      return false
     }
-  })
 
-  await seedApp.ready()
+    return true
+  } finally {
+    await db.dispose()
+  }
+}
 
-  const dbschema = structuredClone(seedApp.platformatic.dbschema)
-  const embeddings = dbschema.find(table => table.table === 'embeddings')
-  embeddings.columns.find(column => column.column_name === 'embedding').udt_name = 'vector'
-
-  await seedApp.close()
+test('[PG] vector fields are exposed as float lists', { skip: !isPg }, async t => {
+  if (!(await ensureVectorExtension(t))) {
+    return
+  }
 
   const app = fastify()
   t.after(() => app.close())
 
   app.register(sqlMapper, {
     ...connInfo,
-    dbschema
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      await db.query(sql`CREATE EXTENSION IF NOT EXISTS vector`)
+      await db.query(sql`DROP TABLE IF EXISTS embeddings`)
+      await db.query(sql`CREATE TABLE embeddings (
+        id SERIAL PRIMARY KEY,
+        embedding vector(3) NOT NULL
+      )`)
+    }
   })
   app.register(sqlGraphQL)
 

--- a/packages/sql-json-schema-mapper/index.js
+++ b/packages/sql-json-schema-mapper/index.js
@@ -58,6 +58,19 @@ export function mapSQLTypeToOpenAPIType (sqlType) {
   }
 }
 
+function mapSQLTypeToOpenAPISchema (sqlType) {
+  if (sqlType === 'vector') {
+    return {
+      type: 'array',
+      items: {
+        type: 'number'
+      }
+    }
+  }
+
+  return { type: mapSQLTypeToOpenAPIType(sqlType) }
+}
+
 export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = false) {
   const fields = entity.camelCasedFields
   const properties = {}
@@ -83,7 +96,7 @@ export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = fals
         additionalProperties: true
       }
     } else {
-      properties[field.camelcase] = { type }
+      properties[field.camelcase] = mapSQLTypeToOpenAPISchema(field.sqlType)
     }
     if (field.isNullable || noRequired || field.autoTimestamp) {
       properties[field.camelcase].nullable = true

--- a/packages/sql-json-schema-mapper/index.js
+++ b/packages/sql-json-schema-mapper/index.js
@@ -58,17 +58,24 @@ export function mapSQLTypeToOpenAPIType (sqlType) {
   }
 }
 
-function mapSQLTypeToOpenAPISchema (sqlType) {
-  if (sqlType === 'vector') {
-    return {
+function mapSQLTypeToOpenAPISchema (field) {
+  if (field.sqlType === 'vector') {
+    const schema = {
       type: 'array',
       items: {
         type: 'number'
       }
     }
+
+    if (field.vectorDimensions) {
+      schema.minItems = field.vectorDimensions
+      schema.maxItems = field.vectorDimensions
+    }
+
+    return schema
   }
 
-  return { type: mapSQLTypeToOpenAPIType(sqlType) }
+  return { type: mapSQLTypeToOpenAPIType(field.sqlType) }
 }
 
 export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = false) {
@@ -96,7 +103,7 @@ export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = fals
         additionalProperties: true
       }
     } else {
-      properties[field.camelcase] = mapSQLTypeToOpenAPISchema(field.sqlType)
+      properties[field.camelcase] = mapSQLTypeToOpenAPISchema(field)
     }
     if (field.isNullable || noRequired || field.autoTimestamp) {
       properties[field.camelcase].nullable = true

--- a/packages/sql-json-schema-mapper/test/vector.test.js
+++ b/packages/sql-json-schema-mapper/test/vector.test.js
@@ -5,7 +5,7 @@ import { mapSQLEntityToJSONSchema } from '../index.js'
 test('vector fields are mapped to arrays of numbers', async () => {
   const entity = {
     name: 'Embedding',
-    fields: {
+    camelCasedFields: {
       id: {
         camelcase: 'id',
         sqlType: 'int4',

--- a/packages/sql-json-schema-mapper/test/vector.test.js
+++ b/packages/sql-json-schema-mapper/test/vector.test.js
@@ -1,0 +1,42 @@
+import { deepEqual as same } from 'node:assert'
+import { test } from 'node:test'
+import { mapSQLEntityToJSONSchema } from '../index.js'
+
+test('vector fields are mapped to arrays of numbers', async () => {
+  const entity = {
+    name: 'Embedding',
+    fields: {
+      id: {
+        camelcase: 'id',
+        sqlType: 'int4',
+        isNullable: false,
+        primaryKey: true
+      },
+      embedding: {
+        camelcase: 'embedding',
+        sqlType: 'vector',
+        isNullable: false
+      }
+    }
+  }
+
+  same(mapSQLEntityToJSONSchema(entity), {
+    $id: 'Embedding',
+    title: 'Embedding',
+    description: 'A Embedding',
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer'
+      },
+      embedding: {
+        type: 'array',
+        items: {
+          type: 'number'
+        }
+      }
+    },
+    required: ['embedding'],
+    additionalProperties: false
+  })
+})

--- a/packages/sql-json-schema-mapper/test/vector.test.js
+++ b/packages/sql-json-schema-mapper/test/vector.test.js
@@ -15,7 +15,8 @@ test('vector fields are mapped to arrays of numbers', async () => {
       embedding: {
         camelcase: 'embedding',
         sqlType: 'vector',
-        isNullable: false
+        isNullable: false,
+        vectorDimensions: 1536
       }
     }
   }
@@ -33,7 +34,9 @@ test('vector fields are mapped to arrays of numbers', async () => {
         type: 'array',
         items: {
           type: 'number'
-        }
+        },
+        minItems: 1536,
+        maxItems: 1536
       }
     },
     required: ['embedding'],

--- a/packages/sql-mapper/index.js
+++ b/packages/sql-mapper/index.js
@@ -77,18 +77,14 @@ const defaultAutoTimestampFields = {
   updatedAt: 'updated_at'
 }
 
-async function registerPostgreSQLExtensionTypes (db, log) {
+async function registerPostgreSQLExtensionTypes (db) {
   try {
     await db.registerTypeParser('vector', parseVector)
-  } catch (err) {
-    log.trace({ err }, 'unable to register the PostgreSQL vector type parser')
-  }
+  } catch {}
 
   try {
     await db.registerTypeParser('_vector', value => db.parseArray(value, parseVector))
-  } catch (err) {
-    log.trace({ err }, 'unable to register the PostgreSQL vector[] type parser')
-  }
+  } catch {}
 }
 
 export async function createConnectionPool ({
@@ -117,7 +113,7 @@ export async function createConnectionPool ({
       queueTimeoutMilliseconds,
       acquireLockTimeoutMilliseconds
     )
-    await registerPostgreSQLExtensionTypes(db, log)
+    await registerPostgreSQLExtensionTypes(db)
     sql = createConnectionPoolPg.sql
     db.isPg = true
   } else if (connectionString.indexOf('mysql') === 0) {

--- a/packages/sql-mapper/index.js
+++ b/packages/sql-mapper/index.js
@@ -13,6 +13,7 @@ import {
 import * as queriesFactory from './lib/queries/index.js'
 import { setupTelemetry } from './lib/telemetry.js'
 import { areSchemasSupported } from './lib/utils.js'
+import { parseVector } from './lib/vector.js'
 
 // Ignore the function as it is only used only for MySQL and PostgreSQL
 /* istanbul ignore next */
@@ -76,6 +77,20 @@ const defaultAutoTimestampFields = {
   updatedAt: 'updated_at'
 }
 
+async function registerPostgreSQLExtensionTypes (db, log) {
+  try {
+    await db.registerTypeParser('vector', parseVector)
+  } catch (err) {
+    log.trace({ err }, 'unable to register the PostgreSQL vector type parser')
+  }
+
+  try {
+    await db.registerTypeParser('_vector', value => db.parseArray(value, parseVector))
+  } catch (err) {
+    log.trace({ err }, 'unable to register the PostgreSQL vector[] type parser')
+  }
+}
+
 export async function createConnectionPool ({
   log,
   connectionString,
@@ -102,6 +117,7 @@ export async function createConnectionPool ({
       queueTimeoutMilliseconds,
       acquireLockTimeoutMilliseconds
     )
+    await registerPostgreSQLExtensionTypes(db, log)
     sql = createConnectionPoolPg.sql
     db.isPg = true
   } else if (connectionString.indexOf('mysql') === 0) {

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -500,7 +500,8 @@ export function buildEntity (
     acc[column.column_name] = {
       sqlType: column.udt_name,
       isNullable: column.is_nullable === 'YES',
-      isArray: column.isArray
+      isArray: column.isArray,
+      vectorDimensions: column.vectorDimensions
     }
 
     // To get enum values in mysql and mariadb

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -14,6 +14,7 @@ import {
 } from './errors.js'
 import { wrapDB } from './telemetry.js'
 import { sanitizeLimit, tableName, toLowerFirst, toSingular, toUpperFirst } from './utils.js'
+import { isVectorType, parseVector, serializeVector } from './vector.js'
 
 function createMapper (
   defaultDb,
@@ -75,7 +76,7 @@ function createMapper (
   function fixInput (input) {
     const newInput = {}
     for (const key of Object.keys(input)) {
-      const value = input[key]
+      let value = input[key]
       let newKey = inputToFieldMap[key]
       if (newKey === undefined) {
         if (fields[key] !== undefined) {
@@ -84,6 +85,11 @@ function createMapper (
           throw new UnknownFieldError(key)
         }
       }
+
+      if (isVectorType(fields[newKey].sqlType)) {
+        value = serializeVector(value)
+      }
+
       newInput[newKey] = value
     }
     return newInput
@@ -99,6 +105,9 @@ function createMapper (
       const newKey = fieldMapToRetrieve[key]
       if (primaryKeys.has(key) && value !== null && value !== undefined) {
         value = value.toString()
+      }
+      if (newKey && isVectorType(fields[key].sqlType)) {
+        value = parseVector(value)
       }
       newOutput[newKey] = value
     }
@@ -327,6 +336,10 @@ function createMapper (
   }
 
   function computeCriteriaValue (fieldWrap, value) {
+    if (isVectorType(fieldWrap.sqlType)) {
+      return sql`${serializeVector(value)}`
+    }
+
     if (Array.isArray(value)) {
       return sql`(${sql.join(
         value.map(v => computeCriteriaValue(fieldWrap, v)),

--- a/packages/sql-mapper/lib/queries/pg.js
+++ b/packages/sql-mapper/lib/queries/pg.js
@@ -46,10 +46,16 @@ export async function listColumns (db, sql, table, schema) {
   */
 
   const res = await db.query(sql`
-    SELECT column_name, udt_name, is_nullable, is_generated, data_type
-    FROM information_schema.columns
-    WHERE table_name = ${table}
-    AND table_schema = ${schema}
+    SELECT c.column_name, c.udt_name, c.is_nullable, c.is_generated, c.data_type,
+      pg_catalog.format_type(a.atttypid, a.atttypmod) AS formatted_type
+    FROM information_schema.columns c
+    JOIN pg_catalog.pg_class cls ON cls.relname = c.table_name
+    JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace AND ns.nspname = c.table_schema
+    JOIN pg_catalog.pg_attribute a ON a.attrelid = cls.oid AND a.attname = c.column_name
+    WHERE c.table_name = ${table}
+    AND c.table_schema = ${schema}
+    AND a.attnum > 0
+    AND NOT a.attisdropped
   `)
 
   for (const col of res) {
@@ -58,6 +64,11 @@ export async function listColumns (db, sql, table, schema) {
       col.isArray = true
     } else {
       col.isArray = false
+    }
+
+    const match = col.formatted_type?.match(/^vector\((\d+)\)$/)
+    if (match) {
+      col.vectorDimensions = Number(match[1])
     }
   }
 

--- a/packages/sql-mapper/lib/vector.js
+++ b/packages/sql-mapper/lib/vector.js
@@ -1,0 +1,34 @@
+export function isVectorType (sqlType) {
+  return sqlType === 'vector'
+}
+
+export function serializeVector (value) {
+  if (Array.isArray(value)) {
+    return JSON.stringify(value)
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return JSON.stringify(Array.from(value))
+  }
+
+  return value
+}
+
+export function parseVector (value) {
+  if (value === null || value === undefined || Array.isArray(value)) {
+    return value
+  }
+
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    if (Array.isArray(parsed)) {
+      return parsed
+    }
+  } catch {}
+
+  return value
+}

--- a/packages/sql-mapper/test/vector.test.js
+++ b/packages/sql-mapper/test/vector.test.js
@@ -1,0 +1,89 @@
+import { createConnectionPool, connect } from '../index.js'
+import { deepEqual as same, equal } from 'node:assert'
+import { test } from 'node:test'
+import { clear, connInfo, isPg } from './helper.js'
+
+const fakeLogger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {}
+}
+
+async function ensureVectorExtension (t) {
+  const { db, sql } = await createConnectionPool({
+    log: fakeLogger,
+    connectionString: connInfo.connectionString,
+    poolSize: 1
+  })
+
+  try {
+    const rows = await db.query(sql`SELECT 1 FROM pg_available_extensions WHERE name = 'vector'`)
+    if (rows.length === 0) {
+      t.skip('pgvector extension not available')
+      return false
+    }
+
+    return true
+  } finally {
+    await db.dispose()
+  }
+}
+
+test('vector support (PG)', { skip: !isPg }, async t => {
+  if (!(await ensureVectorExtension(t))) {
+    return
+  }
+
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      await db.query(sql`CREATE EXTENSION IF NOT EXISTS vector`)
+      await db.query(sql`DROP TABLE IF EXISTS embeddings`)
+      await db.query(sql`CREATE TABLE embeddings (
+        id SERIAL PRIMARY KEY,
+        embedding vector(3) NOT NULL
+      )`)
+    },
+    ignore: {},
+    hooks: {}
+  })
+
+  t.after(() => mapper.db.dispose())
+
+  const embeddingEntity = mapper.entities.embedding
+  equal(embeddingEntity.fields.embedding.sqlType, 'vector')
+  equal(embeddingEntity.fields.embedding.vectorDimensions, 3)
+
+  const saved = await embeddingEntity.save({
+    fields: ['id', 'embedding'],
+    input: {
+      embedding: [1, 2.5, 3]
+    }
+  })
+
+  same(saved, {
+    id: '1',
+    embedding: [1, 2.5, 3]
+  })
+
+  const found = await embeddingEntity.find({
+    fields: ['id', 'embedding'],
+    where: {
+      embedding: {
+        eq: [1, 2.5, 3]
+      }
+    }
+  })
+
+  same(found, [
+    {
+      id: '1',
+      embedding: [1, 2.5, 3]
+    }
+  ])
+})

--- a/packages/sql-openapi/test/vector.test.js
+++ b/packages/sql-openapi/test/vector.test.js
@@ -1,44 +1,58 @@
-import sqlMapper from '@platformatic/sql-mapper'
+import sqlMapper, { createConnectionPool } from '@platformatic/sql-mapper'
 import fastify from 'fastify'
 import { equal, deepEqual as same } from 'node:assert/strict'
 import { test } from 'node:test'
 import sqlOpenAPI from '../index.js'
 import { clear, connInfo, isPg } from './helper.js'
 
-test('expose vector columns as arrays of numbers', { skip: !isPg }, async t => {
-  const seedApp = fastify()
-  t.after(async () => {
-    try {
-      await seedApp.close()
-    } catch {}
+const fakeLogger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {}
+}
+
+async function ensureVectorExtension (t) {
+  const { db, sql } = await createConnectionPool({
+    log: fakeLogger,
+    connectionString: connInfo.connectionString,
+    poolSize: 1
   })
 
-  seedApp.register(sqlMapper, {
-    ...connInfo,
-    async onDatabaseLoad (db, sql) {
-      await clear(db, sql)
-      await db.query(sql`DROP TABLE IF EXISTS embeddings`)
-      await db.query(sql`CREATE TABLE embeddings (
-        id SERIAL PRIMARY KEY,
-        embedding TEXT NOT NULL
-      );`)
+  try {
+    const rows = await db.query(sql`SELECT 1 FROM pg_available_extensions WHERE name = 'vector'`)
+    if (rows.length === 0) {
+      t.skip('pgvector extension not available')
+      return false
     }
-  })
 
-  await seedApp.ready()
+    return true
+  } finally {
+    await db.dispose()
+  }
+}
 
-  const dbschema = structuredClone(seedApp.platformatic.dbschema)
-  const embeddings = dbschema.find(table => table.table === 'embeddings')
-  embeddings.columns.find(column => column.column_name === 'embedding').udt_name = 'vector'
-
-  await seedApp.close()
+test('expose vector columns as arrays of numbers', { skip: !isPg }, async t => {
+  if (!(await ensureVectorExtension(t))) {
+    return
+  }
 
   const app = fastify()
   t.after(() => app.close())
 
   app.register(sqlMapper, {
     ...connInfo,
-    dbschema
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      await db.query(sql`CREATE EXTENSION IF NOT EXISTS vector`)
+      await db.query(sql`DROP TABLE IF EXISTS embeddings`)
+      await db.query(sql`CREATE TABLE embeddings (
+        id SERIAL PRIMARY KEY,
+        embedding vector(3) NOT NULL
+      )`)
+    }
   })
   app.register(sqlOpenAPI)
 
@@ -57,13 +71,17 @@ test('expose vector columns as arrays of numbers', { skip: !isPg }, async t => {
       items: {
         type: 'number'
       },
+      minItems: 3,
+      maxItems: 3,
       nullable: true
     })
     same(json.components.schemas.EmbeddingInput.properties.embedding, {
       type: 'array',
       items: {
         type: 'number'
-      }
+      },
+      minItems: 3,
+      maxItems: 3
     })
   }
 
@@ -81,6 +99,18 @@ test('expose vector columns as arrays of numbers', { skip: !isPg }, async t => {
       id: 1,
       embedding: [1, 2.5, 3]
     })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/embeddings',
+      body: {
+        embedding: [1, 2.5]
+      }
+    })
+
+    equal(res.statusCode, 400)
   }
 
   {

--- a/packages/sql-openapi/test/vector.test.js
+++ b/packages/sql-openapi/test/vector.test.js
@@ -1,0 +1,98 @@
+import sqlMapper from '@platformatic/sql-mapper'
+import fastify from 'fastify'
+import { equal, deepEqual as same } from 'node:assert/strict'
+import { test } from 'node:test'
+import sqlOpenAPI from '../index.js'
+import { clear, connInfo, isPg } from './helper.js'
+
+test('expose vector columns as arrays of numbers', { skip: !isPg }, async t => {
+  const seedApp = fastify()
+  t.after(async () => {
+    try {
+      await seedApp.close()
+    } catch {}
+  })
+
+  seedApp.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      await db.query(sql`DROP TABLE IF EXISTS embeddings`)
+      await db.query(sql`CREATE TABLE embeddings (
+        id SERIAL PRIMARY KEY,
+        embedding TEXT NOT NULL
+      );`)
+    }
+  })
+
+  await seedApp.ready()
+
+  const dbschema = structuredClone(seedApp.platformatic.dbschema)
+  const embeddings = dbschema.find(table => table.table === 'embeddings')
+  embeddings.columns.find(column => column.column_name === 'embedding').udt_name = 'vector'
+
+  await seedApp.close()
+
+  const app = fastify()
+  t.after(() => app.close())
+
+  app.register(sqlMapper, {
+    ...connInfo,
+    dbschema
+  })
+  app.register(sqlOpenAPI)
+
+  await app.ready()
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json'
+    })
+
+    equal(res.statusCode, 200)
+    const json = res.json()
+    same(json.components.schemas.Embedding.properties.embedding, {
+      type: 'array',
+      items: {
+        type: 'number'
+      },
+      nullable: true
+    })
+    same(json.components.schemas.EmbeddingInput.properties.embedding, {
+      type: 'array',
+      items: {
+        type: 'number'
+      }
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/embeddings',
+      body: {
+        embedding: [1, 2.5, 3]
+      }
+    })
+
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      id: 1,
+      embedding: [1, 2.5, 3]
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/embeddings/1'
+    })
+
+    equal(res.statusCode, 200)
+    same(res.json(), {
+      id: 1,
+      embedding: [1, 2.5, 3]
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- map PostgreSQL `vector` columns to GraphQL `[Float]`
- map PostgreSQL `vector` columns to OpenAPI `array<number>` schemas
- register PostgreSQL `vector` parsers and serialize vector values in the SQL mapper
- add coverage for GraphQL, OpenAPI, and JSON schema mapping

## Testing
- `pnpm --filter @platformatic/sql-json-schema-mapper exec node --test test/vector.test.js`
- `cd packages/sql-graphql && DB=postgresql node --test test/vector.test.js`
- `cd packages/sql-openapi && DB=postgresql node --test test/vector.test.js`

Fixes #4732

Also registers the PostgreSQL `vector` type parser in pg connections, which should help with the runtime side reported in #4731.
