### PR TITLE
fix(metrics): export OTLP metrics for command-based services

### DIFF
--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -988,6 +988,15 @@ export class BaseCapability extends EventEmitter {
       return
     }
 
+    // For command-based (childManager) capabilities, metric collection is delegated to the
+    // child process, which owns the populated registry (the parent's `metricsRegistry` stays
+    // empty). The OTLP exporter is therefore set up inside the child over that registry.
+    // Setting it up here would export the empty parent registry.
+    // See https://github.com/platformatic/platformatic/issues/4848
+    if (this.childManager && this.clientWs) {
+      return
+    }
+
     // Wait for telemetry to be ready before loading promotel to avoid race condition
     const telemetryReady = getTelemetryReady({ throwOnMissing: false })
     if (telemetryReady) {

--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -18,6 +18,7 @@ import {
   getReuseTcpPorts,
   getRuntimeBasePath,
   getRuntimeConfig,
+  getTelemetryReady,
   getWantsAbsoluteUrls,
   getWorkerId,
   hasField,
@@ -25,7 +26,7 @@ import {
   updateGlobals
 } from '@platformatic/globals'
 import { ITC } from '@platformatic/itc/lib/index.js'
-import { clearRegistry, client, collectThreadMetrics } from '@platformatic/metrics'
+import { clearRegistry, client, collectThreadMetrics, setupOtlpExporter } from '@platformatic/metrics'
 import diagnosticChannel, { tracingChannel } from 'node:diagnostics_channel'
 import { EventEmitter, once } from 'node:events'
 import { readFile } from 'node:fs/promises'
@@ -99,6 +100,7 @@ export class ChildProcess extends ITC {
   #socket
   #logger
   #metricsRegistry
+  #otlpBridge
   #pendingMessages
   #replStream
 
@@ -272,8 +274,12 @@ export class ChildProcess extends ITC {
     return once(this.#socket, 'close')
   }
 
-  /* c8 ignore next 4 */
+  /* c8 ignore next 8 */
   _close () {
+    if (this.#otlpBridge) {
+      this.#otlpBridge.stop()
+      this.#otlpBridge = null
+    }
     clearRegistry(this.#metricsRegistry)
     this.#socket.close()
   }
@@ -283,16 +289,52 @@ export class ChildProcess extends ITC {
     // by the main runtime thread and duplicated with worker labels
     await collectThreadMetrics(applicationId, workerId, metricsConfig, this.#metricsRegistry)
     this.#setHttpCacheMetrics()
+    await this.#setupOtlpExporter(applicationId, metricsConfig)
   }
 
   async #updateMetricsConfig ({ applicationId, workerId, metricsConfig }) {
     clearRegistry(this.#metricsRegistry)
+
+    if (this.#otlpBridge) {
+      this.#otlpBridge.stop()
+      this.#otlpBridge = null
+    }
 
     if (metricsConfig.enabled !== false) {
       // Use thread-specific metrics collection - process-level metrics are collected
       // by the main runtime thread and duplicated with worker labels
       await collectThreadMetrics(applicationId, workerId, metricsConfig, this.#metricsRegistry)
       this.#setHttpCacheMetrics()
+      await this.#setupOtlpExporter(applicationId, metricsConfig)
+    }
+  }
+
+  // For command-based capabilities the parent's metrics registry is empty (metric collection
+  // is delegated here), so the OTLP exporter must run inside the child over the populated
+  // child registry. See https://github.com/platformatic/platformatic/issues/4848
+  async #setupOtlpExporter (applicationId, metricsConfig) {
+    if (!metricsConfig?.otlpExporter) {
+      return
+    }
+
+    // Wait for telemetry to be ready before loading promotel to avoid race condition
+    const telemetryReady = getTelemetryReady({ throwOnMissing: false })
+    if (telemetryReady) {
+      await telemetryReady
+    }
+
+    // Setup and start OTLP exporter bridge over the child's populated registry
+    this.#otlpBridge = await setupOtlpExporter(this.#metricsRegistry, metricsConfig.otlpExporter, applicationId)
+
+    if (this.#otlpBridge) {
+      this.#otlpBridge.start()
+      this.#logger.info(
+        {
+          endpoint: metricsConfig.otlpExporter.endpoint,
+          interval: metricsConfig.otlpExporter.interval || 60000
+        },
+        'OTLP metrics exporter started'
+      )
     }
   }
 

--- a/packages/runtime/fixtures/otlp-exporter-command/platformatic.json
+++ b/packages/runtime/fixtures/otlp-exporter-command/platformatic.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.48.0.json",
+  "entrypoint": "main",
+  "watch": false,
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": 9090,
+    "otlpExporter": {
+      "endpoint": "http://127.0.0.1:{PLT_OTLP_PORT}/v1/metrics",
+      "interval": 1000,
+      "serviceName": "test-service-command",
+      "serviceVersion": "1.0.0"
+    }
+  }
+}

--- a/packages/runtime/fixtures/otlp-exporter-command/services/main/index.mjs
+++ b/packages/runtime/fixtures/otlp-exporter-command/services/main/index.mjs
@@ -1,0 +1,33 @@
+import { getApplicationId, getLogLevel, getPrometheus, getWorkerId } from '@platformatic/globals'
+import fastify from 'fastify'
+
+// This service runs as a command (`node index.mjs`), so it is executed in a child
+// process through the childManager. Metrics are collected into the child registry.
+const { client, registry } = getPrometheus()
+
+const requestCounter = new client.Counter({
+  name: 'custom_requests_total',
+  help: 'Total number of custom requests',
+  registers: [registry]
+})
+
+const responseGauge = new client.Gauge({
+  name: 'custom_response_time',
+  help: 'Custom response time gauge',
+  registers: [registry]
+})
+
+const app = fastify({
+  logger: {
+    name: [getApplicationId(), getWorkerId()].filter(f => typeof f !== 'undefined').join(':'),
+    level: getLogLevel(false) ?? 'info'
+  }
+})
+
+app.get('/', async () => {
+  requestCounter.inc()
+  responseGauge.set(Math.random() * 100)
+  return { hello: 'world' }
+})
+
+app.listen({ host: '127.0.0.1', port: 0 })

--- a/packages/runtime/fixtures/otlp-exporter-command/services/main/package.json
+++ b/packages/runtime/fixtures/otlp-exporter-command/services/main/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "otlp-exporter-command-main",
+  "main": "index.mjs",
+  "dependencies": {
+    "@platformatic/globals": "workspace:*",
+    "fastify": "^5.0.0"
+  }
+}

--- a/packages/runtime/fixtures/otlp-exporter-command/services/main/platformatic.json
+++ b/packages/runtime/fixtures/otlp-exporter-command/services/main/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.48.0.json",
+  "logger": {
+    "level": "info"
+  },
+  "application": {
+    "commands": {
+      "development": "node index.mjs"
+    }
+  }
+}

--- a/packages/runtime/test/otlp-exporter.test.js
+++ b/packages/runtime/test/otlp-exporter.test.js
@@ -310,3 +310,73 @@ test('should not export metrics when OTLP exporter is disabled', async t => {
   // Verify no requests were made
   strictEqual(requestCount, 0, 'OTLP endpoint should not have received any requests when disabled')
 })
+
+test('should export non-empty metrics for command-based (childManager) services', async t => {
+  let otlpRequestCount = 0
+  let lastOtlpPayload = null
+
+  // Create a mock OTLP server
+  const otlpServer = createServer((req, res) => {
+    if (req.url === '/v1/metrics' && req.method === 'POST') {
+      let body = Buffer.alloc(0)
+      req.on('data', chunk => {
+        body = Buffer.concat([body, chunk])
+      })
+      req.on('end', () => {
+        otlpRequestCount++
+        lastOtlpPayload = body
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ partialSuccess: {} }))
+      })
+    } else {
+      res.writeHead(404)
+      res.end()
+    }
+  })
+
+  await new Promise(resolve => otlpServer.listen(0, '127.0.0.1', resolve))
+  const otlpPort = otlpServer.address().port
+
+  t.after(async () => {
+    otlpServer.close()
+  })
+
+  // Set environment variable for OTLP port
+  process.env.PLT_OTLP_PORT = otlpPort.toString()
+
+  const projectDir = join(fixturesDir, 'otlp-exporter-command')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  const entryUrl = await app.start()
+
+  t.after(async () => {
+    await app.close()
+    delete process.env.PLT_OTLP_PORT
+  })
+
+  // Wait for the runtime to start
+  await sleep(1000)
+
+  // Make some requests to generate metrics
+  for (let i = 0; i < 5; i++) {
+    const res = await request(entryUrl)
+    strictEqual(res.statusCode, 200)
+  }
+
+  // Wait for OTLP export to happen (interval is 1000ms)
+  await sleep(2500)
+
+  // Verify that metrics were exported
+  ok(otlpRequestCount > 0, 'OTLP endpoint should have received at least one request')
+  ok(lastOtlpPayload !== null, 'Should have received OTLP payload')
+  ok(lastOtlpPayload.length > 0, 'OTLP payload should not be empty')
+
+  // The OTLP protobuf payload embeds metric names as UTF-8 strings. For command-based
+  // services the exporter must read the populated child registry; if it was wired to the
+  // empty parent registry (the bug in #4848), these series would be absent.
+  ok(
+    lastOtlpPayload.includes(Buffer.from('nodejs_heap_size_total_bytes')),
+    'OTLP payload should contain default nodejs_* metrics from the child registry'
+  )
+})


### PR DESCRIPTION
## Problem

Fixes #4848.

`metrics.otlpExporter` logs `OTLP metrics exporter started` but **never sends non-empty metrics** for **command-based services** (`application.commands.*`, i.e. Watt running an app via a child process through the `childManager` — e.g. Next.js standalone).

### Root cause

For a command service, `Capability` runs with a `childManager`:

- `Capability.#collectMetrics()` delegates collection to the child (sends a `collectMetrics` message) and returns early, so the parent's `this.metricsRegistry` stays **empty**.
- `Capability.#setupOtlpExporter()` then built the bridge over that **empty parent registry** (`setupOtlpExporter(this.metricsRegistry, …)`).
- The child (`worker/child-process.js`) collects the real per-worker metrics into its **own** `#metricsRegistry` and serves them on `:9090/metrics`, but **never set up the OTLP exporter**.

Net: `:9090/metrics` was fully populated while the OTLP exporter pushed the empty parent registry every interval — a 2xx push of no data.

## Fix

- **Child (`worker/child-process.js`)**: after `collectThreadMetrics`, set up the OTLP exporter over the populated child `#metricsRegistry`. The bridge is torn down on metrics-config update and on child close.
- **Parent (`capability.js`)**: skip the OTLP setup when running in `childManager` mode (it would only export the empty parent registry).

## Testing

- New regression test `should export non-empty metrics for command-based (childManager) services` with a command-based fixture (`otlp-exporter-command`). It asserts the OTLP payload contains the child registry's default `nodejs_*` series.
- Verified the test **fails** on `main` (empty payload) and **passes** with this change.
- Full `test/otlp-exporter.test.js` suite passes (6/6); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)