### PR TITLE
feat(next): add standalone pack command

### DIFF
--- a/docs/guides/deployment/nextjs-in-k8s.md
+++ b/docs/guides/deployment/nextjs-in-k8s.md
@@ -276,6 +276,8 @@ Here's an example of a minimal `package.json` for a Next.js standalone app:
 }
 ```
 
+This is a standard Next.js package.json - no Watt dependencies needed. The `wattpm` and `@platformatic/next` packages are installed only in the Docker production image.
+
 And a minimal `watt.json`:
 
 ```json
@@ -293,7 +295,7 @@ And a minimal `watt.json`:
 }
 ```
 
-The only required configuration change is `next.standalone: true` in `watt.json`.
+The only required change is to insert `standalone: true` in the `next` section.
 
 #### Why use Watt with standalone instead of raw Next.js standalone?
 
@@ -304,7 +306,72 @@ While Next.js standalone mode produces a minimal `server.js` that can run indepe
 - Health check endpoints
 - Unified logging and observability
 
-#### Preferred deployment flow: pack a self-contained bundle
+The trade-off is a slightly larger Docker image since Watt and its dependencies (`@platformatic/*` packages) must be included alongside the standalone build.
+
+#### Dockerfile for Standalone Mode
+
+Next.js standalone mode uses [@vercel/nft](https://github.com/vercel/nft) to trace dependencies and only includes packages that are actually imported by your application code.
+
+The `.next/static` folder and `public` folder must be copied manually if needed.
+
+```Dockerfile
+# Stage 1: Build
+FROM node:24-slim AS builder
+
+WORKDIR /app
+COPY ./ ./
+RUN npm install && npm run build
+
+# Stage 2: Production
+FROM node:24-slim
+
+WORKDIR /app
+
+# Copy the necessary files from the builder stage
+COPY --from=builder /app/.next/standalone .
+COPY --from=builder /app/watt.json ./watt.json
+COPY --from=builder /app/.next/static .next/static
+# Remove or comment out the following if you don't have a public folder
+COPY --from=builder /app/public ./public
+
+# Install Watt and Platformatic Next with a specific version
+ARG PLT_VERSION=3.33.0
+RUN npm install -g wattpm@${PLT_VERSION} @platformatic/next@${PLT_VERSION}
+
+ENV PLT_SERVER_HOSTNAME=0.0.0.0
+ENV PORT=3042
+EXPOSE 3042
+CMD ["wattpm", "start"]
+```
+
+**Important**: You must specify the Platformatic version (`PLT_VERSION`) in the Dockerfile. Both `wattpm` and `@platformatic/next` must use the same version. Update the default value in the `ARG` line, or override it at build time:
+
+```bash
+docker build --build-arg PLT_VERSION=3.30.0 -t my-next-app .
+```
+
+#### Alternative: keep Watt in `package.json`
+
+If you prefer to manage the runtime version through normal package-manager tooling, add `wattpm` and `@platformatic/next` to your app dependencies and start the local binary from the final image.
+
+Example production stage:
+
+```Dockerfile
+FROM node:24-slim
+
+WORKDIR /app
+COPY ./ ./
+RUN npm install && npm run build
+
+ENV PLT_SERVER_HOSTNAME=0.0.0.0
+ENV PORT=3042
+EXPOSE 3042
+CMD ["./node_modules/.bin/wattpm", "start"]
+```
+
+This keeps the Platformatic version in `package.json`, where tools such as Dependabot or Renovate can manage it.
+
+#### Alternative: pack a self-contained bundle
 
 Use the Next-specific application command exposed by Watt to create a deployable bundle that already includes the runtime pieces Watt needs.
 
@@ -327,7 +394,7 @@ The packed bundle contains:
 
 That means the production image only needs to copy the bundle and start it.
 
-#### Dockerfile for the packed bundle
+Example Dockerfile:
 
 ```Dockerfile
 # Stage 1: Build and pack
@@ -355,16 +422,25 @@ This flow has two advantages over installing Watt in the production image:
 - the final image does not run `npm install`
 - the Dockerfile does not need to hardcode a Platformatic version
 
-#### Verifying standalone packing
+#### Verifying Standalone Mode
 
-After packing, verify that the bundle contains the expected files:
+After building, verify that standalone mode is working:
+
+```bash
+# Check that .next/standalone exists
+ls -la .next/standalone/
+
+# The directory should contain server.js and minimal dependencies
+```
+
+If you are using the packed-bundle flow, you can also verify the packed output directly:
 
 ```bash
 ls -la .platformatic/next-bundle/
 ls -la .platformatic/next-bundle/node_modules/.bin/wattpm
 ```
 
-When Watt starts from the packed bundle, it automatically detects and uses the standalone server internally while keeping the Watt runtime features available.
+When Watt starts with a standalone build, it automatically detects and uses the standalone server internally while providing all the Watt runtime features.
 
 ### Building the image
 

--- a/docs/guides/deployment/nextjs-in-k8s.md
+++ b/docs/guides/deployment/nextjs-in-k8s.md
@@ -276,8 +276,6 @@ Here's an example of a minimal `package.json` for a Next.js standalone app:
 }
 ```
 
-This is a standard Next.js package.json - no Watt dependencies needed. The `wattpm` and `@platformatic/next` packages are installed only in the Docker production image.
-
 And a minimal `watt.json`:
 
 ```json
@@ -295,7 +293,7 @@ And a minimal `watt.json`:
 }
 ```
 
-The only required change is to insert `standalone: true` in the `next` section.
+The only required configuration change is `next.standalone: true` in `watt.json`.
 
 #### Why use Watt with standalone instead of raw Next.js standalone?
 
@@ -306,62 +304,67 @@ While Next.js standalone mode produces a minimal `server.js` that can run indepe
 - Health check endpoints
 - Unified logging and observability
 
-The trade-off is a slightly larger Docker image since Watt and its dependencies (`@platformatic/*` packages) must be included alongside the standalone build.
+#### Preferred deployment flow: pack a self-contained bundle
 
-#### Dockerfile for Standalone Mode
+Use the Next-specific application command exposed by Watt to create a deployable bundle that already includes the runtime pieces Watt needs.
 
-Next.js standalone mode uses [@vercel/nft](https://github.com/vercel/nft) to trace dependencies and only includes packages that are actually imported by your application code.
+From the project root:
 
-The `.next/static` folder and `public` folder must be copied manually if needed.
+```bash
+npx wattpm build
+npx wattpm help
+npx wattpm <app-id>:pack --output .platformatic/next-bundle
+```
+
+Use the application command shown under **Applications Commands** in `wattpm help`. For a single imported app, the application id usually comes from `package.json`.
+
+The packed bundle contains:
+- the Next standalone output
+- `.next/static`
+- `public/` when present
+- a bundle-local `watt.json`
+- a bundle-local `./node_modules/.bin/wattpm`
+
+That means the production image only needs to copy the bundle and start it.
+
+#### Dockerfile for the packed bundle
 
 ```Dockerfile
-# Stage 1: Build
+# Stage 1: Build and pack
 FROM node:24-slim AS builder
 
 WORKDIR /app
 COPY ./ ./
-RUN npm install && npm run build
+RUN npm install
+RUN npx wattpm build
+RUN npx wattpm my-next-app:pack --output .platformatic/next-bundle
 
 # Stage 2: Production
 FROM node:24-slim
 
 WORKDIR /app
-
-# Copy the necessary files from the builder stage
-COPY --from=builder /app/.next/standalone .
-COPY --from=builder /app/watt.json ./watt.json
-COPY --from=builder /app/.next/static .next/static
-# Remove or comment out the following if you don't have a public folder
-COPY --from=builder /app/public ./public
-
-# Install Watt and Platformatic Next with a specific version
-ARG PLT_VERSION=3.33.0
-RUN npm install -g wattpm@${PLT_VERSION} @platformatic/next@${PLT_VERSION}
+COPY --from=builder /app/.platformatic/next-bundle/ ./
 
 ENV PLT_SERVER_HOSTNAME=0.0.0.0
 ENV PORT=3042
 EXPOSE 3042
-CMD ["wattpm", "start"]
+CMD ["./node_modules/.bin/wattpm", "start"]
 ```
 
-**Important**: You must specify the Platformatic version (`PLT_VERSION`) in the Dockerfile. Both `wattpm` and `@platformatic/next` must use the same version. Update the default value in the `ARG` line, or override it at build time:
+This flow has two advantages over installing Watt in the production image:
+- the final image does not run `npm install`
+- the Dockerfile does not need to hardcode a Platformatic version
+
+#### Verifying standalone packing
+
+After packing, verify that the bundle contains the expected files:
 
 ```bash
-docker build --build-arg PLT_VERSION=3.30.0 -t my-next-app .
+ls -la .platformatic/next-bundle/
+ls -la .platformatic/next-bundle/node_modules/.bin/wattpm
 ```
 
-#### Verifying Standalone Mode
-
-After building, verify that standalone mode is working:
-
-```bash
-# Check that .next/standalone exists
-ls -la .next/standalone/
-
-# The directory should contain server.js and minimal dependencies
-```
-
-When Watt starts with a standalone build, it automatically detects and uses the standalone server internally while providing all the Watt runtime features.
+When Watt starts from the packed bundle, it automatically detects and uses the standalone server internally while keeping the Watt runtime features available.
 
 ### Building the image
 

--- a/docs/guides/deployment/nextjs-in-k8s.md
+++ b/docs/guides/deployment/nextjs-in-k8s.md
@@ -379,11 +379,10 @@ From the project root:
 
 ```bash
 npx wattpm build
-npx wattpm help
 npx wattpm <app-id>:pack --output .platformatic/next-bundle
 ```
 
-Use the application command shown under **Applications Commands** in `wattpm help`. For a single imported app, the application id usually comes from `package.json`.
+Replace `<app-id>` with your application id. For a single imported app, it usually comes from `package.json`.
 
 The packed bundle contains:
 - the Next standalone output

--- a/docs/reference/next/configuration.md
+++ b/docs/reference/next/configuration.md
@@ -88,7 +88,7 @@ Configures Next.js. Supported object properties:
   }
   ```
 
-- **`standalone`**: Set to `true` when using [Next.js standalone mode](https://nextjs.org/docs/pages/api-reference/config/next-config-js/output).
+- **`standalone`**: Set to `true` when using [Next.js standalone mode](https://nextjs.org/docs/pages/api-reference/config/next-config-js/output). This also enables the Next-specific application command used to pack a self-contained bundle for deployment. Run `wattpm help` in your project to see the available `<app-id>:pack` command.
 - **`https`**: Enables HTTPS in development mode when Platformatic starts Next.js with the default development command.
   - **`enabled`** (`boolean` or `string`): Enables Next.js experimental HTTPS.
   - **`key`**: Path (relative to the application root) to the HTTPS private key file.

--- a/docs/reference/wattpm/cli-commands.md
+++ b/docs/reference/wattpm/cli-commands.md
@@ -162,6 +162,47 @@ wattpm update
 wattpm update --force
 ```
 
+## Application Commands
+
+Some capabilities expose commands for a specific application. These commands are discovered from your project configuration and shown under **Applications Commands** in:
+
+```bash
+wattpm help
+```
+
+Examples include database migration commands such as `service-db:migrations:apply` and capability-specific commands such as Next standalone packing.
+
+### `wattpm <app-id>:pack`
+
+Creates a self-contained standalone bundle for a Next.js application.
+
+```bash
+wattpm <app-id>:pack
+```
+
+**Requirements:**
+
+- the target application must use `@platformatic/next`
+- Next.js must be configured with `output: "standalone"`
+- the Platformatic application config must set `next.standalone: true`
+
+**Options:**
+
+- `-o, --output <path>` - Output directory for the packed bundle
+- `--no-build` - Fail if the standalone build output is missing instead of building it first
+
+**Example:**
+
+```bash
+wattpm my-next-app:pack --output .platformatic/next-bundle
+```
+
+The resulting bundle is intended to be started with:
+
+```bash
+./node_modules/.bin/wattpm start
+```
+
 ## Application Management Commands
 
 These commands help you manage running Watt applications:

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -1,21 +1,8 @@
-import { transform as basicTransform, resolve, validationOptions } from '@platformatic/basic'
-import { kMetadata, loadConfiguration as utilsLoadConfiguration } from '@platformatic/foundation'
+import { kMetadata } from '@platformatic/foundation'
 import { resolve as resolvePath } from 'node:path'
 import { getCacheHandlerPath, NextCapability } from './lib/capability.js'
+import { loadConfiguration, transform } from './lib/config.js'
 import { NextImageOptimizerCapability } from './lib/image-optimizer.js'
-import { schema } from './lib/schema.js'
-
-/* c8 ignore next 9 */
-export async function transform (config, schema, options) {
-  config = await basicTransform(config, schema, options)
-  config.watch = { enabled: false }
-
-  if (config.cache?.adapter === 'redis') {
-    config.cache.adapter = 'valkey'
-  }
-
-  return config
-}
 
 export function getAdapterPath () {
   return resolvePath(import.meta.dirname, 'lib', 'adapter.js')
@@ -99,18 +86,6 @@ export async function enhanceNextConfig (nextConfig, ...args) {
   return nextConfig
 }
 
-export async function loadConfiguration (configOrRoot, sourceOrConfig, context) {
-  const { root, source } = await resolve(configOrRoot, sourceOrConfig, 'application')
-
-  return utilsLoadConfiguration(source, context?.schema ?? schema, {
-    validationOptions,
-    transform,
-    replaceEnv: true,
-    root,
-    ...context
-  })
-}
-
 export async function create (configOrRoot, sourceOrConfig, context) {
   const config = await loadConfiguration(configOrRoot, sourceOrConfig, context)
 
@@ -119,6 +94,8 @@ export async function create (configOrRoot, sourceOrConfig, context) {
 }
 
 export * from './lib/capability.js'
+export * from './lib/commands/index.js'
+export * from './lib/config.js'
 export * as errors from './lib/errors.js'
 export * from './lib/image-optimizer.js'
 export { packageJson, schema, schemaComponents, version } from './lib/schema.js'

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -1,7 +1,7 @@
 import { kMetadata } from '@platformatic/foundation'
 import { resolve as resolvePath } from 'node:path'
 import { getCacheHandlerPath, NextCapability } from './lib/capability.js'
-import { loadConfiguration, transform } from './lib/config.js'
+import { loadConfiguration } from './lib/config.js'
 import { NextImageOptimizerCapability } from './lib/image-optimizer.js'
 
 export function getAdapterPath () {

--- a/packages/next/lib/capability.js
+++ b/packages/next/lib/capability.js
@@ -15,7 +15,6 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve as resolvePath, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse, satisfies } from 'semver'
-import * as errors from './errors.js'
 import { version } from './schema.js'
 import { parseStandaloneNextConfig, requireStandaloneStartServer, resolveStandaloneEntrypoint } from './standalone.js'
 
@@ -521,5 +520,4 @@ export class NextCapability extends BaseCapability {
 
     return distDir
   }
-
 }

--- a/packages/next/lib/capability.js
+++ b/packages/next/lib/capability.js
@@ -11,14 +11,13 @@ import {
 } from '@platformatic/basic'
 import { ChildProcess } from 'node:child_process'
 import { once } from 'node:events'
-import { existsSync } from 'node:fs'
-import { glob, readFile, writeFile } from 'node:fs/promises'
-import { createRequire } from 'node:module'
+import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve as resolvePath, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse, satisfies } from 'semver'
 import * as errors from './errors.js'
 import { version } from './schema.js'
