### PR TITLE
fix(telemetry): improve diag logger object output

### DIFF
--- a/packages/telemetry/lib/diag-logger.js
+++ b/packages/telemetry/lib/diag-logger.js
@@ -22,10 +22,90 @@ function getDiagLogLevel (logger) {
   return DiagLogLevel.INFO
 }
 
+function isObjectLike (value) {
+  return value !== null && typeof value === 'object'
+}
+
+function serializeCustomInspectPayload (value) {
+  const customInspect = value[util.inspect.custom]
+
+  if (typeof customInspect !== 'function') {
+    return value
+  }
+
+  try {
+    return customInspect.call(value)
+  } catch {
+    return value
+  }
+}
+
+function serializeForDiag (value, seen = new WeakSet()) {
+  if (!isObjectLike(value)) {
+    return value
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, serializeForDiag(entry, seen)]))
+    }
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]'
+  }
+
+  seen.add(value)
+
+  try {
+    const inspected = serializeCustomInspectPayload(value)
+    if (inspected !== value) {
+      return serializeForDiag(inspected, seen)
+    }
+
+    if (typeof value.toJSON === 'function') {
+      const json = value.toJSON()
+      if (json !== value) {
+        return serializeForDiag(json, seen)
+      }
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(entry => serializeForDiag(entry, seen))
+    }
+
+    if (value instanceof Map) {
+      return Object.fromEntries(Array.from(value.entries(), ([key, entry]) => [String(key), serializeForDiag(entry, seen)]))
+    }
+
+    if (value instanceof Set) {
+      return Array.from(value, entry => serializeForDiag(entry, seen))
+    }
+
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key, entry]) => !key.startsWith('_') && typeof entry !== 'function')
+        .map(([key, entry]) => [key, serializeForDiag(entry, seen)])
+    )
+  } finally {
+    seen.delete(value)
+  }
+}
+
 function callLogger (logger, method, fallback, args) {
   if (typeof logger?.[method] === 'function') {
     if (typeof args[0] === 'string') {
-      logger[method](util.format(...args))
+      const [message, ...details] = args
+      if (details.length === 0) {
+        logger[method](message)
+      } else if (details.some(isObjectLike)) {
+        logger[method]({ details: details.map(detail => serializeForDiag(detail)) }, message)
+      } else {
+        logger[method](util.format(...args))
+      }
     } else {
       logger[method](...args)
     }

--- a/packages/telemetry/test/diag-logger.test.js
+++ b/packages/telemetry/test/diag-logger.test.js
@@ -1,4 +1,8 @@
 import { diag } from '@opentelemetry/api'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { BatchSpanProcessor, InMemorySpanExporter } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 import { deepStrictEqual, strictEqual } from 'node:assert'
 import { Writable } from 'node:stream'
 import { test } from 'node:test'
@@ -88,7 +92,7 @@ test('setupDiagLogger configures the OpenTelemetry diagnostic logger using the p
   t.after(() => diag.disable())
 })
 
-test('createPlatformaticDiagLogger preserves additional OpenTelemetry diagnostic arguments with pino', async () => {
+test('createPlatformaticDiagLogger preserves additional primitive OpenTelemetry diagnostic arguments with pino', async () => {
   const lines = []
   const stream = new Writable({
     write (chunk, _encoding, callback) {
@@ -100,9 +104,121 @@ test('createPlatformaticDiagLogger preserves additional OpenTelemetry diagnostic
 
   const diagLogger = createPlatformaticDiagLogger(logger)
   diagLogger.warn('first', 'second', 42)
-  diagLogger.debug('caught hook error: ', new Error('boom'))
 
   strictEqual(lines[0].msg, 'first second 42')
-  strictEqual(lines[1].msg.includes('caught hook error:'), true)
-  strictEqual(lines[1].msg.includes('Error: boom'), true)
+})
+
+test('createPlatformaticDiagLogger serializes object diagnostic details with pino', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.debug('caught hook error: ', new Error('boom'))
+
+  strictEqual(lines[0].msg, 'caught hook error: ')
+  strictEqual(lines[0].details[0].name, 'Error')
+  strictEqual(lines[0].details[0].message, 'boom')
+  strictEqual(typeof lines[0].details[0].stack, 'string')
+})
+
+test('createPlatformaticDiagLogger uses toJSON() for diagnostic details when available', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+
+  class SpanLike {
+    constructor (name) {
+      this.name = name
+      this.attributes = { hidden: true }
+    }
+
+    toJSON () {
+      return {
+        name: this.name,
+        attributes: {
+          visible: true
+        }
+      }
+    }
+  }
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.debug('items to be sent', [new SpanLike('first')])
+
+  strictEqual(lines[0].msg, 'items to be sent')
+  deepStrictEqual(lines[0].details, [[{ name: 'first', attributes: { visible: true } }]])
+})
+
+test('createPlatformaticDiagLogger renders spans using the OpenTelemetry custom inspect payload', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test-service' }),
+    spanProcessors: [new BatchSpanProcessor(new InMemorySpanExporter())]
+  })
+  const tracer = provider.getTracer('test-scope')
+  const span = tracer.startSpan('hello')
+  span.setAttribute('foo', 'bar')
+  span.end()
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.debug('items to be sent', [span])
+
+  strictEqual(lines[0].msg, 'items to be sent')
+  strictEqual(lines[0].details[0][0].name, 'hello')
+  strictEqual(lines[0].details[0][0].spanContext.traceId, span.spanContext().traceId)
+  strictEqual(lines[0].details[0][0].spanContext.spanId, span.spanContext().spanId)
+  strictEqual(lines[0].details[0][0].ended, true)
+  strictEqual(lines[0].details[0][0].attributes.foo, 'bar')
+  strictEqual(lines[0].details[0][0].resource.attributes['service.name'], 'test-service')
+  strictEqual(lines[0].details[0][0].instrumentationScope.name, 'test-scope')
+  strictEqual('_spanContext' in lines[0].details[0][0], false)
+  strictEqual('_spanProcessor' in lines[0].details[0][0], false)
+  strictEqual('_performanceStartTime' in lines[0].details[0][0], false)
+})
+
+test('createPlatformaticDiagLogger renders tracer objects using OpenTelemetry custom inspect payloads', async () => {
+  const lines = []
+  const stream = new Writable({
+    write (chunk, _encoding, callback) {
+      lines.push(JSON.parse(chunk.toString()))
+      callback()
+    }
+  })
+  const logger = pino({ level: 'trace' }, stream)
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test-service' }),
+    spanProcessors: [new BatchSpanProcessor(new InMemorySpanExporter())]
+  })
+  const tracer = provider.getTracer('test-scope')
+
+  const diagLogger = createPlatformaticDiagLogger(logger)
+  diagLogger.debug('otel objects', provider, tracer)
+
+  strictEqual(lines[0].msg, 'otel objects')
+  strictEqual(lines[0].details[0].resource.attributes['service.name'], 'test-service')
+  strictEqual(lines[0].details[0].tracers[0].startsWith('test-scope'), true)
+  strictEqual(lines[0].details[0].spanProcessors[0], 'BatchSpanProcessor')
+  strictEqual(lines[0].details[1].instrumentationScope.name, 'test-scope')
+  strictEqual(lines[0].details[1].resource.attributes['service.name'], 'test-service')
+  strictEqual(lines[0].details[1].spanLimits.attributeCountLimit, 128)
+  strictEqual('_registeredSpanProcessors' in lines[0].details[0], false)
+  strictEqual('_tracerProvider' in lines[0].details[1], false)
 })


### PR DESCRIPTION
## Summary
- improve OpenTelemetry diagnostic logger output for object payloads emitted through Pino
- preserve primitive variadic formatting for string-first diagnostic messages
- serialize object details into structured `details` fields
- use OpenTelemetry's upstream `util.inspect.custom` payloads for spans, tracers, and providers, available in the latest OTel packages after open-telemetry/opentelemetry-js#6690

## Testing
- `pnpm install --frozen-lockfile --lockfile-only`
- `pnpm --filter @platformatic/telemetry lint`
- `cd packages/telemetry && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/diag-logger.test.js`
- `cd packages/telemetry && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/no-duplicate-otel.test.js`
