### PR TITLE
test: stabilize flaky runtime and service tests

### DIFF
--- a/packages/runtime/lib/logger.js
+++ b/packages/runtime/lib/logger.js
@@ -63,6 +63,7 @@ const colors = [
 function createLoggerContext () {
   const context = {
     colors: {},
+    closeables: [],
     maxLength: 0,
     updatePrefixes (ids) {
       context.colors = {}
@@ -179,28 +180,29 @@ export async function createLogger (config) {
   const multiStream = pino.multistream([{ stream: cliStream, level: loggerConfig.level }])
 
   if (config.telemetry && config.logger.openTelemetryExporter) {
-    multiStream.add(
-      pino.transport({
-        target: 'pino-opentelemetry-transport',
-        options: {
-          resourceAttributes: {
-            'service.name': config.telemetry.applicationName,
-            'service.version': config.telemetry.version
-          },
-          logRecordProcessorOptions: [
-            {
-              recordProcessorType: 'simple',
-              exporterOptions: {
-                protocol: config.logger.openTelemetryExporter.protocol,
-                httpExporterOptions: {
-                  url: config.logger.openTelemetryExporter.url
-                }
+    const openTelemetryTransport = pino.transport({
+      target: 'pino-opentelemetry-transport',
+      options: {
+        resourceAttributes: {
+          'service.name': config.telemetry.applicationName,
+          'service.version': config.telemetry.version
+        },
+        logRecordProcessorOptions: [
+          {
+            recordProcessorType: 'simple',
+            exporterOptions: {
+              protocol: config.logger.openTelemetryExporter.protocol,
+              httpExporterOptions: {
+                url: config.logger.openTelemetryExporter.url
               }
             }
-          ]
-        }
-      })
-    )
+          }
+        ]
+      }
+    })
+
+    context.closeables.push(openTelemetryTransport)
+    multiStream.add(openTelemetryTransport)
   }
 
   const logsFileMb = 5

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -20,6 +20,7 @@ import { createRequire } from 'node:module'
 import { availableParallelism } from 'node:os'
 import { dirname, isAbsolute, join } from 'node:path'
 import { Readable } from 'node:stream'
+import { finished } from 'node:stream/promises'
 import { setImmediate as immediate, setTimeout as sleep } from 'node:timers/promises'
 import { pathToFileURL } from 'node:url'
 import { Worker } from 'node:worker_threads'
@@ -400,11 +401,22 @@ export class Runtime extends EventEmitter {
     }
 
     if (this.logger) {
-      this.#loggerDestination?.end()
+      const loggerDestination = this.#loggerDestination
+      const loggerCloseables = this.#loggerContext?.closeables ?? []
 
       this.logger = abstractLogger
       this.#loggerDestination = null
       this.#loggerContext = null
+
+      if (loggerDestination) {
+        loggerDestination.end()
+        await finished(loggerDestination).catch(() => {})
+      }
+
+      for (const closeable of loggerCloseables) {
+        closeable.end?.()
+        await finished(closeable).catch(() => {})
+      }
     }
 
     this.#updateStatus('closed')

--- a/packages/runtime/test/multiple-workers/reuse-port.test.js
+++ b/packages/runtime/test/multiple-workers/reuse-port.test.js
@@ -1,5 +1,6 @@
 import { features } from '@platformatic/foundation'
 import { deepStrictEqual, ok } from 'node:assert'
+import { createServer } from 'node:net'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -7,17 +8,49 @@ import { request } from 'undici'
 import { createRuntime, updateConfigFile } from '../helpers.js'
 import { prepareRuntime, waitForEvents } from './helper.js'
 
+async function waitForPortRelease (port, attempts = 50, interval = 100) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const server = createServer()
+
+    try {
+      await new Promise((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(port, '127.0.0.1', resolve)
+      })
+
+      await new Promise((resolve, reject) => {
+        server.close(error => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      })
+
+      return
+    } catch {
+      await sleep(interval)
+    }
+  }
+
+  throw new Error(`Port ${port} was not released in time`)
+}
+
 test('applications are started with multiple workers even for the entrypoint when Node.js supports reusePort', async t => {
   const getPort = await import('get-port')
   const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
   const configFile = resolve(root, './platformatic.json')
-  const port = await getPort.default()
+  const port = await getPort.default({ host: '127.0.0.1' })
 
-  // Give some time to the OS to release the port
-  await sleep(1000)
+  await waitForPortRelease(port)
 
   await updateConfigFile(configFile, contents => {
-    contents.server = { port }
+    contents.server = {
+      hostname: '127.0.0.1',
+      port
+    }
     contents.autoload = undefined
   })
 

--- a/packages/service/test/fixtures/ready-directory/ready-plugin.js
+++ b/packages/service/test/fixtures/ready-directory/ready-plugin.js
@@ -3,5 +3,7 @@ import { setTimeout as sleep } from 'node:timers/promises'
 export default async function (app) {
   app.ready(async function () {})
 
-  await sleep(1000)
+  // Keep a tiny async gap so the test still exercises plugin readiness without
+  // depending on a long timer that can make CI scheduling more brittle.
+  await sleep(10)
 }

--- a/packages/service/test/routes.test.js
+++ b/packages/service/test/routes.test.js
@@ -277,8 +277,5 @@ test('ready in plugin', async t => {
     })
   )
 
-  t.after(async () => {
-    await app.stop()
-  })
   await app.start({ listen: true })
 })


### PR DESCRIPTION
## Summary

This PR stabilizes a few flaky tests by tightening resource cleanup and reducing timing sensitivity:

- wait for runtime logger destinations/transports to finish flushing during shutdown
- make the reuse-port test reserve and validate its chosen port deterministically
- reduce the `ready in plugin` fixture delay and remove redundant teardown in that test

## Testing

- `cd packages/runtime && node --test --test-reporter=spec test/logger.test.js test/multiple-workers/reuse-port.test.js`
- `cd packages/service && node --test --test-reporter=spec test/routes.test.js`
