### PR TITLE
fix(runtime): collect health metrics in parallel and respawn on collection failure

### DIFF
--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -2023,40 +2023,46 @@ export class Runtime extends EventEmitter {
         return
       }
 
-      // Iterate through all workers and collect health metrics
+      // Collect health from all workers in parallel so that a slow ITC
+      // round-trip (e.g. subprocess timeout) does not block every other worker.
+      const pending = []
       for (const worker of this.#workers.values()) {
         if (worker[kWorkerStatus] !== 'started') {
           continue
         }
 
-        const id = worker[kApplicationId]
-        const index = worker[kWorkerId]
-        const errorLabel = this.#workerExtendedLabel(id, index, worker[kConfig].workers)
+        pending.push((async () => {
+          const id = worker[kApplicationId]
+          const index = worker[kWorkerId]
+          const errorLabel = this.#workerExtendedLabel(id, index, worker[kConfig].workers)
 
-        let health = null
-        try {
-          health = await this.getWorkerHealth(worker, {
-            previousELU: worker[kLastHealthCheckELU]
+          let health = null
+          try {
+            health = await this.getWorkerHealth(worker, {
+              previousELU: worker[kLastHealthCheckELU]
+            })
+          } catch (err) {
+            this.logger.error({ err }, `Failed to get health for ${errorLabel}.`)
+          } finally {
+            worker[kLastHealthCheckELU] = health?.currentELU ?? null
+          }
+
+          const healthSignals = worker[kWorkerHealthSignals]?.getAll() ?? []
+
+          // We use emit instead of emitAndNotify to avoid sending a postMessages
+          // to each workers even if they are not interested in health metrics.
+          // No one of the known capabilities use this event yet.
+          this.emit('application:worker:health:metrics', {
+            id: worker[kId],
+            application: id,
+            worker: index,
+            currentHealth: health,
+            healthSignals
           })
-        } catch (err) {
-          this.logger.error({ err }, `Failed to get health for ${errorLabel}.`)
-        } finally {
-          worker[kLastHealthCheckELU] = health?.currentELU ?? null
-        }
-
-        const healthSignals = worker[kWorkerHealthSignals]?.getAll() ?? []
-
-        // We use emit instead of emitAndNotify to avoid sending a postMessages
-        // to each workers even if they are not interested in health metrics.
-        // No one of the known capabilities use this event yet.
-        this.emit('application:worker:health:metrics', {
-          id: worker[kId],
-          application: id,
-          worker: index,
-          currentHealth: health,
-          healthSignals
-        })
+        })())
       }
+
+      await Promise.allSettled(pending)
 
       // Reschedule the next check. We are not using .refresh() because it's more
       // expensive (weird).
@@ -2109,53 +2115,45 @@ export class Runtime extends EventEmitter {
     worker[kHealthCheckTimer] = setTimeout(async () => {
       if (worker[kWorkerStatus] !== 'started') return
 
-      if (lastHealthMetrics) {
-        const health = lastHealthMetrics.currentHealth
-        const memoryUsage = health.heapUsed / maxHeapTotal
-        const unhealthy = health.elu > maxELU || memoryUsage > maxHeapUsed
+      // No health data received yet — reschedule and wait.
+      if (!lastHealthMetrics) {
+        worker[kHealthCheckTimer].refresh()
+        return
+      }
+
+      const health = lastHealthMetrics.currentHealth
+
+      // When health collection failed (threw) or timed out, currentHealth is
+      // null.  Treat this as an unhealthy check so that a stuck worker that
+      // cannot even report its own health is eventually replaced.
+      if (!health) {
+        unhealthyChecks++
+
+        this.logger.error(
+          `Health collection failed for the ${errorLabel}. ` +
+            `Unhealthy check ${unhealthyChecks}/${maxUnhealthyChecks}.`
+        )
 
         this.emit('application:worker:health', {
           id: worker[kId],
           application: id,
           worker: index,
-          currentHealth: health,
-          unhealthy,
+          currentHealth: null,
+          unhealthy: true,
           healthConfig
         })
-
-        if (health.elu > maxELU) {
-          this.logger.error(
-            `The ${errorLabel} has an ELU of ${(health.elu * 100).toFixed(2)} %, ` +
-              `above the maximum allowed usage of ${(maxELU * 100).toFixed(2)} %.`
-          )
-        }
-
-        if (memoryUsage > maxHeapUsed) {
-          this.logger.error(
-            `The ${errorLabel} is using ${(memoryUsage * 100).toFixed(2)} % of the memory, ` +
-              `above the maximum allowed usage of ${(maxHeapUsed * 100).toFixed(2)} %.`
-          )
-        }
-
-        if (unhealthy) {
-          unhealthyChecks++
-        } else {
-          unhealthyChecks = 0
-        }
 
         if (unhealthyChecks === maxUnhealthyChecks) {
           try {
             this.emitAndNotify('application:worker:unhealthy', { application: id, worker: index })
 
             this.logger.error(
-              { elu: health.elu, maxELU, memoryUsage: health.heapUsed, maxMemoryUsage: maxHeapUsed },
-              `The ${errorLabel} is unhealthy. Replacing it ...`
+              `The ${errorLabel} is unhealthy (health collection failed). Replacing it ...`
             )
 
             await this.#replaceWorker(config, applicationConfig, workersCount, id, index, worker)
           } catch (e) {
             this.logger.error(
-              { elu: health.elu, maxELU, memoryUsage: health.heapUsed, maxMemoryUsage: maxHeapUsed },
               `Cannot replace the ${errorLabel}. Forcefully terminating it ...`
             )
 
@@ -2164,6 +2162,61 @@ export class Runtime extends EventEmitter {
         } else {
           worker[kHealthCheckTimer].refresh()
         }
+        return
+      }
+
+      const memoryUsage = health.heapUsed != null ? health.heapUsed / maxHeapTotal : 0
+      const unhealthy = health.elu > maxELU || memoryUsage > maxHeapUsed
+
+      this.emit('application:worker:health', {
+        id: worker[kId],
+        application: id,
+        worker: index,
+        currentHealth: health,
+        unhealthy,
+        healthConfig
+      })
+
+      if (health.elu > maxELU) {
+        this.logger.error(
+          `The ${errorLabel} has an ELU of ${(health.elu * 100).toFixed(2)} %, ` +
+            `above the maximum allowed usage of ${(maxELU * 100).toFixed(2)} %.`
+        )
+      }
+
+      if (memoryUsage > maxHeapUsed) {
+        this.logger.error(
+          `The ${errorLabel} is using ${(memoryUsage * 100).toFixed(2)} % of the memory, ` +
+            `above the maximum allowed usage of ${(maxHeapUsed * 100).toFixed(2)} %.`
+        )
+      }
+
+      if (unhealthy) {
+        unhealthyChecks++
+      } else {
+        unhealthyChecks = 0
+      }
+
+      if (unhealthyChecks === maxUnhealthyChecks) {
+        try {
+          this.emitAndNotify('application:worker:unhealthy', { application: id, worker: index })
+
+          this.logger.error(
+            { elu: health.elu, maxELU, memoryUsage: health.heapUsed, maxMemoryUsage: maxHeapUsed },
+            `The ${errorLabel} is unhealthy. Replacing it ...`
+          )
+
+          await this.#replaceWorker(config, applicationConfig, workersCount, id, index, worker)
+        } catch (e) {
+          this.logger.error(
+            { elu: health.elu, maxELU, memoryUsage: health.heapUsed, maxMemoryUsage: maxHeapUsed },
+            `Cannot replace the ${errorLabel}. Forcefully terminating it ...`
+          )
+
+          worker.terminate()
+        }
+      } else {
+        worker[kHealthCheckTimer].refresh()
       }
     }, interval).unref()
   }

--- a/packages/runtime/test/health-thread-worker.test.js
+++ b/packages/runtime/test/health-thread-worker.test.js
@@ -2,7 +2,8 @@ import { ok, strictEqual } from 'node:assert'
 import { once } from 'node:events'
 import { join } from 'node:path'
 import { test } from 'node:test'
-import { kIsSubprocessHost } from '../lib/worker/symbols.js'
+import { transform } from '../index.js'
+import { kApplicationId, kIsSubprocessHost } from '../lib/worker/symbols.js'
 import { createRuntime } from './helpers.js'
 
 const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
@@ -93,5 +94,102 @@ test(
       samplesDuringBlock >= 2,
       `expected multiple entrypoint health samples during the ${blockMs}ms block, got ${samplesDuringBlock}`
     )
+  }
+)
+
+test(
+  'health collection collects from multiple workers in parallel',
+  { skip: isWindows && 'Skipping on Windows' },
+  async t => {
+    const configFile = join(fixturesDir, 'child-process-health', 'platformatic.json')
+
+    const app = await createRuntime(configFile)
+
+    t.after(async () => {
+      await app.close()
+    })
+
+    await app.start()
+
+    // Block the entrypoint worker for 3s.  Because collection is parallel,
+    // the subprocess worker's health metrics should still arrive within the
+    // normal 1-second cadence — not delayed until the block ends.
+    const blockMs = 3000
+    const blockPromise = app.inject('entrypoint', { method: 'GET', url: `/block/${blockMs}` })
+
+    const startedAt = Date.now()
+    let subprocessSampleDuringBlock = false
+    while (Date.now() - startedAt < blockMs - 500) {
+      const [m] = await once(app, 'application:worker:health:metrics')
+      if (m.application === 'subprocess' && m.currentHealth) {
+        subprocessSampleDuringBlock = true
+        break
+      }
+    }
+
+    await blockPromise
+
+    ok(
+      subprocessSampleDuringBlock,
+      'subprocess health metrics should arrive while entrypoint is blocked (parallel collection)'
+    )
+  }
+)
+
+test(
+  'worker is replaced when health collection consistently fails',
+  { skip: isWindows && 'Skipping on Windows', timeout: 30_000 },
+  async t => {
+    const configFile = join(fixturesDir, 'child-process-health', 'platformatic.json')
+
+    const app = await createRuntime(configFile, undefined, {
+      async transform (config, ...args) {
+        config = await transform(config, ...args)
+        // Aggressive health check settings so the test completes quickly.
+        config.health = {
+          ...config.health,
+          enabled: true,
+          gracePeriod: 100,
+          interval: 1000,
+          maxUnhealthyChecks: 2,
+          maxELU: 0.95,
+          maxHeapUsed: 0.95,
+          maxHeapTotal: '512MB'
+        }
+        return config
+      }
+    })
+
+    t.after(async () => {
+      await app.close()
+    })
+
+    await app.start()
+
+    // Wait until we get at least one healthy metric from the entrypoint so
+    // the health check timer has been set up and is running.
+    while (true) {
+      const [m] = await once(app, 'application:worker:health:metrics')
+      if (m.application === 'entrypoint' && m.currentHealth) break
+    }
+
+    // Override getWorkerHealth to throw for the entrypoint worker, simulating
+    // a stuck worker whose health cannot be collected.
+    const originalGetWorkerHealth = app.getWorkerHealth.bind(app)
+    app.getWorkerHealth = function (worker, options) {
+      if (worker[kApplicationId] === 'entrypoint') {
+        throw new Error('simulated health collection failure')
+      }
+      return originalGetWorkerHealth(worker, options)
+    }
+
+    // The health check timer should count null-health results as unhealthy.
+    // After maxUnhealthyChecks (2) consecutive failures it should replace
+    // the worker, emitting 'application:worker:unhealthy'.
+    const [unhealthyEvent] = await once(app, 'application:worker:unhealthy')
+    strictEqual(unhealthyEvent.application, 'entrypoint')
+
+    // Restore so the replacement worker can be health-checked normally.
+    app.getWorkerHealth = originalGetWorkerHealth
   }
 )


### PR DESCRIPTION
## Summary

Follow-up to #4748 — addresses two remaining issues in the runtime health system:

- **Parallel health collection**: The metrics loop previously iterated workers sequentially with `await`, so a single slow ITC round-trip (e.g. a 5s subprocess timeout) blocked health collection for every other worker. Now uses `Promise.allSettled` so each worker's health is collected independently.

- **Respawn on health collection failure**: When `getWorkerHealth` threw (e.g. worker exits mid-collection), `currentHealth` was `null` in the emitted event. The health check timer then crashed on `null.heapUsed` (TypeError), silently killing the timer and preventing the worker from ever being replaced. Now null health counts toward `unhealthyChecks` and triggers the normal respawn cycle after `maxUnhealthyChecks` consecutive failures.

- **Null heapUsed guard**: Subprocess timeout returns `heapUsed: null`, which produced `NaN` in the memory usage calculation. Now explicitly treated as 0.

## Test plan

- [x] `node --test test/health-thread-worker.test.js` — 4 tests pass (2 existing + 2 new)
- [x] `node --test test/health-1.test.js` — 6 tests pass
- [x] `node --test test/health-2.test.js` — 1 test passes (worker replacement on threshold)
- [x] `node --test test/health-subprocess.test.js` — 3 tests pass
- [x] `node --test test/health-signals.test.js` — 3 tests pass

New tests:
- **Parallel collection**: blocks entrypoint worker for 3s, verifies subprocess worker health metrics still arrive within that window
- **Null-health respawn**: overrides `getWorkerHealth` to throw for a specific worker, verifies the `application:worker:unhealthy` event fires and the worker is replaced
