### PR TITLE
fix: honor camelCase openapi ignore fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ packages/runtime/test/tmp
 packages/*/CLAUDE.md
 .githuman
 .plt
+
+# Pi
+.pi/

--- a/packages/sql-json-schema-mapper/index.js
+++ b/packages/sql-json-schema-mapper/index.js
@@ -59,7 +59,7 @@ export function mapSQLTypeToOpenAPIType (sqlType) {
 }
 
 export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = false) {
-  const fields = entity.fields
+  const fields = entity.camelCasedFields
   const properties = {}
   const required = []
   for (const name of Object.keys(fields)) {

--- a/packages/sql-json-schema-mapper/test/simple.test.js
+++ b/packages/sql-json-schema-mapper/test/simple.test.js
@@ -65,6 +65,20 @@ async function createBasicGeneratedTests (db, sql) {
   }
 }
 
+async function createBasicUsers (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE users (
+      id INTEGER PRIMARY KEY,
+      password_hash VARCHAR(255)
+    );`)
+  } else {
+    await db.query(sql`CREATE TABLE users (
+      id SERIAL PRIMARY KEY,
+      password_hash VARCHAR(255)
+    );`)
+  }
+}
+
 test('simple db, simple rest API', async t => {
   const app = fastify()
   app.register(sqlMapper, {
@@ -218,6 +232,31 @@ test('stored and virtual generated columns should be read only', async t => {
       same(generatedTestJsonSchema.properties.testStored, { type: 'integer', nullable: true, readOnly: true })
       same(generatedTestJsonSchema.properties.testVirtual, { type: 'integer', nullable: true, readOnly: true })
     }
+  }
+})
+
+test('ignore one snake_case field using camelCase', async t => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicUsers(db, sql)
+    }
+  })
+  t.after(() => app.close())
+
+  await app.ready()
+
+  {
+    const user = app.platformatic.entities.user
+    const userJsonSchema = mapSQLEntityToJSONSchema(user, {
+      passwordHash: true
+    })
+
+    equal(userJsonSchema.properties.passwordHash, undefined)
   }
 })
 

--- a/packages/sql-openapi/test/ignore.test.js
+++ b/packages/sql-openapi/test/ignore.test.js
@@ -28,6 +28,22 @@ async function createBasicPages (db, sql) {
   }
 }
 
+async function createUsersWithPasswordHash (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE users (
+      id INTEGER PRIMARY KEY,
+      password_hash VARCHAR(255)
+    );`)
+    await db.query(sql`INSERT INTO users (id, password_hash) VALUES (1, 'hashed-secret');`)
+  } else {
+    await db.query(sql`CREATE TABLE users (
+      id SERIAL PRIMARY KEY,
+      password_hash VARCHAR(255)
+    );`)
+    await db.query(sql`INSERT INTO users (password_hash) VALUES ('hashed-secret');`)
+  }
+}
+
 test('ignore a table', async t => {
   const app = fastify()
   app.register(sqlMapper, {
@@ -241,6 +257,57 @@ test('ignore a column in OpenAPI', async t => {
   })
 
   same(fieldsParameter.schema.items.enum, ['id'])
+})
+
+test('ignore a snake_case column in OpenAPI responses using camelCase', async t => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createUsersWithPasswordHash(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, {
+    ignore: {
+      user: {
+        passwordHash: true
+      }
+    }
+  })
+  t.after(() => app.close())
+
+  await app.ready()
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json'
+    })
+    equal(res.statusCode, 200, 'GET /documentation/json status code')
+    const data = res.json()
+    equal(data.components.schemas.User.properties.passwordHash, undefined, 'passwordHash property is ignored')
+
+    const fieldsParameter = data.paths['/users/'].get.parameters.find(parameter => {
+      return parameter.name === 'fields' && parameter.in === 'query'
+    })
+
+    same(fieldsParameter.schema.items.enum, ['id'])
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/users'
+    })
+    equal(res.statusCode, 200, 'GET /users status code')
+
+    const data = res.json()
+    same(data.map(user => Object.keys(user).sort()), [['id']])
+    ok(data[0].id !== undefined)
+  }
 })
 
 test('show a warning if there is no ignored entity field', async t => {


### PR DESCRIPTION
## Summary

Fix `db.openapi.ignore` field-level handling so camelCase ignore entries work consistently for OpenAPI response schemas and actual API responses.

Fixes #4734.

## What changed

- update `mapSQLEntityToJSONSchema()` to iterate `entity.camelCasedFields` instead of `entity.fields`
- add a mapper-level regression test for ignoring a snake_case column via camelCase
- add an OpenAPI integration regression test covering docs and `GET /users` responses

## Why

`sql-openapi` already validates and exposes ignored fields using camelCase names, but `sql-json-schema-mapper` was still checking the ignore map against snake_case keys from `entity.fields`. That made camelCase ignores appear valid while still leaving the field in generated response schemas.

Using `entity.camelCasedFields` makes the ignore lookup consistent with the API-visible field names and the existing warning behavior.

## Validation

- `DB=sqlite node --test --test-reporter=spec --test-concurrency=1 packages/sql-json-schema-mapper/test/simple.test.js packages/sql-openapi/test/ignore.test.js`
- `cd packages/sql-json-schema-mapper && npm run test:sqlite`
- `cd packages/sql-openapi && npm run test:sqlite`
- `cd packages/sql-json-schema-mapper && npm run lint -- index.js test/simple.test.js`
- `cd packages/sql-openapi && npm run lint -- test/ignore.test.js`
