### PR TITLE
fix(runtime): read thread worker health from the worker handle, not via ITC

### DIFF
--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -529,6 +529,9 @@ export class BaseCapability extends EventEmitter {
       await this.childManager.inject()
       this.subprocess = await this.spawn(command)
       this.#subprocessStarted = true
+      // Let the runtime know this worker hosts a child process so it reads
+      // health metrics via ITC instead of from the coordinator thread handle.
+      globalThis[kITC]?.notify('subprocess:started')
     } catch (e) {
       this.childManager.close()
 

--- a/packages/runtime/fixtures/child-process-health/entrypoint/index.mjs
+++ b/packages/runtime/fixtures/child-process-health/entrypoint/index.mjs
@@ -12,5 +12,16 @@ export function create () {
     return { from: 'entrypoint' }
   })
 
+  // Used by the health regression test: blocks the worker thread's event loop
+  // for `ms` milliseconds so we can verify the runtime still collects health
+  // metrics for other workers while one thread worker is unresponsive.
+  app.get('/block/:ms', async request => {
+    const deadline = Date.now() + Number(request.params.ms)
+    while (Date.now() < deadline) {
+      // Busy-wait to block the worker thread's event loop.
+    }
+    return { blocked: Number(request.params.ms) }
+  })
+
   return app
 }

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -1519,7 +1519,7 @@ export class Runtime extends EventEmitter {
     return status
   }
 
-  async getWorkerHealth (worker, options = {}) {
+  getWorkerHealth (worker, options = {}) {
     // For subprocess workers we must round-trip through ITC to reach the child;
     // for pure worker-thread workers we can read ELU/heap directly from the
     // worker handle, which is served by Node's C++ layer and does not depend
@@ -1542,13 +1542,16 @@ export class Runtime extends EventEmitter {
       return { elu: elu.utilization, currentELU }
     }
 
-    // Only check heap statistics every 60 health checks (once per minute)
+    // Only refresh heap statistics every 60 health checks (once per minute).
+    // This keeps the common path fully synchronous — no promise allocation.
     const counter = (worker[kHeapCheckCounter] ?? 0) + 1
     worker[kHeapCheckCounter] = counter >= 60 ? 0 : counter
 
     if (counter >= 60 || !worker[kLastHeapStats]) {
-      const { used_heap_size: heapUsed, total_heap_size: heapTotal } = await worker.getHeapStatistics()
-      worker[kLastHeapStats] = { heapUsed, heapTotal }
+      return worker.getHeapStatistics().then(({ used_heap_size: heapUsed, total_heap_size: heapTotal }) => {
+        worker[kLastHeapStats] = { heapUsed, heapTotal }
+        return { elu: elu.utilization, heapUsed, heapTotal, currentELU }
+      })
     }
 
     const { heapUsed, heapTotal } = worker[kLastHeapStats]

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -61,6 +61,7 @@ import {
   kHealthCheckTimer,
   kId,
   kInterceptorReadyPromise,
+  kIsSubprocessHost,
   kITC,
   kLastHealthCheckELU,
   kStderrMarker,
@@ -73,6 +74,9 @@ import {
 
 const kWorkerFile = join(import.meta.dirname, 'worker/main.js')
 const kInspectorOptions = Symbol('plt.runtime.worker.inspectorOptions')
+const kHeapCheckCounter = Symbol('plt.runtime.worker.heapCheckCounter')
+const kLastHeapStats = Symbol('plt.runtime.worker.lastHeapStats')
+const kHealthITCTimeoutMs = 5000
 
 const MAX_LISTENERS_COUNT = 100
 
@@ -1516,11 +1520,53 @@ export class Runtime extends EventEmitter {
   }
 
   async getWorkerHealth (worker, options = {}) {
-    // Use ITC to get health from the worker. This correctly forwards to child
-    // processes when the service uses startWithCommand (subprocess mode),
-    // instead of reading the coordinator thread's metrics.
-    const { currentELU, heapUsed, heapTotal } = await sendViaITC(worker, 'getHealth')
+    // For subprocess workers we must round-trip through ITC to reach the child;
+    // for pure worker-thread workers we can read ELU/heap directly from the
+    // worker handle, which is served by Node's C++ layer and does not depend
+    // on the worker's event loop being responsive. Going through ITC for
+    // thread workers means a CPU-bound or stuck worker can freeze the whole
+    // health-collection loop, which in turn blocks the management API.
+    if (worker[kIsSubprocessHost]) {
+      return this.#getSubprocessWorkerHealth(worker, options)
+    }
 
+    const currentELU = worker.performance.eventLoopUtilization()
+    const previousELU = options.previousELU
+
+    let elu = currentELU
+    if (previousELU) {
+      elu = worker.performance.eventLoopUtilization(elu, previousELU)
+    }
+
+    if (!features.node.worker.getHeapStatistics) {
+      return { elu: elu.utilization, currentELU }
+    }
+
+    // Only check heap statistics every 60 health checks (once per minute)
+    const counter = (worker[kHeapCheckCounter] ?? 0) + 1
+    worker[kHeapCheckCounter] = counter >= 60 ? 0 : counter
+
+    if (counter >= 60 || !worker[kLastHeapStats]) {
+      const { used_heap_size: heapUsed, total_heap_size: heapTotal } = await worker.getHeapStatistics()
+      worker[kLastHeapStats] = { heapUsed, heapTotal }
+    }
+
+    const { heapUsed, heapTotal } = worker[kLastHeapStats]
+    return { elu: elu.utilization, heapUsed, heapTotal, currentELU }
+  }
+
+  async #getSubprocessWorkerHealth (worker, options) {
+    // Bound the ITC call so a hung child cannot freeze the health loop.
+    // On timeout we fall back to last-known ELU with a null heap reading so
+    // that the loop keeps rescheduling and signals remain observable.
+    const result = await executeWithTimeout(sendViaITC(worker, 'getHealth'), kHealthITCTimeoutMs, kTimeout)
+
+    if (result === kTimeout) {
+      const previousELU = options.previousELU ?? worker.performance.eventLoopUtilization()
+      return { elu: 1, heapUsed: null, heapTotal: null, currentELU: previousELU }
+    }
+
+    const { currentELU, heapUsed, heapTotal } = result
     const previousELU = options.previousELU
     let elu = currentELU
     if (previousELU) {
@@ -1851,6 +1897,14 @@ export class Runtime extends EventEmitter {
 
       this.emit(event, ...payload, workerId, applicationId, index)
       this.logger.trace({ event, payload, id: workerId, application: applicationId, worker: index }, 'Runtime event')
+    })
+
+    // The worker notifies us when its capability has spawned a child process
+    // (e.g. Next.js in dev mode). From that point on health metrics must come
+    // from the child via ITC; for thread-only workers we keep reading the
+    // handle directly in getWorkerHealth().
+    worker[kITC].on('subprocess:started', () => {
+      worker[kIsSubprocessHost] = true
     })
 
     worker[kITC].on('request:restart', async () => {

--- a/packages/runtime/lib/worker/symbols.js
+++ b/packages/runtime/lib/worker/symbols.js
@@ -12,6 +12,7 @@ export const kInterceptors = Symbol.for('plt.runtime.worker.interceptors')
 export const kLastHealthCheckELU = Symbol.for('plt.runtime.worker.lastHealthCheckELU')
 export const kLastWorkerScalerELU = Symbol.for('plt.runtime.worker.lastWorkerScalerELU')
 export const kInterceptorReadyPromise = Symbol.for('plt.runtime.worker.interceptorReadyPromise')
+export const kIsSubprocessHost = Symbol.for('plt.runtime.worker.isSubprocessHost')
 
 // This string marker should be safe to use since it belongs to Unicode private area
 export const kStderrMarker = '\ue002'

--- a/packages/runtime/test/health-thread-worker.test.js
+++ b/packages/runtime/test/health-thread-worker.test.js
@@ -1,0 +1,97 @@
+import { ok, strictEqual } from 'node:assert'
+import { once } from 'node:events'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { kIsSubprocessHost } from '../lib/worker/symbols.js'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+const isWindows = process.platform === 'win32'
+
+test(
+  'health metrics for a thread-only worker are read from the worker handle, not via ITC',
+  { skip: isWindows && 'Skipping on Windows' },
+  async t => {
+    const configFile = join(fixturesDir, 'child-process-health', 'platformatic.json')
+
+    const app = await createRuntime(configFile)
+
+    t.after(async () => {
+      await app.close()
+    })
+
+    await app.start()
+
+    // Find the entrypoint worker (runs as a Node worker thread — no subprocess)
+    // and the subprocess worker (spawned via `application.commands.development`).
+    const workers = await app.getWorkers(true)
+    const entrypoint = Object.values(workers).find(w => w.application === 'entrypoint').raw
+    const subprocess = Object.values(workers).find(w => w.application === 'subprocess').raw
+
+    ok(!entrypoint[kIsSubprocessHost], 'entrypoint worker should not be flagged as subprocess host')
+    strictEqual(subprocess[kIsSubprocessHost], true, 'subprocess worker should be flagged as subprocess host')
+
+    // Collect one health sample for each application and ensure both shapes are valid.
+    const seen = new Map()
+    while (seen.size < 2) {
+      const [m] = await once(app, 'application:worker:health:metrics')
+      if (!seen.has(m.application)) {
+        seen.set(m.application, m)
+      }
+    }
+
+    for (const [applicationId, metric] of seen) {
+      ok(metric.currentHealth, `${applicationId} should have currentHealth`)
+      ok(typeof metric.currentHealth.elu === 'number', `${applicationId} should have ELU`)
+      ok(
+        typeof metric.currentHealth.heapUsed === 'number' || metric.currentHealth.heapUsed === null,
+        `${applicationId} should expose heapUsed`
+      )
+    }
+  }
+)
+
+test(
+  'health metrics keep flowing while a thread worker is blocking its event loop',
+  { skip: isWindows && 'Skipping on Windows' },
+  async t => {
+    const configFile = join(fixturesDir, 'child-process-health', 'platformatic.json')
+
+    const app = await createRuntime(configFile)
+
+    t.after(async () => {
+      await app.close()
+    })
+
+    await app.start()
+
+    // Wait for at least one baseline health metric from the entrypoint so we
+    // know the collection loop is running.
+    while (true) {
+      const [m] = await once(app, 'application:worker:health:metrics')
+      if (m.application === 'entrypoint') break
+    }
+
+    // Block the entrypoint worker's event loop for 4s. If getWorkerHealth
+    // were routed through ITC for thread workers (as it was before this
+    // patch), the postMessage response would be delayed by the block and the
+    // whole health loop would stall. Reading from the worker handle directly
+    // doesn't depend on the blocked loop, so metrics should keep arriving.
+    const blockMs = 4000
+    const blockPromise = app.inject('entrypoint', { method: 'GET', url: `/block/${blockMs}` })
+
+    const startedAt = Date.now()
+    let samplesDuringBlock = 0
+    while (Date.now() - startedAt < blockMs - 500) {
+      const [m] = await once(app, 'application:worker:health:metrics')
+      if (m.application === 'entrypoint') samplesDuringBlock++
+    }
+
+    await blockPromise
+
+    ok(
+      samplesDuringBlock >= 2,
+      `expected multiple entrypoint health samples during the ${blockMs}ms block, got ${samplesDuringBlock}`
+    )
+  }
+)


### PR DESCRIPTION
## Summary

`Runtime.getWorkerHealth()` was rewritten in #4729 to always go through
`sendViaITC(worker, 'getHealth')`, even for pure worker-thread workers — where
ELU/heap used to be read directly from the worker handle. The ITC round-trip
requires the worker's event loop to be draining its message port every second.
A CPU-bound or stuck worker silently freezes the health-collection loop, which
in turn can block the runtime's management API (`wattpm ps`, control
endpoints).

This PR restores the parent-local fast path for thread workers and bounds the
subprocess path:

- **Thread workers**: read `worker.performance.eventLoopUtilization()` and
  `worker.getHeapStatistics()` on the parent. Both are served by Node's C++
  layer and do not depend on the worker's JS event loop, so a stuck worker
  cannot stall health collection.
- **Subprocess workers**: still round-trip through ITC to reach the child (we
  still need the correct, in-child heap reading), but wrap the call in
  `executeWithTimeout` so a hung child no longer freezes the loop. On timeout
  the function degrades gracefully (`heap*: null`, `elu: 1`) and lets the loop
  reschedule.

The capability notifies the runtime via ITC (`subprocess:started`) the first
time it actually spawns a child process (after `this.subprocess = await
this.spawn(command)` in `BaseCapability.startWithCommand`). The runtime stores
a per-worker flag (`kIsSubprocessHost`) and routes `getWorkerHealth()` based on
it — no polling, no extra round-trips.

## Why this matters

We observed in production a pattern where a Watt pod upgraded from v3.42.0 to
v3.52.x stops responding to all requests, including Kubernetes health checks,
and `wattpm ps` against PID 1 times out with `UND_ERR_HEADERS_TIMEOUT`. Going
via ITC for every thread worker every second is a likely trigger.

## Test plan

- [x] Added `packages/runtime/test/health-thread-worker.test.js`:
  - Verifies `kIsSubprocessHost` is `true` only for subprocess-hosting workers.
  - Regression test: blocks the entrypoint (thread) worker's event loop for
    4s and asserts health samples keep arriving during the block. With the
    old ITC-only path this test fails because the health loop stalls behind
    the blocked postMessage.
- [x] All existing `test/health-*.test.js` suites pass:
  `health-1`, `health-2`, `health-child-process`, `health-signals`,
  `health-subprocess`, `health-thread-worker`.
- [x] `pnpm --filter @platformatic/runtime lint` and
  `pnpm --filter @platformatic/basic lint` clean.

Assisted-by: claude-code:claude-opus-4-7