### PR TITLE
chore: remove emoji from compiling-typescript docs

### DIFF
--- a/docs/guides/deployment/compiling-typescript.md
+++ b/docs/guides/deployment/compiling-typescript.md
@@ -1,8 +1,8 @@
-# 🚀 Compiling TypeScript for Deployment
+# Compiling TypeScript for Deployment
 
 Watt provides TypeScript support across different capabilities with varying compilation approaches depending on the type of application you're building.
 
-## 🔧 Server-Side Capabilities
+## Server-Side Capabilities
 
 For server-side capabilities like `@platformatic/node`, `@platformatic/gateway`, `@platformatic/service` and `@platformatic/db`, TypeScript support is provided through Node.js native type stripping:
 
@@ -11,7 +11,7 @@ For server-side capabilities like `@platformatic/node`, `@platformatic/gateway`,
 
 These capabilities leverage Node.js's built-in ability to execute TypeScript files directly by stripping type annotations at runtime.
 
-## 🎨 Frontend Capabilities
+## Frontend Capabilities
 
 For frontend capabilities like `@platformatic/next` and `@platformatic/vite`, TypeScript compilation is handled by the underlying frontend technology:
 
@@ -27,7 +27,7 @@ During development, no special compilation steps are required. Platformatic auto
 - For `@platformatic/node`: If a `application.commands.build` is defined in your configuration or a `build` script exists in `package.json`, the build step will be executed automatically
 - For frontend capabilities: Development servers handle TypeScript compilation transparently
 
-## 🏗️ Production Deployment
+## Production Deployment
 
 For production deployments, you must compile TypeScript before starting your application:
 
@@ -44,21 +44,21 @@ For production deployments, you must compile TypeScript before starting your app
    wattpm start
    ```
 
-### ⚠️ Important Notes
+### Important Notes
 
 - Always run `wattpm build` before `wattpm start` in production environments
 - The build process will compile TypeScript files and prepare your application for production
 - Ensure all TypeScript dependencies are properly installed before building
 - For frontend capabilities, the build process includes bundling, optimization, and asset generation
 
-## ✨ Best Practices
+## Best Practices
 
 - Use TypeScript configuration files (`tsconfig.json`) to customize compilation settings
 - Enable strict mode for better type safety
 - Configure proper module resolution for your target environment
 - Test your built application in a production-like environment before deployment
 
-## 📝 Recommended TypeScript Configuration
+## Recommended TypeScript Configuration
 
 Platformatic provides a recommended TypeScript configuration through the `@platformatic/tsconfig` package. You can use it by extending it in your `tsconfig.json`:
 


### PR DESCRIPTION
Proposal:

- Removes emoji from the `"Compiling TypeScript for Deployment"` page (headings/sections)

#### Why
- To keep the page consistent with the formatting style used across the rest of the documentation, where emoji are not used in headings.

#### Changes
- Removed emoji from section titles in `compiling-typescript.md`
- No content or structural changes text and links remain unchanged

--- 

<img width="2124" height="1206" alt="screenshot" src="https://github.com/user-attachments/assets/45e47bca-28f7-46e2-9cbd-fb8645060c7f" />
