### PR TITLE
feat(sql-mapper): friendly error when the SQLite database file is not accessible

### DIFF
--- a/packages/sql-mapper/index.js
+++ b/packages/sql-mapper/index.js
@@ -1,10 +1,13 @@
 import { findNearestString } from '@platformatic/foundation'
 import fp from 'fastify-plugin'
+import { access, constants } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
 import { setupCache } from './lib/cache.js'
 import { buildCleanUp } from './lib/clean-up.js'
 import { getConnectionInfo } from './lib/connection-info.js'
 import { buildEntity } from './lib/entity.js'
 import {
+  CannotAccessDatabaseFileError,
   CannotFindEntityError,
   ConnectionStringRequiredError,
   SpecifyProtocolError,
@@ -87,6 +90,34 @@ async function registerPostgreSQLExtensionTypes (db) {
   } catch {}
 }
 
+// Provide a developer friendly error instead of the bare SQLITE_CANTOPEN
+// emitted when the database file cannot be opened or created.
+async function checkSQLiteFileAccess (path) {
+  const file = resolve(path)
+
+  try {
+    // SQLite falls back to read-only when the file exists but is not writable,
+    // so reading the file is all that is required here.
+    await access(file, constants.R_OK)
+    return
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw new CannotAccessDatabaseFileError(file, 'the file is not readable by the current user')
+    }
+  }
+
+  // The file does not exist, SQLite will create it: the directory must exist and be writable
+  const dir = dirname(file)
+  try {
+    await access(dir, constants.W_OK | constants.X_OK)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new CannotAccessDatabaseFileError(file, `the directory "${dir}" does not exist`)
+    }
+    throw new CannotAccessDatabaseFileError(file, `the directory "${dir}" is not writable by the current user`)
+  }
+}
+
 export async function createConnectionPool ({
   log,
   connectionString,
@@ -138,6 +169,9 @@ export async function createConnectionPool ({
   } else if (connectionString.indexOf('sqlite') === 0) {
     const { default: sqlite } = await import('@matteo.collina/sqlite-pool')
     const path = connectionString.replace('sqlite://', '')
+    if (connectionString !== 'sqlite://:memory:') {
+      await checkSQLiteFileAccess(path)
+    }
     db = sqlite.default(
       connectionString === 'sqlite://:memory:' ? undefined : path,
       {},

--- a/packages/sql-mapper/lib/errors.js
+++ b/packages/sql-mapper/lib/errors.js
@@ -17,6 +17,10 @@ export const TableMustBeAStringError = createError(
 )
 export const UnknownFieldError = createError(`${ERROR_PREFIX}_UNKNOWN_FIELD`, 'Unknown field %s')
 export const InputNotProvidedError = createError(`${ERROR_PREFIX}_INPUT_NOT_PROVIDED`, 'Input not provided.')
+export const CannotAccessDatabaseFileError = createError(
+  `${ERROR_PREFIX}_CANNOT_ACCESS_DATABASE_FILE`,
+  'Cannot open SQLite database file "%s": %s'
+)
 export const UnsupportedWhereClauseError = createError(
   `${ERROR_PREFIX}_UNSUPPORTED_WHERE_CLAUSE`,
   'Unsupported where clause %s'

--- a/packages/sql-mapper/test/create-connection.test.js
+++ b/packages/sql-mapper/test/create-connection.test.js
@@ -1,4 +1,7 @@
-import { deepEqual } from 'node:assert'
+import { deepEqual, equal, match, rejects } from 'node:assert'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { test } from 'node:test'
 import { createConnectionPool } from '../index.js'
 import { clear, connInfo, isSQLite } from './helper.js'
@@ -41,4 +44,56 @@ test('createConnectionPool', async () => {
       is_published: true
     }
   ])
+})
+
+test('friendly error when the SQLite directory does not exist', { skip: !isSQLite }, async () => {
+  await rejects(
+    createConnectionPool({
+      connectionString: 'sqlite:///this/directory/does/not/exist/db.sqlite',
+      log: fakeLogger
+    }),
+    err => {
+      equal(err.code, 'PLT_SQL_MAPPER_CANNOT_ACCESS_DATABASE_FILE')
+      match(err.message, /the directory "\/this\/directory\/does\/not\/exist" does not exist/)
+      return true
+    }
+  )
+})
+
+test('friendly error when the SQLite file is not readable', { skip: !isSQLite || process.getuid() === 0 }, async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plt-sql-mapper-'))
+  const file = join(dir, 'db.sqlite')
+  await writeFile(file, '')
+  await chmod(file, 0o000)
+  test.after(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  await rejects(
+    createConnectionPool({
+      connectionString: `sqlite://${file}`,
+      log: fakeLogger
+    }),
+    err => {
+      equal(err.code, 'PLT_SQL_MAPPER_CANNOT_ACCESS_DATABASE_FILE')
+      match(err.message, /the file is not readable by the current user/)
+      return true
+    }
+  )
+})
+
+test('the SQLite database file is created when the directory is writable', { skip: !isSQLite }, async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plt-sql-mapper-'))
+  const file = join(dir, 'db.sqlite')
+  const { db, sql } = await createConnectionPool({
+    connectionString: `sqlite://${file}`,
+    log: fakeLogger
+  })
+  test.after(async () => {
+    await db.dispose()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const res = await db.query(sql`SELECT 1 as one`)
+  deepEqual(res, [{ one: 1 }])
 })


### PR DESCRIPTION
## Summary

When SQLite could not open the database file, the driver emitted a bare, hard-to-diagnose error:

```
Error: SQLITE_CANTOPEN: unable to open database file
```

The database file path is now checked at connection time, and a descriptive `PLT_SQL_MAPPER_CANNOT_ACCESS_DATABASE_FILE` error is thrown explaining exactly what is wrong:

- `Cannot open SQLite database file "/path/db.sqlite": the file is not readable by the current user`
- `Cannot open SQLite database file "/path/db.sqlite": the directory "/path" does not exist`
- `Cannot open SQLite database file "/path/db.sqlite": the directory "/path" is not writable by the current user`

Existing files are only checked for readability (SQLite falls back to read-only mode when a file is not writable), and `sqlite://:memory:` is unaffected.

Fixes #413

## Test plan

Added tests in `packages/sql-mapper/test/create-connection.test.js` for the missing-directory case, the unreadable-file case (skipped when running as root), and successful file creation in a writable directory.

> Stacked on #4885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF