### PR TITLE
fix(db-authorization): harden role path traversal

### DIFF
--- a/packages/db-authorization/lib/utils.js
+++ b/packages/db-authorization/lib/utils.js
@@ -18,6 +18,10 @@ export function getRoles (request, roleKey, anonymousRole, isRolePath = false) {
     const roleKeys = roleKey.split('.')
     rolesRaw = user
     for (const key of roleKeys) {
+      if (rolesRaw === null || rolesRaw === undefined || typeof rolesRaw !== 'object') {
+        rolesRaw = undefined
+        break
+      }
       rolesRaw = rolesRaw[key]
     }
   } else {
@@ -25,9 +29,9 @@ export function getRoles (request, roleKey, anonymousRole, isRolePath = false) {
   }
 
   if (typeof rolesRaw === 'string') {
-    output = rolesRaw.split(',')
+    output = rolesRaw.split(',').map(role => role.trim()).filter(Boolean)
   } else if (Array.isArray(rolesRaw)) {
-    output = rolesRaw
+    output = rolesRaw.filter(role => typeof role === 'string').map(role => role.trim()).filter(Boolean)
   }
   if (output.length === 0) {
     output.push(anonymousRole)

--- a/packages/db-authorization/test/utils.test.js
+++ b/packages/db-authorization/test/utils.test.js
@@ -105,4 +105,28 @@ test('should get roles from user with path', t => {
     }
     deepEqual(getRoles(requestWithStringRoles, roleKey, ANONYMOUS_ROLE, isRolePath), ['role1', 'role2', 'role3'])
   }
+
+  {
+    // Malformed path should not throw and should fall back to anonymous
+    const roleKey = 'resource_access.rest-api.roles'
+    const requestWithMalformedPath = {
+      user: {
+        resource_access: null
+      }
+    }
+    deepEqual(getRoles(requestWithMalformedPath, roleKey, ANONYMOUS_ROLE, isRolePath), [ANONYMOUS_ROLE])
+  }
+
+  {
+    // Primitive intermediate value should not throw and should fall back to anonymous
+    const roleKey = 'resource_access.rest-api.roles'
+    const requestWithPrimitiveInPath = {
+      user: {
+        resource_access: {
+          'rest-api': 'admin'
+        }
+      }
+    }
+    deepEqual(getRoles(requestWithPrimitiveInPath, roleKey, ANONYMOUS_ROLE, isRolePath), [ANONYMOUS_ROLE])
+  }
 })


### PR DESCRIPTION
## Summary

Harden `rolePath` traversal in `getRoles` so malformed `request.user` payloads fall back to the anonymous role instead of throwing.

## Changes

- guard nested `rolePath` traversal when an intermediate value is `null`, `undefined`, or a primitive
- normalize extracted role strings by trimming and dropping empty values
- add regression coverage for malformed and primitive intermediate path segments

## Testing

- `cd packages/db-authorization && npm test`

Supersedes #4722.
