### PR TITLE
fix(telemetry): improve diag logger object output

### DIFF
--- a/packages/telemetry/lib/diag-logger.js
+++ b/packages/telemetry/lib/diag-logger.js
@@ -21,10 +21,104 @@ function getDiagLogLevel (logger) {
   return DiagLogLevel.INFO
 }
 
+function isObjectLike (value) {
+  return value !== null && typeof value === 'object'
+}
+
+function isSpanLike (value) {
+  return typeof value?.spanContext === 'function' && typeof value?.name === 'string' && typeof value?.kind === 'number'
+}
+
+function serializeResource (resource, seen) {
+  if (!isObjectLike(resource)) {
+    return resource
+  }
+
+  if (Array.isArray(resource._rawAttributes)) {
+    return Object.fromEntries(resource._rawAttributes.map(([key, value]) => [key, serializeForDiag(value, seen)]))
+  }
+
+  return serializeForDiag(resource, seen)
+}
+
+function serializeSpanLike (span, seen) {
+  return {
+    traceId: span.spanContext().traceId,
+    spanId: span.spanContext().spanId,
+    traceFlags: span.spanContext().traceFlags,
+    traceState: span.spanContext().traceState,
+    name: span.name,
+    kind: span.kind,
+    parentSpanContext: serializeForDiag(span.parentSpanContext, seen),
+    attributes: serializeForDiag(span.attributes, seen),
+    links: serializeForDiag(span.links, seen),
+    events: serializeForDiag(span.events, seen),
+    status: serializeForDiag(span.status, seen),
+    startTime: serializeForDiag(span.startTime, seen),
+    endTime: serializeForDiag(span.endTime, seen),
+    resource: serializeResource(span.resource, seen),
+    instrumentationScope: serializeForDiag(span.instrumentationScope, seen)
+  }
+}
+
+function serializeForDiag (value, seen = new WeakSet()) {
+  if (!isObjectLike(value)) {
+    return value
+  }
+
+  if (typeof value.toJSON === 'function') {
+    return serializeForDiag(value.toJSON(), seen)
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, serializeForDiag(entry, seen)]))
+    }
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]'
+  }
+
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    return value.map(entry => serializeForDiag(entry, seen))
+  }
+
+  if (value instanceof Map) {
+    return Object.fromEntries(Array.from(value.entries(), ([key, entry]) => [String(key), serializeForDiag(entry, seen)]))
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value, entry => serializeForDiag(entry, seen))
+  }
+
+  if (isSpanLike(value)) {
+    return serializeSpanLike(value, seen)
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key, entry]) => !key.startsWith('_') && typeof entry !== 'function')
+      .map(([key, entry]) => [key, serializeForDiag(entry, seen)])
+  )
+}
+
 function callLogger (logger, method, fallback, args) {
   if (typeof logger?.[method] === 'function') {
     if (typeof args[0] === 'string') {
-      logger[method](util.format(...args))
+      const [message, ...details] = args
+      if (details.length === 0) {
+        logger[method](message)
+      } else if (details.some(isObjectLike)) {
+        logger[method]({ details: details.map(detail => serializeForDiag(detail)) }, message)
+      } else {
+        logger[method](util.format(...args))
+      }
     } else {
       logger[method](...args)
     }

--- a/packages/telemetry/test/diag-logger.test.js
+++ b/packages/telemetry/test/diag-logger.test.js
@@ -1,4 +1,8 @@
 import { diag } from '@opentelemetry/api'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { BatchSpanProcessor, InMemorySpanExporter } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 import { deepStrictEqual, strictEqual } from 'node:assert'
 import { Writable } from 'node:stream'
 import { test } from 'node:test'
@@ -88,7 +92,7 @@ test('setupDiagLogger configures the OpenTelemetry diagnostic logger using the p
   t.after(() => diag.disable())
 })
 
-test('createPlatformaticDiagLogger preserves additional OpenTelemetry diagnostic arguments with pino', async () => {
+test('createPlatformaticDiagLogger preserves additional primitive OpenTelemetry diagnostic arguments with pino', async () => {
   const lines = []
   const stream = new Writable({
     write (chunk, _encoding, callback) {
@@ -100,9 +104,88 @@ test('createPlatformaticDiagLogger preserves additional OpenTelemetry diagnostic
 
   const diagLogger = createPlatformaticDiagLogger(logger)
   diagLogger.warn('first', 'second', 42)
-  diagLogger.debug('caught hook error: ', new Error('boom'))
 
   strictEqual(lines[0].msg, 'first second 42')
-  strictEqual(lines[1].msg.includes('caught hook error:'), true)
-  strictEqual(lines[1].msg.includes('Error: boom'), true)
+})
+
+test('createPlatformaticDiagLogger serializes object diagnostic details with pino', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.debug('caught hook error: ', new Error('boom'))
+
+  strictEqual(lines[0].msg, 'caught hook error: ')
+  strictEqual(lines[0].details[0].name, 'Error')
+  strictEqual(lines[0].details[0].message, 'boom')
+  strictEqual(typeof lines[0].details[0].stack, 'string')
+})
+
+test('createPlatformaticDiagLogger uses toJSON() for diagnostic details when available', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+
+  class SpanLike {
+    constructor (name) {
+      this.name = name
+      this.attributes = { hidden: true }
+    }
+
+    toJSON () {
+      return {
+        name: this.name,
+        attributes: {
+          visible: true
+        }
+      }
+    }
+  }
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.debug('items to be sent', [new SpanLike('first')])
+
+  strictEqual(lines[0].msg, 'items to be sent')
+  deepStrictEqual(lines[0].details, [[{ name: 'first', attributes: { visible: true } }]])
+})
+
+test('createPlatformaticDiagLogger renders spans with a compact structured shape', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test-service' }),
+    spanProcessors: [new BatchSpanProcessor(new InMemorySpanExporter())]
+  })
+  const tracer = provider.getTracer('test-scope')
+  const span = tracer.startSpan('hello')
+  span.setAttribute('foo', 'bar')
+  span.end()
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.debug('items to be sent', [span])
+
+  strictEqual(lines[0].msg, 'items to be sent')
+  strictEqual(lines[0].details[0][0].name, 'hello')
+  strictEqual(lines[0].details[0][0].attributes.foo, 'bar')
+  strictEqual(lines[0].details[0][0].resource['service.name'], 'test-service')
+  strictEqual(lines[0].details[0][0].instrumentationScope.name, 'test-scope')
+  strictEqual('_spanProcessor' in lines[0].details[0][0], false)
+  strictEqual('_performanceStartTime' in lines[0].details[0][0], false)
 })


### PR DESCRIPTION
## Summary
- improve OpenTelemetry diag logger output for object payloads
- keep primitive variadic formatting for string-first diag messages
- serialize object details into structured `details` fields instead of flattening everything into `msg`
- use `.toJSON()` when available and render spans in a compact structured shape

## Reproduction
This reproduces the current problem before the fix:

```js
const diagLogger = createPlatformaticDiagLogger(logger)
diagLogger.debug('items to be sent', [obj])
```

Before, this produced a single inspected string in `msg`, for example:

```json
{
  "msg": "items to be sent [ Thing { foo: 'bar', nested: { a: 1 } } ]"
}
```

With this change, object payloads are emitted as structured data instead.

## Testing
- `pnpm --filter @platformatic/telemetry test -- test/diag-logger.test.js`

## Notes
- local full telemetry package runs still show the existing unrelated failures:
  - `packages/telemetry/test/pg.test.js` requires PostgreSQL
  - `packages/telemetry/test/runtimes.test.js` still has the pre-existing ESM express instrumentation failure
