### PR TITLE
feat(sql-mapper): add isNull where filter

### DIFF
--- a/docs/reference/sql-mapper/entities/api.md
+++ b/docs/reference/sql-mapper/entities/api.md
@@ -31,6 +31,8 @@ The `where` object's key is the field you want to check, the value is a key/valu
 | lt                    | `\'<\'`      |
 | lte                   | `\'<=\'`     |
 | like                  | `\'LIKE\'`   |
+| ilike                 | `\'ILIKE\'`  |
+| isNull                | `\'IS NULL\'` (`isNull: false` maps to `IS NOT NULL`) |
 
 
 ### Handling Null Values

--- a/docs/reference/sql-openapi/api.md
+++ b/docs/reference/sql-openapi/api.md
@@ -51,6 +51,9 @@ You can define many `WHERE` clauses in REST API, each clause includes a **field*
 | gte | `'>='` |
 | lt | `'<'` |
 | lte | `'<='` |
+| like | `'LIKE'` |
+| ilike | `'ILIKE'` |
+| isNull | `'IS NULL'` (use `false` for `IS NOT NULL`) |
 
 - **Value**: The value you want to compare the field to.
 

--- a/packages/db/test/fixtures/snapshots/env.js
+++ b/packages/db/test/fixtures/snapshots/env.js
@@ -46,6 +46,7 @@ input PageWhereArgumentsid {
   like: ID
   in: [ID]
   nin: [ID]
+  isNull: Boolean
 }
 
 input PageWhereArgumentstitle {
@@ -58,6 +59,7 @@ input PageWhereArgumentstitle {
   like: String
   in: [String]
   nin: [String]
+  isNull: Boolean
 }
 
 input PageWhereArgumentsOr {

--- a/packages/runtime/test/management-api/service-graphqlschema.test.js
+++ b/packages/runtime/test/management-api/service-graphqlschema.test.js
@@ -96,6 +96,7 @@ input MovieWhereArgumentsid {
   like: ID
   in: [ID]
   nin: [ID]
+  isNull: Boolean
 }
 
 input MovieWhereArgumentstitle {
@@ -108,6 +109,7 @@ input MovieWhereArgumentstitle {
   like: String
   in: [String]
   nin: [String]
+  isNull: Boolean
 }
 
 input MovieWhereArgumentsOr {

--- a/packages/sql-graphql/lib/entity-to-type.js
+++ b/packages/sql-graphql/lib/entity-to-type.js
@@ -1,6 +1,7 @@
 import { findNearestString } from '@platformatic/foundation'
 import camelcase from 'camelcase'
 import {
+  GraphQLBoolean,
   GraphQLEnumType,
   GraphQLID,
   GraphQLInputObjectType,
@@ -138,7 +139,8 @@ export function constructGraph (app, entity, opts, ignore) {
         lte: { type: fields[field].type },
         like: { type: fields[field].type },
         in: { type: new GraphQLList(fields[field].type) },
-        nin: { type: new GraphQLList(fields[field].type) }
+        nin: { type: new GraphQLList(fields[field].type) },
+        isNull: { type: GraphQLBoolean }
       }
     } else {
       graphqlFields = {

--- a/packages/sql-graphql/test/where.test.js
+++ b/packages/sql-graphql/test/where.test.js
@@ -1272,3 +1272,129 @@ test('like', async t => {
     )
   }
 })
+
+test('isNull', async t => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+
+      if (isSQLite) {
+        await db.query(sql`CREATE TABLE posts (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT
+        );`)
+      } else {
+        await db.query(sql`CREATE TABLE posts (
+          id SERIAL PRIMARY KEY,
+          title VARCHAR(42),
+          long_text TEXT
+        );`)
+      }
+    }
+  })
+  app.register(sqlGraphQL)
+  t.after(() => app.close())
+
+  await app.ready()
+
+  const posts = [
+    {
+      title: 'Dog',
+      longText: 'The dog barks'
+    },
+    {
+      title: 'Cat',
+      longText: null
+    }
+  ]
+
+  await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: {
+      query: `
+          mutation batch($inputs : [PostInput]!) {
+            insertPosts(inputs: $inputs) {
+              id
+            }
+          }
+        `,
+      variables: {
+        inputs: posts
+      }
+    }
+  })
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { longText: { isNull: true } }) {
+              id
+              title
+              longText
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'where: { longText: { isNull: true } } status code')
+    same(
+      res.json(),
+      {
+        data: {
+          posts: [
+            {
+              id: '2',
+              title: 'Cat',
+              longText: null
+            }
+          ]
+        }
+      },
+      'where: { longText: { isNull: true } } response'
+    )
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `
+          query {
+            posts(where: { longText: { isNull: false } }) {
+              id
+              title
+              longText
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'where: { longText: { isNull: false } } status code')
+    same(
+      res.json(),
+      {
+        data: {
+          posts: [
+            {
+              id: '1',
+              title: 'Dog',
+              longText: 'The dog barks'
+            }
+          ]
+        }
+      },
+      'where: { longText: { isNull: false } } response'
+    )
+  }
+})

--- a/packages/sql-mapper/index.d.ts
+++ b/packages/sql-mapper/index.d.ts
@@ -136,7 +136,11 @@ export interface WhereCondition {
     /**
      * Overlaps with values
      */
-    overlaps?: any[]
+    overlaps?: any[],
+    /**
+     * IS NULL (true) or IS NOT NULL (false)
+     */
+    isNull?: boolean
   }
 }
 

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -288,6 +288,14 @@ function createMapper (
         throw new UnknownFieldError(key)
       }
       for (const key of Object.keys(value)) {
+        if (key === 'isNull') {
+          if (value[key] === true) {
+            criteria.push(sql`${sql.ident(field)} IS NULL`)
+          } else if (value[key] === false) {
+            criteria.push(sql`${sql.ident(field)} IS NOT NULL`)
+          }
+          continue
+        }
         const operator = whereMap[key]
         /* istanbul ignore next */
         if (!operator) {

--- a/packages/sql-mapper/test/where.test.js
+++ b/packages/sql-mapper/test/where.test.js
@@ -700,6 +700,20 @@ test('is NULL', async () => {
       title: 'Dog'
     }
   ])
+
+  deepEqual(await entity.find({ where: { title: { isNull: true } } }), [
+    {
+      id: '2',
+      title: null
+    }
+  ])
+
+  deepEqual(await entity.find({ where: { title: { isNull: false } } }), [
+    {
+      id: '1',
+      title: 'Dog'
+    }
+  ])
 })
 
 test('LIKE', async () => {

--- a/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/0.json
+++ b/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/0.json
@@ -245,6 +245,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -345,6 +353,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -453,6 +469,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -553,6 +577,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -822,6 +854,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -922,6 +962,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -1030,6 +1078,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -1130,6 +1186,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/1.json
+++ b/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/1.json
@@ -282,6 +282,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -382,6 +390,14 @@
             },
             "in": "query",
             "name": "where.name.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
             "required": false
           },
           {
@@ -630,6 +646,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -730,6 +754,14 @@
             },
             "in": "query",
             "name": "where.name.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
             "required": false
           },
           {
@@ -1208,6 +1240,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -1308,6 +1348,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -1416,6 +1464,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -1520,6 +1576,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.ownerId.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -1620,6 +1684,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -1910,6 +1982,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -2010,6 +2090,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -2118,6 +2206,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -2222,6 +2318,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.ownerId.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -2322,6 +2426,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/2.json
+++ b/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/2.json
@@ -16,16 +16,16 @@
             "type": "integer",
             "nullable": true
           },
-          "counter": {
-            "type": "integer",
+          "title": {
+            "type": "string",
             "nullable": true
           },
           "longText": {
             "type": "string",
             "nullable": true
           },
-          "title": {
-            "type": "string",
+          "counter": {
+            "type": "integer",
             "nullable": true
           }
         },
@@ -39,14 +39,14 @@
           "id": {
             "type": "integer"
           },
-          "counter": {
-            "type": "integer"
+          "title": {
+            "type": "string"
           },
           "longText": {
             "type": "string"
           },
-          "title": {
-            "type": "string"
+          "counter": {
+            "type": "integer"
           }
         },
         "additionalProperties": false,
@@ -247,6 +247,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -347,6 +355,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -455,6 +471,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -555,6 +579,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -824,6 +856,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -924,6 +964,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -1032,6 +1080,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -1132,6 +1188,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/21ca681e6081425b45eee7a661271ef7/0.json
+++ b/packages/sql-openapi/.snapshots/21ca681e6081425b45eee7a661271ef7/0.json
@@ -245,6 +245,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -345,6 +353,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -453,6 +469,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -553,6 +577,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -822,6 +854,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -922,6 +962,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -1030,6 +1078,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -1130,6 +1186,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/0.json
+++ b/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/0.json
@@ -229,6 +229,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -329,6 +337,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -570,6 +586,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -670,6 +694,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/1.json
+++ b/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/1.json
@@ -229,6 +229,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -329,6 +337,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -570,6 +586,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -670,6 +694,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/2.json
+++ b/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/2.json
@@ -229,6 +229,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -329,6 +337,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -570,6 +586,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -670,6 +694,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/a2201917da7f38b2633837c006be92ea/0.json
+++ b/packages/sql-openapi/.snapshots/a2201917da7f38b2633837c006be92ea/0.json
@@ -245,6 +245,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -345,6 +353,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -453,6 +469,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -553,6 +577,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -822,6 +854,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -922,6 +962,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -1030,6 +1078,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -1130,6 +1186,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/0.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/0.json
@@ -229,6 +229,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -329,6 +337,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -570,6 +586,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -670,6 +694,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/1.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/1.json
@@ -227,6 +227,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -327,6 +335,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -568,6 +584,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -668,6 +692,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/2.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/2.json
@@ -229,6 +229,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -329,6 +337,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -570,6 +586,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -670,6 +694,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/3.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/3.json
@@ -229,6 +229,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -329,6 +337,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -570,6 +586,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -670,6 +694,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/0.json
+++ b/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/0.json
@@ -282,6 +282,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -382,6 +390,14 @@
             },
             "in": "query",
             "name": "where.name.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
             "required": false
           },
           {
@@ -630,6 +646,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -730,6 +754,14 @@
             },
             "in": "query",
             "name": "where.name.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
             "required": false
           },
           {
@@ -1208,6 +1240,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -1308,6 +1348,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -1416,6 +1464,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -1520,6 +1576,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.ownerId.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -1620,6 +1684,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -1910,6 +1982,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -2010,6 +2090,14 @@
             },
             "in": "query",
             "name": "where.id.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
             "required": false
           },
           {
@@ -2118,6 +2206,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.longText.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -2222,6 +2318,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.ownerId.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -2322,6 +2426,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/1.json
+++ b/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/1.json
@@ -238,6 +238,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -342,6 +350,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -442,6 +458,14 @@
             },
             "in": "query",
             "name": "where.parentId.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.parentId.isNull",
             "required": false
           },
           {
@@ -710,6 +734,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -814,6 +846,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -914,6 +954,14 @@
             },
             "in": "query",
             "name": "where.parentId.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.parentId.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/0.json
+++ b/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/0.json
@@ -236,6 +236,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.createdAt.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -340,6 +348,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -440,6 +456,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -695,6 +719,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.createdAt.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -799,6 +831,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -899,6 +939,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/1.json
+++ b/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/1.json
@@ -236,6 +236,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.category.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -340,6 +348,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -440,6 +456,14 @@
             },
             "in": "query",
             "name": "where.name.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
             "required": false
           },
           {
@@ -695,6 +719,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.category.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -799,6 +831,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -899,6 +939,14 @@
             },
             "in": "query",
             "name": "where.name.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.name.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/e68742984434a6b3af32e10666135459/0.json
+++ b/packages/sql-openapi/.snapshots/e68742984434a6b3af32e10666135459/0.json
@@ -236,6 +236,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -340,6 +348,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -440,6 +456,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -695,6 +719,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.counter.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "integer"
             },
             "in": "query",
@@ -799,6 +831,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -899,6 +939,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
+++ b/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
@@ -244,6 +244,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -360,6 +368,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {
@@ -603,6 +619,14 @@
           },
           {
             "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.id.isNull",
+            "required": false
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "query",
@@ -719,6 +743,14 @@
             },
             "in": "query",
             "name": "where.title.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "where.title.isNull",
             "required": false
           },
           {

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -27,6 +27,8 @@ export function generateArgs (entity, ignore) {
         const key = baseKey + modifier
         acc[key] = { type: 'string' }
       }
+
+      acc[baseKey + 'isNull'] = { type: 'boolean' }
     }
 
     return acc

--- a/packages/sql-openapi/test/where.test.js
+++ b/packages/sql-openapi/test/where.test.js
@@ -191,6 +191,45 @@ test('list', async t => {
     )
   }
 
+  // test isNull filter
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.longText.isNull=true&fields=id,title,longText'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.longText.isNull=true status code')
+    same(
+      res.json(),
+      [
+        {
+          id: 5,
+          title: 'Bear',
+          longText: null
+        }
+      ],
+      'GET /posts?where.longText.isNull=true response'
+    )
+  }
+
+  // test isNull=false filter
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/posts?where.longText.isNull=false&fields=id,title'
+    })
+    equal(res.statusCode, 200, 'GET /posts?where.longText.isNull=false status code')
+    same(
+      res.json(),
+      [
+        { id: 1, title: 'Dog' },
+        { id: 2, title: 'Cat' },
+        { id: 3, title: 'Mouse' },
+        { id: 4, title: 'Duck' }
+      ],
+      'GET /posts?where.longText.isNull=false response'
+    )
+  }
+
   // test NOT NULL filter
   {
     const res = await app.inject({


### PR DESCRIPTION
## Summary

Adds an `isNull` operator to `where` clauses to filter columns by `NULL` / `NOT NULL`, exposed consistently at every layer:

- **mapper API**: `entity.find({ where: { title: { isNull: true } } })`
- **REST**: `GET /posts?where.longText.isNull=true` (a typed `boolean` query parameter — works for every column type)
- **GraphQL**: `posts(where: { longText: { isNull: false } })`

Filtering by null was previously only possible via `eq`/`neq` with a null value, which the REST layer only supported for **nullable string fields** through the literal `null` string — impossible for e.g. integer columns whose query parameter schema rejects the string.

Docs for the where-operator tables updated (also adding the previously undocumented `like`/`ilike` to the sql-openapi table).

Fixes #3522

## Test plan

- `sql-mapper`: isNull true/false assertions in `where.test.js`
- `sql-openapi`: query-string tests in `where.test.js` + regenerated OpenAPI snapshots (SQLite and PostgreSQL runs)
- `sql-graphql`: new `isNull` test in `where.test.js`
- Full suites of the three packages pass on SQLite, PostgreSQL, MariaDB, MySQL and MySQL 8 (sql-openapi) locally.

> Stacked on #4893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF