### PR TITLE
feat(telemetry): add OTLP gRPC transport option

### DIFF
--- a/docs/guides/deployment/watt-in-ecs.md
+++ b/docs/guides/deployment/watt-in-ecs.md
@@ -104,6 +104,8 @@ This makes sure our logs are shipped to Cloudwatch and we integrate with the
 
 Next, a `telemetry` block must be added to _watt.json_ so that metrics flow into Cloudwatch.
 
+This example uses OTLP over HTTP. You can also use OTLP over gRPC by setting `"protocol": "grpc"` (or `"transport": "grpc"`) and using `http://localhost:4317` without `/v1/traces`.
+
 ```json
 {
     "telemetry": {

--- a/docs/guides/distributed-tracing.md
+++ b/docs/guides/distributed-tracing.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Platformatic supports Open Telemetry integration. This allows you to send telemetry data to one of the OTLP compatible servers ([see here](https://opentelemetry.io/ecosystem/vendors/)) or to a Zipkin server. Let's show this with [Jaeger](https://www.jaegertracing.io/).
+Platformatic supports Open Telemetry integration. This allows you to send telemetry data to one of the OTLP compatible servers ([see here](https://opentelemetry.io/ecosystem/vendors/)) over HTTP or gRPC, or to a Zipkin server. Let's show this with [Jaeger](https://www.jaegertracing.io/).
 
 :::tip Advanced Setup
 For manual OpenTelemetry SDK setup with custom instrumentations or exporters, see the [Advanced OpenTelemetry Setup](./opentelemetry-sdk-setup.md) guide.
@@ -22,6 +22,29 @@ docker run -d --name jaeger \
 ```
 
 Check that the server is running by opening [http://localhost:16686/](http://localhost:16686/) in your browser.
+
+:::tip OTLP transport selection
+The examples below use OTLP over HTTP with `http://localhost:4318/v1/traces`.
+
+You can also use OTLP over gRPC by setting `"protocol": "grpc"` (or `"transport": "grpc"`) and changing the URL to `http://localhost:4317`.
+
+```json
+{
+  "telemetry": {
+    "applicationName": "test-db",
+    "exporter": {
+      "type": "otlp",
+      "options": {
+        "protocol": "grpc",
+        "url": "http://localhost:4317"
+      }
+    }
+  }
+}
+```
+
+When using gRPC, do not include `/v1/traces` in the URL.
+:::
 
 ## Platformatic setup
 
@@ -268,7 +291,7 @@ Starting from this example, it's also possible to run the same test using Zipkin
 docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 
-Then, you need to change the `telemetry` configuration in all the `platformatic.*.json` to the following (only the `exporter` object is different`)
+Then, you need to change the `telemetry` configuration in all the `platformatic.*.json` files to the following (only the `exporter` object is different):
 
 ```json
   "telemetry": {

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -149,6 +149,24 @@ This automatically:
 - Includes trace context (trace ID, span ID, flags)
 - Adds service metadata for filtering
 
+The trace exporter shown here uses OTLP over HTTP. Telemetry traces also support OTLP over gRPC with:
+
+```json
+{
+  "telemetry": {
+    "exporter": {
+      "type": "otlp",
+      "options": {
+        "protocol": "grpc",
+        "url": "http://otel-collector:4317"
+      }
+    }
+  }
+}
+```
+
+When using gRPC, do not include `/v1/traces` in the URL.
+
 See the [OpenTelemetry Logging Guide](./opentelemetry-logging.md) for detailed configuration.
 
 ### Elasticsearch

--- a/docs/guides/opentelemetry-logging.md
+++ b/docs/guides/opentelemetry-logging.md
@@ -46,6 +46,24 @@ This configuration:
 - Identifies the service as "my-service" v1.0.0
 - Automatically correlates logs with traces
 
+The trace exporter in the `telemetry` block also supports OTLP over gRPC:
+
+```json
+{
+  "telemetry": {
+    "exporter": {
+      "type": "otlp",
+      "options": {
+        "protocol": "grpc",
+        "url": "http://localhost:4317"
+      }
+    }
+  }
+}
+```
+
+When using gRPC for traces, do not include `/v1/traces` in the URL.
+
 ### Protocol Options
 
 The `openTelemetryExporter` supports two protocols:

--- a/docs/guides/opentelemetry-sdk-setup.md
+++ b/docs/guides/opentelemetry-sdk-setup.md
@@ -4,7 +4,7 @@ import Issues from '../getting-started/issues.md';
 
 ## Introduction
 
-Watt includes [built-in telemetry support](./distributed-tracing.md) that can be configured declaratively in your `watt.json` or `platformatic.json` files. This works well for most use cases with OTLP and Zipkin exporters.
+Watt includes [built-in telemetry support](./distributed-tracing.md) that can be configured declaratively in your `watt.json` or `platformatic.json` files. This works well for most use cases with OTLP over HTTP or gRPC, and Zipkin exporters.
 
 However, you may need manual OpenTelemetry SDK setup when you:
 

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -381,7 +381,7 @@ Watt uses [Pino](https://getpino.io/) for high-performance structured logging ac
 
 ### Distributed Tracing Architecture
 
-Watt implements distributed tracing using [OpenTelemetry](https://opentelemetry.io/) with support for multiple trace exporters:
+Watt implements distributed tracing using [OpenTelemetry](https://opentelemetry.io/) with support for multiple trace exporters, including OTLP over HTTP, OTLP over gRPC, Zipkin, console, memory, and file:
 
 ```ascii
 ┌──────────────────────────────────────────────────────────────────────┐

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -261,10 +261,13 @@ The object supports the following settings:
   - `method`: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE
   - `path`. e.g.: `/documentation/json`
 - **`exporter`** (`object` or `array`) — Exporter configuration. If not defined, the exporter defaults to `console`. If an array of objects is configured, every object must be a valid exporter object. The exporter object has the following properties:
-  - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes.
+  - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin`, `memory`, and `file` (default: `console`). `memory` is only supported for testing purposes.
   - **`options`** (`object`) — These options are supported:
-    - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.
-    - **`headers`** (`object`) — Optional headers to send with the telemetry. This has no effect on `console` and `memory` exporters.
+    - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console`, `memory`, and `file` exporters.
+    - **`headers`** (`object`) — Optional headers to send with the telemetry. This has no effect on `console`, `memory`, and `file` exporters.
+    - **`path`** (`string`) — The path where spans are written when using the `file` exporter.
+    - **`protocol`** (`string`) — OTLP transport protocol. Supported values are `http` and `grpc`. Defaults to `http`.
+    - **`transport`** (`string`) — Alias for `protocol`. Supported values are `http` and `grpc`. Defaults to `http`.
 - **`diagLogger`** (`boolean`) — Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
 
 ### `basePath`
@@ -274,6 +277,10 @@ The runtime will automatically strip the base path from the incoming requests.
 
 :::important
 OTLP traces can be consumed by different solutions, like [Jaeger](https://www.jaegertracing.io/). See the full list [here](https://opentelemetry.io/ecosystem/vendors/).
+
+For OTLP exporters:
+- Use HTTP with URLs like `http://localhost:4318/v1/traces`
+- Use gRPC with URLs like `http://localhost:4317` and do not include `/v1/traces`
 :::
 
 ```json title="Example JSON object"

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -240,13 +240,20 @@ Configure `@platformatic/service` specific settings such as `graphql` or `openap
   - `method`: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE
   - `path`. e.g.: `/documentation/json`
 - **`exporter`** (`object` or `array`) — Exporter configuration. If not defined, the exporter defaults to `console`. If an array of objects is configured, every object must be a valid exporter object. The exporter object has the following properties:
-  - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin` and `memory` (default: `console`). `memory` is only supported for testing purposes.
+  - **`type`** (`string`) — Exporter type. Supported values are `console`, `otlp`, `zipkin`, `memory`, and `file` (default: `console`). `memory` is only supported for testing purposes.
   - **`options`** (`object`) — These options are supported:
-    - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console` and `memory` exporters.
-    - **`headers`** (`object`) — Optional headers to send with the telemetry. This has no effect on `console` and `memory` exporters.
+    - **`url`** (`string`) — The URL to send the telemetry to. Required for `otlp` exporter. This has no effect on `console`, `memory`, and `file` exporters.
+    - **`headers`** (`object`) — Optional headers to send with the telemetry. This has no effect on `console`, `memory`, and `file` exporters.
+    - **`path`** (`string`) — The path where spans are written when using the `file` exporter.
+    - **`protocol`** (`string`) — OTLP transport protocol. Supported values are `http` and `grpc`. Defaults to `http`.
+    - **`transport`** (`string`) — Alias for `protocol`. Supported values are `http` and `grpc`. Defaults to `http`.
 - **`diagLogger`** (`boolean`) — Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
 
 Note that OTLP traces can be consumed by different solutions, like [Jaeger](https://www.jaegertracing.io/). [Here](https://opentelemetry.io/ecosystem/vendors/) the full list.
+
+For OTLP exporters:
+- Use HTTP with URLs like `http://localhost:4318/v1/traces`
+- Use gRPC with URLs like `http://localhost:4317` and do not include `/v1/traces`
 
 _Example_
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -393,7 +393,7 @@ graph TD
     G --> I[Trace Context<br/>Propagation]
     H --> I
 
-    I --> J[OTLP Exporter]
+    I --> J[OTLP Exporter<br/>HTTP or gRPC]
     I --> K[Jaeger Exporter]
     I --> L[Zipkin Exporter]
 

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticAstroConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticAstroConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -374,6 +374,14 @@ export interface PlatformaticBasicConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -399,6 +407,14 @@ export interface PlatformaticBasicConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -1540,6 +1540,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1576,6 +1592,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -542,6 +542,14 @@ export interface PlatformaticComposerConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -567,6 +575,14 @@ export interface PlatformaticComposerConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -773,6 +789,14 @@ export interface PlatformaticComposerConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -798,6 +822,14 @@ export interface PlatformaticComposerConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -2213,6 +2213,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -2249,6 +2265,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },
@@ -2916,6 +2948,22 @@
                       "path": {
                         "type": "string",
                         "description": "The path to write the traces to. Only for file exporter."
+                      },
+                      "protocol": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                       }
                     }
                   },
@@ -2952,6 +3000,22 @@
                     "path": {
                       "type": "string",
                       "description": "The path to write the traces to. Only for file exporter."
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                    },
+                    "transport": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                     }
                   }
                 },

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -451,6 +451,14 @@ export interface PlatformaticDatabaseConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -476,6 +484,14 @@ export interface PlatformaticDatabaseConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -852,6 +868,14 @@ export interface PlatformaticDatabaseConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -877,6 +901,14 @@ export interface PlatformaticDatabaseConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1274,6 +1274,22 @@
                       "path": {
                         "type": "string",
                         "description": "The path to write the traces to. Only for file exporter."
+                      },
+                      "protocol": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                       }
                     }
                   },
@@ -1310,6 +1326,22 @@
                     "path": {
                       "type": "string",
                       "description": "The path to write the traces to. Only for file exporter."
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                    },
+                    "transport": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                     }
                   }
                 },
@@ -2865,6 +2897,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -2901,6 +2949,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -649,6 +649,16 @@ export const openTelemetryExporter = {
         path: {
           type: 'string',
           description: 'The path to write the traces to. Only for file exporter.'
+        },
+        protocol: {
+          type: 'string',
+          enum: ['http', 'grpc'],
+          description: 'The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.'
+        },
+        transport: {
+          type: 'string',
+          enum: ['http', 'grpc'],
+          description: 'Alias for protocol. Only for the otlp exporter. Defaults to http.'
         }
       }
     },

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -760,6 +760,14 @@ export interface PlatformaticGatewayConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -785,6 +793,14 @@ export interface PlatformaticGatewayConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -991,6 +1007,14 @@ export interface PlatformaticGatewayConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -1016,6 +1040,14 @@ export interface PlatformaticGatewayConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -2854,6 +2854,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -2890,6 +2906,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },
@@ -3557,6 +3589,22 @@
                       "path": {
                         "type": "string",
                         "description": "The path to write the traces to. Only for file exporter."
+                      },
+                      "protocol": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                       }
                     }
                   },
@@ -3593,6 +3641,22 @@
                     "path": {
                       "type": "string",
                       "description": "The path to write the traces to. Only for file exporter."
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                    },
+                    "transport": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                     }
                   }
                 },

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticNestJSConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticNestJSConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticNextJsConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticNextJsConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticNodeJsConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticNodeJsConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticReactRouterConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticReactRouterConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticRemixConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticRemixConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -471,6 +471,14 @@ export type PlatformaticRuntimeConfig = {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -496,6 +504,14 @@ export type PlatformaticRuntimeConfig = {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -2676,6 +2676,22 @@
                       "path": {
                         "type": "string",
                         "description": "The path to write the traces to. Only for file exporter."
+                      },
+                      "protocol": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                       }
                     }
                   },
@@ -2712,6 +2728,22 @@
                     "path": {
                       "type": "string",
                       "description": "The path to write the traces to. Only for file exporter."
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                    },
+                    "transport": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                     }
                   }
                 },

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -213,6 +213,14 @@ export interface PlatformaticServiceConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -238,6 +246,14 @@ export interface PlatformaticServiceConfig {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -681,6 +697,14 @@ export interface PlatformaticServiceConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -706,6 +730,14 @@ export interface PlatformaticServiceConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -741,6 +741,22 @@
                       "path": {
                         "type": "string",
                         "description": "The path to write the traces to. Only for file exporter."
+                      },
+                      "protocol": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                       }
                     }
                   },
@@ -777,6 +793,22 @@
                     "path": {
                       "type": "string",
                       "description": "The path to write the traces to. Only for file exporter."
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                    },
+                    "transport": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                     }
                   }
                 },
@@ -2550,6 +2582,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -2586,6 +2634,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticTanStackConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticTanStackConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/telemetry/lib/span-processors.js
+++ b/packages/telemetry/lib/span-processors.js
@@ -35,8 +35,15 @@ export function getSpanProcessors (opts = {}, logger = abstractLogger) {
     if (exp.type === 'console') {
       exporterObj = new ConsoleSpanExporter(exporterOptions)
     } else if (exp.type === 'otlp') {
-      const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto')
-      exporterObj = new OTLPTraceExporter(exporterOptions)
+      const transport = exporterOptions.protocol ?? exporterOptions.transport ?? 'http'
+
+      if (transport === 'grpc') {
+        const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc')
+        exporterObj = new OTLPTraceExporter(exporterOptions)
+      } else {
+        const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto')
+        exporterObj = new OTLPTraceExporter(exporterOptions)
+      }
     } else if (exp.type === 'zipkin') {
       const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin')
       exporterObj = new ZipkinExporter(exporterOptions)

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -29,6 +29,7 @@
     "@fastify/swagger": "^9.5.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/core": "2.7.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.218.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.218.0",
     "@opentelemetry/exporter-zipkin": "2.7.1",
     "@opentelemetry/instrumentation": "0.218.0",

--- a/packages/telemetry/test/telemetry.test.js
+++ b/packages/telemetry/test/telemetry.test.js
@@ -252,6 +252,60 @@ test('should configure OTLP correctly', async () => {
   equal(exporterUrl, 'http://localhost:4317/')
 })
 
+test('should configure OTLP grpc correctly', async () => {
+  const handler = async (request, reply) => {
+    return {}
+  }
+  const app = await setupApp(
+    {
+      applicationName: 'test-application',
+      version: '1.0.0',
+      exporter: {
+        type: 'otlp',
+        options: {
+          protocol: 'grpc',
+          url: 'http://localhost:4317'
+        }
+      }
+    },
+    handler,
+    test.after
+  )
+
+  const { exporters } = app.openTelemetry
+  const exporter = exporters[0]
+  const exporterAddress = (exporter._delegate ?? exporter)._transport._parameters.address
+  equal(exporter.constructor.name, 'OTLPTraceExporter')
+  equal(exporterAddress, 'localhost:4317')
+})
+
+test('should configure OTLP grpc correctly using the transport alias', async () => {
+  const handler = async (request, reply) => {
+    return {}
+  }
+  const app = await setupApp(
+    {
+      applicationName: 'test-application',
+      version: '1.0.0',
+      exporter: {
+        type: 'otlp',
+        options: {
+          transport: 'grpc',
+          url: 'http://localhost:4317'
+        }
+      }
+    },
+    handler,
+    test.after
+  )
+
+  const { exporters } = app.openTelemetry
+  const exporter = exporters[0]
+  const exporterAddress = (exporter._delegate ?? exporter)._transport._parameters.address
+  equal(exporter.constructor.name, 'OTLPTraceExporter')
+  equal(exporterAddress, 'localhost:4317')
+})
+
 test('should configure Zipkin correctly', async () => {
   const handler = async (request, reply) => {
     return {}

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -490,6 +490,14 @@ export interface PlatformaticViteConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;
@@ -515,6 +523,14 @@ export interface PlatformaticViteConfig {
                * The path to write the traces to. Only for file exporter.
                */
               path?: string;
+              /**
+               * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+               */
+              protocol?: "http" | "grpc";
+              /**
+               * Alias for protocol. Only for the otlp exporter. Defaults to http.
+               */
+              transport?: "http" | "grpc";
               [k: string]: unknown;
             };
             additionalProperties?: never;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -1931,6 +1931,22 @@
                           "path": {
                             "type": "string",
                             "description": "The path to write the traces to. Only for file exporter."
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                          },
+                          "transport": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ],
+                            "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                           }
                         }
                       },
@@ -1967,6 +1983,22 @@
                         "path": {
                           "type": "string",
                           "description": "The path to write the traces to. Only for file exporter."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                        },
+                        "transport": {
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ],
+                          "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                         }
                       }
                     },

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -471,6 +471,14 @@ export type PlatformaticRuntimeConfig = {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;
@@ -496,6 +504,14 @@ export type PlatformaticRuntimeConfig = {
              * The path to write the traces to. Only for file exporter.
              */
             path?: string;
+            /**
+             * The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http.
+             */
+            protocol?: "http" | "grpc";
+            /**
+             * Alias for protocol. Only for the otlp exporter. Defaults to http.
+             */
+            transport?: "http" | "grpc";
             [k: string]: unknown;
           };
           additionalProperties?: never;

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -2676,6 +2676,22 @@
                       "path": {
                         "type": "string",
                         "description": "The path to write the traces to. Only for file exporter."
+                      },
+                      "protocol": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ],
+                        "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                       }
                     }
                   },
@@ -2712,6 +2728,22 @@
                     "path": {
                       "type": "string",
                       "description": "The path to write the traces to. Only for file exporter."
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "The OTLP transport protocol to use. Only for the otlp exporter. Defaults to http."
+                    },
+                    "transport": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ],
+                      "description": "Alias for protocol. Only for the otlp exporter. Defaults to http."
                     }
                   }
                 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2152,6 +2152,9 @@ importers:
       '@opentelemetry/core':
         specifier: 2.7.1
         version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc':
+        specifier: 0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: 0.218.0
         version: 0.218.0(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
## Summary
- add OTLP trace export over gRPC behind telemetry exporter options
- keep HTTP as the default OTLP transport
- document `protocol` / `transport` options and OTLP URL differences across docs

## Changes
- support `telemetry.exporter.options.protocol = "grpc"`
- support `telemetry.exporter.options.transport = "grpc"` as an alias
- add `@opentelemetry/exporter-trace-otlp-grpc`
- extend telemetry schema and generated config types
- add tests for OTLP gRPC exporter selection
- update docs wherever telemetry is documented in `docs/`

## Notes
- OTLP/HTTP uses URLs like `http://host:4318/v1/traces`
- OTLP/gRPC uses URLs like `http://host:4317` and must not include `/v1/traces`

## Validation
- `pnpm --filter @platformatic/telemetry lint`
- `cd packages/telemetry && node --test test/telemetry.test.js`
