### PR TITLE
fix(sql-events): publish events when the primary key is not selected

### DIFF
--- a/packages/sql-events/index.js
+++ b/packages/sql-events/index.js
@@ -27,12 +27,31 @@ export function setupEmitter ({ log, mq, mapper, connectionString }) {
       continue
     }
     const primaryKey = camelcase(entity.primaryKeys.values().next().value)
+
+    // The publish topic requires the primary key, so make sure it is always
+    // retrieved even when the caller did not select it
+    function ensurePrimaryKeyField (data) {
+      if (Array.isArray(data.fields) && data.fields.length > 0 && !data.fields.includes(primaryKey)) {
+        return { ...data, fields: data.fields.concat(primaryKey) }
+      }
+      return data
+    }
+
+    // Remove the primary key from the result when the caller did not select it
+    function stripPrimaryKey (res, requestedFields) {
+      if (Array.isArray(requestedFields) && requestedFields.length > 0 && !requestedFields.includes(primaryKey)) {
+        const { [primaryKey]: _, ...rest } = res
+        return rest
+      }
+      return res
+    }
+
     mapper.addEntityHooks(entityName, {
       async save (original, data) {
         const ctx = data.ctx
         /* istanbul ignore next */
         const _log = ctx?.reply?.request?.log || log
-        const res = await original(data)
+        const res = await original(ensurePrimaryKeyField(data))
         const topic = await entity.getPublishTopic({ action: 'save', data: res, ctx })
         if (topic) {
           const payload = {
@@ -49,7 +68,7 @@ export function setupEmitter ({ log, mq, mapper, connectionString }) {
             )
           })
         }
-        return res
+        return stripPrimaryKey(res, data.fields)
       },
 
       delete: multiElement('delete'),
@@ -61,7 +80,7 @@ export function setupEmitter ({ log, mq, mapper, connectionString }) {
         const ctx = data.ctx
         /* istanbul ignore next */
         const _log = ctx?.reply?.request?.log || log
-        const res = await original(data)
+        const res = await original(ensurePrimaryKeyField(data))
 
         await Promise.all(
           res.map(async payload => {
@@ -83,7 +102,7 @@ export function setupEmitter ({ log, mq, mapper, connectionString }) {
           })
         )
 
-        return res
+        return res.map(r => stripPrimaryKey(r, data.fields))
       }
     }
 

--- a/packages/sql-events/test/simple.test.js
+++ b/packages/sql-events/test/simple.test.js
@@ -295,3 +295,86 @@ test('more than one element for delete', async t => {
     }
   }
 })
+
+test('emit events when the primary key is not in the requested fields', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1805 */
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    t.after(() => db.dispose())
+
+    if (isSQLite) {
+      await db.query(sql`CREATE TABLE pages (
+        id INTEGER PRIMARY KEY,
+        title VARCHAR(42)
+      );`)
+    } else {
+      await db.query(sql`CREATE TABLE pages (
+        id SERIAL PRIMARY KEY,
+        title VARCHAR(255) NOT NULL
+      );`)
+    }
+  }
+  const mapper = await connect({
+    log: fakeLogger,
+    ...connInfo,
+    onDatabaseLoad
+  })
+  const pageEntity = mapper.entities.page
+
+  const mq = MQEmitter()
+  equal(setupEmitter({ mapper, mq, log: fakeLogger }), undefined)
+  const queue = await mapper.subscribe(['/entity/page/save/+', '/entity/page/delete/+'])
+
+  const expected = []
+
+  // save - new record, without the primary key in the fields
+  const page = await pageEntity.save({
+    input: { title: 'a page' },
+    fields: ['title']
+  })
+  same(page, { title: 'a page' }, 'save returns only the requested fields')
+
+  const [found] = await pageEntity.find({ fields: ['id'] })
+  expected.push({
+    topic: '/entity/page/save/' + found.id,
+    payload: {
+      id: found.id
+    }
+  })
+
+  // insert - without the primary key in the fields
+  const inserted = await pageEntity.insert({
+    inputs: [{ title: 'another page' }],
+    fields: ['title']
+  })
+  same(inserted, [{ title: 'another page' }], 'insert returns only the requested fields')
+
+  const [found2] = await pageEntity.find({ fields: ['id'], orderBy: [{ field: 'id', direction: 'desc' }], limit: 1 })
+  expected.push({
+    topic: '/entity/page/save/' + found2.id,
+    payload: {
+      id: found2.id
+    }
+  })
+
+  // delete - without the primary key in the fields
+  const deleted = await pageEntity.delete({
+    where: { id: { eq: found2.id } },
+    fields: ['title']
+  })
+  same(deleted, [{ title: 'another page' }], 'delete returns only the requested fields')
+
+  expected.push({
+    topic: '/entity/page/delete/' + found2.id,
+    payload: {
+      id: found2.id
+    }
+  })
+
+  for await (const ev of queue) {
+    same(ev, expected.shift())
+    if (expected.length === 0) {
+      break
+    }
+  }
+})


### PR DESCRIPTION
## Summary

With events/subscriptions enabled, a mutation that did not select the primary key crashed:

```graphql
mutation { saveMovie (input: { title: "A new movie" }) { title } }
# → "The primaryKey is necessary inside data"
```

The `sql-events` hooks passed the caller's `fields` straight to the underlying operation, so the result lacked the primary key that `getPublishTopic` requires. The hooks now always retrieve the primary key and strip it from the returned result when the caller did not ask for it, so the API response shape is unchanged.

Applies to `save`, `insert` and `delete`.

Fixes #1805

## Test plan

New regression test in `packages/sql-events/test/simple.test.js` covering save/insert/delete with `fields` excluding the primary key: the events are published with the right topic/payload and the results contain only the requested fields. Full `sql-events` suite passes on SQLite and PostgreSQL; `sql-graphql` subscription tests pass.

> Stacked on #4894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF