### PR TITLE
feat: Added healthProbes runtime configuration.

### DIFF
--- a/docs/guides/deployment/k8s-readiness-liveness.md
+++ b/docs/guides/deployment/k8s-readiness-liveness.md
@@ -109,6 +109,28 @@ Watt provides built-in health check endpoints through its metrics server. The me
 - **`/ready`** (Readiness endpoint): Indicates if all services are started and ready to accept traffic
 - **`/status`** (Liveness endpoint): Indicates if all services are healthy and their custom health checks pass
 
+The top-level `healthProbes` setting controls these Kubernetes probe endpoints. It defaults to `true`. Set it to `false` to disable both `/ready` and `/status` while keeping Prometheus metrics enabled.
+
+```json
+{
+  "healthProbes": false,
+  "metrics": true
+}
+```
+
+To expose Kubernetes probes without Prometheus metrics, disable metrics collection but keep the metrics server configuration for the probe host and port:
+
+```json
+{
+  "healthProbes": true,
+  "metrics": {
+    "enabled": false,
+    "hostname": "0.0.0.0",
+    "port": 9090
+  }
+}
+```
+
 ### Endpoint Customization
 
 You can customize the health check endpoints in your Watt configuration:

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -25,6 +25,15 @@ Note that the metrics port is not the default in this configuration. This is bec
 
 All the configuration settings are optional. To use the default settings, set `"metrics": true`. See the [configuration reference](../reference/runtime/_shared-configuration.md#metrics) for more details.
 
+The same server exposes Kubernetes readiness and liveness probes by default. Set the top-level `healthProbes` option to `false` to expose metrics without `/ready` and `/status`:
+
+```json
+{
+  "healthProbes": false,
+  "metrics": true
+}
+```
+
 ## Serving metrics over HTTPS (SSL/TLS)
 
 The metrics server can use HTTPS (TLS, often referred to as SSL). This also applies to the readiness and liveness endpoints exposed by the same server.

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -255,6 +255,12 @@ The object supports the following settings:
 - `maxYoungGeneration`(`number` or `string`): The maximum amount of memory that can be used by the young generation. The value must be an amount in bytes, in bytes or in memory units. Default: `128MB`
 - `codeRangeSize` (`number` or `string`): The maximum amount of memory that can be used for code range (compiled code). The value must be an amount in bytes or in memory units. Default: `268435456` (256MB).
 
+### `healthProbes`
+
+Enables the Kubernetes readiness and liveness probe endpoints on the Prometheus server. It can be a boolean or a string. Default: `true`.
+
+Set this to `false` to disable both probe endpoints globally. Individual probe endpoints can still be configured with `metrics.readiness` and `metrics.liveness` when `healthProbes` is enabled.
+
 ### `telemetry`
 
 [Open Telemetry](https://opentelemetry.io/) is optionally supported with these settings:
@@ -427,6 +433,8 @@ Setting a lower value can be useful when:
 ### `metrics`
 
 This configures the Platformatic Runtime Prometheus server. The Prometheus server exposes aggregated metrics from the Platformatic Runtime applications.
+
+The same server also exposes Kubernetes readiness and liveness probes when [`healthProbes`](#healthprobes) is enabled. If `metrics.enabled` is `false` and `healthProbes` is enabled, the server exposes only the probe endpoints. If both `metrics.enabled` and `healthProbes` are `false`, the server is not started.
 
 - **`enabled`** (`boolean` or `string`). If `true`, the Prometheus server will be started. Default: `true`.
 - **`hostname`** (`string`). The hostname where the Prometheus server will be listening. Default: `0.0.0.0`.

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticAstroConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -146,6 +146,7 @@ export interface PlatformaticBasicConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -981,6 +981,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -1654,6 +1654,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -640,6 +640,7 @@ export interface PlatformaticDatabaseConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -2338,6 +2338,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -1058,6 +1058,10 @@ export const runtimeProperties = {
     additionalProperties: false
   },
   health,
+  healthProbes: {
+    anyOf: [{ type: 'boolean' }, { type: 'string' }],
+    default: true
+  },
   undici: {
     type: 'object',
     properties: {

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -532,6 +532,7 @@ export interface PlatformaticGatewayConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -2295,6 +2295,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticNestJSConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticNextJsConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticNodeJsConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticReactRouterConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticRemixConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -243,6 +243,7 @@ export type PlatformaticRuntimeConfig = {
     bufferPoolSize?: number | string;
     defaultHighWaterMark?: number | string;
   };
+  healthProbes?: boolean | string;
   undici?: {
     agentOptions?: {
       [k: string]: unknown;

--- a/packages/runtime/fixtures/prom-server/health-probes-disabled.json
+++ b/packages/runtime/fixtures/prom-server/health-probes-disabled.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.48.0.json",
+  "entrypoint": "main",
+  "watch": false,
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": 9090
+  },
+  "healthProbes": false
+}

--- a/packages/runtime/fixtures/prom-server/metrics-and-health-probes-disabled.json
+++ b/packages/runtime/fixtures/prom-server/metrics-and-health-probes-disabled.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.48.0.json",
+  "entrypoint": "main",
+  "watch": false,
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "metrics": {
+    "enabled": false,
+    "hostname": "127.0.0.1",
+    "port": 9090
+  },
+  "healthProbes": false
+}

--- a/packages/runtime/lib/prom-server.js
+++ b/packages/runtime/lib/prom-server.js
@@ -76,8 +76,11 @@ async function checkLiveness (runtime) {
   return { response, status }
 }
 
-export async function startPrometheusServer (runtime, opts) {
-  if (opts.enabled === false) {
+export async function startPrometheusServer (runtime, opts, healthProbes) {
+  const metricsEnabled = opts.enabled !== false
+  const healthProbesEnabled = healthProbes !== false
+
+  if (!metricsEnabled && !healthProbesEnabled) {
     return
   }
   const host = opts.hostname ?? DEFAULT_HOSTNAME
@@ -113,13 +116,17 @@ export async function startPrometheusServer (runtime, opts) {
     logLevel: 'warn',
     handler (req, reply) {
       reply.type('text/plain')
-      let response = `Hello from Platformatic Prometheus Server!\nThe metrics are available at ${metricsEndpoint}.`
+      let response = 'Hello from Platformatic Prometheus Server!'
 
-      if (opts.readiness !== false) {
+      if (metricsEnabled) {
+        response += `\nThe metrics are available at ${metricsEndpoint}.`
+      }
+
+      if (healthProbesEnabled && opts.readiness !== false) {
         response += `\nThe readiness endpoint is available at ${readinessEndpoint}.`
       }
 
-      if (opts.liveness !== false) {
+      if (healthProbesEnabled && opts.liveness !== false) {
         response += `\nThe liveness endpoint is available at ${livenessEndpoint}.`
       }
 
@@ -127,22 +134,24 @@ export async function startPrometheusServer (runtime, opts) {
     }
   })
 
-  promServer.route({
-    url: metricsEndpoint,
-    method: 'GET',
-    logLevel: 'warn',
-    onRequest: onRequestHook,
-    handler: async (req, reply) => {
-      const accepts = req.accepts()
-      const reqType = !accepts.type('text/plain') && accepts.type('application/json') ? 'json' : 'text'
-      if (reqType === 'text') {
-        reply.type('text/plain')
+  if (metricsEnabled) {
+    promServer.route({
+      url: metricsEndpoint,
+      method: 'GET',
+      logLevel: 'warn',
+      onRequest: onRequestHook,
+      handler: async (req, reply) => {
+        const accepts = req.accepts()
+        const reqType = !accepts.type('text/plain') && accepts.type('application/json') ? 'json' : 'text'
+        if (reqType === 'text') {
+          reply.type('text/plain')
+        }
+        return (await runtime.getMetrics(reqType)).metrics
       }
-      return (await runtime.getMetrics(reqType)).metrics
-    }
-  })
+    })
+  }
 
-  if (opts.readiness !== false) {
+  if (healthProbesEnabled && opts.readiness !== false) {
     const successStatusCode = opts.readiness?.success?.statusCode ?? DEFAULT_READINESS_SUCCESS_STATUS_CODE
     const successBody = opts.readiness?.success?.body ?? DEFAULT_READINESS_SUCCESS_BODY
     const failStatusCode = opts.readiness?.fail?.statusCode ?? DEFAULT_READINESS_FAIL_STATUS_CODE
@@ -181,7 +190,7 @@ export async function startPrometheusServer (runtime, opts) {
     })
   }
 
-  if (opts.liveness !== false) {
+  if (healthProbesEnabled && opts.liveness !== false) {
     const successStatusCode = opts.liveness?.success?.statusCode ?? DEFAULT_LIVENESS_SUCCESS_STATUS_CODE
     const successBody = opts.liveness?.success?.body ?? DEFAULT_LIVENESS_SUCCESS_BODY
     const failStatusCode = opts.liveness?.fail?.statusCode ?? DEFAULT_LIVENESS_FAIL_STATUS_CODE

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -227,7 +227,7 @@ export class Runtime extends EventEmitter {
     if (config.metrics) {
       // Use the configured application label name for metrics (defaults to 'applicationId')
       this.#metricsLabelName = config.metrics.applicationLabel || 'applicationId'
-      this.#prometheusServer = await startPrometheusServer(this, config.metrics)
+      this.#prometheusServer = await startPrometheusServer(this, config.metrics, config.healthProbes)
     } else {
       // Default to applicationId if metrics are not configured
       this.#metricsLabelName = 'applicationId'
@@ -855,8 +855,8 @@ export class Runtime extends EventEmitter {
     this.#config.metrics = metricsConfig
     this.#metricsLabelName = metricsConfig?.applicationLabel || 'applicationId'
 
-    if (metricsConfig.enabled !== false) {
-      this.#prometheusServer = await startPrometheusServer(this, metricsConfig)
+    if (metricsConfig.enabled !== false || this.#config.healthProbes !== false) {
+      this.#prometheusServer = await startPrometheusServer(this, metricsConfig, this.#config.healthProbes)
     }
 
     const promises = []

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -2117,6 +2117,17 @@
       },
       "additionalProperties": false
     },
+    "healthProbes": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": true
+    },
     "undici": {
       "type": "object",
       "properties": {

--- a/packages/runtime/test/prom-metrics.test.js
+++ b/packages/runtime/test/prom-metrics.test.js
@@ -339,9 +339,117 @@ test('should track http cache hits/misses', async t => {
   ok(metrics.includes('http_cache_miss_count{applicationId="service-2",workerId="0"} 1'))
 })
 
-test('metrics can be disabled', async t => {
+test('metrics can be disabled while health probes stay enabled', async t => {
   const projectDir = join(fixturesDir, 'prom-server')
   const configFile = join(projectDir, 'metrics-disabled.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Wait for the prometheus server to start
+  await sleep(2000)
+
+  {
+    const { statusCode, body } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/'
+    })
+    strictEqual(statusCode, 200)
+    strictEqual(
+      await body.text(),
+      `Hello from Platformatic Prometheus Server!
+The readiness endpoint is available at /ready.
+The liveness endpoint is available at /status.`
+    )
+  }
+
+  {
+    const { statusCode } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/metrics'
+    })
+    strictEqual(statusCode, 404)
+  }
+
+  {
+    const { statusCode, body } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/ready'
+    })
+    strictEqual(statusCode, 200)
+    strictEqual(await body.text(), 'OK')
+  }
+
+  {
+    const { statusCode, body } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/status'
+    })
+    strictEqual(statusCode, 200)
+    strictEqual(await body.text(), 'OK')
+  }
+})
+
+test('health probes can be disabled while metrics stay enabled', async t => {
+  const projectDir = join(fixturesDir, 'prom-server')
+  const configFile = join(projectDir, 'health-probes-disabled.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Wait for the prometheus server to start
+  await sleep(2000)
+
+  {
+    const { statusCode, body } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/'
+    })
+    strictEqual(statusCode, 200)
+    strictEqual(
+      await body.text(),
+      `Hello from Platformatic Prometheus Server!
+The metrics are available at /metrics.`
+    )
+  }
+
+  {
+    const { statusCode, body } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/metrics'
+    })
+    strictEqual(statusCode, 200)
+    ok((await body.text()).includes('nodejs_version_info'))
+  }
+
+  {
+    const { statusCode } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/ready'
+    })
+    strictEqual(statusCode, 404)
+  }
+
+  {
+    const { statusCode } = await request('http://127.0.0.1:9090', {
+      method: 'GET',
+      path: '/status'
+    })
+    strictEqual(statusCode, 404)
+  }
+})
+
+test('prometheus server is not started when metrics and health probes are disabled', async t => {
+  const projectDir = join(fixturesDir, 'prom-server')
+  const configFile = join(projectDir, 'metrics-and-health-probes-disabled.json')
   const app = await createRuntime(configFile)
 
   await app.start()
@@ -356,7 +464,7 @@ test('metrics can be disabled', async t => {
   await rejects(
     request('http://127.0.0.1:9090', {
       method: 'GET',
-      path: '/metrics'
+      path: '/'
     })
   )
 })

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -469,6 +469,7 @@ export interface PlatformaticServiceConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -2023,6 +2023,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticTanStackConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -262,6 +262,7 @@ export interface PlatformaticViteConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?: boolean | string;
     undici?: {
       agentOptions?: {
         [k: string]: unknown;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -1372,6 +1372,17 @@
           },
           "additionalProperties": false
         },
+        "healthProbes": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": true
+        },
         "undici": {
           "type": "object",
           "properties": {

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -243,6 +243,7 @@ export type PlatformaticRuntimeConfig = {
     bufferPoolSize?: number | string;
     defaultHighWaterMark?: number | string;
   };
+  healthProbes?: boolean | string;
   undici?: {
     agentOptions?: {
       [k: string]: unknown;

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -2117,6 +2117,17 @@
       },
       "additionalProperties": false
     },
+    "healthProbes": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": true
+    },
     "undici": {
       "type": "object",
       "properties": {

--- a/packages/wattpm/test/management.test.js
+++ b/packages/wattpm/test/management.test.js
@@ -347,6 +347,7 @@ test('config - should list configuration for the runtime', async t => {
       bufferPoolSize: 262144,
       defaultHighWaterMark: 262144
     },
+    healthProbes: true,
     resolvedApplicationsBasePath: 'external',
     metrics: {
       enabled: true,


### PR DESCRIPTION
## Summary

Added top-level `healthProbes` runtime configuration to control Kubernetes readiness and liveness probes independently from Prometheus metrics.

## Changes

- Added `healthProbes` as a top-level runtime config option with boolean/string support and default `true`.
- Kept health probes available when `metrics.enabled` is `false`.
- Disabled `/ready` and `/status` when `healthProbes` is `false`.
- Avoided starting the Prometheus server when both metrics and health probes are disabled.
- Added tests and fixtures for metrics/probe combinations.
- Regenerated schemas and TypeScript config definitions.
- Documented `healthProbes` in runtime reference, metrics guide, and Kubernetes probes guide.

Assisted-By: OpenAI:GPT-5.5 <openai/gpt-5.5>