### PR TITLE
chore: remove unused prettier.config.cjs

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,1 +1,0 @@
-/home/perseveranza/development/platformatic/ide-settings/prettier.config.cjs


### PR DESCRIPTION
Proposal:

- Remove unused `prettier.config.cjs`, this file was accidentally added at some point (see here: https://github.com/platformatic/platformatic/blob/428e0708283e7c7c77ec866e96e5bbc510f0b1dd/prettier.config.cjs) and is not actually used in this project. 

