### PR TITLE
fix(sql-mapper): do not run a query when insert receives an empty inputs array

### DIFF
--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -161,6 +161,12 @@ function createMapper (
     const db = getDB(args)
     const fieldsToRetrieve = computeFields(args.fields).map(f => sql.ident(f))
     const inputs = args.inputs
+    if (inputs === undefined || inputs === null) {
+      throw new InputNotProvidedError()
+    }
+    if (inputs.length === 0) {
+      return []
+    }
     // This else is skipped on MySQL because of https://github.com/ForbesLindesay/atdatabases/issues/221
     /* istanbul ignore else */
     if (autoTimestamp) {

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -198,6 +198,35 @@ test('empty save', async () => {
   deepEqual(insertResult, { id: '1', theTitle: null })
 })
 
+test('insert with empty inputs array returns an empty array', async () => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+    await db.query(sql`CREATE TABLE pages (
+      id INTEGER PRIMARY KEY,
+      title varchar(255) NOT NULL
+    );`)
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {}
+  })
+  const pageEntity = mapper.entities.page
+
+  const res = await pageEntity.insert({ inputs: [] })
+  deepEqual(res, [])
+
+  await rejects(pageEntity.insert({}), {
+    code: 'PLT_SQL_MAPPER_INPUT_NOT_PROVIDED'
+  })
+})
+
 test('insert with explicit integer PK value', async () => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)


### PR DESCRIPTION
## Summary

`entity.insert` crashed with a malformed SQL query when `inputs` was an empty array. It now:

- returns `[]` without touching the database when `inputs` is an empty array
- throws `PLT_SQL_MAPPER_INPUT_NOT_PROVIDED` when `inputs` is missing, matching the behavior of `save`/`updateMany`

Fixes #2708

## Test plan

- Added a test in `packages/sql-mapper/test/entity.test.js` covering both the empty array and the missing `inputs` cases (runs on all supported databases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF