### PR TITLE
Do not use pnpm cache for releases to protect against cache poisoning

### DIFF
--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
       - run: npm install npm -g
       - name: pnpm install
         uses: nick-fields/retry@v3.0.2


### PR DESCRIPTION
Ref: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem