### PR TITLE
fix(sql-mapper): support JSON fields on SQLite writes

### DIFF
--- a/packages/db/lib/commands/migrations-apply.js
+++ b/packages/db/lib/commands/migrations-apply.js
@@ -43,7 +43,7 @@ export async function applyMigrations (logger, configFile, args, context) {
 
     utimesSync(configFile, now, now)
   } catch (err) {
-    if (err.code === 'PTL_DB_MIGRATE_ERROR') {
+    if (err.code === 'PLT_DB_MIGRATE_ERROR') {
       logFatalError(logger, err.message)
       return
     }

--- a/packages/db/lib/commands/migrations-create.js
+++ b/packages/db/lib/commands/migrations-create.js
@@ -1,5 +1,5 @@
 import { kMetadata, loadConfiguration } from '@platformatic/foundation'
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import { transform } from '../config.js'
 import * as errors from '../errors.js'
@@ -15,6 +15,11 @@ export async function createMigrations (logger, configFile, _, { colorette: { bo
     const migrationsConfig = config.migrations
     if (migrationsConfig === undefined) {
       throw new errors.MigrateMissingMigrationsError()
+    }
+
+    const createdDir = await mkdir(migrationsConfig.dir, { recursive: true })
+    if (createdDir) {
+      logger.info(`Created migrations directory ${bold(relative(root, migrationsConfig.dir))}.`)
     }
 
     migrator = new Migrator(migrationsConfig, config.db, logger)

--- a/packages/db/lib/errors.js
+++ b/packages/db/lib/errors.js
@@ -11,6 +11,10 @@ export const MigrateMissingMigrationsDirError = createError(
   `${ERROR_PREFIX}_MIGRATE_ERROR`,
   'Migrations directory %s does not exist'
 )
+export const ApplyMigrationError = createError(
+  `${ERROR_PREFIX}_MIGRATE_ERROR`,
+  'Unable to apply migration %s: %s'
+)
 export const MissingSeedFileError = createError(`${ERROR_PREFIX}_MISSING_SEED_FILE_ERROR`, 'Missing seed file')
 export const MigrationsToApplyError = createError(
   `${ERROR_PREFIX}_MIGRATIONS_TO_APPLY_ERROR`,

--- a/packages/db/lib/migrator.js
+++ b/packages/db/lib/migrator.js
@@ -2,7 +2,7 @@ import { createConnectionPool } from '@platformatic/sql-mapper'
 import { readdir, stat } from 'node:fs/promises'
 import { basename } from 'node:path'
 import Postgrator from 'postgrator'
-import { MigrateMissingMigrationsDirError, MigrateMissingMigrationsError } from './errors.js'
+import { ApplyMigrationError, MigrateMissingMigrationsDirError, MigrateMissingMigrationsError } from './errors.js'
 
 export class Migrator {
   constructor (migrationConfig, coreConfig, logger) {
@@ -18,6 +18,7 @@ export class Migrator {
     this.db = null
     this.postgrator = null
     this.appliedMigrationsCount = 0
+    this.lastStartedMigration = null
   }
 
   async setupPostgrator () {
@@ -74,10 +75,12 @@ export class Migrator {
       })
     }
     this.postgrator.on('migration-started', migration => {
+      this.lastStartedMigration = migration
       const migrationName = basename(migration.filename)
       this.logger.info(`running ${migrationName}`)
     })
     this.postgrator.on('migration-finished', migration => {
+      this.lastStartedMigration = null
       this.appliedMigrationsCount++
       const migrationName = basename(migration.filename)
       this.logger.debug(`completed ${migrationName}`)
@@ -97,7 +100,20 @@ export class Migrator {
   async applyMigrations (to) {
     await this.checkIfMigrationFilesExist()
     await this.setupPostgrator()
-    await this.postgrator.migrate(to)
+    await this.migrate(to)
+  }
+
+  async migrate (to) {
+    try {
+      await this.postgrator.migrate(to)
+    } catch (error) {
+      // A migration started but did not finish: give the user a clear
+      // pointer to the file that could not be applied
+      if (this.lastStartedMigration) {
+        throw new ApplyMigrationError(basename(this.lastStartedMigration.filename), error.message)
+      }
+      throw error
+    }
   }
 
   async rollbackMigration () {
@@ -123,7 +139,7 @@ export class Migrator {
     }
 
     const prevMigrationVersionStr = this.convertVersionToStr(prevMigrationVersion)
-    await this.postgrator.migrate(prevMigrationVersionStr)
+    await this.migrate(prevMigrationVersionStr)
   }
 
   convertVersionToStr (version) {

--- a/packages/db/test/cli/gen-migration.test.js
+++ b/packages/db/test/cli/gen-migration.test.js
@@ -103,15 +103,16 @@ test('throws if there is no migrations in the config', async t => {
   assert.match(errorMessage, /Missing "migrations" section in config file/)
 })
 
-test('throws if migrations directory does not exist', async t => {
+test('creates the migrations directory if it does not exist', async t => {
   const cwd = await mkdtemp(join(tmpdir(), 'gen-migration-test-'))
   const configFilePath = join(cwd, 'gen-migration.json')
-  const migrationsDirPath = join(cwd, 'migrations')
+  const migrationsDirPath = join(cwd, 'nested', 'migrations')
 
   const config = {
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
+      logger: { level: 'fatal' }
     },
     db: {
       connectionString: 'sqlite://db.sqlite'
@@ -124,16 +125,16 @@ test('throws if migrations directory does not exist', async t => {
   await writeFile(configFilePath, JSON.stringify(config))
 
   let errorMessage = ''
-  const logger = {
-    info: () => {},
-    warn: () => {},
-    debug: () => {},
-    trace: () => {},
-    error: (msg) => {
-      errorMessage += msg
-    }
+  const logger = pino({ level: 'fatal' })
+  logger.error = msg => {
+    errorMessage += msg
   }
 
   await createMigrations(logger, configFilePath, [], { colorette: { bold: (str) => str } })
-  assert.match(errorMessage, /Migrations directory (.*) does not exist/)
+  const newMigrations = await readdir(migrationsDirPath)
+
+  assert.equal(errorMessage, '')
+  assert.equal(newMigrations.length, 2)
+  assert.equal(newMigrations[0], '001.do.sql')
+  assert.equal(newMigrations[1], '001.undo.sql')
 })

--- a/packages/db/test/migrate/validations.test.js
+++ b/packages/db/test/migrate/validations.test.js
@@ -3,7 +3,7 @@ import { test } from 'node:test'
 import { applyMigrations } from '../../lib/commands/migrations-apply.js'
 import { getConnectionInfo } from '../helper.js'
 import { getFixturesConfigFileLocation } from './helper.js'
-import { createTestContext, createThrowingLogger } from '../cli/test-utilities.js'
+import { createCapturingLogger, createTestContext, createThrowingLogger } from '../cli/test-utilities.js'
 
 test('missing config', async t => {
   const logger = createThrowingLogger()
@@ -66,4 +66,20 @@ test('not applied migrations', async t => {
   await assert.rejects(async () => {
     await applyMigrations(logger, getFixturesConfigFileLocation('bad-migrations.json'), [], context)
   })
+})
+
+test('friendly error when a migration contains invalid SQL', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('postgresql')
+  t.after(async () => {
+    await dropTestDB()
+  })
+
+  const logger = createCapturingLogger()
+  const context = createTestContext()
+
+  process.env.DATABASE_URL = connectionInfo.connectionString
+  await applyMigrations(logger, getFixturesConfigFileLocation('bad-migrations.json'), [], context)
+
+  const output = logger.getCaptured()
+  assert.match(output, /Unable to apply migration 002\.do\.sql/)
 })

--- a/packages/runtime/test/start/logs-errors-during-migrations.test.js
+++ b/packages/runtime/test/start/logs-errors-during-migrations.test.js
@@ -39,7 +39,7 @@ test('logs errors during db migrations', async t => {
     async () => {
       await runtime.start()
     },
-    { code: 'SQLITE_ERROR' }
+    { code: 'PLT_DB_MIGRATE_ERROR' }
   )
 
   const messages = await readLogs(join(root, 'logs.txt'), 10000)

--- a/packages/sql-mapper/index.js
+++ b/packages/sql-mapper/index.js
@@ -1,10 +1,13 @@
 import { findNearestString } from '@platformatic/foundation'
 import fp from 'fastify-plugin'
+import { access, constants } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
 import { setupCache } from './lib/cache.js'
 import { buildCleanUp } from './lib/clean-up.js'
 import { getConnectionInfo } from './lib/connection-info.js'
 import { buildEntity } from './lib/entity.js'
 import {
+  CannotAccessDatabaseFileError,
   CannotFindEntityError,
   ConnectionStringRequiredError,
   SpecifyProtocolError,
@@ -87,6 +90,34 @@ async function registerPostgreSQLExtensionTypes (db) {
   } catch {}
 }
 
+// Provide a developer friendly error instead of the bare SQLITE_CANTOPEN
+// emitted when the database file cannot be opened or created.
+async function checkSQLiteFileAccess (path) {
+  const file = resolve(path)
+
+  try {
+    // SQLite falls back to read-only when the file exists but is not writable,
+    // so reading the file is all that is required here.
+    await access(file, constants.R_OK)
+    return
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw new CannotAccessDatabaseFileError(file, 'the file is not readable by the current user')
+    }
+  }
+
+  // The file does not exist, SQLite will create it: the directory must exist and be writable
+  const dir = dirname(file)
+  try {
+    await access(dir, constants.W_OK | constants.X_OK)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new CannotAccessDatabaseFileError(file, `the directory "${dir}" does not exist`)
+    }
+    throw new CannotAccessDatabaseFileError(file, `the directory "${dir}" is not writable by the current user`)
+  }
+}
+
 export async function createConnectionPool ({
   log,
   connectionString,
@@ -138,6 +169,9 @@ export async function createConnectionPool ({
   } else if (connectionString.indexOf('sqlite') === 0) {
     const { default: sqlite } = await import('@matteo.collina/sqlite-pool')
     const path = connectionString.replace('sqlite://', '')
+    if (connectionString !== 'sqlite://:memory:') {
+      await checkSQLiteFileAccess(path)
+    }
     db = sqlite.default(
       connectionString === 'sqlite://:memory:' ? undefined : path,
       {},

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -161,6 +161,12 @@ function createMapper (
     const db = getDB(args)
     const fieldsToRetrieve = computeFields(args.fields).map(f => sql.ident(f))
     const inputs = args.inputs
+    if (inputs === undefined || inputs === null) {
+      throw new InputNotProvidedError()
+    }
+    if (inputs.length === 0) {
+      return []
+    }
     // This else is skipped on MySQL because of https://github.com/ForbesLindesay/atdatabases/issues/221
     /* istanbul ignore else */
     if (autoTimestamp) {

--- a/packages/sql-mapper/lib/errors.js
+++ b/packages/sql-mapper/lib/errors.js
@@ -17,6 +17,10 @@ export const TableMustBeAStringError = createError(
 )
 export const UnknownFieldError = createError(`${ERROR_PREFIX}_UNKNOWN_FIELD`, 'Unknown field %s')
 export const InputNotProvidedError = createError(`${ERROR_PREFIX}_INPUT_NOT_PROVIDED`, 'Input not provided.')
+export const CannotAccessDatabaseFileError = createError(
+  `${ERROR_PREFIX}_CANNOT_ACCESS_DATABASE_FILE`,
+  'Cannot open SQLite database file "%s": %s'
+)
 export const UnsupportedWhereClauseError = createError(
   `${ERROR_PREFIX}_UNSUPPORTED_WHERE_CLAUSE`,
   'Unsupported where clause %s'

--- a/packages/sql-mapper/lib/queries/mysql-shared.js
+++ b/packages/sql-mapper/lib/queries/mysql-shared.js
@@ -8,6 +8,7 @@ export async function listTables (db, sql, schemas) {
       FROM information_schema.tables
       WHERE table_schema in (${schemaList})
       AND TABLE_TYPE = 'BASE TABLE'
+      ORDER BY TABLE_SCHEMA, TABLE_NAME
     `)
     return res.map(r => ({ schema: r.TABLE_SCHEMA, table: r.TABLE_NAME }))
   } else {
@@ -16,6 +17,7 @@ export async function listTables (db, sql, schemas) {
       FROM information_schema.tables
       WHERE table_schema = (SELECT DATABASE())
       AND TABLE_TYPE = 'BASE TABLE'
+      ORDER BY TABLE_SCHEMA, TABLE_NAME
     `)
     return res.map(r => ({ schema: r.TABLE_SCHEMA, table: r.TABLE_NAME }))
   }
@@ -27,6 +29,7 @@ export async function listColumns (db, sql, table, schema) {
     FROM information_schema.columns
     WHERE table_name = ${table}
     AND table_schema = ${schema}
+    ORDER BY ordinal_position
   `
   return db.query(query)
 }
@@ -39,6 +42,7 @@ export async function listConstraints (db, sql, table, schema) {
     USING (constraint_name, table_schema, table_name)
     WHERE t.table_name = ${table}
     AND t.table_schema = ${schema}
+    ORDER BY k.constraint_name, k.ordinal_position
     `
   return db.query(query)
 }
@@ -115,6 +119,7 @@ export async function listViews (db, sql, schemas) {
       SELECT TABLE_SCHEMA, TABLE_NAME
       FROM information_schema.views
       WHERE table_schema in (${schemaList})
+      ORDER BY TABLE_SCHEMA, TABLE_NAME
     `)
     return res.map(r => ({ schema: r.TABLE_SCHEMA, table: r.TABLE_NAME, isView: true }))
   } else {
@@ -122,6 +127,7 @@ export async function listViews (db, sql, schemas) {
       SELECT TABLE_SCHEMA, TABLE_NAME
       FROM information_schema.views
       WHERE table_schema = (SELECT DATABASE())
+      ORDER BY TABLE_SCHEMA, TABLE_NAME
     `)
     return res.map(r => ({ schema: r.TABLE_SCHEMA, table: r.TABLE_NAME, isView: true }))
   }

--- a/packages/sql-mapper/lib/queries/pg.js
+++ b/packages/sql-mapper/lib/queries/pg.js
@@ -23,7 +23,8 @@ export async function listTables (db, sql, schemas) {
     SELECT tablename, schemaname
     FROM pg_catalog.pg_tables
     WHERE
-      schemaname in (${schemaList})`)
+      schemaname in (${schemaList})
+    ORDER BY schemaname, tablename`)
     return res.map(r => ({ schema: r.schemaname, table: r.tablename }))
   }
   const res = await db.query(sql`
@@ -31,6 +32,7 @@ export async function listTables (db, sql, schemas) {
     FROM pg_catalog.pg_tables
     WHERE
       schemaname = current_schema()
+    ORDER BY schemaname, tablename
   `)
   return res.map(r => ({ schema: r.schemaname, table: r.tablename }))
 }
@@ -56,6 +58,7 @@ export async function listColumns (db, sql, table, schema) {
     AND c.table_schema = ${schema}
     AND a.attnum > 0
     AND NOT a.attisdropped
+    ORDER BY a.attnum
   `)
 
   for (const col of res) {
@@ -86,6 +89,7 @@ export async function listConstraints (db, sql, table, schema) {
         ON usage.constraint_name = usage2.constraint_name
         AND ( usage.table_name = ${table}
         AND usage.table_schema = ${schema} )
+    ORDER BY usage.constraint_name, usage.ordinal_position, usage2.table_name, usage2.column_name
   `
   const constraintsList = await db.query(query)
   return constraintsList
@@ -117,7 +121,8 @@ export async function listEnumValues (db, sql, table, schema) {
     JOIN pg_type t ON e.enumtypid = t.oid 
     JOIN information_schema.columns c on c.udt_name = t.typname
     WHERE table_name = ${table}
-    AND table_schema = ${schema};
+    AND table_schema = ${schema}
+    ORDER BY column_name, e.enumsortorder;
     `
   return db.query(query)
 }
@@ -129,7 +134,8 @@ export async function listViews (db, sql, schemas) {
     SELECT viewname, schemaname
     FROM pg_catalog.pg_views
     WHERE
-      schemaname in (${schemaList})`)
+      schemaname in (${schemaList})
+    ORDER BY schemaname, viewname`)
     return res.map(r => ({ schema: r.schemaname, table: r.viewname, isView: true }))
   }
   const res = await db.query(sql`
@@ -137,6 +143,7 @@ export async function listViews (db, sql, schemas) {
     FROM pg_catalog.pg_views
     WHERE
       schemaname = current_schema()
+    ORDER BY schemaname, viewname
   `)
   return res.map(r => ({ schema: r.schemaname, table: r.viewname, isView: true }))
 }

--- a/packages/sql-mapper/lib/queries/sqlite.js
+++ b/packages/sql-mapper/lib/queries/sqlite.js
@@ -6,6 +6,9 @@ function fixValue (value) {
     return value.toISOString()
   } else if (typeof value === 'boolean') {
     return value ? 1 : 0
+  } else if (value && typeof value === 'object' && !Buffer.isBuffer(value)) {
+    // This is a JSON field
+    return JSON.stringify(value)
   }
   return value
 }

--- a/packages/sql-mapper/lib/queries/sqlite.js
+++ b/packages/sql-mapper/lib/queries/sqlite.js
@@ -14,6 +14,7 @@ export async function listTables (db, sql) {
   const res = await db.query(sql`
     SELECT name FROM sqlite_master
     WHERE type='table'
+    ORDER BY name
   `)
   // sqlite has no schemas
   return res.map(r => ({ schema: null, table: r.name }))
@@ -24,6 +25,7 @@ export async function listColumns (db, sql, table) {
   // therefore it is changed to pragma_table_xinfo
   const columns = await db.query(sql`
     SELECT * FROM pragma_table_xinfo(${table})
+    ORDER BY cid
   `)
   for (const column of columns) {
     column.column_name = column.name
@@ -235,6 +237,7 @@ export async function listViews (db, sql) {
   const res = await db.query(sql`
     SELECT name FROM sqlite_master
     WHERE type='view'
+    ORDER BY name
   `)
   return res.map(r => ({ schema: null, table: r.name, isView: true }))
 }

--- a/packages/sql-mapper/test/create-connection.test.js
+++ b/packages/sql-mapper/test/create-connection.test.js
@@ -1,4 +1,7 @@
-import { deepEqual } from 'node:assert'
+import { deepEqual, equal, match, rejects } from 'node:assert'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { test } from 'node:test'
 import { createConnectionPool } from '../index.js'
 import { clear, connInfo, isSQLite } from './helper.js'
@@ -41,4 +44,56 @@ test('createConnectionPool', async () => {
       is_published: true
     }
   ])
+})
+
+test('friendly error when the SQLite directory does not exist', { skip: !isSQLite }, async () => {
+  await rejects(
+    createConnectionPool({
+      connectionString: 'sqlite:///this/directory/does/not/exist/db.sqlite',
+      log: fakeLogger
+    }),
+    err => {
+      equal(err.code, 'PLT_SQL_MAPPER_CANNOT_ACCESS_DATABASE_FILE')
+      match(err.message, /the directory "\/this\/directory\/does\/not\/exist" does not exist/)
+      return true
+    }
+  )
+})
+
+test('friendly error when the SQLite file is not readable', { skip: !isSQLite || process.getuid() === 0 }, async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plt-sql-mapper-'))
+  const file = join(dir, 'db.sqlite')
+  await writeFile(file, '')
+  await chmod(file, 0o000)
+  test.after(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  await rejects(
+    createConnectionPool({
+      connectionString: `sqlite://${file}`,
+      log: fakeLogger
+    }),
+    err => {
+      equal(err.code, 'PLT_SQL_MAPPER_CANNOT_ACCESS_DATABASE_FILE')
+      match(err.message, /the file is not readable by the current user/)
+      return true
+    }
+  )
+})
+
+test('the SQLite database file is created when the directory is writable', { skip: !isSQLite }, async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plt-sql-mapper-'))
+  const file = join(dir, 'db.sqlite')
+  const { db, sql } = await createConnectionPool({
+    connectionString: `sqlite://${file}`,
+    log: fakeLogger
+  })
+  test.after(async () => {
+    await db.dispose()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const res = await db.query(sql`SELECT 1 as one`)
+  deepEqual(res, [{ one: 1 }])
 })

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -198,6 +198,35 @@ test('empty save', async () => {
   deepEqual(insertResult, { id: '1', theTitle: null })
 })
 
+test('insert with empty inputs array returns an empty array', async () => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+    await db.query(sql`CREATE TABLE pages (
+      id INTEGER PRIMARY KEY,
+      title varchar(255) NOT NULL
+    );`)
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {}
+  })
+  const pageEntity = mapper.entities.page
+
+  const res = await pageEntity.insert({ inputs: [] })
+  deepEqual(res, [])
+
+  await rejects(pageEntity.insert({}), {
+    code: 'PLT_SQL_MAPPER_INPUT_NOT_PROVIDED'
+  })
+})
+
 test('insert with explicit integer PK value', async () => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)

--- a/packages/sql-mapper/test/helper.js
+++ b/packages/sql-mapper/test/helper.js
@@ -13,6 +13,7 @@ export const connInfo = {
 
 export let isPg = false
 export let isMysql = false
+export let isMariaDB = false
 export let isMysql8 = false
 export let isSQLite = false
 export let expectedTelemetryPrefix = 'pg'
@@ -27,6 +28,7 @@ if (!process.env.DB || process.env.DB === 'postgresql') {
   connInfo.connectionString = 'mysql://root@127.0.0.1:3307/graph'
   connInfo.poolSize = 10
   isMysql = true
+  isMariaDB = true
   expectedTelemetryPrefix = 'mysql'
   expectedPort = 3307
 } else if (process.env.DB === 'mysql') {

--- a/packages/sql-mapper/test/introspection-order.test.js
+++ b/packages/sql-mapper/test/introspection-order.test.js
@@ -1,0 +1,63 @@
+import { deepEqual } from 'node:assert'
+import { test } from 'node:test'
+import { connect } from '../index.js'
+import { clear, connInfo, isSQLite } from './helper.js'
+
+const fakeLogger = {
+  trace: () => {},
+  error: () => {}
+}
+
+test('tables and views are introspected in a deterministic order', async () => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await db.query(sql`DROP VIEW IF EXISTS zzz_view`)
+      await db.query(sql`DROP VIEW IF EXISTS aaa_view`)
+      await db.query(sql`DROP TABLE IF EXISTS zzz`)
+      await db.query(sql`DROP TABLE IF EXISTS mmm`)
+      await db.query(sql`DROP TABLE IF EXISTS aaa`)
+      db.dispose()
+    })
+
+    // Created on purpose in non-alphabetical order
+    if (isSQLite) {
+      await db.query(sql`CREATE TABLE zzz (id INTEGER PRIMARY KEY, title VARCHAR(42))`)
+      await db.query(sql`CREATE TABLE mmm (id INTEGER PRIMARY KEY, title VARCHAR(42))`)
+      await db.query(sql`CREATE TABLE aaa (id INTEGER PRIMARY KEY, title VARCHAR(42))`)
+    } else {
+      await db.query(sql`CREATE TABLE zzz (id SERIAL PRIMARY KEY, title VARCHAR(42))`)
+      await db.query(sql`CREATE TABLE mmm (id SERIAL PRIMARY KEY, title VARCHAR(42))`)
+      await db.query(sql`CREATE TABLE aaa (id SERIAL PRIMARY KEY, title VARCHAR(42))`)
+    }
+    await db.query(sql`CREATE VIEW zzz_view AS SELECT id, title FROM zzz`)
+    await db.query(sql`CREATE VIEW aaa_view AS SELECT id, title FROM aaa`)
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {},
+    include: {
+      aaa: true,
+      mmm: true,
+      zzz: true,
+      aaa_view: true,
+      zzz_view: true
+    }
+  })
+
+  const tables = mapper.dbschema.filter(t => !t.isView).map(t => t.table)
+  deepEqual(tables, ['aaa', 'mmm', 'zzz'])
+
+  const views = mapper.dbschema.filter(t => t.isView).map(t => t.table)
+  deepEqual(views, ['aaa_view', 'zzz_view'])
+
+  // Columns must follow the table definition order
+  const zzz = mapper.dbschema.find(t => t.table === 'zzz')
+  deepEqual(
+    zzz.columns.map(c => c.column_name),
+    ['id', 'title']
+  )
+})

--- a/packages/sql-mapper/test/json.test.js
+++ b/packages/sql-mapper/test/json.test.js
@@ -1,0 +1,81 @@
+import { deepEqual } from 'node:assert'
+import { test } from 'node:test'
+import { connect } from '../index.js'
+import { clear, connInfo, isPg, isSQLite } from './helper.js'
+
+const fakeLogger = {
+  trace: () => {},
+  error: () => {}
+}
+
+// Postgres returns JSON fields as parsed objects, the other databases as strings
+function parseJSONField (value) {
+  return typeof value === 'string' ? JSON.parse(value) : value
+}
+
+test('insert, save and updateMany support JSON fields', async () => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+
+    if (isPg) {
+      await db.query(sql`CREATE TABLE pages (
+        id SERIAL PRIMARY KEY,
+        metadata JSONB DEFAULT '{}'::jsonb
+      );`)
+    } else if (isSQLite) {
+      await db.query(sql`CREATE TABLE pages (
+        id INTEGER PRIMARY KEY,
+        metadata JSON
+      );`)
+    } else {
+      await db.query(sql`CREATE TABLE pages (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        metadata JSON
+      );`)
+    }
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {}
+  })
+  const pageEntity = mapper.entities.page
+
+  // insert
+  const [inserted] = await pageEntity.insert({
+    inputs: [{ metadata: { foo: 'bar' } }]
+  })
+  deepEqual(parseJSONField(inserted.metadata), { foo: 'bar' })
+
+  // save on an existing record (update path)
+  const updated = await pageEntity.save({
+    input: { id: inserted.id, metadata: { baz: 'buz' } }
+  })
+  deepEqual(parseJSONField(updated.metadata), { baz: 'buz' })
+
+  // save without a primary key (insert path)
+  const saved = await pageEntity.save({
+    input: { metadata: { hello: 'world' } }
+  })
+  deepEqual(parseJSONField(saved.metadata), { hello: 'world' })
+
+  // updateMany
+  const [updatedMany] = await pageEntity.updateMany({
+    where: { id: { eq: inserted.id } },
+    input: { metadata: { updated: true } }
+  })
+  deepEqual(parseJSONField(updatedMany.metadata), { updated: true })
+
+  // the stored values are correct
+  const rows = await pageEntity.find({ orderBy: [{ field: 'id', direction: 'asc' }] })
+  deepEqual(
+    rows.map(r => parseJSONField(r.metadata)),
+    [{ updated: true }, { hello: 'world' }]
+  )
+})

--- a/packages/sql-mapper/test/no-primary-key.test.js
+++ b/packages/sql-mapper/test/no-primary-key.test.js
@@ -1,7 +1,7 @@
 import { deepEqual, equal, notEqual } from 'node:assert'
 import { test } from 'node:test'
 import { connect } from '../index.js'
-import { clear, connInfo, isMysql8, isSQLite } from './helper.js'
+import { clear, connInfo } from './helper.js'
 
 const fakeLogger = {
   trace: () => {},
@@ -38,13 +38,10 @@ test('unique key', async t => {
   equal(pageEntity.name, 'Page')
   equal(pageEntity.singularName, 'page')
   equal(pageEntity.pluralName, 'pages')
-  if (isMysql8 || isSQLite) {
-    deepEqual(pageEntity.primaryKeys, new Set(['name']))
-    equal(pageEntity.camelCasedFields.name.primaryKey, true)
-  } else {
-    deepEqual(pageEntity.primaryKeys, new Set(['xx']))
-    equal(pageEntity.camelCasedFields.xx.primaryKey, true)
-  }
+  // Constraints are introspected in a deterministic (alphabetical) order,
+  // so the first unique constraint is the same on every database.
+  deepEqual(pageEntity.primaryKeys, new Set(['name']))
+  equal(pageEntity.camelCasedFields.name.primaryKey, true)
   equal(pageEntity.camelCasedFields.xx.unique, true)
   equal(pageEntity.camelCasedFields.name.unique, true)
 })

--- a/packages/sql-mapper/test/schema.test.js
+++ b/packages/sql-mapper/test/schema.test.js
@@ -2,7 +2,7 @@ import { match } from '@platformatic/foundation'
 import { deepEqual, equal, ifError, ok, throws } from 'node:assert'
 import { test } from 'node:test'
 import { connect } from '../index.js'
-import { clear, connInfo, isMysql, isMysql8, isPg, isSQLite } from './helper.js'
+import { clear, connInfo, isMariaDB, isMysql, isMysql8, isPg, isSQLite } from './helper.js'
 
 const fakeLogger = {
   trace: () => {},
@@ -117,7 +117,10 @@ test('find enums correctly using schemas', { skip: isSQLite }, async () => {
         table: 'pages',
         constraints: [
           {
-            constraint_type: isMysql8 ? 'UNIQUE' : 'PRIMARY KEY'
+            // On MySQL the UNIQUE constraint created by SERIAL ("id") sorts before
+            // "PRIMARY", while MariaDB uses a binary collation which sorts the
+            // other way around
+            constraint_type: isMysql && !isMariaDB ? 'UNIQUE' : 'PRIMARY KEY'
           }
         ],
         columns: [


### PR DESCRIPTION
## Summary

While investigating #3882 (`entity.save()` storing an empty object for JSON fields on Postgres), I could not reproduce the reported behavior on `main` — `insert`, `save` (both update and insert paths) and `updateMany` all store JSON fields correctly on Postgres, MySQL, MariaDB and MySQL 8 today.

However, the same scenario **crashes on SQLite** with:

```
RangeError: Too few parameter values were provided
```

because `fixValue` in the SQLite queries handles `Date` and `boolean` but not plain objects, which the driver cannot bind. Objects are now serialized to JSON strings, matching what `insertMany` already does for the other databases.

Fixes #3882

## Test plan

New `packages/sql-mapper/test/json.test.js` covers the exact reproduction from the issue (insert, save on an existing record, save without a primary key, updateMany, plus verifying the stored values) — verified locally on SQLite, PostgreSQL, MariaDB, MySQL and MySQL 8.

> Stacked on #4886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF