### PR TITLE
Allow runtime without entrypoint

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -158,9 +158,14 @@ The base path, relative to the configuration file to store resolved applications
 
 ### `entrypoint`
 
-The Platformatic Runtime's entrypoint is an applicaiton that is exposed
-publicly. This value must be the `ID` of an application defined via the `autoload` or
+The Platformatic Runtime's entrypoint is an application that is exposed
+publicly. This optional value must be the `ID` of an application defined via the `autoload` or
 `applications` configuration.
+
+If `entrypoint` is omitted, the runtime automatically selects one when there is a single
+application or exactly one Gateway application. If it cannot select a single entrypoint,
+the runtime starts without a public entrypoint; applications remain reachable through their
+internal `.plt.local` URLs and APIs such as `runtime.inject()`.
 
 ### `workers`
 

--- a/docs/reference/runtime/overview.md
+++ b/docs/reference/runtime/overview.md
@@ -42,8 +42,10 @@ or as a Platformatic Runtime application. Runtime application enables certain co
 ## Inter-application communication
 
 Platformatic Runtime allows multiple microservice applications to run
-within a single process. Only the entrypoint binds to an operating system
-port and can be reached from outside the runtime.
+within a single process. When an entrypoint is configured or automatically detected,
+only the entrypoint binds to an operating system port and can be reached from outside
+the runtime. If no entrypoint is configured or detected, the runtime starts without an
+external application URL.
 
 Within the runtime, all inter-application communication happens by injecting HTTP
 requests into the running servers, without binding them to ports. This injection

--- a/docs/reference/runtime/programmatic.md
+++ b/docs/reference/runtime/programmatic.md
@@ -87,7 +87,7 @@ Walks the applications declared in the nearest runtime configuration and aggrega
 ### Lifecycle
 
 - **`runtime.start(silent = false): Promise<string | undefined>`** — Starts all applications. Returns the entrypoint's external URL (or `undefined` if no entrypoint binds an external port). If `init()` hasn't been called yet, `start()` calls it.
-- **`runtime.stop(silent = false): Promise<void>`** — Stops all applications. The entrypoint is stopped first so it stops accepting new requests immediately.
+- **`runtime.stop(silent = false): Promise<void>`** — Stops all applications. If an entrypoint exists, it is stopped first so it stops accepting new requests immediately.
 - **`runtime.close(silent = false): Promise<void>`** — Stops applications and tears the runtime down completely (closes the management API, broadcast channels, dispatcher, etc.). After `close()` the runtime cannot be restarted; create a new instance.
 - **`runtime.restart(applications?: string[]): Promise<string | undefined>`** — Restarts every application (or only the IDs in `applications`). Returns the entrypoint URL once the restart completes.
 - **`runtime.init(): Promise<void>`** — Performs one-time setup (loads capabilities, prepares workers). Usually called transitively by `start()`; call it explicitly only if you need the runtime in `init`'ed state without starting applications.
