### PR TITLE
docs(runtime): refresh programmatic API reference

### DIFF
--- a/docs/reference/runtime/overview.md
+++ b/docs/reference/runtime/overview.md
@@ -25,7 +25,7 @@ The following configuration file can be used to start a new Platformatic Runtime
 
 ```json
 {
-  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.54.0.json",
   "autoload": {
     "path": "./packages",
     "exclude": ["docs"]

--- a/docs/reference/runtime/programmatic.md
+++ b/docs/reference/runtime/programmatic.md
@@ -2,108 +2,151 @@ import Issues from '../../getting-started/issues.md';
 
 # Programmatic API
 
-Using the `@platformatic/runtime` API, you can start Platformatic applications programmatically, bypassing the command line. This API facilitates interaction with various application types such as `service`, `db`, `gateway`, and `runtime`, simplifying operations across different applications.
+The `@platformatic/runtime` package can be used to start, control, and inspect a Platformatic application from Node.js code, without going through the CLI. This is useful for tests, custom tooling, and embedding Platformatic in another application.
 
-## `create()`
+The API works with all Platformatic application types — `service`, `db`, `gateway`, `composer`, and `runtime` itself. Configurations that are not already a `runtime` configuration are automatically wrapped in one.
 
-`create` function initializes a server based on a configuration object or file. It supports configurations for Platformatic Service, Platformatic DB, Platformatic Gateway, and any other applications developed on top of [Platformatic Service](../service/programmatic.md).
+## Getting started
 
 ```js
 import { create } from '@platformatic/runtime'
 
-// Initialize the server using a configuration file
 const app = await create('path/to/platformatic.runtime.json')
 const entrypointUrl = await app.start()
 
-// Sample request to the server's entrypoint
 const res = await fetch(entrypointUrl)
 console.log(await res.json())
-
-// Perform other operations
 
 await app.close()
 ```
 
-## Custom Configuration
+`create()` returns a `Runtime` instance. The instance exposes lifecycle, introspection, HTTP-injection, and per-application control methods documented below.
 
-You can customize your server setup directly within your code by specifying the configuration details:
+## Top-level functions
+
+### `create(configOrRoot, sourceOrConfig?, context?)`
+
+Builds a `Runtime` from a configuration file path or an in-memory configuration object. The returned runtime is **not** started — call `start()` (or pass `context.start = true`) to bring applications up.
+
+When the configuration's `$schema` resolves to a non-runtime module (e.g. `@platformatic/service`, `@platformatic/db`, `@platformatic/gateway`), it is automatically wrapped in a runtime configuration so the same API works for any application type.
 
 ```js
 import { create } from '@platformatic/runtime'
 
-const config = {
-  // $schema: 'https://schemas.platformatic.dev/@platformatic/runtime/3.0.0.json',
-  // $schema: 'https://schemas.platformatic.dev/@platformatic/service/3.0.0.json',
-  // $schema: 'https://schemas.platformatic.dev/@platformatic/db/3.0.0.json',
-  // $schema: 'https://schemas.platformatic.dev/@platformatic/gateway/3.0.0.json'
-  ...
-}
-const app = await create(config)
+const app = await create({
+  $schema: 'https://schemas.platformatic.dev/@platformatic/runtime/3.54.0.json',
+  entrypoint: 'main',
+  applications: [{ id: 'main', path: './main' }]
+})
 
 await app.start()
 ```
 
-## `loadConfiguration()`
+Equivalent `$schema` values that `create()` accepts and wraps transparently:
 
-The `loadConfig` function reads and parses a configuration file for any Platformatic application. It can automatically detect the type of application or accept explicit instructions.
+```text
+https://schemas.platformatic.dev/@platformatic/runtime/3.54.0.json
+https://schemas.platformatic.dev/@platformatic/service/3.54.0.json
+https://schemas.platformatic.dev/@platformatic/db/3.54.0.json
+https://schemas.platformatic.dev/@platformatic/gateway/3.54.0.json
+https://schemas.platformatic.dev/@platformatic/composer/3.54.0.json
+```
+
+By default `create()` installs signal handlers (`SIGTERM`/`SIGINT` via `close-with-grace`, and `SIGUSR2` to trigger `runtime.restart()`). Pass `context: { setupSignals: false }` to opt out — recommended when embedding the runtime in tests or another process that owns its own signal handling.
+
+### `loadConfiguration(configOrRoot, sourceOrConfig?, context?)`
+
+Reads a configuration file (or accepts an in-memory object), validates it against the runtime schema, applies the upgrade pipeline for older schemas, and resolves environment variables. The application type is auto-detected from the `$schema`; non-runtime configurations are wrapped in a runtime configuration via `wrapInRuntimeConfig()`.
 
 ```js
 import { loadConfiguration } from '@platformatic/runtime'
 
-// Read the configuration and automatically detect the application type.
 const config = await loadConfiguration('/path/to/platformatic.config.json')
 ```
 
-## Adding and Removing applications at runtime
+Use this when you need to inspect or mutate the resolved configuration before passing it to `create()`.
 
-The Runtime object provides methods to dynamically add and remove applications during runtime execution.
+### `prepareApplication(runtimeConfig, application)`
 
-### API Documentation
+Normalizes an application descriptor (resolving paths, detecting the capability type, applying defaults for `watch`, `management`, `workers`, `localUrl`, etc.) so it is ready to be passed to `runtime.addApplications()`.
 
-### `runtime.addApplications(applications, start = false)`
+You must call `prepareApplication()` before adding an application at runtime — see [Adding and removing applications at runtime](#adding-and-removing-applications-at-runtime).
 
-Dynamically adds new applications to a running runtime instance. This allows you to register applications after the runtime has been initialized.
+### `wrapInRuntimeConfig(config, context?)`
 
-If `start` is `true`, then the new application will immediately be started in parallel. Defaults to `false`.
+Wraps a single-application configuration (service, db, gateway, composer) into a synthetic one-application runtime configuration. Called automatically by `create()` and `loadConfiguration()`; exported for advanced use cases.
 
-**Important**: Application objects passed in the `applications` argument should always be processed via `prepareApplication` first to ensure proper options normalization.
+### `loadApplicationsCommands(executableName?)`
 
-```js
-import { create, prepareApplication } from '@platformatic/runtime'
+Walks the applications declared in the nearest runtime configuration and aggregates any custom CLI commands they expose (via each capability's `createCommands` hook). Returns `{ applications, commands, help }`. Used by the CLI to surface application-specific subcommands.
 
-const app = await create('path/to/platformatic.runtime.json')
-// const app = await create('path/to/watt.json')
-await app.start()
+## The `Runtime` instance
 
-// Prepare and add new applications dynamically
-const newApplications = [
-  await prepareApplication(app.getRuntimeConfig(true), { id: 'my-new-service', path: './new-service' })
-]
+`create()` resolves to a `Runtime` instance. Its methods are listed below.
 
-await app.addApplications(newApplications, true) // true to start immediately
-```
+### Lifecycle
 
-#### `runtime.removeApplications(applications, silent = false)`
+- **`runtime.start(silent = false): Promise<string | undefined>`** — Starts all applications. Returns the entrypoint's external URL (or `undefined` if no entrypoint binds an external port). If `init()` hasn't been called yet, `start()` calls it.
+- **`runtime.stop(silent = false): Promise<void>`** — Stops all applications. The entrypoint is stopped first so it stops accepting new requests immediately.
+- **`runtime.close(silent = false): Promise<void>`** — Stops applications and tears the runtime down completely (closes the management API, broadcast channels, dispatcher, etc.). After `close()` the runtime cannot be restarted; create a new instance.
+- **`runtime.restart(applications?: string[]): Promise<string | undefined>`** — Restarts every application (or only the IDs in `applications`). Returns the entrypoint URL once the restart completes.
+- **`runtime.init(): Promise<void>`** — Performs one-time setup (loads capabilities, prepares workers). Usually called transitively by `start()`; call it explicitly only if you need the runtime in `init`'ed state without starting applications.
 
-Dynamically removes applications from the runtime. This will stop the applications and clean up their resources.
+### HTTP injection
+
+**`runtime.inject(id, injectParams): Promise<InjectResponse>`**
+
+Dispatches an HTTP request straight into an application by its `id`, without going through the network. Behaves like Fastify's `inject` and is the recommended way to write integration tests against a runtime.
 
 ```js
 import { create } from '@platformatic/runtime'
 
-const app = await create('path/to/watt.json')
+const app = await create('path/to/watt.json', { setupSignals: false })
 await app.start()
 
-// Remove applications by ID
-const applicationsToRemove = ['service-1', 'service-2']
+const res = await app.inject('main', {
+  method: 'POST',
+  url: '/items',
+  headers: { 'content-type': 'application/json' },
+  body: { name: 'widget' }
+})
 
-await app.removeApplications(applicationsToRemove)
+console.log(res.statusCode, JSON.parse(res.body))
+
+await app.close()
 ```
 
-If `silent` is `true`, then logging will be suppressed during the removal process. Defaults to `false`.
+`injectParams` accepts a plain URL string as shorthand, or an object with `method`, `url`, `headers`, `query`, and `body`. When `content-type: application/json` is set, an object `body` is automatically `JSON.stringify`'d.
 
-**Important**: The entrypoint application cannot be removed, attempting to do so will throw a `CannotRemoveEntrypointError`.
+The response object exposes `statusCode`, `statusMessage`, `headers`, `body` (string), `payload` (alias of `body`), and `rawPayload` (`ArrayBuffer`).
 
-### Example: Dynamic Service Management
+### Introspection
+
+- **`runtime.getUrl(): string | undefined`** — The entrypoint's external URL once started.
+- **`runtime.getRuntimeStatus(): string`** — One of `starting`, `started`, `stopping`, `stopped`, `closed`.
+- **`runtime.getRuntimeMetadata(): Promise<RuntimeMetadata>`** — `pid`, `cwd`, `argv`, `uptimeSeconds`, `execPath`, `nodeVersion`, `projectDir`, `packageName`, `packageVersion`, `url`, `platformaticVersion`.
+- **`runtime.getRuntimeConfig(includeMeta = false): object`** — The resolved configuration. When `includeMeta` is `true` the `[kMetadata]` symbol is preserved (needed by `prepareApplication()`).
+- **`runtime.getRuntimeEnv(): Record<string, string>`** — Environment variables visible to the runtime process.
+- **`runtime.getApplicationsIds(): string[]`** — IDs of all configured applications.
+- **`runtime.getApplicationDetails(id, allowUnloaded = false): Promise<ApplicationDetails>`** — Per-application info: `type`, `status`, `dependencies`, `version`, `localUrl`, `entrypoint`, `workers`, `url`.
+
+### Per-application control
+
+- **`runtime.startApplication(id, silent = false): Promise<void>`**
+- **`runtime.stopApplication(id, silent = false): Promise<void>`**
+- **`runtime.restartApplication(id): Promise<void>`**
+
+These act on a single application by `id`. The entrypoint can be restarted but cannot be removed (see below).
+
+## Adding and removing applications at runtime
+
+The runtime supports adding and removing applications after `start()` has been called.
+
+### `runtime.addApplications(applications, start = false)`
+
+Registers new applications on a running runtime. If `start` is `true`, the new applications are started in parallel; otherwise they remain stopped until `startApplication()` is called.
+
+Each entry in `applications` must be processed through `prepareApplication()` first — it normalizes paths, detects the capability type, and applies defaults the runtime expects.
 
 ```js
 import { create, prepareApplication } from '@platformatic/runtime'
@@ -111,7 +154,37 @@ import { create, prepareApplication } from '@platformatic/runtime'
 const app = await create('path/to/watt.json')
 await app.start()
 
-// Add a new service dynamically
+const newApplications = [
+  await prepareApplication(app.getRuntimeConfig(true), {
+    id: 'analytics-service',
+    path: './analytics',
+    workers: 2
+  })
+]
+
+await app.addApplications(newApplications, true)
+```
+
+Pass `app.getRuntimeConfig(true)` (with `includeMeta: true`) so `prepareApplication()` can resolve relative paths against the runtime's root.
+
+### `runtime.removeApplications(applications, silent = false)`
+
+Stops the listed applications and removes them from the runtime. `applications` is an array of application IDs. Set `silent` to `true` to suppress logging.
+
+```js
+await app.removeApplications(['analytics-service'])
+```
+
+The entrypoint cannot be removed; attempting to do so throws a `CannotRemoveEntrypointError`.
+
+### Example: dynamic application management
+
+```js
+import { create, prepareApplication } from '@platformatic/runtime'
+
+const app = await create('path/to/watt.json')
+await app.start()
+
 const newService = await prepareApplication(app.getRuntimeConfig(true), {
   id: 'analytics-service',
   path: './analytics',
@@ -120,8 +193,20 @@ const newService = await prepareApplication(app.getRuntimeConfig(true), {
 
 await app.addApplications([newService], true)
 
-// Later, remove it when no longer needed
+// Later, when no longer needed
 await app.removeApplications(['analytics-service'])
 ```
+
+## Other exports
+
+The package also exports:
+
+- **`Runtime`** — the class itself, for `instanceof` checks and advanced subclassing scenarios.
+- **`Generator`**, **`WrappedGenerator`** — generators used by `create-platformatic` to scaffold new runtimes.
+- **`schema`** — the JSON Schema for runtime configuration.
+- **`transform`** — the configuration transform pipeline used internally.
+- **`errors`** — a namespace of `@fastify/error` constructors (`ApplicationNotFoundError`, `MissingEntrypointError`, `CannotRemoveEntrypointError`, etc.).
+- **`symbols`** — internal symbols (`kConfig`, `kId`, `kITC`, ...) used to attach metadata to configuration and worker objects.
+- **`version`** — the package version string.
 
 <Issues />

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -144,7 +144,7 @@ export declare const schema: JSONSchemaType<PlatformaticRuntimeConfig>
 
 export declare class Runtime {
   init (): Promise<void>
-  start (silent?: boolean): Promise<void>
+  start (silent?: boolean): Promise<string | undefined>
   stop (silent?: boolean): Promise<void>
   close (silent?: boolean): Promise<void>
   restart (applications?: string[]): Promise<string | undefined>

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -31,8 +31,8 @@ test('Runtime.init', () => {
 })
 
 test('Runtime.start', () => {
-  expect(runtime.start()).type.toBe<Promise<void>>()
-  expect(runtime.start(true)).type.toBe<Promise<void>>()
+  expect(runtime.start()).type.toBe<Promise<string | undefined>>()
+  expect(runtime.start(true)).type.toBe<Promise<string | undefined>>()
 })
 
 test('Runtime.stop', () => {


### PR DESCRIPTION
## Summary

- Rewrite `docs/reference/runtime/programmatic.md` to cover the full `Runtime` instance API (lifecycle, `inject`, introspection getters, per-app control) and the `prepareApplication` / `loadApplicationsCommands` / `wrapInRuntimeConfig` exports that were absent.
- Fix the `loadConfig` → `loadConfiguration` typo and bump stale `3.0.0` / `2.0.0` schema URL examples to `3.54.0` in both `programmatic.md` and `overview.md`.
- Correct `Runtime.start`'s return type in `packages/runtime/index.d.ts` to `Promise<string | undefined>` (the implementation already returns the entrypoint URL) and update the matching tstyche assertion.

## Test plan

- [x] `npm run test:types` in `packages/runtime` passes.
- [ ] Docs preview renders the new sections correctly.