### PR TITLE
fix: Skipped nested pnpm installs.

### DIFF
--- a/packages/wattpm-utils/lib/commands/dependencies.js
+++ b/packages/wattpm-utils/lib/commands/dependencies.js
@@ -12,7 +12,7 @@ import { bold } from 'colorette'
 import { execa } from 'execa'
 import { existsSync } from 'node:fs'
 import { readFile, rm, writeFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { isAbsolute, relative, resolve } from 'node:path'
 import { parseEnv } from 'node:util'
 import { rsort, satisfies } from 'semver'
 import { packages } from '../packages.js'
@@ -67,6 +67,11 @@ async function withTemporaryPnpmConfig (directory, fn) {
   }
 }
 
+function isPathInsideDirectory (directory, path) {
+  const relativePath = relative(directory, path)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
 export async function installDependencies (logger, root, applications, production, packageManager) {
   if (typeof applications === 'string') {
     const config = await loadConfiguration(applications, null, { validate: false })
@@ -84,6 +89,7 @@ export async function installDependencies (logger, root, applications, productio
   }
 
   const args = getInstallationCommand(packageManager, production)
+  const isPnpmWorkspace = packageManager === 'pnpm' && existsSync(resolve(root, 'pnpm-workspace.yaml'))
 
   // Install dependencies of the application
   try {
@@ -110,8 +116,14 @@ export async function installDependencies (logger, root, applications, productio
   }
 
   for (let { id, path, packageManager: applicationPackageManager } of applications) {
+    const hasConfiguredPackageManager = !!applicationPackageManager
     applicationPackageManager ??= await getPackageManager(path, packageManager)
     const applicationPackageArgs = getInstallationCommand(applicationPackageManager, production)
+    const applicationRoot = resolve(root, path)
+
+    if (!hasConfiguredPackageManager && isPnpmWorkspace && applicationPackageManager === 'pnpm' && isPathInsideDirectory(root, applicationRoot)) {
+      continue
+    }
 
     try {
       logger.info(
@@ -138,7 +150,6 @@ export async function installDependencies (logger, root, applications, productio
         }
       }
 
-      const applicationRoot = resolve(root, path)
       const installApplicationDependencies = () => executeCommand(root, applicationPackageManager, applicationPackageArgs, {
         cwd: applicationRoot,
         stdio: 'inherit',

--- a/packages/wattpm-utils/test/import.test.js
+++ b/packages/wattpm-utils/test/import.test.js
@@ -475,6 +475,38 @@ test('import - when launched without arguments, should fix the configuration of 
   ok(importProcess.stdout.includes('Installing dependencies for the application third using npm ...'))
 })
 
+test('import - should not install applications individually inside a pnpm workspace', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'no-dependencies', false, 'watt.json')
+  t.after(() => safeRemove(rootDir))
+
+  await writeFile(resolve(rootDir, '.npmrc'), 'dry-run=true\n', 'utf-8')
+  await writeFile(
+    resolve(rootDir, 'pnpm-workspace.yaml'),
+    `packages:
+  - web-1/*
+  - web-2/*
+
+catalog:
+  vite: ^5.0.0
+`,
+    'utf-8'
+  )
+  await writeFile(
+    resolve(rootDir, 'web-1/fourth/package.json'),
+    JSON.stringify({ dependencies: { '@platformatic/globals': '>=3.0.0', vite: 'catalog:' } }),
+    'utf-8'
+  )
+
+  changeWorkingDirectory(t, rootDir)
+  const importProcess = await wattpmUtils('import', '-P', 'pnpm')
+
+  ok(importProcess.stdout.includes('Installing dependencies for the project using pnpm ...'))
+  ok(!importProcess.stdout.includes('Installing dependencies for the application first using pnpm ...'))
+  ok(!importProcess.stdout.includes('Installing dependencies for the application second using pnpm ...'))
+  ok(!importProcess.stdout.includes('Installing dependencies for the application fourth using pnpm ...'))
+  ok(!importProcess.stdout.includes('Installing dependencies for the application third using pnpm ...'))
+})
+
 test('import - when launched without arguments, should fix the configuration of all known applications without installing dependencies', async t => {
   const { root: rootDir } = await prepareRuntime(t, 'no-dependencies', false, 'watt.json')
   t.after(() => safeRemove(rootDir))


### PR DESCRIPTION
## Summary

Fixes `wattpm-utils import` for pnpm workspace projects that use catalog dependencies.

## Changes

- Skip inferred per-application `pnpm install` calls when the Watt project root is a pnpm workspace.
- Keep the root `pnpm install`, which handles workspace catalog resolution.
- Preserve explicit per-application `packageManager` behavior.
- Add regression coverage for pnpm workspace catalog imports.

Assisted-By: OpenAI:GPT-5.5 <openai/gpt-5.5>