### PR TITLE
feat(telemetry): add OpenTelemetry diag logger support

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -260,6 +260,7 @@ The object supports the following settings:
   - **`options`** (`object`) — These options are supported:
     - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.
     - **`headers`** (`object`) — Optional headers to send with the telemetry. This has no effect on `console` and `memory` exporters.
+- **`diagLogger`** (`boolean`) — Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
 
 ### `basePath`
 
@@ -274,6 +275,7 @@ OTLP traces can be consumed by different solutions, like [Jaeger](https://www.ja
 {
   "telemetry": {
     "applicationName": "test-application",
+    "diagLogger": true,
     "exporter": {
       "type": "otlp",
       "options": {

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -244,6 +244,7 @@ Configure `@platformatic/service` specific settings such as `graphql` or `openap
   - **`options`** (`object`) — These options are supported:
     - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.
     - **`headers`** (`object`) — Optional headers to send with the telemetry. This has no effect on `console` and `memory` exporters.
+- **`diagLogger`** (`boolean`) — Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
 
 Note that OTLP traces can be consumed by different solutions, like [Jaeger](https://www.jaegertracing.io/). [Here](https://opentelemetry.io/ecosystem/vendors/) the full list.
 
@@ -253,6 +254,7 @@ _Example_
 {
   "telemetry": {
     "applicationName": "test-application",
+    "diagLogger": true,
     "exporter": {
       "type": "otlp",
       "options": {

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticAstroConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -398,6 +398,10 @@ export interface PlatformaticBasicConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -1525,6 +1525,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -566,6 +566,10 @@ export interface PlatformaticComposerConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;
@@ -603,6 +607,7 @@ export interface PlatformaticComposerConfig {
     env?: {
       [k: string]: string;
     };
+    envfile?: string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {
@@ -790,6 +795,10 @@ export interface PlatformaticComposerConfig {
           additionalProperties?: never;
           [k: string]: unknown;
         };
+    /**
+     * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+     */
+    diagLogger?: boolean;
   };
   watch?:
     | {
@@ -891,6 +900,8 @@ export interface PlatformaticComposerConfig {
             routes?: string[];
             upstream?: string;
             prefix?: string;
+            rewritePrefix?: string;
+            rewriteLocationHeader?: boolean;
             hostname?: string;
             custom?: {
               path: string;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -2198,6 +2198,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [
@@ -2868,6 +2872,10 @@
               }
             }
           ]
+        },
+        "diagLogger": {
+          "type": "boolean",
+          "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
       "required": [

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -481,6 +481,10 @@ export interface PlatformaticDatabaseConfig {
           additionalProperties?: never;
           [k: string]: unknown;
         };
+    /**
+     * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+     */
+    diagLogger?: boolean;
   };
   runtime?: {
     preload?: string | string[];
@@ -872,6 +876,10 @@ export interface PlatformaticDatabaseConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1317,6 +1317,10 @@
               }
             }
           ]
+        },
+        "diagLogger": {
+          "type": "boolean",
+          "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
       "required": [
@@ -2839,6 +2843,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -702,6 +702,10 @@ export const telemetry = {
         },
         openTelemetryExporter
       ]
+    },
+    diagLogger: {
+      type: 'boolean',
+      description: 'Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.'
     }
   },
   required: ['applicationName'],

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -783,6 +783,10 @@ export interface PlatformaticGatewayConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;
@@ -1008,6 +1012,10 @@ export interface PlatformaticGatewayConfig {
           additionalProperties?: never;
           [k: string]: unknown;
         };
+    /**
+     * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+     */
+    diagLogger?: boolean;
   };
   watch?:
     | {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -2836,6 +2836,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [
@@ -3506,6 +3510,10 @@
               }
             }
           ]
+        },
+        "diagLogger": {
+          "type": "boolean",
+          "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
       "required": [

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticNestJSConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticNextJsConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticNodeJsConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticReactRouterConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticRemixConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -493,6 +493,10 @@ export type PlatformaticRuntimeConfig = {
           additionalProperties?: never;
           [k: string]: unknown;
         };
+    /**
+     * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+     */
+    diagLogger?: boolean;
   };
   verticalScaler?: {
     enabled?: boolean;

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -2595,6 +2595,10 @@
               }
             }
           ]
+        },
+        "diagLogger": {
+          "type": "boolean",
+          "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
       "required": [

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -243,6 +243,10 @@ export interface PlatformaticServiceConfig {
           additionalProperties?: never;
           [k: string]: unknown;
         };
+    /**
+     * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+     */
+    diagLogger?: boolean;
   };
   watch?:
     | {
@@ -701,6 +705,10 @@ export interface PlatformaticServiceConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -784,6 +784,10 @@
               }
             }
           ]
+        },
+        "diagLogger": {
+          "type": "boolean",
+          "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
       "required": [
@@ -2524,6 +2528,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticTanStackConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/telemetry/lib/diag-logger.js
+++ b/packages/telemetry/lib/diag-logger.js
@@ -1,0 +1,67 @@
+import { diag, DiagLogLevel } from '@opentelemetry/api'
+import util from 'node:util'
+
+const pinoToDiagLogLevels = {
+  silent: DiagLogLevel.NONE,
+  fatal: DiagLogLevel.ERROR,
+  error: DiagLogLevel.ERROR,
+  warn: DiagLogLevel.WARN,
+  info: DiagLogLevel.INFO,
+  debug: DiagLogLevel.DEBUG,
+  trace: DiagLogLevel.VERBOSE
+}
+
+function getDiagLogLevel (logger) {
+  const logLevel = logger?.level
+
+  if (typeof logLevel === 'string') {
+    return pinoToDiagLogLevels[logLevel] ?? DiagLogLevel.INFO
+  }
+
+  return DiagLogLevel.INFO
+}
+
+function callLogger (logger, method, fallback, args) {
+  if (typeof logger?.[method] === 'function') {
+    if (typeof args[0] === 'string') {
+      logger[method](util.format(...args))
+    } else {
+      logger[method](...args)
+    }
+
+    return
+  }
+
+  fallback(...args)
+}
+
+export function createPlatformaticDiagLogger (logger = globalThis.platformatic?.logger) {
+  let target = logger
+
+  if (typeof target?.child === 'function') {
+    try {
+      target = target.child({ name: '@platformatic/telemetry/diag' })
+    } catch {
+      // Ignore child logger creation failures and use the parent logger.
+    }
+  }
+
+  return {
+    error: (...args) => callLogger(target, 'error', console.error.bind(console), args),
+    warn: (...args) => callLogger(target, 'warn', console.warn.bind(console), args),
+    info: (...args) => callLogger(target, 'info', console.info.bind(console), args),
+    debug: (...args) => callLogger(target, 'debug', console.debug.bind(console), args),
+    verbose: (...args) => callLogger(target, 'trace', console.debug.bind(console), args)
+  }
+}
+
+export function setupDiagLogger (opts, logger = globalThis.platformatic?.logger) {
+  if (opts?.diagLogger !== true) {
+    return false
+  }
+
+  return diag.setLogger(createPlatformaticDiagLogger(logger), {
+    logLevel: getDiagLogLevel(logger),
+    suppressOverrideMessage: true
+  })
+}

--- a/packages/telemetry/lib/node-telemetry.js
+++ b/packages/telemetry/lib/node-telemetry.js
@@ -10,6 +10,7 @@ import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { readFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { setupDiagLogger } from './diag-logger.js'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import util from 'node:util'
@@ -35,6 +36,8 @@ contextManager.enable()
 context.setGlobalContextManager(contextManager)
 
 const setupNodeHTTPTelemetry = async (opts, applicationDir) => {
+  setupDiagLogger(opts)
+
   const { applicationName, instrumentations = [] } = opts
   const additionalInstrumentations = await getInstrumentations(instrumentations, applicationDir)
 

--- a/packages/telemetry/lib/telemetry-config.js
+++ b/packages/telemetry/lib/telemetry-config.js
@@ -4,6 +4,7 @@ import { resourceFromAttributes } from '@opentelemetry/resources'
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 import fastUri from 'fast-uri'
 import { fastifyTextMapGetter, fastifyTextMapSetter } from './fastify-text-map.js'
+import { setupDiagLogger } from './diag-logger.js'
 import { PlatformaticContext } from './platformatic-context.js'
 import { PlatformaticTracerProvider } from './platformatic-trace-provider.js'
 import { getSpanProcessors } from './span-processors.js'
@@ -89,6 +90,8 @@ const initTelemetry = (opts, logger) => {
 }
 
 export function setupTelemetry (opts, logger) {
+  setupDiagLogger(opts, logger)
+
   const openTelemetryAPIs = initTelemetry(opts, logger)
   const { tracer, propagator, provider } = openTelemetryAPIs
   const skipOperations =

--- a/packages/telemetry/test/diag-logger.test.js
+++ b/packages/telemetry/test/diag-logger.test.js
@@ -1,0 +1,108 @@
+import { diag } from '@opentelemetry/api'
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { Writable } from 'node:stream'
+import { test } from 'node:test'
+import pino from 'pino'
+import { createPlatformaticDiagLogger, setupDiagLogger } from '../lib/diag-logger.js'
+
+test('createPlatformaticDiagLogger forwards OpenTelemetry diagnostic logs to the platformatic logger', t => {
+  const calls = []
+  const logger = {
+    child (bindings) {
+      calls.push(['child', bindings])
+      return this
+    },
+    error (...args) {
+      calls.push(['error', args])
+    },
+    warn (...args) {
+      calls.push(['warn', args])
+    },
+    info (...args) {
+      calls.push(['info', args])
+    },
+    debug (...args) {
+      calls.push(['debug', args])
+    },
+    trace (...args) {
+      calls.push(['trace', args])
+    }
+  }
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.error('error message')
+  diagLogger.warn('warn message')
+  diagLogger.info('info message')
+  diagLogger.debug('debug message')
+  diagLogger.verbose('verbose message')
+
+  deepStrictEqual(calls, [
+    ['child', { name: '@platformatic/telemetry/diag' }],
+    ['error', ['error message']],
+    ['warn', ['warn message']],
+    ['info', ['info message']],
+    ['debug', ['debug message']],
+    ['trace', ['verbose message']]
+  ])
+
+  t.after(() => diag.disable())
+})
+
+test('setupDiagLogger configures the OpenTelemetry diagnostic logger using the platformatic logger level', t => {
+  const calls = []
+  const logger = {
+    level: 'debug',
+    child () {
+      return this
+    },
+    error (...args) {
+      calls.push(['error', args])
+    },
+    warn (...args) {
+      calls.push(['warn', args])
+    },
+    info (...args) {
+      calls.push(['info', args])
+    },
+    debug (...args) {
+      calls.push(['debug', args])
+    },
+    trace (...args) {
+      calls.push(['trace', args])
+    }
+  }
+
+  const configured = setupDiagLogger({ diagLogger: true }, logger)
+  strictEqual(configured, true)
+
+  diag.debug('debug message')
+  diag.info('info message')
+
+  strictEqual(calls[0][0], 'debug')
+  strictEqual(calls[0][1][0].startsWith('@opentelemetry/api: Registered a global for diag v1.9.'), true)
+  deepStrictEqual(calls.slice(1), [
+    ['debug', ['debug message']],
+    ['info', ['info message']]
+  ])
+
+  t.after(() => diag.disable())
+})
+
+test('createPlatformaticDiagLogger preserves additional OpenTelemetry diagnostic arguments with pino', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.warn('first', 'second', 42)
+  diagLogger.debug('caught hook error: ', new Error('boom'))
+
+  strictEqual(lines[0].msg, 'first second 42')
+  strictEqual(lines[1].msg.includes('caught hook error:'), true)
+  strictEqual(lines[1].msg.includes('Error: boom'), true)
+})

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -514,6 +514,10 @@ export interface PlatformaticViteConfig {
             additionalProperties?: never;
             [k: string]: unknown;
           };
+      /**
+       * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+       */
+      diagLogger?: boolean;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -1916,6 +1916,10 @@
                   }
                 }
               ]
+            },
+            "diagLogger": {
+              "type": "boolean",
+              "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
           "required": [

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -493,6 +493,10 @@ export type PlatformaticRuntimeConfig = {
           additionalProperties?: never;
           [k: string]: unknown;
         };
+    /**
+     * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
+     */
+    diagLogger?: boolean;
   };
   verticalScaler?: {
     enabled?: boolean;

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -2595,6 +2595,10 @@
               }
             }
           ]
+        },
+        "diagLogger": {
+          "type": "boolean",
+          "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
       "required": [


### PR DESCRIPTION
## Summary
- add `telemetry.diagLogger` as a boolean config option
- route OpenTelemetry diagnostic logs to the Platformatic global logger in both runtime and Fastify telemetry setup
- map OpenTelemetry diagnostic verbosity from the current Pino logger level and document the new config
- add coverage for the diag logger bridge and regenerate schemas/types

## Testing
- `pnpm run gen-schema`
- `pnpm run gen-types`
- `pnpm --filter @platformatic/telemetry test`

## Notes
- `packages/telemetry/test/pg.test.js` still requires PostgreSQL and fails locally without it
- `packages/telemetry/test/runtimes.test.js` still has the pre-existing ESM express instrumentation failure
