### PR TITLE
fix(basic): exit worker when child dies from a signal

### DIFF
--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -544,11 +544,21 @@ export class BaseCapability extends EventEmitter {
       await this.childManager.eject()
     }
 
-    // If the process exits prematurely, terminate the thread with the same code
-    this.subprocess.on('exit', code => {
-      if (this.#subprocessStarted && typeof code === 'number' && code !== 0) {
+    // If the process exits prematurely, terminate the thread with the same code.
+    // When the child is killed by a signal (V8 FATAL/SIGABRT, OOM SIGKILL, native
+    // segfault, etc.) Node invokes the listener with code=null and signal set —
+    // propagate those as a non-zero exit so the runtime can replace the worker
+    // promptly instead of waiting for ELU/heap monitoring to flag it unhealthy.
+    this.subprocess.on('exit', (code, signal) => {
+      if (!this.#subprocessStarted) {
+        return
+      }
+      if (typeof code === 'number' && code !== 0) {
         this.childManager.close()
         process.exit(code)
+      } else if (signal) {
+        this.childManager.close()
+        process.exit(1)
       }
     })
 

--- a/packages/basic/test/capability.test.js
+++ b/packages/basic/test/capability.test.js
@@ -740,6 +740,30 @@ test('BaseCapability - startCommand - should kill the process on non-zero exit c
   deepStrictEqual(await promise, 123)
 })
 
+test(
+  'BaseCapability - startCommand - should kill the process when the child dies from a signal',
+  { skip: isWindows },
+  async t => {
+    const capability = await create(t)
+
+    const { promise, resolve, reject } = Promise.withResolvers()
+    t.mock.method(process, 'exit', code => {
+      resolve(code)
+    })
+
+    const timeout = setTimeout(() => {
+      reject(new Error('process.exit was not called within 5s after signal-induced child exit'))
+    }, 5000)
+    timeout.unref()
+    t.after(() => clearTimeout(timeout))
+
+    const executablePath = fileURLToPath(new URL('./fixtures/signal-exit.js', import.meta.url))
+    await capability.startWithCommand(`node ${executablePath}`)
+
+    deepStrictEqual(await promise, 1)
+  }
+)
+
 test('BaseCapability - stopCommand - should forcefully exit the process if it doesnt exit within the allowed timeout', async t => {
   const capability = await create(
     t,

--- a/packages/basic/test/fixtures/signal-exit.js
+++ b/packages/basic/test/fixtures/signal-exit.js
@@ -1,0 +1,7 @@
+import { createServer } from 'node:http'
+
+createServer().listen({ host: '127.0.0.1', port: 0 })
+
+setTimeout(() => {
+  process.kill(process.pid, 'SIGABRT')
+}, 100)


### PR DESCRIPTION
Fixes #4771.

## Summary

When a child spawned via `commands.production` is killed by a signal (V8 FATAL → SIGABRT, OOM → SIGKILL, native segfault → SIGSEGV), the Worker thread hosting the capability stayed alive indefinitely. The runtime only replaced the unhealthy worker after `maxUnhealthyChecks * interval` of ELU/heap monitoring (~2.5 min with defaults), producing 2–3 min service-degradation windows per crash.

Per [Node's `child_process` exit-event docs](https://nodejs.org/api/child_process.html#event-exit), signal-terminated children invoke the listener with `(code=null, signal='SIGABRT'|…)`. The handler at `packages/basic/lib/capability.js:548` ignored `signal` and gated on `typeof code === 'number'`, so `process.exit` was never called for signal-class deaths.

## Fix

Read `signal` in the listener and propagate signal deaths as `process.exit(1)` so the runtime restarts the worker promptly — matching the comment immediately above the handler ("terminate the thread with the same code").

## Test plan

- [x] New test `BaseCapability - startCommand - should kill the process when the child dies from a signal` reproduces the bug (added `test/fixtures/signal-exit.js` that calls `process.kill(process.pid, 'SIGABRT')`). Test fails on unfixed code (5 s timeout because `process.exit` is never called) and passes after the fix.
- [x] Existing `should kill the process on non-zero exit code` test still passes (numeric-code path unchanged).
- [x] Full `packages/basic/test/capability.test.js` suite green (35/35).
- [x] Lint clean.

Skipped on Windows (signal semantics differ).

Assisted-by: claude-code:claude-opus-4-7[1m]