@@ -122,7 +122,7 @@ The response object exposes `statusCode`, `statusMessage`, `headers`, `body` (st
 
 ### Introspection
 
-- **`runtime.getUrl(): string | undefined`** — The entrypoint's external URL once started.
+- **`runtime.getUrl(): string | undefined`** — The entrypoint's external URL once started, or `undefined` when there is no entrypoint.
 - **`runtime.getRuntimeStatus(): string`** — One of `starting`, `started`, `stopping`, `stopped`, `closed`.
 - **`runtime.getRuntimeMetadata(): Promise<RuntimeMetadata>`** — `pid`, `cwd`, `argv`, `uptimeSeconds`, `execPath`, `nodeVersion`, `projectDir`, `packageName`, `packageVersion`, `url`, `platformaticVersion`.
 - **`runtime.getRuntimeConfig(includeMeta = false): object`** — The resolved configuration. When `includeMeta` is `true` the `[kMetadata]` symbol is preserved (needed by `prepareApplication()`).
@@ -136,7 +136,7 @@ The response object exposes `statusCode`, `statusMessage`, `headers`, `body` (st
 - **`runtime.stopApplication(id, silent = false): Promise<void>`**
 - **`runtime.restartApplication(id): Promise<void>`**
 
-These act on a single application by `id`. The entrypoint can be restarted but cannot be removed (see below).
+These act on a single application by `id`. If an entrypoint exists, it can be restarted but cannot be removed (see below).
 
 ## Adding and removing applications at runtime
 
@@ -175,7 +175,7 @@ Stops the listed applications and removes them from the runtime. `applications` 
 await app.removeApplications(['analytics-service'])
 ```
 
-The entrypoint cannot be removed; attempting to do so throws a `CannotRemoveEntrypointError`.
+The entrypoint, when configured or automatically detected, cannot be removed; attempting to do so throws a `CannotRemoveEntrypointError`.
 
 ### Example: dynamic application management
 

--- a/docs/reference/wattpm/cli-commands.md
+++ b/docs/reference/wattpm/cli-commands.md
@@ -460,7 +460,7 @@ wattpm inject [id] [application]
 **Arguments:**
 
 - `id` - Process ID or application name (optional if only one app is running)
-- `application` - Application name (optional, uses entrypoint if omitted)
+- `application` - Application name (optional, uses the entrypoint if omitted and one exists)
 
 **Options:**
 

--- a/docs/reference/wattpm/reference.md
+++ b/docs/reference/wattpm/reference.md
@@ -164,13 +164,13 @@ Arguments:
 Injects a request to a running application.
 
 The command sends a request to the runtime application and prints the
-response to the standard output. If the application is not specified the
-request is sent to the runtime entrypoint.
+response to the standard output. If the application is not specified and the runtime has an
+entrypoint, the request is sent to the runtime entrypoint.
 
 Arguments:
 
 - `id`: The process ID or the name of the application (it can be omitted only if there is a single application running)
-- `application`: The application name (the default is the entrypoint)
+- `application`: The application name (the default is the entrypoint, when one exists)
 
 Options:
 

--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -18,8 +18,7 @@ import {
   InspectorHostError,
   InspectorPortError,
   InvalidArgumentError,
-  InvalidEntrypointError,
-  MissingEntrypointError
+  InvalidEntrypointError
 } from './errors.js'
 import { schema } from './schema.js'
 import { upgrade } from './upgrade.js'
@@ -438,15 +437,8 @@ export async function transform (config, _, context) {
     }
   }
 
-  if (!hasValidEntrypoint && !context.allowMissingEntrypoint) {
-    if (config.entrypoint) {
-      throw new InvalidEntrypointError(config.entrypoint)
-    } else if (applications.length >= 1) {
-      throw new MissingEntrypointError()
-    }
-    // If there are no applications, and no entrypoint it's an empty app.
-    // It won't start, but we should be able to parse and operate on it,
-    // like adding other applications.
+  if (!hasValidEntrypoint && config.entrypoint && !context.allowMissingEntrypoint) {
+    throw new InvalidEntrypointError(config.entrypoint)
   }
 
   if (typeof config.metrics === 'boolean') {

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -37,7 +37,6 @@ import {
   CannotRemoveEntrypointError,
   InvalidArgumentError,
   MessagingError,
-  MissingEntrypointError,
   MissingPprofCapture,
   RuntimeAbortedError,
   WorkerInterceptorJoinTimeoutError,
@@ -275,9 +274,6 @@ export class Runtime extends EventEmitter {
       await this.init()
     }
 
-    if (typeof this.#config.entrypoint === 'undefined') {
-      throw new MissingEntrypointError()
-    }
     this.#updateStatus('starting')
     this.#createWorkersBroadcastChannel()
 
@@ -328,7 +324,9 @@ export class Runtime extends EventEmitter {
     this.#startHealthMetricsCollectionIfNeeded()
 
     await this.#dynamicWorkersScaler?.start()
-    this.#showUrl()
+    if (this.#url) {
+      this.#showUrl()
+    }
     return this.#url
   }
 
@@ -1123,6 +1121,10 @@ export class Runtime extends EventEmitter {
   }
 
   async getEntrypointDetails () {
+    if (!this.#entrypointId) {
+      return null
+    }
+
     return this.getApplicationDetails(this.#entrypointId)
   }
 

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -278,7 +278,14 @@ export class Runtime extends EventEmitter {
     this.#createWorkersBroadcastChannel()
 
     try {
-      await this.startApplications(this.getApplicationsIds(), silent)
+      const applications = this.getApplicationsIds()
+      await this.startApplications(applications, silent)
+
+      if (applications.length === 0) {
+        this.#updateStatus('started')
+        await this.close(silent)
+        return
+      }
 
       if (this.#config.inspectorOptions) {
         const { port } = this.#config.inspectorOptions
@@ -2720,6 +2727,12 @@ export class Runtime extends EventEmitter {
 
   async #createWorkersBroadcastChannel () {
     this.#workersBroadcastChannel?.close()
+
+    if (this.#config.applications.length === 0) {
+      this.#workersBroadcastChannel = undefined
+      return
+    }
+
     this.#workersBroadcastChannel = new BroadcastChannel(kWorkersBroadcast)
   }
 

--- a/packages/runtime/test/cli/start/start.5.test.js
+++ b/packages/runtime/test/cli/start/start.5.test.js
@@ -1,11 +1,10 @@
 import { execa } from 'execa'
 import assert from 'node:assert'
-import { on } from 'node:events'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import { startPath } from '../helper.js'
 
-test('do not start if there are no applications', async t => {
+test('exits without starting if there are no applications', async t => {
   const config = join(
     import.meta.dirname,
     '..',
@@ -19,30 +18,9 @@ test('do not start if there are no applications', async t => {
     encoding: 'utf8',
     env: { PLT_USE_PLAIN_CREATE: 'true' }
   })
-  let stdout = ''
-  let found = false
+  const result = await child
 
-  child.stderr.setEncoding('utf8')
-  for await (const messages of on(child.stderr, 'data')) {
-    for (const message of messages) {
-      stdout += message
-
-      if (/Missing application entrypoint/.test(stdout)) {
-        found = true
-        break
-      }
-    }
-
-    if (found) {
-      break
-    }
-  }
-
-  assert(found)
-
-  child.kill('SIGKILL')
-
-  // if we do not await this, the test will crash because the event loop has nothing to do
-  // but there is still a promise waiting
-  await child.catch(() => {})
+  assert.strictEqual(result.exitCode, 0)
+  assert.strictEqual(result.stdout, '')
+  assert.strictEqual(result.stderr, '')
 })

--- a/packages/runtime/test/entrypoint.test.js
+++ b/packages/runtime/test/entrypoint.test.js
@@ -46,16 +46,40 @@ test('should automatically detect the entrypoint if it there exacty a gateway', 
   deepStrictEqual(entrypoint, 'composer')
 })
 
-test('should throw an exception if there is no gateway', async t => {
+test('should allow no entrypoint if one cannot be automatically detected', async t => {
   const configFile = join(fixturesDir, 'configs', 'no-entrypoint-no-composers.json')
+  const runtime = await createRuntime(configFile)
 
-  await rejects(() => createRuntime(configFile), /Cannot parse config file. Missing application entrypoint./)
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  const url = await runtime.start(true)
+  ifError(url)
+  const { entrypoint } = await runtime.getApplications()
+
+  const config = await runtime.getRuntimeConfig()
+  ifError(config.entrypoint)
+  deepStrictEqual(config.applications.some(s => s.entrypoint), false)
+  ifError(entrypoint)
 })
 
-test('should throw an exception if there are multiple gateway', async t => {
+test('should allow no entrypoint if there are multiple gateways', async t => {
   const configFile = join(fixturesDir, 'configs', 'no-entrypoint-multiple-composers.json')
+  const runtime = await createRuntime(configFile)
 
-  await rejects(() => createRuntime(configFile), /Cannot parse config file. Missing application entrypoint./)
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  const url = await runtime.start(true)
+  ifError(url)
+  const { entrypoint } = await runtime.getApplications()
+
+  const config = await runtime.getRuntimeConfig()
+  ifError(config.entrypoint)
+  deepStrictEqual(config.applications.some(s => s.entrypoint), false)
+  ifError(entrypoint)
 })
 
 test('should not throw if there are no applications', async t => {

--- a/packages/runtime/test/logger.test.js
+++ b/packages/runtime/test/logger.test.js
@@ -278,15 +278,20 @@ test('should inherit full logger options from runtime to different applications'
 test('should get json logs from thread applications when they are not pino default config', async t => {
   const configPath = join(import.meta.dirname, '..', 'fixtures', 'logger-options-all', 'platformatic.json')
 
-  let requested = false
+  let incomingRequest = false
+  let requestCompleted = false
   const { stdout } = await execRuntime({
     configPath,
     onReady: async ({ url }) => {
       await requestAndDump(url, { path: '/' })
-      requested = true
     },
     done: message => {
-      return requested
+      for (const log of stdioOutputToLogs([message]).filter(log => log.caller === 'STDOUT')) {
+        incomingRequest ||= log.stdout.msg === 'incoming request'
+        requestCompleted ||= log.stdout.msg === 'request completed'
+      }
+
+      return incomingRequest && requestCompleted
     }
   })
   const logs = stdioOutputToLogs(stdout).filter(log => log.caller === 'STDOUT')

--- a/packages/wattpm-utils/package.json
+++ b/packages/wattpm-utils/package.json
@@ -37,6 +37,7 @@
     "create-wattpm": "workspace:*",
     "dotenv": "^16.4.5",
     "execa": "^9.4.0",
+    "fast-json-patch": "^3.1.1",
     "semver": "^7.7.0",
     "tar": "^7.5.7"
   },

--- a/packages/wattpm/test/execution.test.js
+++ b/packages/wattpm/test/execution.test.js
@@ -7,6 +7,7 @@ import { on } from 'node:events'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
 import split2 from 'split2'
 import { request } from 'undici'
 import { prepareRuntime } from '../../basic/test/helper.js'
@@ -72,22 +73,22 @@ test('dev - should complain if no configuration file is found', async t => {
   )
 })
 
-test('dev - should complain if no entrypoint is defined', async t => {
+test('dev - should start if no entrypoint is defined', async t => {
   const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
 
   await updateConfigFile(resolve(rootDir, 'watt.json'), config => {
     delete config.entrypoint
   })
 
-  const devstartProcess = await wattpm('dev', rootDir, { reject: false })
+  t.after(() => {
+    startProcess.kill('SIGINT')
+    return startProcess.catch(() => {})
+  })
 
-  deepStrictEqual(devstartProcess.exitCode, 1)
+  const startProcess = wattpm('dev', rootDir, { reject: false })
+  await sleep(2000)
 
-  ok(
-    devstartProcess.stdout.includes(
-      'Cannot determine the application entrypoint. Please define it via the "entrypoint" key in your configuration file.'
-    )
-  )
+  ok(startProcess.exitCode !== 1)
 })
 
 test('dev - should restart an application if files are changed', async t => {
@@ -454,22 +455,22 @@ test('start - should throw an error when an application has no path and it is no
   )
 })
 
-test('start - should complain if no entrypoint is defined', async t => {
+test('start - should start if no entrypoint is defined', async t => {
   const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
 
   await updateConfigFile(resolve(rootDir, 'watt.json'), config => {
     delete config.entrypoint
   })
 
-  const devstartProcess = await wattpm('start', rootDir, { reject: false })
+  t.after(() => {
+    startProcess.kill('SIGINT')
+    return startProcess.catch(() => {})
+  })
 
-  deepStrictEqual(devstartProcess.exitCode, 1)
+  const startProcess = wattpm('start', rootDir, { reject: false })
+  await sleep(2000)
 
-  ok(
-    devstartProcess.stdout.includes(
-      'Cannot determine the application entrypoint. Please define it via the "entrypoint" key in your configuration file.'
-    )
-  )
+  ok(startProcess.exitCode !== 1)
 })
 
 test('stop - should stop an application', async t => {

--- a/packages/wattpm/test/execution.test.js
+++ b/packages/wattpm/test/execution.test.js
@@ -7,11 +7,20 @@ import { on } from 'node:events'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
-import { setTimeout as sleep } from 'node:timers/promises'
 import split2 from 'split2'
 import { request } from 'undici'
 import { prepareRuntime } from '../../basic/test/helper.js'
 import { changeWorkingDirectory, prepareGitRepository, waitForStart, wattpm } from './helper.js'
+
+async function waitForRuntimeStarted (startProcess) {
+  for await (const log of on(startProcess.stdout.pipe(split2()), 'data')) {
+    const parsed = JSON.parse(log.toString())
+
+    if (parsed.event === 'started') {
+      return
+    }
+  }
+}
 
 test('dev - should start in development mode', async t => {
   const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
@@ -85,10 +94,10 @@ test('dev - should start if no entrypoint is defined', async t => {
     return startProcess.catch(() => {})
   })
 
-  const startProcess = wattpm('dev', rootDir, { reject: false })
-  await sleep(2000)
+  const startProcess = wattpm('dev', rootDir)
+  await waitForRuntimeStarted(startProcess)
 
-  ok(startProcess.exitCode !== 1)
+  ok(startProcess.exitCode === null)
 })
 
 test('dev - should restart an application if files are changed', async t => {
@@ -467,10 +476,10 @@ test('start - should start if no entrypoint is defined', async t => {
     return startProcess.catch(() => {})
   })
 
-  const startProcess = wattpm('start', rootDir, { reject: false })
-  await sleep(2000)
+  const startProcess = wattpm('start', rootDir)
+  await waitForRuntimeStarted(startProcess)
 
-  ok(startProcess.exitCode !== 1)
+  ok(startProcess.exitCode === null)
 })
 
 test('stop - should stop an application', async t => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2405,6 +2405,9 @@ importers:
       execa:
         specifier: ^9.4.0
         version: 9.6.1
+      fast-json-patch:
+        specifier: ^3.1.1
+        version: 3.1.1
       semver:
         specifier: ^7.7.0
         version: 7.8.2


### PR DESCRIPTION
## Summary
- allow runtimes to start when no entrypoint can be autodetected
- keep explicit invalid entrypoint validation
- update runtime and wattpm tests for no-entrypoint startup

## Tests
- node --test --test-reporter=spec --test-timeout=200000 packages/runtime/test/entrypoint.test.js
- node --test --test-reporter=spec --test-timeout=60000 --test-name-pattern='(dev|start) - should start if no entrypoint is defined' packages/wattpm/test/execution.test.js