### PR TITLE
fix(sql-mapper): serialize date primary keys in ISO format

### DIFF
--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -103,7 +103,9 @@ function createMapper (
     for (const key of Object.keys(output)) {
       let value = output[key]
       const newKey = fieldMapToRetrieve[key]
-      if (primaryKeys.has(key) && value !== null && value !== undefined) {
+      // Do not convert Date objects: they are serialized according to the
+      // schema of the field, like non primary key columns
+      if (primaryKeys.has(key) && value !== null && value !== undefined && !(value instanceof Date)) {
         value = value.toString()
       }
       if (newKey && isVectorType(fields[key].sqlType)) {

--- a/packages/sql-openapi/test/composite.test.js
+++ b/packages/sql-openapi/test/composite.test.js
@@ -1,6 +1,6 @@
 import sqlMapper from '@platformatic/sql-mapper'
 import fastify from 'fastify'
-import { equal, deepEqual as same } from 'node:assert/strict'
+import { equal, match, deepEqual as same } from 'node:assert/strict'
 import { test } from 'node:test'
 import sqlOpenAPI from '../index.js'
 import { clear, connInfo, isMysql, isPg, isSQLite } from './helper.js'
@@ -499,5 +499,45 @@ test('composite primary keys withour relations', async t => {
       url: '/editors/pageId/1/userId/2'
     })
     equal(res.statusCode, 404, 'DELETE /editors/pageId/1/userId/2 status code')
+  }
+})
+
+test('composite primary keys with a date column are serialized in ISO format', { skip: isSQLite }, async t => {
+  /* https://github.com/platformatic/platformatic/issues/1954 */
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    await db.query(sql`CREATE TABLE dailies (
+      foo_id VARCHAR(42) NOT NULL,
+      day DATE NOT NULL,
+      PRIMARY KEY (foo_id, day)
+    );`)
+  }
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    onDatabaseLoad
+  })
+  app.register(sqlOpenAPI)
+  t.after(() => app.close())
+
+  await app.ready()
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/dailies',
+      body: { fooId: 'a', day: '2023-06-23' }
+    })
+    equal(res.statusCode, 200, 'POST /dailies status code')
+    const body = res.json()
+    equal(body.fooId, 'a')
+    // The date must be serialized in ISO format, not with Date.prototype.toString()
+    match(body.day, /^\d{4}-\d{2}-\d{2}/, 'POST /dailies day format')
+  }
+
+  {
+    const res = await app.inject({ method: 'GET', url: '/dailies' })
+    equal(res.statusCode, 200, 'GET /dailies status code')
+    match(res.json()[0].day, /^\d{4}-\d{2}-\d{2}/, 'GET /dailies day format')
   }
 })


### PR DESCRIPTION
## Summary

With a composite primary key containing a `DATE` column, REST responses returned the date as `Date.prototype.toString()` output:

```json
{"fooId": "a", "day": "Thu Jun 22 2023 20:00:00 GMT-0400 (Eastern Daylight Time)"}
```

The culprit is the primary-key stringification in `fixOutput` (needed for GraphQL `ID` compatibility) which called `.toString()` on the `Date` returned by the driver. `Date` values are now left untouched so they are serialized according to the field's schema — the same ISO format non-primary-key date columns already use.

Fixes #1954

## Test plan

New test in `packages/sql-openapi/test/composite.test.js` reproducing the issue's schema (`PRIMARY KEY (foo_id, day)` with a `DATE` column), asserting POST/GET responses use ISO format. Verified on PostgreSQL, MariaDB, MySQL and MySQL 8 (skipped on SQLite, where date primary keys are stored as plain strings). Full sql-mapper, sql-openapi and sql-graphql suites pass.

> Stacked on #4892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF