### PR TITLE
fix(runtime): add method declarations to Runtime class

### DIFF
--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -142,7 +142,26 @@ export class WrappedGenerator extends BaseGenerator {}
 
 export declare const schema: JSONSchemaType<PlatformaticRuntimeConfig>
 
-export declare class Runtime {}
+export declare class Runtime {
+  init (): Promise<void>
+  start (silent?: boolean): Promise<void>
+  stop (silent?: boolean): Promise<void>
+  close (silent?: boolean): Promise<void>
+  restart (applications?: string[]): Promise<string | undefined>
+  inject (id: string, injectParams: InjectParams): Promise<InjectResponse>
+  getUrl (): string | undefined
+  getRuntimeStatus (): string
+  getRuntimeMetadata (): Promise<RuntimeMetadata>
+  getRuntimeEnv (): Record<string, string>
+  getRuntimeConfig (includeMeta?: boolean): Record<string, unknown>
+  getApplicationsIds (): string[]
+  getApplicationDetails (id: string, allowUnloaded?: boolean): Promise<ApplicationDetails>
+  startApplication (id: string, silent?: boolean): Promise<void>
+  stopApplication (id: string, silent?: boolean): Promise<void>
+  restartApplication (id: string): Promise<void>
+  addApplications (applications: unknown[], start?: boolean): Promise<ApplicationDetails[]>
+  removeApplications (applications: string[], silent?: boolean): Promise<ApplicationDetails[]>
+}
 
 export function wrapInRuntimeConfig (
   config: Configuration<unknown>,

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'tstyche'
 import type { Configuration } from '@platformatic/foundation'
-import { create, loadConfiguration, type Runtime, type RuntimeConfiguration, } from '../../index.js'
+import { create, loadConfiguration, type Runtime, type RuntimeConfiguration, type ApplicationDetails, type InjectParams, type InjectResponse, type RuntimeMetadata } from '../../index.js'
 
 const context = {} as Configuration
 
@@ -22,4 +22,90 @@ test('loadConfiguration', () => {
 
   expect(loadConfiguration('.', './config.json', context)).type.toBe<Promise<RuntimeConfiguration>>()
   expect(loadConfiguration({ baseUrl: 'http://localhost:3000' }, './config.json', context)).type.toBe<Promise<RuntimeConfiguration>>()
+})
+
+const runtime = {} as Runtime
+
+test('Runtime.init', () => {
+  expect(runtime.init()).type.toBe<Promise<void>>()
+})
+
+test('Runtime.start', () => {
+  expect(runtime.start()).type.toBe<Promise<void>>()
+  expect(runtime.start(true)).type.toBe<Promise<void>>()
+})
+
+test('Runtime.stop', () => {
+  expect(runtime.stop()).type.toBe<Promise<void>>()
+  expect(runtime.stop(false)).type.toBe<Promise<void>>()
+})
+
+test('Runtime.close', () => {
+  expect(runtime.close()).type.toBe<Promise<void>>()
+  expect(runtime.close(true)).type.toBe<Promise<void>>()
+})
+
+test('Runtime.restart', () => {
+  expect(runtime.restart()).type.toBe<Promise<string | undefined>>()
+  expect(runtime.restart(['api', 'worker'])).type.toBe<Promise<string | undefined>>()
+})
+
+test('Runtime.inject', () => {
+  const params: InjectParams = { url: '/health' }
+  expect(runtime.inject('api', params)).type.toBe<Promise<InjectResponse>>()
+  expect(runtime.inject('api', { method: 'POST', url: '/seed', body: {} })).type.toBe<Promise<InjectResponse>>()
+})
+
+test('Runtime.getUrl', () => {
+  expect(runtime.getUrl()).type.toBe<string | undefined>()
+})
+
+test('Runtime.getRuntimeStatus', () => {
+  expect(runtime.getRuntimeStatus()).type.toBe<string>()
+})
+
+test('Runtime.getRuntimeMetadata', () => {
+  expect(runtime.getRuntimeMetadata()).type.toBe<Promise<RuntimeMetadata>>()
+})
+
+test('Runtime.getRuntimeEnv', () => {
+  expect(runtime.getRuntimeEnv()).type.toBe<Record<string, string>>()
+})
+
+test('Runtime.getRuntimeConfig', () => {
+  expect(runtime.getRuntimeConfig()).type.toBe<Record<string, unknown>>()
+  expect(runtime.getRuntimeConfig(true)).type.toBe<Record<string, unknown>>()
+})
+
+test('Runtime.getApplicationsIds', () => {
+  expect(runtime.getApplicationsIds()).type.toBe<string[]>()
+})
+
+test('Runtime.getApplicationDetails', () => {
+  expect(runtime.getApplicationDetails('api')).type.toBe<Promise<ApplicationDetails>>()
+  expect(runtime.getApplicationDetails('api', true)).type.toBe<Promise<ApplicationDetails>>()
+})
+
+test('Runtime.startApplication', () => {
+  expect(runtime.startApplication('api')).type.toBe<Promise<void>>()
+  expect(runtime.startApplication('api', true)).type.toBe<Promise<void>>()
+})
+
+test('Runtime.stopApplication', () => {
+  expect(runtime.stopApplication('api')).type.toBe<Promise<void>>()
+  expect(runtime.stopApplication('api', false)).type.toBe<Promise<void>>()
+})
+
+test('Runtime.restartApplication', () => {
+  expect(runtime.restartApplication('api')).type.toBe<Promise<void>>()
+})
+
+test('Runtime.addApplications', () => {
+  expect(runtime.addApplications([])).type.toBe<Promise<ApplicationDetails[]>>()
+  expect(runtime.addApplications([], true)).type.toBe<Promise<ApplicationDetails[]>>()
+})
+
+test('Runtime.removeApplications', () => {
+  expect(runtime.removeApplications(['api'])).type.toBe<Promise<ApplicationDetails[]>>()
+  expect(runtime.removeApplications(['api'], true)).type.toBe<Promise<ApplicationDetails[]>>()
 })


### PR DESCRIPTION
Add all public method declarations to `Runtime`, derived directly from `lib/runtime.js`:

- Lifecycle: `init`, `start`, `stop`, `close`, `restart`
- HTTP: `inject`
- Introspection: `getUrl`, `getRuntimeStatus`, `getRuntimeMetadata`, `getRuntimeEnv`, `getRuntimeConfig`
- Application management: `getApplicationsIds`, `getApplicationDetails`, `startApplication`, `stopApplication`, `restartApplication`, `addApplications`, `removeApplications`