### PR TITLE
docs: fix broken Markdown links flagged by Docusaurus build

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -23,7 +23,7 @@ In this case, we are exposing the metrics on port 9091 (defaults to `9090`), and
 We can also specify the IP address to bind to (defaults to `0.0.0.0`).
 Note that the metrics port is not the default in this configuration. This is because if you want to test the integration running both Prometheus and Platformatic on the same host, Prometheus starts on `9090` port too.
 
-All the configuration settings are optional. To use the default settings, set `"metrics": true`. See the [configuration reference](../reference/runtime/_shared-configuration.md#metrics) for more details.
+All the configuration settings are optional. To use the default settings, set `"metrics": true`. See the [configuration reference](../reference/runtime/configuration.md#metrics) for more details.
 
 The same server exposes Kubernetes readiness and liveness probes by default. Set the top-level `healthProbes` option to `false` to expose metrics without `/ready` and `/status`:
 

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -558,8 +558,8 @@ Watt uses [Prometheus](https://prometheus.io/) client libraries for metrics coll
 
 ## Next Steps
 
-- **[Configuration Guide](../reference/watt/configuration.md)**: Learn how to configure Watt applications
-- **[Application Mesh Details](../guides/application-mesh.md)**: Deep dive into inter-application communication
+- **[Configuration Guide](../reference/wattpm/configuration.md)**: Learn how to configure Watt applications
+- **[Application Mesh Details](../reference/runtime/multithread-architecture.md)**: Deep dive into inter-application communication
 - **[Deployment Patterns](../guides/deployment/)**: Production deployment strategies
 - **[Monitoring Setup](../guides/metrics.md)**: Setting up monitoring stack
 

--- a/docs/reference/db/overview.md
+++ b/docs/reference/db/overview.md
@@ -9,7 +9,7 @@ The Database Service is a core application type that runs within Watt (the Node.
 
 The Database Service supports PostgreSQL, MySQL, MariaDB, and SQLite, automatically introspecting your database schema to create type-safe, fully-featured APIs with support for relationships, filtering, pagination, and real-time subscriptions.
 
-For a high level overview of how Watt and its applications work, please reference the [Overview](../../overview.md) guide.
+For a high level overview of how Watt and its applications work, please reference the [Overview](../../Overview.md) guide.
 
 ## Features
 
@@ -45,7 +45,7 @@ For a high level overview of how Watt and its applications work, please referenc
 
 ### Command Line usage (CLI)
 
-When using [Watt](../watt/overview.md), `@platformatic/db` applications will make some additional commands available on the terminal.
+When using [Watt](../wattpm/overview.md), `@platformatic/db` applications will make some additional commands available on the terminal.
 
 All the commands will be prefixed by the application id. For instance, if your application id is `movies`, then you will have the following commands available:
 
@@ -85,7 +85,7 @@ Database Service is perfect when you need:
 - **Enterprise Features**: Advanced authorization, migrations, and schema management
 
 :::info
-Ready to start? Check out our [Getting Started Guide](../../getting-started/quick-start-watt.md) to create your first Watt application with a Database Service! ⚡
+Ready to start? Check out our [Getting Started Guide](../../getting-started/quick-start.md) to create your first Watt application with a Database Service! ⚡
 :::
 
 ## Supported databases

--- a/docs/reference/db/seed.md
+++ b/docs/reference/db/seed.md
@@ -10,7 +10,7 @@ script that will populate — or "seed" — our database (where `$db` is the id 
 ## Example
 
 Our seed script should export a `Function` that accepts an argument:
-an instance of [`@platformatic/sql-mapper`](/packages/sql-mapper/overview.md).
+an instance of [`@platformatic/sql-mapper`](../sql-mapper/overview.md).
 
 ```javascript title="seed.js"
 'use strict'

--- a/docs/reference/gateway/overview.md
+++ b/docs/reference/gateway/overview.md
@@ -6,7 +6,7 @@ The Gateway Service is an API Gateway that runs within Watt (the Node.js Applica
 
 The Gateway Service aggregates APIs from multiple sources - whether they're other applications in your Watt application, external APIs, or legacy systems - presenting them as a cohesive, well-documented API to your clients.
 
-For a high level overview of how Watt and its applications work, please reference the [Overview](../../overview.md) guide.
+For a high level overview of how Watt and its applications work, please reference the [Overview](../../Overview.md) guide.
 
 ## Features
 

--- a/docs/reference/service/overview.md
+++ b/docs/reference/service/overview.md
@@ -11,7 +11,7 @@ The HTTP Service is a core application type that runs within Watt (the Node.js A
 
 The HTTP Service handles custom application logic, business rules, and API endpoints that aren't automatically generated from your database schema. It's perfect for authentication, complex business logic, third-party integrations, and custom endpoints.
 
-For a high level overview of how Watt and its applications work, please reference the [Overview](../../overview.md) guide.
+For a high level overview of how Watt and its applications work, please reference the [Overview](../../Overview.md) guide.
 
 ## Features
 


### PR DESCRIPTION
## What

Fixes internal Markdown links in `docs/` that the documentation site build (`platformatic/docs`) reports as `[WARNING] Markdown link ... couldn't be resolved`. Each target was renamed, moved, or never existed.

| File | Before | After | Reason |
|------|--------|-------|--------|
| `overview/architecture-overview.md` | `../reference/watt/configuration.md` | `../reference/wattpm/configuration.md` | `watt/` dir renamed to `wattpm/` |
| `overview/architecture-overview.md` | `../guides/application-mesh.md` | `../reference/runtime/multithread-architecture.md` | target never existed; mesh is documented in the multithread architecture page |
| `reference/db/seed.md` | `/packages/sql-mapper/overview.md` | `../sql-mapper/overview.md` | bad absolute path |
| `reference/db/overview.md` | `../watt/overview.md` | `../wattpm/overview.md` | `watt/` dir renamed |
| `reference/db/overview.md` | `../../getting-started/quick-start-watt.md` | `../../getting-started/quick-start.md` | target never existed |
| `guides/metrics.md` | `../reference/runtime/_shared-configuration.md#metrics` | `../reference/runtime/configuration.md#metrics` | `_shared-configuration.md` is a Docusaurus partial (underscore-prefixed → not a routable page); `configuration.md` renders it |
| `reference/db/overview.md`, `reference/service/overview.md`, `reference/gateway/overview.md` | `../../overview.md` | `../../Overview.md` | actual file is `Overview.md`; lowercase links only resolved on case-insensitive filesystems and broke on the case-sensitive CI build |

## Why

These warnings surface on every docs deploy. They're all pure link-target corrections — no content changes. The last group also fixes a latent case-sensitivity bug that works locally on macOS but fails on the Linux CI build.

## Notes

Frozen released versions (e.g. `version-1.53.4`) still emit similar warnings from their published release zips; those can't be corrected retroactively and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)