### PR TITLE
feat(db): create the migrations directory when running migrations create

### DIFF
--- a/packages/db/lib/commands/migrations-create.js
+++ b/packages/db/lib/commands/migrations-create.js
@@ -1,5 +1,5 @@
 import { kMetadata, loadConfiguration } from '@platformatic/foundation'
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import { transform } from '../config.js'
 import * as errors from '../errors.js'
@@ -15,6 +15,11 @@ export async function createMigrations (logger, configFile, _, { colorette: { bo
     const migrationsConfig = config.migrations
     if (migrationsConfig === undefined) {
       throw new errors.MigrateMissingMigrationsError()
+    }
+
+    const createdDir = await mkdir(migrationsConfig.dir, { recursive: true })
+    if (createdDir) {
+      logger.info(`Created migrations directory ${bold(relative(root, migrationsConfig.dir))}.`)
     }
 
     migrator = new Migrator(migrationsConfig, config.db, logger)

--- a/packages/db/test/cli/gen-migration.test.js
+++ b/packages/db/test/cli/gen-migration.test.js
@@ -103,15 +103,16 @@ test('throws if there is no migrations in the config', async t => {
   assert.match(errorMessage, /Missing "migrations" section in config file/)
 })
 
-test('throws if migrations directory does not exist', async t => {
+test('creates the migrations directory if it does not exist', async t => {
   const cwd = await mkdtemp(join(tmpdir(), 'gen-migration-test-'))
   const configFilePath = join(cwd, 'gen-migration.json')
-  const migrationsDirPath = join(cwd, 'migrations')
+  const migrationsDirPath = join(cwd, 'nested', 'migrations')
 
   const config = {
     server: {
       hostname: '127.0.0.1',
-      port: 0
+      port: 0,
+      logger: { level: 'fatal' }
     },
     db: {
       connectionString: 'sqlite://db.sqlite'
@@ -124,16 +125,16 @@ test('throws if migrations directory does not exist', async t => {
   await writeFile(configFilePath, JSON.stringify(config))
 
   let errorMessage = ''
-  const logger = {
-    info: () => {},
-    warn: () => {},
-    debug: () => {},
-    trace: () => {},
-    error: (msg) => {
-      errorMessage += msg
-    }
+  const logger = pino({ level: 'fatal' })
+  logger.error = msg => {
+    errorMessage += msg
   }
 
   await createMigrations(logger, configFilePath, [], { colorette: { bold: (str) => str } })
-  assert.match(errorMessage, /Migrations directory (.*) does not exist/)
+  const newMigrations = await readdir(migrationsDirPath)
+
+  assert.equal(errorMessage, '')
+  assert.equal(newMigrations.length, 2)
+  assert.equal(newMigrations[0], '001.do.sql')
+  assert.equal(newMigrations[1], '001.undo.sql')
 })


### PR DESCRIPTION
## Summary

`platformatic db migrations create` (and `wattpm <app>:migrations:create`) failed with `Migrations directory <dir> does not exist` when the configured directory was missing. Since the whole point of the command is to scaffold new migration files, it now creates the directory (recursively) first and logs that it did so.

`migrations apply` is unchanged: applying migrations from a missing directory is still an error.

Fixes #1225

## Test plan

Updated `packages/db/test/cli/gen-migration.test.js`: the test that previously asserted the error now asserts the directory (including nested paths) is created and the migration files are generated in it.

> Stacked on #4887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF