### PR TITLE
fix: revert dependencies moved from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "generate-errors-doc": "node ./scripts/generate-errors-doc.js",
     "global-links": "cd packages/cli && pnpm link --global && cd ../wattpm && pnpm link --global && cd ../create-wattpm && pnpm link --global"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.33.2",
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "markdownlint-cli2": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "generate-errors-doc": "node ./scripts/generate-errors-doc.js",
     "global-links": "cd packages/cli && pnpm link --global && cd ../wattpm && pnpm link --global && cd ../create-wattpm && pnpm link --global"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@9.15.9",
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "markdownlint-cli2": "^0.18.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,6 @@
     "c8": "^10.0.0",
     "cleaner-spec-reporter": "^0.5.0",
     "eslint": "9",
-    "execa": "^9.0.0",
     "license-checker": "^25.0.1",
     "neostandard": "^0.12.0",
     "typescript": "^5.5.3"

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -24,7 +24,6 @@
     "@fastify/deepmerge": "^2.0.0",
     "@fastify/error": "^4.0.0",
     "@iarna/toml": "^2.2.5",
-    "@types/debug": "^4.1.12",
     "@watchable/unpromise": "^1.0.2",
     "ajv": "^8.12.0",
     "boring-name-generator": "^1.0.3",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/platformatic/platformatic#readme",
   "devDependencies": {
     "@fastify/aws-lambda": "^5.0.0",
+    "@fastify/compress": "^8.0.0",
     "bindings": "^1.5.0",
     "cleaner-spec-reporter": "^0.5.0",
     "eslint": "9",
@@ -43,7 +44,6 @@
   "dependencies": {
     "@fastify/accepts": "^5.0.0",
     "@fastify/autoload": "^6.0.0",
-    "@fastify/compress": "^8.0.0",
     "@fastify/cors": "^10.0.0",
     "@fastify/deepmerge": "^2.0.0",
     "@fastify/error": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,9 +167,6 @@ importers:
       eslint:
         specifier: '9'
         version: 9.39.4(jiti@2.6.1)
-      execa:
-        specifier: ^9.0.0
-        version: 9.6.1
       license-checker:
         specifier: ^25.0.1
         version: 25.0.1
@@ -657,9 +654,6 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.12
       '@watchable/unpromise':
         specifier: ^1.0.2
         version: 1.0.2
@@ -1572,9 +1566,6 @@ importers:
       '@fastify/autoload':
         specifier: ^6.0.0
         version: 6.3.1
-      '@fastify/compress':
-        specifier: ^8.0.0
-        version: 8.3.1
       '@fastify/cors':
         specifier: ^10.0.0
         version: 10.1.0
@@ -1690,6 +1681,9 @@ importers:
       '@fastify/aws-lambda':
         specifier: ^5.0.0
         version: 5.1.4
+      '@fastify/compress':
+        specifier: ^8.0.0
+        version: 8.3.1
       bindings:
         specifier: ^1.5.0
         version: 1.5.0


### PR DESCRIPTION
Restore packages to devDependencies where they belong:

- **sql-openapi**: ajv, fast-json-stringify, fast-uri, secure-json-parse
- **service**: @fastify/compress
- **cli**: execa
- **foundation**: @types/debug