### PR TITLE
fix(gateway): persist compose-endpoint miss cache across poll cycles

### DIFF
--- a/packages/gateway/lib/application.js
+++ b/packages/gateway/lib/application.js
@@ -13,7 +13,7 @@ import { isFetchable } from './utils.js'
 
 const EXPERIMENTAL_GRAPHQL_GATEWAY_FEATURE_MESSAGE = 'graphql composer is an experimental feature'
 
-async function detectApplicationsUpdate ({ app, applications, fetchOpenApiSchema, fetchGraphqlSubgraphs }) {
+async function detectApplicationsUpdate ({ app, applications, fetchOpenApiSchema, fetchGraphqlSubgraphs, composeEndpointMissCache }) {
   let changed
 
   const graphqlApplications = []
@@ -44,7 +44,7 @@ async function detectApplicationsUpdate ({ app, applications, fetchOpenApiSchema
   }
 
   if (!changed && graphqlApplications.length > 0) {
-    const graphqlSupergraph = await fetchGraphqlSubgraphs(graphqlApplications, app.graphqlComposerOptions, app)
+    const graphqlSupergraph = await fetchGraphqlSubgraphs(graphqlApplications, app.graphqlComposerOptions, app, composeEndpointMissCache)
     if (!isSameGraphqlSchema(graphqlSupergraph, app.graphqlSupergraph)) {
       changed = true
       app.graphqlSupergraph = graphqlSupergraph
@@ -70,6 +70,8 @@ async function watchApplications (app, { config, capability }) {
     return
   }
 
+  const composeEndpointMissCache = new Map()
+
   try {
     getRuntimeId()
   } catch {
@@ -83,7 +85,7 @@ async function watchApplications (app, { config, capability }) {
 
   const timer = setInterval(async () => {
     try {
-      if (await detectApplicationsUpdate({ app, applications: watching, fetchOpenApiSchema, fetchGraphqlSubgraphs })) {
+      if (await detectApplicationsUpdate({ app, applications: watching, fetchOpenApiSchema, fetchGraphqlSubgraphs, composeEndpointMissCache })) {
         clearInterval(timer)
         app.log.info('detected applications changes, restarting ...')
 

--- a/packages/gateway/lib/graphql-fetch.js
+++ b/packages/gateway/lib/graphql-fetch.js
@@ -71,9 +71,9 @@ export function applicationToSubgraphConfig (application) {
   }
 }
 
-export async function fetchGraphqlSubgraphs (applications, options, app) {
+export async function fetchGraphqlSubgraphs (applications, options, app, composeEndpointMissCache) {
   const subgraphs = applications.map(applicationToSubgraphConfig).filter(s => !!s)
-  const gateway = await compose({ ...toGatewayOptions(options, app), subgraphs })
+  const gateway = await compose({ ...toGatewayOptions(options, app), subgraphs, composeEndpointMissCache })
 
   return createSupergraph({
     logger: app.log,


### PR DESCRIPTION
## Problem

`@platformatic/gateway` calls `compose()` fresh on every `refreshTimeout` tick
(`fetchGraphqlSubgraphs` in `graphql-fetch.js`). Each call constructs a new
`Composer` instance with a new empty `Map` for the compose-endpoint miss cache
(added in `platformatic/graphql-composer#84`). The cache therefore resets every
cycle — repeated `GET /.well-known/graphql-composition` 404 log noise for
subgraphs that don't expose a compose endpoint returns indefinitely.

See platformatic/platformatic#2126.

## Fix

Allocate one `Map` in `watchApplications` scope (lives as long as the watch loop,
GC'd when the gateway closes) and thread it down through:

```
watchApplications
  └─ detectApplicationsUpdate  (new composeEndpointMissCache param)
       └─ fetchGraphqlSubgraphs (new composeEndpointMissCache param)
            └─ compose({ ..., composeEndpointMissCache })
```

The Map is allocated once outside the `setInterval` callback, so it survives
across all `refreshTimeout` ticks for the lifetime of the watch loop.

## Dependency

> ⚠️ **This PR depends on platformatic/graphql-composer#92** which makes the
> cache injectable in the `Composer` constructor. Until that change is merged
> and a new version of `@platformatic/graphql-composer` is published, passing
> `composeEndpointMissCache` to `compose()` has no effect (the option is
> currently ignored). This PR should remain **draft** until the composer change
> lands.

## Related

- platformatic/graphql-composer#92 (required — makes cache injectable)
- platformatic/platformatic#2126 (original issue)
- platformatic/graphql-composer#84 (where the cache was introduced)