+import { parseStandaloneNextConfig, requireStandaloneStartServer, resolveStandaloneEntrypoint } from './standalone.js'
 
 export const supportedVersions = ['^14.0.0', '^15.0.0', '^16.0.0']
 
@@ -53,7 +52,7 @@ export class NextCapability extends BaseCapability {
     process.env.NEXT_IGNORE_INCORRECT_LOCKFILE = 'true'
 
     if (!building && this.isProduction && this.config.next?.standalone) {
-      this.#standaloneEntrypoint = await this.#resolveStandaloneEntrypoint()
+      this.#standaloneEntrypoint = await resolveStandaloneEntrypoint(this.root)
       this.#next = resolvePath(dirname(await resolvePackageViaCJS(this.#standaloneEntrypoint, 'next')), '../..')
     } else {
       this.#next = resolvePath(dirname(await resolvePackageViaCJS(this.root, 'next')), '../..')
@@ -382,14 +381,7 @@ export class NextCapability extends BaseCapability {
 
     // Parse the server.js to extract the nextConfig.
     // For now we use simple regex parsing, if it breaks, we can switch to proper AST parsing.
-    let nextConfig
-    try {
-      const serverJsContent = await readFile(this.#standaloneEntrypoint, 'utf-8')
-      const nextConfigMatch = serverJsContent.match(/(?:const|let)\s*nextConfig\s*=\s*(\{.+)/)
-      nextConfig = JSON.parse(nextConfigMatch[1])
-    } catch (e) {
-      throw new errors.CannotParseStandaloneServer({ cause: e })
-    }
+    const nextConfig = await parseStandaloneNextConfig(this.#standaloneEntrypoint)
 
     // Fix cache handlers path
     if (nextConfig.env?.PLT_NEXT_MODIFICATIONS) {
@@ -430,7 +422,7 @@ export class NextCapability extends BaseCapability {
 
       // This is needed by Next.js standalone server to pick up the correct configuration
       process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(nextConfig)
-      const { startServer } = this.#requireStandaloneEntrypoint(this.#standaloneEntrypoint)
+      const { startServer } = requireStandaloneStartServer(this.#standaloneEntrypoint)
 
       await startServer({
         dir: dirname(this.#standaloneEntrypoint),
@@ -530,44 +522,4 @@ export class NextCapability extends BaseCapability {
     return distDir
   }
 
-  async #resolveStandaloneEntrypoint () {
-    // If built in standalone mode, the generated standalone directory is not on the root of the project but somewhere
-    // inside .next/standalone due to turbopack limitations in determining the root of the project.
-    // In that case we search a server.js next to a .next folder inside the .next /standalone folder.
-    const serverEntrypoints = await Array.fromAsync(
-      glob(['**/server.js'], { cwd: this.root, ignore: ['node_modules', '**/node_modules/**'] })
-    )
-
-    let serverEntrypoint
-    for (const entrypoint of serverEntrypoints) {
-      if (existsSync(resolvePath(this.root, dirname(entrypoint), '.next'))) {
-        const candidate = resolvePath(this.root, entrypoint)
-        const contents = await readFile(candidate, 'utf-8')
-
-        if (contents.includes('process.env.__NEXT_PRIVATE_STANDALONE_CONFIG =')) {
-          serverEntrypoint = candidate
-          break
-        }
-      }
-    }
-
-    if (!serverEntrypoint) {
-      throw new errors.StandaloneServerNotFound()
-    }
-
-    return serverEntrypoint
-  }
-
-  #requireStandaloneEntrypoint (serverEntrypoint) {
-    let serverModule
-
-    try {
-      serverModule = createRequire(serverEntrypoint)('next/dist/server/lib/start-server.js')
-    } catch (e) {
-      // Fallback to bundled capability
-      serverModule = createRequire(import.meta.file)('next/dist/server/lib/start-server.js')
-    }
-
-    return serverModule.default ?? serverModule
-  }
 }

--- a/packages/next/lib/commands/index.js
+++ b/packages/next/lib/commands/index.js
@@ -1,0 +1,26 @@
+import { packCommand, helpFooter as packHelpFooter } from './pack.js'
+
+export function createCommands (id) {
+  return {
+    commands: {
+      [`${id}:pack`]: packCommand
+    },
+    help: {
+      [`${id}:pack`]: {
+        usage: `${id}:pack`,
+        description: 'Create a self-contained standalone bundle for a Next.js application',
+        footer: packHelpFooter,
+        options: [
+          {
+            usage: '-o, --output <path>',
+            description: 'Output directory for the packed bundle'
+          },
+          {
+            usage: '--no-build',
+            description: 'Fail if the standalone build output is missing instead of building it first'
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/next/lib/commands/pack.js
+++ b/packages/next/lib/commands/pack.js
@@ -1,0 +1,121 @@
+import { ensureLoggableError, findRuntimeConfigurationFile, kMetadata, logFatalError } from '@platformatic/foundation'
+import { dirname } from 'node:path'
+import {
+  copyStandaloneFiles,
+  ensurePortableNodeModules,
+  materializeRuntimeDependencies,
+  prepareBundleDirectory,
+  resolveOutputDirectory,
+  writeBundleConfiguration,
+  writeBundleMetadata
+} from '../pack.js'
+import { NextCapability } from '../capability.js'
+import { loadConfiguration } from '../config.js'
+import { resolveStandaloneEntrypoint } from '../standalone.js'
+
+export async function packCommand (logger, configFile, args, context) {
+  const {
+    values: { output, 'no-build': noBuild },
+    positionals
+  } = context.parseArgs(
+    args,
+    {
+      output: {
+        type: 'string',
+        short: 'o'
+      },
+      'no-build': {
+        type: 'boolean'
+      }
+    },
+    false
+  )
+
+  if (positionals.length > 0) {
+    return logFatalError(logger, `Unexpected positional arguments: ${positionals.join(' ')}`)
+  }
+
+  let config
+  try {
+    config = await loadConfiguration(configFile)
+  } catch (error) {
+    return logFatalError(
+      logger,
+      { err: ensureLoggableError(error) },
+      `Cannot load the Next.js application configuration: ${error.message}`
+    )
+  }
+
+  if (config.next?.standalone !== true) {
+    return logFatalError(logger, 'The Next.js pack command requires next.standalone to be set to true.')
+  }
+
+  const applicationRoot = config[kMetadata].root
+  const applicationId = context.application?.id ?? 'main'
+  const invocationCwd = context.cwd ?? process.cwd()
+  const bundleRoot = resolveOutputDirectory(output, `.platformatic/${applicationId}-bundle`, invocationCwd)
+
+  let standaloneEntrypoint
+  try {
+    standaloneEntrypoint = await resolveStandaloneEntrypoint(applicationRoot)
+  } catch (error) {
+    if (noBuild) {
+      return logFatalError(logger, 'Cannot find a Next standalone build. Run the build first or omit --no-build.')
+    }
+
+    const capability = new NextCapability(applicationRoot, config, {
+      applicationId,
+      isProduction: true
+    })
+
+    try {
+      logger.info(`Building application ${applicationId} before packing ...`)
+      await capability.build()
+      standaloneEntrypoint = await resolveStandaloneEntrypoint(applicationRoot)
+    } catch (buildError) {
+      return logFatalError(
+        logger,
+        { err: ensureLoggableError(buildError) },
+        `Cannot build the Next.js application for packing: ${buildError.message}`
+      )
+    }
+  }
+
+  const standaloneRoot = dirname(standaloneEntrypoint)
+
+  try {
+    const runtimeConfig = await findRuntimeConfigurationFile(logger, invocationCwd, null, false, false, false)
+
+    await prepareBundleDirectory(bundleRoot)
+    await copyStandaloneFiles({ applicationRoot, standaloneRoot, bundleRoot })
+    await writeBundleConfiguration(config, bundleRoot)
+    const packages = await materializeRuntimeDependencies({ bundleRoot, logger })
+    await writeBundleMetadata({
+      applicationId,
+      applicationConfig: configFile,
+      runtimeConfig,
+      bundleRoot,
+      packages
+    })
+    await ensurePortableNodeModules(bundleRoot)
+  } catch (error) {
+    return logFatalError(
+      logger,
+      { err: ensureLoggableError(error) },
+      `Cannot pack the Next.js application: ${error.message}`
+    )
+  }
+
+  logger.done(`Packed application ${applicationId} into ${bundleRoot}.`)
+}
+
+export const helpFooter = `
+This command only supports Next.js applications configured with:
+
+- Next.js standalone output enabled in next.config.js
+- next.standalone = true in the Platformatic application config
+
+The packed output is intended to be started with:
+
+- ./node_modules/.bin/wattpm start
+`

--- a/packages/next/lib/config.js
+++ b/packages/next/lib/config.js
@@ -1,0 +1,26 @@
+import { transform as basicTransform, resolve, validationOptions } from '@platformatic/basic'
+import { loadConfiguration as utilsLoadConfiguration } from '@platformatic/foundation'
+import { schema } from './schema.js'
+
+export async function transform (config, schema, options) {
+  config = await basicTransform(config, schema, options)
+  config.watch = { enabled: false }
+
+  if (config.cache?.adapter === 'redis') {
+    config.cache.adapter = 'valkey'
+  }
+
+  return config
+}
+
+export async function loadConfiguration (configOrRoot, sourceOrConfig, context) {
+  const { root, source } = await resolve(configOrRoot, sourceOrConfig, 'application')
+
+  return utilsLoadConfiguration(source, context?.schema ?? schema, {
+    validationOptions,
+    transform,
+    replaceEnv: true,
+    root,
+    ...context
+  })
+}

--- a/packages/next/lib/pack.js
+++ b/packages/next/lib/pack.js
@@ -1,0 +1,467 @@
+import { saveConfigurationFile } from '@platformatic/foundation'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import {
+  chmod,
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  realpath,
+  rm,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, isAbsolute, relative, resolve as resolvePath } from 'node:path'
+import { version as platformaticVersion } from './schema.js'
+
+const runtimePackages = ['wattpm', '@platformatic/next']
+
+export function resolveOutputDirectory (output, fallback, cwd) {
+  const target = output ?? fallback
+  return isAbsolute(target) ? target : resolvePath(cwd, target)
+}
+
+export async function prepareBundleDirectory (directory) {
+  await rm(directory, { recursive: true, force: true })
+  await mkdir(directory, { recursive: true })
+}
+
+export async function copyStandaloneFiles ({ applicationRoot, standaloneRoot, bundleRoot }) {
+  await cp(standaloneRoot, bundleRoot, {
+    recursive: true,
+    dereference: true,
+    preserveTimestamps: true
+  })
+
+  try {
+    await cp(resolvePath(applicationRoot, '.next', 'static'), resolvePath(bundleRoot, '.next', 'static'), {
+      recursive: true,
+      force: true,
+      errorOnExist: false,
+      preserveTimestamps: true
+    })
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  try {
+    await cp(resolvePath(applicationRoot, 'public'), resolvePath(bundleRoot, 'public'), {
+      recursive: true,
+      force: true,
+      errorOnExist: false,
+      preserveTimestamps: true
+    })
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
+
+export async function writeBundleConfiguration (config, bundleRoot) {
+  const bundleConfig = JSON.parse(JSON.stringify(config))
+  bundleConfig.next ??= {}
+  bundleConfig.next.standalone = true
+  await saveConfigurationFile(resolvePath(bundleRoot, 'watt.json'), bundleConfig)
+}
+
+export async function materializeRuntimeDependencies ({ bundleRoot, logger }) {
+  const bundleNodeModules = resolvePath(bundleRoot, 'node_modules')
+  const stagingRoot = await mkdtemp(resolvePath(tmpdir(), 'platformatic-next-pack-'))
+
+  try {
+    await mkdir(bundleNodeModules, { recursive: true })
+
+    const workspacePackages = await collectWorkspacePackages(runtimePackages)
+    const tarballDirectory = resolvePath(stagingRoot, 'tarballs')
+    const dependencies = {}
+    const packages = new Map()
+
+    await mkdir(tarballDirectory, { recursive: true })
+
+    for (const name of runtimePackages) {
+      const pkg = workspacePackages.get(name) ?? (await loadInstalledPackage(name, import.meta.url))
+      packages.set(pkg.name, pkg)
+    }
+
+    for (const pkg of workspacePackages.values()) {
+      const tarball = await packWorkspacePackage(pkg, tarballDirectory)
+      dependencies[pkg.name] = `file:${relative(stagingRoot, tarball)}`
+    }
+
+    for (const pkg of packages.values()) {
+      dependencies[pkg.name] ??= pkg.version
+    }
+
+    await writeFile(
+      resolvePath(stagingRoot, 'package.json'),
+      JSON.stringify({ name: 'platformatic-next-pack', private: true, dependencies }, null, 2),
+      'utf-8'
+    )
+
+    await runCommand('npm', ['install', '--omit=dev', '--ignore-scripts', '--no-fund', '--no-audit'], { cwd: stagingRoot })
+    await mergeDirectory(resolvePath(stagingRoot, 'node_modules'), bundleNodeModules)
+    await cleanupBrokenSymlinks(resolvePath(bundleNodeModules, '.bin'))
+    await writePackageBins(packages, bundleNodeModules)
+
+    logger?.debug?.({ packages: [...packages.keys()] }, 'Materialized runtime packages for packed bundle.')
+
+    return packages
+  } finally {
+    await rm(stagingRoot, { recursive: true, force: true })
+  }
+}
+
+async function collectWorkspacePackages (rootNames) {
+  const packages = new Map()
+  const queue = [...rootNames]
+
+  while (queue.length) {
+    const name = queue.shift()
+    if (packages.has(name)) {
+      continue
+    }
+
+    const root = resolveWorkspacePackageRoot(name)
+    if (!root) {
+      continue
+    }
+
+    const pkg = await loadPackageFromRoot(root, name)
+    packages.set(pkg.name, pkg)
+
+    for (const dependencyName of listWorkspaceDependencies(pkg.packageJson)) {
+      queue.push(dependencyName)
+    }
+  }
+
+  return packages
+}
+
+function listWorkspaceDependencies (packageJson) {
+  return Object.keys({
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.optionalDependencies ?? {})
+  }).filter(name => !!resolveWorkspacePackageRoot(name))
+}
+
+async function loadInstalledPackage (name, from) {
+  const root = await realpath(await resolvePackageRoot(name, from))
+  return loadPackageFromRoot(root, name)
+}
+
+async function loadPackageFromRoot (root, fallbackName) {
+  const packageJson = JSON.parse(await readFile(resolvePath(root, 'package.json'), 'utf-8'))
+  return {
+    name: packageJson.name ?? fallbackName,
+    version: packageJson.version,
+    root,
+    packageJson
+  }
+}
+
+async function resolvePackageRoot (name, from) {
+  const require = createRequire(from)
+
+  try {
+    const packageJsonPath = require.resolve(`${name}/package.json`)
+    return dirname(packageJsonPath)
+  } catch (error) {
+    const packageJsonPath = resolvePackageJsonFromSearchPaths(require, name)
+    if (packageJsonPath) {
+      return dirname(packageJsonPath)
+    }
+
+    try {
+      const resolvedEntry = require.resolve(name)
+      return await findPackageRoot(dirname(resolvedEntry))
+    } catch (resolveError) {
+      const workspacePackage = resolveWorkspacePackageRoot(name)
+      if (workspacePackage) {
+        return workspacePackage
+      }
+
+      throw resolveError
+    }
+  }
+}
+
+function resolvePackageJsonFromSearchPaths (require, name) {
+  const searchPaths = require.resolve.paths(name) ?? []
+  const packageSegments = name.split('/')
+
+  for (const searchPath of searchPaths) {
+    const candidate = resolvePath(searchPath, ...packageSegments, 'package.json')
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+async function findPackageRoot (directory) {
+  let current = directory
+
+  while (true) {
+    const candidate = resolvePath(current, 'package.json')
+    if (existsSync(candidate)) {
+      return current
+    }
+
+    const parent = resolvePath(current, '..')
+    if (parent === current) {
+      throw new Error(`Cannot determine package root for ${directory}.`)
+    }
+
+    current = parent
+  }
+}
+
+function resolveWorkspacePackageRoot (name) {
+  if (name !== 'wattpm' && !name.startsWith('@platformatic/')) {
+    return null
+  }
+
+  const packageDirectory = name === 'wattpm' ? 'wattpm' : name.replace('@platformatic/', '')
+  const candidate = resolvePath(import.meta.dirname, '..', '..', packageDirectory)
+
+  if (existsSync(resolvePath(candidate, 'package.json'))) {
+    return candidate
+  }
+
+  return null
+}
+
+async function packWorkspacePackage (pkg, tarballDirectory) {
+  const { stdout } = await runCommand('pnpm', ['pack', '--pack-destination', tarballDirectory], { cwd: pkg.root })
+  const tarball = stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.endsWith('.tgz'))
+    .at(-1)
+
+  if (!tarball) {
+    throw new Error(`Cannot determine the tarball path for ${pkg.name}.`)
+  }
+
+  return tarball
+}
+
+async function runCommand (command, args, options) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.on('data', chunk => {
+      stdout += chunk.toString()
+    })
+
+    child.stderr.on('data', chunk => {
+      stderr += chunk.toString()
+    })
+
+    child.on('error', reject)
+    child.on('close', code => {
+      if (code === 0) {
+        resolve({ stdout, stderr })
+      } else {
+        reject(new Error(`Command failed: ${command} ${args.join(' ')}\n${stderr || stdout}`))
+      }
+    })
+  })
+}
+
+async function mergeDirectory (source, destination) {
+  await mkdir(destination, { recursive: true })
+  const entries = await readdir(source, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const sourcePath = resolvePath(source, entry.name)
+    const destinationPath = resolvePath(destination, entry.name)
+    const stats = await lstat(sourcePath)
+
+    if (stats.isSymbolicLink()) {
+      await copySymlink(sourcePath, destinationPath)
+      continue
+    }
+
+    if (entry.isDirectory()) {
+      if (!existsSync(destinationPath)) {
+        await cp(sourcePath, destinationPath, {
+          recursive: true,
+          dereference: false,
+          preserveTimestamps: true
+        })
+      } else {
+        await mergeDirectory(sourcePath, destinationPath)
+      }
+      continue
+    }
+
+    if (!existsSync(destinationPath)) {
+      await cp(sourcePath, destinationPath, { dereference: false, preserveTimestamps: true })
+    }
+  }
+}
+
+async function copySymlink (source, destination) {
+  if (existsSync(destination)) {
+    return
+  }
+
+  await mkdir(dirname(destination), { recursive: true })
+  await symlink(await readlink(source), destination)
+}
+
+async function cleanupBrokenSymlinks (directory) {
+  if (!existsSync(directory)) {
+    return
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const path = resolvePath(directory, entry.name)
+    const stats = await lstat(path)
+
+    if (!stats.isSymbolicLink()) {
+      continue
+    }
+
+    try {
+      await realpath(path)
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        await rm(path, { force: true })
+        continue
+      }
+
+      throw error
+    }
+  }
+}
+
+async function writePackageBins (packages, bundleNodeModules) {
+  const binDirectory = resolvePath(bundleNodeModules, '.bin')
+  await mkdir(binDirectory, { recursive: true })
+
+  for (const pkg of packages.values()) {
+    const bin = normalizeBinField(pkg.packageJson.bin, pkg.name)
+    for (const [name, target] of Object.entries(bin)) {
+      await writeNodeShim(resolvePath(binDirectory, name), pkg.name, target)
+    }
+  }
+}
+
+function normalizeBinField (bin, pkgName) {
+  if (!bin) {
+    return {}
+  }
+
+  if (typeof bin === 'string') {
+    return { [pkgName]: bin }
+  }
+
+  return bin
+}
+
+async function writeNodeShim (destination, packageName, target) {
+  const normalizedTarget = target.replaceAll('\\', '/')
+  const unixScript = `#!/usr/bin/env node\nimport '../${packageName}/${normalizedTarget}'\n`
+
+  await rm(destination, { force: true })
+  await rm(`${destination}.cmd`, { force: true })
+  await writeFile(destination, unixScript, 'utf-8')
+  await chmod(destination, 0o755)
+  await writeFile(
+    `${destination}.cmd`,
+    `@ECHO off\r\nnode "%~dp0\\..\\${packageName.replaceAll('/', '\\')}\\${normalizedTarget.replaceAll('/', '\\')}" %*\r\n`,
+    'utf-8'
+  )
+}
+
+export async function writeBundleMetadata ({
+  applicationId,
+  applicationConfig,
+  runtimeConfig,
+  bundleRoot,
+  packages
+}) {
+  const metadataRoot = resolvePath(bundleRoot, '.platformatic')
+  await mkdir(metadataRoot, { recursive: true })
+
+  await writeFile(
+    resolvePath(metadataRoot, 'manifest.json'),
+    JSON.stringify(
+      {
+        bundleVersion: 1,
+        applicationId,
+        packedAt: new Date().toISOString(),
+        source: {
+          applicationConfig,
+          runtimeConfig: runtimeConfig ?? null
+        },
+        platformaticVersion,
+        packages: Object.fromEntries(
+          [...packages.values()].map(pkg => [pkg.name, { version: pkg.version, root: pkg.root }])
+        )
+      },
+      null,
+      2
+    ) + '\n',
+    'utf-8'
+  )
+
+  await writeFile(
+    resolvePath(metadataRoot, 'NOTICE'),
+    'This directory was generated by the Next standalone pack command.\n',
+    'utf-8'
+  )
+}
+
+export async function ensurePortableNodeModules (bundleRoot) {
+  const nodeModules = resolvePath(bundleRoot, 'node_modules')
+  await assertNoExternalSymlinks(nodeModules, bundleRoot)
+}
+
+async function assertNoExternalSymlinks (directory, bundleRoot) {
+  const entries = await readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const path = resolvePath(directory, entry.name)
+    const stats = await lstat(path)
+
+    if (stats.isSymbolicLink()) {
+      let target
+      try {
+        target = await realpath(path)
+      } catch (error) {
+        if (error.code === 'ENOENT') {
+          continue
+        }
+        throw error
+      }
+
+      if (!target.startsWith(bundleRoot)) {
+        throw new Error(`Packed bundle contains a symlink outside the bundle: ${relative(bundleRoot, path)} -> ${target}`)
+      }
+    } else if (entry.isDirectory()) {
+      await assertNoExternalSymlinks(path, bundleRoot)
+    }
+  }
+}

--- a/packages/next/lib/standalone.js
+++ b/packages/next/lib/standalone.js
@@ -1,0 +1,46 @@
+import { glob, readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { resolve as resolvePath } from 'node:path'
+import * as errors from './errors.js'
+
+export async function resolveStandaloneEntrypoint (root) {
+  const serverEntrypoints = await Array.fromAsync(
+    glob(['server.js', '.next/standalone/**/server.js'], {
+      cwd: root,
+      exclude: ['node_modules', '**/node_modules/**']
+    })
+  )
+
+  for (const entrypoint of serverEntrypoints) {
+    const candidate = resolvePath(root, entrypoint)
+    const contents = await readFile(candidate, 'utf-8')
+
+    if (contents.includes('process.env.__NEXT_PRIVATE_STANDALONE_CONFIG =')) {
+      return candidate
+    }
+  }
+
+  throw new errors.StandaloneServerNotFound()
+}
+
+export async function parseStandaloneNextConfig (serverEntrypoint) {
+  try {
+    const serverJsContent = await readFile(serverEntrypoint, 'utf-8')
+    const nextConfigMatch = serverJsContent.match(/(?:const|let)\s*nextConfig\s*=\s*(\{.+)/)
+    return JSON.parse(nextConfigMatch[1])
+  } catch (e) {
+    throw new errors.CannotParseStandaloneServer({ cause: e })
+  }
+}
+
+export function requireStandaloneStartServer (serverEntrypoint) {
+  let serverModule
+
+  try {
+    serverModule = createRequire(serverEntrypoint)('next/dist/server/lib/start-server.js')
+  } catch (e) {
+    serverModule = createRequire(import.meta.url)('next/dist/server/lib/start-server.js')
+  }
+
+  return serverModule.default ?? serverModule
+}

--- a/packages/next/lib/standalone.js
+++ b/packages/next/lib/standalone.js
@@ -1,17 +1,22 @@
+import { existsSync } from 'node:fs'
 import { glob, readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
-import { resolve as resolvePath } from 'node:path'
+import { dirname, resolve as resolvePath } from 'node:path'
 import * as errors from './errors.js'
 
 export async function resolveStandaloneEntrypoint (root) {
   const serverEntrypoints = await Array.fromAsync(
-    glob('**/server.js', {
+    glob(['server.js', '.next/standalone/**/server.js', '**/server.js'], {
       cwd: root,
       exclude: ['node_modules', '**/node_modules/**']
     })
   )
 
   for (const entrypoint of serverEntrypoints) {
+    if (entrypoint !== 'server.js' && !existsSync(resolvePath(root, dirname(entrypoint), '.next'))) {
+      continue
+    }
+
     const candidate = resolvePath(root, entrypoint)
     const contents = await readFile(candidate, 'utf-8')
 

--- a/packages/next/lib/standalone.js
+++ b/packages/next/lib/standalone.js
@@ -5,7 +5,7 @@ import * as errors from './errors.js'
 
 export async function resolveStandaloneEntrypoint (root) {
   const serverEntrypoints = await Array.fromAsync(
-    glob(['server.js', '.next/standalone/**/server.js'], {
+    glob('**/server.js', {
       cwd: root,
       exclude: ['node_modules', '**/node_modules/**']
     })

--- a/packages/next/test/pack-command.test.js
+++ b/packages/next/test/pack-command.test.js
@@ -1,0 +1,66 @@
+import { ok, strictEqual } from 'node:assert'
+import { existsSync } from 'node:fs'
+import { lstat, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { isWindows, prepareRuntime, setFixturesDir, updateFile } from '../../basic/test/helper.js'
+import { executeCommand, waitForStart, wattpm } from '../../wattpm/test/helper.js'
+
+setFixturesDir(resolve(import.meta.dirname, './fixtures'))
+
+test('can pack a Next standalone application and start it with the bundled wattpm binary', async t => {
+  const { root } = await prepareRuntime(t, 'server-side-standalone', true, null, async root => {
+    await updateFile(resolve(root, 'services/frontend/next.config.js'), () => {
+      return 'module.exports = { output: "standalone" }\n'
+    })
+
+    await updateFile(resolve(root, 'services/frontend/platformatic.application.json'), raw => {
+      const json = JSON.parse(raw)
+      json.next ??= {}
+      json.next.standalone = true
+      return JSON.stringify(json, null, 2)
+    })
+  })
+
+  const packProcess = await wattpm('frontend:pack', '--output', '.platformatic/frontend-bundle', { cwd: root })
+  ok(packProcess.stdout.includes('Packed application frontend into'))
+
+  const bundleRoot = resolve(root, '.platformatic/frontend-bundle')
+  ok(existsSync(resolve(bundleRoot, 'server.js')))
+  ok(existsSync(resolve(bundleRoot, '.next/static')))
+  ok(existsSync(resolve(bundleRoot, 'watt.json')))
+  ok(existsSync(resolve(bundleRoot, 'node_modules/wattpm/package.json')))
+  ok(existsSync(resolve(bundleRoot, 'node_modules/@platformatic/next/package.json')))
+
+  strictEqual((await lstat(resolve(bundleRoot, 'node_modules/wattpm'))).isSymbolicLink(), false)
+  strictEqual((await lstat(resolve(bundleRoot, 'node_modules/@platformatic/next'))).isSymbolicLink(), false)
+
+  const bundleConfigPath = resolve(bundleRoot, 'watt.json')
+  const bundleConfig = JSON.parse(await readFile(bundleConfigPath, 'utf-8'))
+  bundleConfig.server = { ...(bundleConfig.server ?? {}), hostname: '127.0.0.1', port: 0 }
+  await writeFile(bundleConfigPath, JSON.stringify(bundleConfig, null, 2))
+
+  const bundledWattpm = resolve(bundleRoot, 'node_modules/.bin', isWindows ? 'wattpm.cmd' : 'wattpm')
+  const startProcess = executeCommand(bundledWattpm, 'start', {
+    cwd: bundleRoot,
+    reject: false,
+    env: {
+      PLT_SERVER_HOSTNAME: '127.0.0.1'
+    }
+  })
+
+  t.after(async () => {
+    startProcess.kill('SIGTERM')
+    try {
+      await startProcess
+    } catch {}
+  })
+
+  const { url } = await waitForStart(startProcess)
+  ok(url)
+
+  const { statusCode, body } = await request(url)
+  strictEqual(statusCode, 200)
+  ok((await body.text()).includes('Hello from v'))
+})

--- a/packages/runtime/test/services-commands.test.js
+++ b/packages/runtime/test/services-commands.test.js
@@ -1,8 +1,9 @@
 import { createDirectory, safeRemove } from '@platformatic/foundation'
 import { deepStrictEqual, ok, strictEqual } from 'node:assert'
-import { writeFile } from 'node:fs/promises'
+import { cp, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { test } from 'node:test'
+import { ensureDependencies } from '../../basic/test/helper.js'
 import { loadApplicationsCommands } from '../index.js'
 
 async function createTmpDir (t) {
@@ -174,4 +175,25 @@ test('loadApplicationsCommands works with existing fixtures that have commands',
   const gatewayCommands = applicationKeys.filter(key => key.startsWith('service-1:'))
   ok(gatewayCommands.length > 0, 'Should have found Gateway application commands')
   ok(gatewayCommands.includes('service-1:fetch-openapi-schemas'))
+})
+
+test('loadApplicationsCommands discovers Next.js pack commands', async t => {
+  const originalCwd = process.cwd()
+  const fixtureDir = join(import.meta.dirname, '..', '..', 'next', 'test', 'fixtures', 'server-side-standalone')
+  const tmpDir = await createTmpDir(t)
+
+  await cp(fixtureDir, tmpDir, { recursive: true })
+  await ensureDependencies([tmpDir, join(tmpDir, 'services', 'frontend')])
+
+  t.after(() => {
+    process.chdir(originalCwd)
+  })
+
+  process.chdir(tmpDir)
+
+  const result = await loadApplicationsCommands()
+
+  ok(result.commands['frontend:pack'])
+  ok(result.help['frontend:pack'])
+  strictEqual(result.applications['frontend:pack'].id, 'frontend')
 })

--- a/packages/wattpm-utils/lib/commands/dependencies.js
+++ b/packages/wattpm-utils/lib/commands/dependencies.js
@@ -11,7 +11,7 @@ import { loadConfiguration } from '@platformatic/runtime'
 import { bold } from 'colorette'
 import { execa } from 'execa'
 import { existsSync } from 'node:fs'
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, rm, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { parseEnv } from 'node:util'
 import { rsort, satisfies } from 'semver'
@@ -37,6 +37,36 @@ async function executeCommand (root, ...args) {
   return execa(...args)
 }
 
+async function withTemporaryPnpmConfig (directory, fn) {
+  const npmrc = resolve(directory, '.npmrc')
+  const marker = 'minimum-release-age-exclude[]=@platformatic/*'
+  let originalContents = null
+
+  if (!existsSync(npmrc)) {
+    await writeFile(npmrc, `${marker}\n`, 'utf-8')
+  } else {
+    const contents = await readFile(npmrc, 'utf-8')
+    if (!contents.includes(marker)) {
+      originalContents = contents
+      const prefix = contents.endsWith('\n') || contents.length === 0 ? '' : '\n'
+      await writeFile(npmrc, `${contents}${prefix}${marker}\n`, 'utf-8')
+    }
+  }
+
+  try {
+    return await fn()
+  } finally {
+    if (originalContents !== null) {
+      await writeFile(npmrc, originalContents, 'utf-8')
+    } else if (existsSync(npmrc)) {
+      const contents = await readFile(npmrc, 'utf-8')
+      if (contents === `${marker}\n`) {
+        await rm(npmrc, { force: true })
+      }
+    }
+  }
+}
+
 export async function installDependencies (logger, root, applications, production, packageManager) {
   if (typeof applications === 'string') {
     const config = await loadConfiguration(applications, null, { validate: false })
@@ -59,11 +89,17 @@ export async function installDependencies (logger, root, applications, productio
   try {
     logger.info(`Installing ${production ? 'production ' : ''}dependencies for the project using ${packageManager} ...`)
 
-    await executeCommand(root, packageManager, args, {
+    const installProjectDependencies = () => executeCommand(root, packageManager, args, {
       cwd: root,
       stdio: 'inherit',
       reject: process.env.PLT_IGNORE_INSTALL_FAILURES !== 'true'
     })
+
+    if (packageManager === 'pnpm') {
+      await withTemporaryPnpmConfig(root, installProjectDependencies)
+    } else {
+      await installProjectDependencies()
+    }
     /* c8 ignore next 7 */
   } catch (error) {
     return logFatalError(
@@ -102,11 +138,18 @@ export async function installDependencies (logger, root, applications, productio
         }
       }
 
-      await executeCommand(root, applicationPackageManager, applicationPackageArgs, {
-        cwd: resolve(root, path),
+      const applicationRoot = resolve(root, path)
+      const installApplicationDependencies = () => executeCommand(root, applicationPackageManager, applicationPackageArgs, {
+        cwd: applicationRoot,
         stdio: 'inherit',
         reject: process.env.PLT_IGNORE_INSTALL_FAILURES !== 'true'
       })
+
+      if (applicationPackageManager === 'pnpm') {
+        await withTemporaryPnpmConfig(applicationRoot, installApplicationDependencies)
+      } else {
+        await installApplicationDependencies()
+      }
       /* c8 ignore next 7 */
     } catch (error) {
       return logFatalError(

--- a/packages/wattpm/index.js
+++ b/packages/wattpm/index.js
@@ -144,7 +144,6 @@ export async function main () {
     default:
       if (requestedCommand) {
         const applicationsCommands = await loadApplicationsCommands(this.executableName)
-        console.log(applicationsCommands)
         const applicationCommand = applicationsCommands.commands[requestedCommand]
 
         if (applicationCommand) {
@@ -166,8 +165,11 @@ export async function main () {
   }
 
   if (applicationCommandContext) {
+    const invocationCwd = process.cwd()
     process.chdir(applicationCommandContext.path)
     return command.call(this, logger, applicationCommandContext.config, unparsed.slice(1), {
+      application: applicationCommandContext,
+      cwd: invocationCwd,
       colorette,
       parseArgs,
       logFatalError

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,8 @@ autoInstallPeers: true
 childConcurrency: 1
 hoist: false
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@platformatic/*'
 nodeLinker: hoisted
 packageImportMethod: copy
 preferSymlinkedExecutables: true


### PR DESCRIPTION
## Summary
- add a Next-specific `<app-id>:pack` application command via `createCommands()`
- pack standalone Next output into a self-contained bundle with bundled `wattpm` and `@platformatic/next`
- add command discovery and end-to-end startup coverage for the packed bundle

## Testing
- `node --test --test-timeout=2000000 packages/runtime/test/services-commands.test.js packages/next/test/pack-command.test.js`

Related docs-only PR: #4764