### PR TITLE
fix(next): avoid empty DEL when revalidating Valkey tags with no entries

### DIFF
--- a/packages/next/lib/caching/valkey-components.js
+++ b/packages/next/lib/caching/valkey-components.js
@@ -215,14 +215,18 @@ export class CacheHandler {
             toDelete.add(key)
 
             // Batch full, execute it
-            if (toDelete.length >= MAX_BATCH_SIZE) {
+            if (toDelete.size >= MAX_BATCH_SIZE) {
               await this.#store.del(...toDelete)
               toDelete.clear()
             }
           }
         }
 
-        await this.#store.del(...toDelete)
+        // Spreading an empty Set would issue a DEL with no keys, which Valkey
+        // rejects. Only delete when there is something to delete.
+        if (toDelete.size) {
+          await this.#store.del(...toDelete)
+        }
         await this.#store.del(tagsKey)
       }
     } catch (e) {

--- a/packages/next/lib/caching/valkey-isr.js
+++ b/packages/next/lib/caching/valkey-isr.js
@@ -254,7 +254,11 @@ export class CacheHandler {
           }
         }
 
-        await this.#store.del(...toDelete)
+        // Spreading an empty Set would issue a DEL with no keys, which Valkey
+        // rejects. Only delete when there is something to delete.
+        if (toDelete.size) {
+          await this.#store.del(...toDelete)
+        }
         await this.#store.del(tagsKey)
       }
     } catch (e) {

--- a/packages/next/test/caching/valkey-isr.test.js
+++ b/packages/next/test/caching/valkey-isr.test.js
@@ -505,6 +505,54 @@ test('should properly revalidate tags in Valkey', async t => {
   ])
 })
 
+test('should not issue an empty DEL when revalidating a tag with no entries', async t => {
+  const errors = []
+  const logger = {
+    trace: () => {},
+    error: (obj, msg) => { errors.push({ msg, obj }) }
+  }
+
+  const valkey = new Redis(await getValkeyUrl(resolve(fixturesDir, configuration)))
+  const monitorCollection = new Redis(await getValkeyUrl(resolve(fixturesDir, configuration)))
+
+  await cleanupCache(valkey)
+  const monitor = await monitorCollection.monitor()
+  const valkeyCalls = []
+
+  const tagsKey = keyFor(valkeyPrefix, '', 'tags', 'missing')
+
+  const monitorPromise = Promise.withResolvers()
+  monitor.on('monitor', (_, args) => {
+    valkeyCalls.push(args)
+
+    if (args[0] === 'del' && args[1] === tagsKey) {
+      monitorPromise.resolve()
+    }
+  })
+
+  t.after(async () => {
+    await cleanupCache(valkey)
+    await monitor.disconnect()
+    await valkey.disconnect()
+    await monitorCollection.disconnect()
+  })
+
+  const handler = new CacheHandler({ standalone: true, store: valkey, prefix: valkeyPrefix, logger })
+
+  // The tag set has no live entries, so toDelete stays empty. Spreading it into
+  // DEL used to issue a keyless DEL, which Valkey rejects with
+  // "ERR wrong number of arguments for 'del' command".
+  await handler.revalidateTag('missing')
+  await monitorPromise.promise
+
+  verifyValkeySequence(valkeyCalls, [
+    ['sscan', tagsKey, '0'],
+    ['del', tagsKey]
+  ])
+
+  deepStrictEqual(errors, [])
+})
+
 test('should extend TTL when our limit is smaller than the user one', async t => {
   const { url } = await prepareRuntimeWithBackend(t, configuration, false, false, false, async root => {
     await setCacheSettings(root, cache => {


### PR DESCRIPTION
Fixes #4852

When a tag set has no live entries, the accumulated `toDelete` Set is empty and spreading it into `del(...toDelete)` issues a keyless `DEL`, which Valkey rejects with `ERR wrong number of arguments for 'del' command` (surfaced as `Cannot expire cache tags in Valkey`). This is hit whenever a tag is revalidated with no cached entries - e.g. right after a deploy (the cache subprefix is the Next.js `BUILD_ID`, so the previous build's tag-sets no longer match) or once a tag's set has expired via its own TTL.

### Changes
- Guard the spread so `DEL` is only issued when there is something to delete, in both the ISR (`valkey-isr.js`) and cache-components (`valkey-components.js`) handlers.
- Fix the components handler checking `toDelete.length` - `toDelete` is a `Set` (`.size`, not `.length`), which prevented its in-loop batch flush from ever triggering.
- Add a regression test that revalidates a tag with no entries and asserts no empty `DEL` is issued.

### Testing
- `cd packages/next && pnpm run lint` ✅
- New test in `test/caching/valkey-isr.test.js` ✅ — verified it **fails on `main`** with the exact production error (`ERR wrong number of arguments for 'del' command`) and **passes with the fix**.