### PR TITLE
fix: allow env var substitution for telemetry.diagLogger

### DIFF
--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticAstroConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -401,7 +401,7 @@ export interface PlatformaticBasicConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -1527,7 +1527,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -569,7 +569,7 @@ export interface PlatformaticComposerConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;
@@ -798,7 +798,7 @@ export interface PlatformaticComposerConfig {
     /**
      * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
      */
-    diagLogger?: boolean;
+    diagLogger?: boolean | string;
   };
   watch?:
     | {

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -2200,7 +2200,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
@@ -2874,7 +2881,14 @@
           ]
         },
         "diagLogger": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -484,7 +484,7 @@ export interface PlatformaticDatabaseConfig {
     /**
      * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
      */
-    diagLogger?: boolean;
+    diagLogger?: boolean | string;
   };
   runtime?: {
     preload?: string | string[];
@@ -879,7 +879,7 @@ export interface PlatformaticDatabaseConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1319,7 +1319,14 @@
           ]
         },
         "diagLogger": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
@@ -2845,7 +2852,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -704,7 +704,14 @@ export const telemetry = {
       ]
     },
     diagLogger: {
-      type: 'boolean',
+      anyOf: [
+        {
+          type: 'boolean'
+        },
+        {
+          type: 'string'
+        }
+      ],
       description: 'Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.'
     }
   },

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -786,7 +786,7 @@ export interface PlatformaticGatewayConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;
@@ -1015,7 +1015,7 @@ export interface PlatformaticGatewayConfig {
     /**
      * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
      */
-    diagLogger?: boolean;
+    diagLogger?: boolean | string;
   };
   watch?:
     | {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -2838,7 +2838,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },
@@ -3512,7 +3519,14 @@
           ]
         },
         "diagLogger": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticNestJSConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticNextJsConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticNodeJsConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticReactRouterConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticRemixConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -496,7 +496,7 @@ export type PlatformaticRuntimeConfig = {
     /**
      * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
      */
-    diagLogger?: boolean;
+    diagLogger?: boolean | string;
   };
   verticalScaler?: {
     enabled?: boolean;

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -2597,7 +2597,14 @@
           ]
         },
         "diagLogger": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -246,7 +246,7 @@ export interface PlatformaticServiceConfig {
     /**
      * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
      */
-    diagLogger?: boolean;
+    diagLogger?: boolean | string;
   };
   watch?:
     | {
@@ -708,7 +708,7 @@ export interface PlatformaticServiceConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -786,7 +786,14 @@
           ]
         },
         "diagLogger": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },
@@ -2530,7 +2537,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticTanStackConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -517,7 +517,7 @@ export interface PlatformaticViteConfig {
       /**
        * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
        */
-      diagLogger?: boolean;
+      diagLogger?: boolean | string;
     };
     verticalScaler?: {
       enabled?: boolean;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -1918,7 +1918,14 @@
               ]
             },
             "diagLogger": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
             }
           },

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -496,7 +496,7 @@ export type PlatformaticRuntimeConfig = {
     /**
      * Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level.
      */
-    diagLogger?: boolean;
+    diagLogger?: boolean | string;
   };
   verticalScaler?: {
     enabled?: boolean;

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -2597,7 +2597,14 @@
           ]
         },
         "diagLogger": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Enable the OpenTelemetry diagnostic logger. Diagnostic messages are forwarded to the Platformatic global logger using the current logger level."
         }
       },


### PR DESCRIPTION
Change `telemetry.diagLogger` from `type: boolean` to `anyOf: [boolean, string]` to match other boolean config options, enabling env var substitution (e.g. $TELEMETRY_DIAG_LOGGER).