### PR TITLE
feat(wattpm): add --config option to application commands

### DIFF
--- a/packages/db/lib/commands/index.js
+++ b/packages/db/lib/commands/index.js
@@ -4,6 +4,11 @@ import { printSchema } from './print-schema.js'
 import { seed, helpFooter as seedFooter } from './seed.js'
 import { generateTypes, helpFooter as typesFooter } from './types.js'
 
+const configOption = {
+  usage: '-c, --config <config>',
+  description: 'Name of the runtime configuration file to use'
+}
+
 export function createCommands (id) {
   return {
     commands: {
@@ -17,13 +22,15 @@ export function createCommands (id) {
       [`${id}:migrations:create`]: {
         usage: `${id}:migrations:create`,
         description: 'Create a new migration file',
-        footer: createMigrationsFooter
+        footer: createMigrationsFooter,
+        options: [configOption]
       },
       [`${id}:migrations:apply`]: {
         usage: `${id}:migrations:apply`,
         description: 'Apply all configured migrations to the database',
         footer: applyMigrationsFooter,
         options: [
+          configOption,
           {
             usage: '-r, --rollback',
             description: 'Rollback migrations instead of applying them'
@@ -43,16 +50,19 @@ export function createCommands (id) {
             name: 'file',
             description: 'The seed file to load.'
           }
-        ]
+        ],
+        options: [configOption]
       },
       [`${id}:types`]: {
         usage: `${id}:types`,
         description: 'Generate TypeScript types for your entities from the database',
-        footer: typesFooter
+        footer: typesFooter,
+        options: [configOption]
       },
       [`${id}:schema`]: {
         usage: `${id}:schema [openapi|graphql]`,
-        description: 'Prints the OpenAPI or GraphQL schema for the database'
+        description: 'Prints the OpenAPI or GraphQL schema for the database',
+        options: [configOption]
       }
     }
   }

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -87,7 +87,7 @@ export async function loadConfiguration (configOrRoot, sourceOrConfig, context) 
   })
 }
 
-export async function loadApplicationsCommands (executableName = '') {
+export async function loadApplicationsCommands (executableName = '', configurationFile = null) {
   const applications = {}
   const commands = {}
   const help = {}
@@ -97,7 +97,7 @@ export async function loadApplicationsCommands (executableName = '') {
     const file = await findRuntimeConfigurationFile(
       abstractLogger,
       process.cwd(),
-      null,
+      configurationFile,
       false,
       false,
       true,

--- a/packages/wattpm/index.js
+++ b/packages/wattpm/index.js
@@ -20,6 +20,28 @@ import { version } from './lib/schema.js'
 
 export * from './lib/schema.js'
 
+// Extract the -c/--config option from application command arguments, leaving
+// all the other arguments for the application command itself
+function extractConfigOption (args) {
+  const remaining = []
+  let config = null
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+
+    if (arg === '-c' || arg === '--config') {
+      config = args[i + 1]
+      i++
+    } else if (arg.startsWith('--config=')) {
+      config = arg.slice('--config='.length)
+    } else {
+      remaining.push(arg)
+    }
+  }
+
+  return { config, remaining }
+}
+
 export async function main () {
   updateGlobals({ executable: this.executableId })
 
@@ -75,6 +97,7 @@ export async function main () {
   let command
   const requestedCommand = unparsed[0] || 'help'
   let applicationCommandContext
+  let applicationCommandArgs
   switch (requestedCommand) {
     case 'build':
       command = buildCommand
@@ -144,11 +167,14 @@ export async function main () {
       break
     default:
       if (requestedCommand) {
-        const applicationsCommands = await loadApplicationsCommands(this.executableName)
+        // Extract the -c/--config option, which selects the runtime configuration file
+        const { config: runtimeConfigFile, remaining } = extractConfigOption(unparsed.slice(1))
+        const applicationsCommands = await loadApplicationsCommands(this.executableName, runtimeConfigFile)
         const applicationCommand = applicationsCommands.commands[requestedCommand]
 
         if (applicationCommand) {
           applicationCommandContext = applicationsCommands.applications[requestedCommand]
+          applicationCommandArgs = remaining
           command = applicationCommand
         }
       }
@@ -168,7 +194,7 @@ export async function main () {
   if (applicationCommandContext) {
     const invocationCwd = process.cwd()
     process.chdir(applicationCommandContext.path)
-    return command.call(this, logger, applicationCommandContext.config, unparsed.slice(1), {
+    return command.call(this, logger, applicationCommandContext.config, applicationCommandArgs, {
       application: applicationCommandContext,
       cwd: invocationCwd,
       colorette,

--- a/packages/wattpm/test/applications-commands.test.js
+++ b/packages/wattpm/test/applications-commands.test.js
@@ -1,4 +1,6 @@
 import { ok } from 'node:assert'
+import { rename } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { prepareRuntime } from '../../basic/test/helper.js'
 import { wattpm } from './helper.js'
@@ -6,6 +8,26 @@ import { wattpm } from './helper.js'
 test('should execute applications commands', async t => {
   const { root: rootDir } = await prepareRuntime(t, 'help', false, 'watt.json')
   const applicationCommandProcess = await wattpm('main:fetch-openapi-schemas', { cwd: rootDir })
+
+  ok(applicationCommandProcess.stdout.includes('Fetching schemas for all applications.'))
+})
+
+test('should execute applications commands with an explicit configuration file via --config', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'help', false, 'watt.json')
+
+  // Rename the configuration file to something which cannot be autodetected
+  await rename(resolve(rootDir, 'watt.json'), resolve(rootDir, 'custom-watt.json'))
+
+  // Without --config the application command cannot be found
+  const failingProcess = await wattpm('main:fetch-openapi-schemas', { cwd: rootDir, reject: false })
+  ok(failingProcess.stdout.includes('Unknown command main:fetch-openapi-schemas'))
+
+  const applicationCommandProcess = await wattpm(
+    'main:fetch-openapi-schemas',
+    '--config',
+    'custom-watt.json',
+    { cwd: rootDir }
+  )
 
   ok(applicationCommandProcess.stdout.includes('Fetching schemas for all applications.'))
 })


### PR DESCRIPTION
## Summary

Application commands such as `wattpm db:seed` resolved the runtime configuration file only by autodetection from the current working directory. This adds a `-c/--config` option to all application commands so the runtime configuration file can be selected explicitly — the use case from the issue being API test scenarios:

```
wattpm db:seed --config watt.test.json seed.js
```

- `loadApplicationsCommands` now accepts an optional configuration file which is threaded to `findRuntimeConfigurationFile`.
- wattpm extracts `-c/--config` before dispatching, leaving every other argument untouched for the application command (so e.g. `db:migrations:apply -t 001` keeps working).
- The `@platformatic/db` command help entries now document the option.

Fixes #4350

## Test plan

New test in `packages/wattpm/test/applications-commands.test.js`: renames the runtime config to a non-autodetectable name, asserts the application command fails without `--config` and succeeds with it. Runtime `services-commands` and wattpm help tests pass.

> Stacked on #4891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF