### PR TITLE
feat(runtime): tune Buffer.poolSize and stream highWaterMark per worker

### DIFF
--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticAstroConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticAstroConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticAstroConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticAstroConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -143,6 +143,7 @@ export interface PlatformaticBasicConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -507,6 +508,7 @@ export interface PlatformaticBasicConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -144,6 +144,7 @@ export interface PlatformaticBasicConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -509,6 +510,7 @@ export interface PlatformaticBasicConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -215,6 +215,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -924,6 +935,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -1940,6 +1963,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -226,6 +226,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -937,6 +948,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -1974,6 +1997,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -311,6 +311,7 @@ export interface PlatformaticComposerConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -675,6 +676,7 @@ export interface PlatformaticComposerConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -312,6 +312,7 @@ export interface PlatformaticComposerConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -677,6 +678,7 @@ export interface PlatformaticComposerConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -888,6 +888,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1597,6 +1608,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2613,6 +2636,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -899,6 +899,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1610,6 +1621,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2647,6 +2670,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -621,6 +621,7 @@ export interface PlatformaticDatabaseConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -985,6 +986,7 @@ export interface PlatformaticDatabaseConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -622,6 +622,7 @@ export interface PlatformaticDatabaseConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -987,6 +988,7 @@ export interface PlatformaticDatabaseConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1551,6 +1551,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -2262,6 +2273,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -3299,6 +3322,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1540,6 +1540,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -2249,6 +2260,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -3265,6 +3288,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -617,7 +617,9 @@ export const health = {
     maxHeapUsed: overridableValue({ type: 'number', minimum: 0, maximum: 1 }, 0.99),
     maxHeapTotal: overridableValue({ type: 'number', minimum: 0 }, 4 * Math.pow(1024, 3)), // 4GB
     maxYoungGeneration: overridableValue({ type: 'number', minimum: 0 }, 128 * Math.pow(1024, 2)), // 128MB,
-    codeRangeSize: overridableValue({ type: 'number', minimum: 0 }, 268435456)
+    codeRangeSize: overridableValue({ type: 'number', minimum: 0 }, 268435456),
+    bufferPoolSize: overridableValue({ type: 'number', minimum: 0 }, 256 * 1024), // 256KB
+    defaultHighWaterMark: overridableValue({ type: 'number', minimum: 0 }, 256 * 1024) // 256KB
   },
   additionalProperties: false
 }

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -528,6 +528,7 @@ export interface PlatformaticGatewayConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -892,6 +893,7 @@ export interface PlatformaticGatewayConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -529,6 +529,7 @@ export interface PlatformaticGatewayConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -894,6 +895,7 @@ export interface PlatformaticGatewayConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1537,6 +1537,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -2248,6 +2259,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -3285,6 +3308,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1526,6 +1526,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -2235,6 +2246,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -3251,6 +3274,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticNestJSConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticNestJSConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticNestJSConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticNestJSConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticNextJsConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticNextJsConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticNextJsConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticNextJsConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticNodeJsConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticNodeJsConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticNodeJsConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticNodeJsConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticReactRouterConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticReactRouterConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticReactRouterConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticReactRouterConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticRemixConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticRemixConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticRemixConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticRemixConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -42,6 +42,8 @@ export type PlatformaticRuntimeConfig = {
           maxHeapTotal?: number | string;
           maxYoungGeneration?: number | string;
           codeRangeSize?: number | string;
+          bufferPoolSize?: number | string;
+          defaultHighWaterMark?: number | string;
         };
         dependencies?: string[];
         arguments?: string[];
@@ -238,6 +240,8 @@ export type PlatformaticRuntimeConfig = {
     maxHeapTotal?: number | string;
     maxYoungGeneration?: number | string;
     codeRangeSize?: number | string;
+    bufferPoolSize?: number | string;
+    defaultHighWaterMark?: number | string;
   };
   undici?: {
     agentOptions?: {

--- a/packages/runtime/fixtures/health-buffer-pool/platformatic.json
+++ b/packages/runtime/fixtures/health-buffer-pool/platformatic.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.44.0.json",
+  "entrypoint": "service",
+  "services": [
+    {
+      "id": "service",
+      "path": "./service",
+      "config": "platformatic.json"
+    }
+  ],
+  "logger": {
+    "level": "info"
+  },
+  "health": {
+    "enabled": false,
+    "bufferPoolSize": 262144,
+    "defaultHighWaterMark": 262144
+  },
+  "restartOnError": 1000
+}

--- a/packages/runtime/fixtures/health-buffer-pool/service/platformatic.json
+++ b/packages/runtime/fixtures/health-buffer-pool/service/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.6.0.json",
+  "plugins": {
+    "paths": ["./plugin.js"]
+  },
+  "server": {
+    "logger": {
+      "level": "error"
+    }
+  }
+}

--- a/packages/runtime/fixtures/health-buffer-pool/service/plugin.js
+++ b/packages/runtime/fixtures/health-buffer-pool/service/plugin.js
@@ -1,0 +1,11 @@
+import { Buffer } from 'node:buffer'
+import { getDefaultHighWaterMark } from 'node:stream'
+
+export default async function (app) {
+  app.get('/', async () => {
+    return {
+      bufferPoolSize: Buffer.poolSize,
+      defaultHighWaterMark: getDefaultHighWaterMark(false)
+    }
+  })
+}

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -3,15 +3,18 @@ import {
   buildPinoTimestamp,
   disablePinoDirectWrite,
   ensureLoggableError,
-  getPrivateSymbol
+  getPrivateSymbol,
+  parseMemorySize
 } from '@platformatic/foundation'
 import { addPinoInstrumentation } from '@platformatic/telemetry'
+import { Buffer } from 'node:buffer'
 import { subscribe } from 'node:diagnostics_channel'
 import { EventEmitter } from 'node:events'
 import { ServerResponse } from 'node:http'
 import inspector from 'node:inspector'
 import { hostname } from 'node:os'
 import { join, resolve } from 'node:path'
+import { setDefaultHighWaterMark } from 'node:stream'
 import { pathToFileURL } from 'node:url'
 import { threadId, workerData } from 'node:worker_threads'
 import pino from 'pino'
@@ -113,6 +116,36 @@ async function performPreloading (...sources) {
   }
 }
 
+function resolveHealthSize (runtimeConfig, applicationConfig, field, logger) {
+  const raw = applicationConfig.health?.[field] ?? runtimeConfig.health?.[field]
+  if (raw === undefined) {
+    return undefined
+  }
+
+  const size = typeof raw === 'string' ? parseMemorySize(raw) : raw
+
+  if (!Number.isInteger(size) || size < 0) {
+    logger.warn({ [field]: raw }, `Invalid health.${field}, ignoring`)
+    return undefined
+  }
+
+  return size
+}
+
+function setupBufferPool (runtimeConfig, applicationConfig, logger) {
+  const size = resolveHealthSize(runtimeConfig, applicationConfig, 'bufferPoolSize', logger)
+  if (size !== undefined) {
+    Buffer.poolSize = size
+  }
+}
+
+function setupDefaultHighWaterMark (runtimeConfig, applicationConfig, logger) {
+  const size = resolveHealthSize(runtimeConfig, applicationConfig, 'defaultHighWaterMark', logger)
+  if (size !== undefined) {
+    setDefaultHighWaterMark(false, size)
+  }
+}
+
 // Enable compile cache if configured (Node.js 22.1.0+)
 async function setupCompileCache (runtimeConfig, applicationConfig, logger) {
   // Normalize boolean shorthand: true -> { enabled: true }
@@ -176,6 +209,9 @@ async function main () {
 
   const runtimeConfig = workerData.config
   const applicationConfig = workerData.applicationConfig
+
+  setupBufferPool(runtimeConfig, applicationConfig, globalThis.platformatic.logger)
+  setupDefaultHighWaterMark(runtimeConfig, applicationConfig, globalThis.platformatic.logger)
 
   // Enable compile cache early before loading user modules
   await setupCompileCache(runtimeConfig, applicationConfig, globalThis.platformatic.logger)

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -208,6 +208,28 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -558,6 +580,28 @@
                 ]
               },
               "codeRangeSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "bufferPoolSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "defaultHighWaterMark": {
                 "anyOf": [
                   {
                     "type": "number",
@@ -924,6 +968,28 @@
                     "type": "string"
                   }
                 ]
+              },
+              "bufferPoolSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "defaultHighWaterMark": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -1272,6 +1338,28 @@
                 ]
               },
               "codeRangeSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "bufferPoolSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "defaultHighWaterMark": {
                 "anyOf": [
                   {
                     "type": "number",
@@ -1994,6 +2082,30 @@
             }
           ],
           "default": 268435456
+        },
+        "bufferPoolSize": {
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 262144
+        },
+        "defaultHighWaterMark": {
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 262144
         }
       },
       "additionalProperties": false

--- a/packages/runtime/test/health-1.test.js
+++ b/packages/runtime/test/health-1.test.js
@@ -114,6 +114,26 @@ test('set the code range size correctly', { skip: isWindows && 'Skipping on Wind
   }
 })
 
+test(
+  'set Buffer.poolSize and default stream highWaterMark from health config',
+  { skip: isWindows && 'Skipping on Windows' },
+  async t => {
+    const configFile = join(fixturesDir, 'health-buffer-pool', 'platformatic.json')
+    const server = await createRuntime(configFile)
+
+    const url = await server.start()
+
+    t.after(() => {
+      return server.close()
+    })
+
+    const res = await request(url + '/')
+    const { bufferPoolSize, defaultHighWaterMark } = await res.body.json()
+    strictEqual(bufferPoolSize, 262144)
+    strictEqual(defaultHighWaterMark, 262144)
+  }
+)
+
 test('should continously monitor workers health', { skip: isWindows && 'Skipping on Windows' }, async t => {
   const configFile = join(fixturesDir, 'configs', 'health-grace-period.json')
   const server = await createRuntime(configFile)

--- a/packages/runtime/test/multiple-workers/update-resources.test.js
+++ b/packages/runtime/test/multiple-workers/update-resources.test.js
@@ -529,7 +529,9 @@ test('should report on failures', async t => {
           maxHeapUsed: 0.99,
           maxHeapTotal: 536870912,
           maxYoungGeneration: 134217728,
-          codeRangeSize: 268435456
+          codeRangeSize: 268435456,
+          bufferPoolSize: 262144,
+          defaultHighWaterMark: 262144
         },
         new: {
           maxHeapTotal: 536870912

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -450,6 +450,7 @@ export interface PlatformaticServiceConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -814,6 +815,7 @@ export interface PlatformaticServiceConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -451,6 +451,7 @@ export interface PlatformaticServiceConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -816,6 +817,7 @@ export interface PlatformaticServiceConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1225,6 +1225,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1934,6 +1945,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2950,6 +2973,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1236,6 +1236,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1947,6 +1958,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2984,6 +3007,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticTanStackConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticTanStackConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticTanStackConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticTanStackConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -259,6 +259,7 @@ export interface PlatformaticViteConfig {
       maxHeapTotal?: number | string;
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
+      bufferPoolSize?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -623,6 +624,7 @@ export interface PlatformaticViteConfig {
         maxHeapTotal?: number | string;
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
+        bufferPoolSize?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -260,6 +260,7 @@ export interface PlatformaticViteConfig {
       maxYoungGeneration?: number | string;
       codeRangeSize?: number | string;
       bufferPoolSize?: number | string;
+      defaultHighWaterMark?: number | string;
     };
     undici?: {
       agentOptions?: {
@@ -625,6 +626,7 @@ export interface PlatformaticViteConfig {
         maxYoungGeneration?: number | string;
         codeRangeSize?: number | string;
         bufferPoolSize?: number | string;
+        defaultHighWaterMark?: number | string;
       };
       arguments?: string[];
       env?: {

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -606,6 +606,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1315,6 +1326,18 @@
                 }
               ],
               "default": 268435456
+            },
+            "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
             }
           },
           "additionalProperties": false
@@ -2331,6 +2354,17 @@
                   ]
                 },
                 "codeRangeSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "bufferPoolSize": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -617,6 +617,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1328,6 +1339,18 @@
               "default": 268435456
             },
             "bufferPoolSize": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "default": 262144
+            },
+            "defaultHighWaterMark": {
               "anyOf": [
                 {
                   "type": "number",
@@ -2365,6 +2388,17 @@
                   ]
                 },
                 "bufferPoolSize": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "defaultHighWaterMark": {
                   "anyOf": [
                     {
                       "type": "number",

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -43,6 +43,7 @@ export type PlatformaticRuntimeConfig = {
           maxYoungGeneration?: number | string;
           codeRangeSize?: number | string;
           bufferPoolSize?: number | string;
+          defaultHighWaterMark?: number | string;
         };
         dependencies?: string[];
         arguments?: string[];
@@ -240,6 +241,7 @@ export type PlatformaticRuntimeConfig = {
     maxYoungGeneration?: number | string;
     codeRangeSize?: number | string;
     bufferPoolSize?: number | string;
+    defaultHighWaterMark?: number | string;
   };
   undici?: {
     agentOptions?: {

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -42,6 +42,7 @@ export type PlatformaticRuntimeConfig = {
           maxHeapTotal?: number | string;
           maxYoungGeneration?: number | string;
           codeRangeSize?: number | string;
+          bufferPoolSize?: number | string;
         };
         dependencies?: string[];
         arguments?: string[];
@@ -238,6 +239,7 @@ export type PlatformaticRuntimeConfig = {
     maxHeapTotal?: number | string;
     maxYoungGeneration?: number | string;
     codeRangeSize?: number | string;
+    bufferPoolSize?: number | string;
   };
   undici?: {
     agentOptions?: {

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -219,6 +219,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "defaultHighWaterMark": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -580,6 +591,17 @@
                 ]
               },
               "bufferPoolSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "defaultHighWaterMark": {
                 "anyOf": [
                   {
                     "type": "number",
@@ -957,6 +979,17 @@
                     "type": "string"
                   }
                 ]
+              },
+              "defaultHighWaterMark": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -1316,6 +1349,17 @@
                 ]
               },
               "bufferPoolSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "defaultHighWaterMark": {
                 "anyOf": [
                   {
                     "type": "number",
@@ -2040,6 +2084,18 @@
           "default": 268435456
         },
         "bufferPoolSize": {
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 262144
+        },
+        "defaultHighWaterMark": {
           "anyOf": [
             {
               "type": "number",

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -208,6 +208,17 @@
                         "type": "string"
                       }
                     ]
+                  },
+                  "bufferPoolSize": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -558,6 +569,17 @@
                 ]
               },
               "codeRangeSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "bufferPoolSize": {
                 "anyOf": [
                   {
                     "type": "number",
@@ -924,6 +946,17 @@
                     "type": "string"
                   }
                 ]
+              },
+              "bufferPoolSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -1272,6 +1305,17 @@
                 ]
               },
               "codeRangeSize": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "bufferPoolSize": {
                 "anyOf": [
                   {
                     "type": "number",
@@ -1994,6 +2038,18 @@
             }
           ],
           "default": 268435456
+        },
+        "bufferPoolSize": {
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 262144
         }
       },
       "additionalProperties": false

--- a/packages/wattpm/test/management.test.js
+++ b/packages/wattpm/test/management.test.js
@@ -343,7 +343,9 @@ test('config - should list configuration for the runtime', async t => {
       maxHeapUsed: 0.99,
       maxUnhealthyChecks: 10,
       maxYoungGeneration: 134217728,
-      codeRangeSize: 268435456
+      codeRangeSize: 268435456,
+      bufferPoolSize: 262144,
+      defaultHighWaterMark: 262144
     },
     resolvedApplicationsBasePath: 'external',
     metrics: {


### PR DESCRIPTION
## Summary

Adds two new options to the runtime `health` configuration section that are applied in each application worker thread before user code loads:

- **`bufferPoolSize`** — sets `Buffer.poolSize` (default `256 * 1024`, was Node's default of 8KB).
- **`defaultHighWaterMark`** — calls `stream.setDefaultHighWaterMark(false, value)` for binary streams (default `256 * 1024`, was Node's default of 64KB).

Both options follow the existing `maxHeapTotal` / `codeRangeSize` convention:

- Accept a number (bytes) or a memory-size string (e.g. `"256KB"`, parsed via `parseMemorySize`).
- Application-level `health.*` overrides runtime-level `health.*`.
- Applied early in `packages/runtime/lib/worker/main.js` `main()`, before preload and compile-cache setup.

The new defaults give application workers a larger reusable buffer pool and a larger default highWaterMark for binary streams, which typically improves throughput for HTTP/file I/O workloads at a modest steady-state memory cost.

## Test plan

- [x] `node --test test/health-1.test.js` — new test asserts `Buffer.poolSize` and `getDefaultHighWaterMark(false)` inside the worker match the configured values.
- [x] `node --test test/schema.test.js` — schema generation still passes.
- [x] `pnpm lint` (runtime package) — clean.
- [x] `pnpm run gen-schema` / `gen-types` — regenerated JSON schemas and `.d.ts` files across all packages that include the health section.

Assisted-by: claude-code:claude-opus-4-7