### PR TITLE
fix: don't fail metrics collection when http stats globals are not tracked

### DIFF
--- a/packages/runtime/fixtures/metrics-legacy-globals/package.json
+++ b/packages/runtime/fixtures/metrics-legacy-globals/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-runtime-metrics-legacy-globals",
+  "version": "1.0.0",
+  "type": "commonjs"
+}

--- a/packages/runtime/fixtures/metrics-legacy-globals/platformatic.json
+++ b/packages/runtime/fixtures/metrics-legacy-globals/platformatic.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.3.1.json",
+  "entrypoint": "service-1",
+  "watch": false,
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "logger": {
+    "level": "silent"
+  },
+  "metrics": {
+    "httpClientMetrics": true
+  }
+}

--- a/packages/runtime/fixtures/metrics-legacy-globals/services/service-1/platformatic.json
+++ b/packages/runtime/fixtures/metrics-legacy-globals/services/service-1/platformatic.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/1.52.0.json",
+  "service": {
+    "openapi": true
+  },
+  "plugins": {
+    "paths": ["plugin.js"]
+  }
+}

--- a/packages/runtime/fixtures/metrics-legacy-globals/services/service-1/plugin.js
+++ b/packages/runtime/fixtures/metrics-legacy-globals/services/service-1/plugin.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const kFields = Symbol.for('plt.globals.fields')
+const statsGlobals = [
+  'onHttpStatsFree',
+  'onHttpStatsConnected',
+  'onHttpStatsPending',
+  'onHttpStatsQueued',
+  'onHttpStatsRunning',
+  'onHttpStatsSize'
+]
+
+/** @param {import('fastify').FastifyInstance} app */
+module.exports = async function (app, options) {
+  app.get('/hello', async () => {
+    return { service: 'service-1' }
+  })
+
+  // Simulate a capability built with an older @platformatic/basic, which assigned
+  // the http stats globals directly without registering them in the fields set.
+  app.get('/simulate-legacy-globals', async () => {
+    for (const name of statsGlobals) {
+      globalThis.platformatic[kFields].delete(name)
+    }
+
+    return { ok: true }
+  })
+}

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -263,20 +263,22 @@ export class Controller extends EventEmitter {
     const onHttpStatsFree = getOnHttpStatsFree({ throwOnMissing: false })
 
     if (onHttpStatsFree && dispatcher?.stats) {
-      const onHttpStatsConnected = getOnHttpStatsConnected()
-      const onHttpStatsPending = getOnHttpStatsPending()
-      const onHttpStatsQueued = getOnHttpStatsQueued()
-      const onHttpStatsRunning = getOnHttpStatsRunning()
-      const onHttpStatsSize = getOnHttpStatsSize()
+      // The capability might come from an older version of @platformatic/basic
+      // which registered these globals without the fields tracking, so never throw.
+      const onHttpStatsConnected = getOnHttpStatsConnected({ throwOnMissing: false })
+      const onHttpStatsPending = getOnHttpStatsPending({ throwOnMissing: false })
+      const onHttpStatsQueued = getOnHttpStatsQueued({ throwOnMissing: false })
+      const onHttpStatsRunning = getOnHttpStatsRunning({ throwOnMissing: false })
+      const onHttpStatsSize = getOnHttpStatsSize({ throwOnMissing: false })
 
       for (const url in dispatcher.stats) {
         const { free, connected, pending, queued, running, size } = dispatcher.stats[url]
         onHttpStatsFree(url, free || 0)
-        onHttpStatsConnected(url, connected || 0)
-        onHttpStatsPending(url, pending || 0)
-        onHttpStatsQueued(url, queued || 0)
-        onHttpStatsRunning(url, running || 0)
-        onHttpStatsSize(url, size || 0)
+        onHttpStatsConnected?.(url, connected || 0)
+        onHttpStatsPending?.(url, pending || 0)
+        onHttpStatsQueued?.(url, queued || 0)
+        onHttpStatsRunning?.(url, running || 0)
+        onHttpStatsSize?.(url, size || 0)
       }
     }
     const onActiveResourcesEventLoop = getOnActiveResourcesEventLoop({ throwOnMissing: false })

--- a/packages/runtime/test/api/metrics.test.js
+++ b/packages/runtime/test/api/metrics.test.js
@@ -504,3 +504,30 @@ test('should get runtime metrics in a json format without a application call', a
     ok(value < 0.1)
   }
 })
+
+test('should get metrics when an application registered http stats globals without fields tracking', async t => {
+  const projectDir = join(fixturesDir, 'metrics-legacy-globals')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.inject('service-1', {
+    method: 'GET',
+    url: '/hello'
+  })
+
+  await app.inject('service-1', {
+    method: 'GET',
+    url: '/simulate-legacy-globals'
+  })
+
+  const { metrics } = await app.getMetrics()
+
+  const metricsNames = metrics.map(({ name }) => name)
+  ok(metricsNames.includes('http_request_all_summary_seconds'))
+})


### PR DESCRIPTION
Applications using @platformatic/basic < 3.56 register the http stats globals via plain assignment, without tracking them in the fields set introduced by the New Global API (#4814). `getMetrics()` guarded only `onHttpStatsFree` with `throwOnMissing: false` and then called the other getters with the throwing default, so retrieving metrics for any such application failed with:

```
PLT_RUNTIME_FAILED_TO_RETRIEVE_METRICS: Failed to retrieve metrics for application with id "...":
globalThis.platformatic.onHttpStatsConnected is not available
```

This breaks the whole /metrics endpoint of a runtime as soon as one application uses an older capability (e.g. a watt app resolving services pinned to @platformatic/node 3.55).

Use `throwOnMissing: false` for all http stats getters and guard each call, so older capabilities keep reporting metrics. Applications too old to register these globals at all simply skip the http_client_stats_* gauges instead of failing.

Includes a regression test with a fixture simulating a capability without fields tracking: it fails with the error above before the fix and passes with it.