### PR TITLE
feat(db-authorization): support '*' wildcard in rule entities

### DIFF
--- a/docs/reference/db/authorization/rules.md
+++ b/docs/reference/db/authorization/rules.md
@@ -11,7 +11,7 @@ Authorization rules in Platformatic DB define what operations users can perform 
 Every authorization rule must include the following:
 
 - `role` (required) — Specifies the user role name as a string, which must align with roles set by an external authentication service.
-- `entity` or `entities` (optional) — Defines one or more Platformatic DB entities the rule applies to. At least one of `entity` or `entities` must be specified.
+- `entity` or `entities` (optional) — Defines one or more Platformatic DB entities the rule applies to. At least one of `entity` or `entities` must be specified. Use `'*'` to apply the rule to all entities; rules are evaluated in order, so more specific rules for the same role must be defined before the wildcard one.
 - `defaults` (optional) — Sets default values for entity fields from [user metadata](#set-entity-fields-from-user-metadata).
 
 ### Supported Operations

--- a/packages/db-authorization/index.js
+++ b/packages/db-authorization/index.js
@@ -97,6 +97,14 @@ async function auth (app, opts) {
         throw new Error(`Missing entity in authorization rule ${i}`)
       }
 
+      // The '*' wildcard applies the rule to all the entities.
+      // Rules are evaluated in order, so more specific rules for the same
+      // role must be defined before the wildcard one.
+      if (ruleEntities.includes('*')) {
+        const allEntities = Object.keys(app.platformatic.entities)
+        ruleEntities = Array.from(new Set([...ruleEntities.filter(e => e !== '*'), ...allEntities]))
+      }
+
       for (const ruleEntity of ruleEntities) {
         const newRule = { ...rule, entity: ruleEntity, entities: undefined }
         if (!app.platformatic.entities[newRule.entity]) {

--- a/packages/db-authorization/test/wildcard-entities.test.js
+++ b/packages/db-authorization/test/wildcard-entities.test.js
@@ -1,0 +1,192 @@
+import core from '@platformatic/db-core'
+import fastify from 'fastify'
+import { deepEqual, equal, ok } from 'node:assert'
+import { test } from 'node:test'
+import auth from '../index.js'
+import { clear, connInfo, isSQLite } from './helper.js'
+
+async function createPagesAndCategories (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE IF NOT EXISTS pages (
+      id INTEGER PRIMARY KEY,
+      title VARCHAR(42),
+      user_id INTEGER
+    );`)
+    await db.query(sql`CREATE TABLE IF NOT EXISTS categories (
+      id INTEGER PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+  } else {
+    await db.query(sql`CREATE TABLE IF NOT EXISTS pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(42),
+      user_id INTEGER
+    );`)
+    await db.query(sql`CREATE TABLE IF NOT EXISTS categories (
+      id SERIAL PRIMARY KEY,
+      name VARCHAR(42)
+    );`)
+  }
+}
+
+test("the '*' wildcard applies a rule to all the entities", async () => {
+  const app = fastify()
+  app.register(core, {
+    ...connInfo,
+    events: false,
+    async onDatabaseLoad (db, sql) {
+      ok('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await db.query(sql`DROP TABLE IF EXISTS categories`)
+      await createPagesAndCategories(db, sql)
+    }
+  })
+  app.register(auth, {
+    jwt: {
+      secret: 'supersecret'
+    },
+    roleKey: 'X-PLATFORMATIC-ROLE',
+    anonymousRole: 'anonymous',
+    rules: [
+      // More specific rules for a role must come before the wildcard one
+      {
+        role: 'user',
+        entity: 'page',
+        find: true,
+        delete: false,
+        save: true
+      },
+      {
+        role: 'user',
+        entities: ['*'],
+        find: false,
+        delete: false,
+        save: false
+      },
+      {
+        role: 'anonymous',
+        entity: '*',
+        find: false,
+        delete: false,
+        save: false
+      }
+    ]
+  })
+  test.after(() => {
+    app.close()
+  })
+
+  await app.ready()
+
+  const token = await app.jwt.sign({
+    'X-PLATFORMATIC-USER-ID': 42,
+    'X-PLATFORMATIC-ROLE': 'user'
+  })
+
+  // The specific rule for pages wins over the wildcard one
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          mutation {
+            savePage(input: { title: "Hello" }) {
+              id
+              title
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'savePage status code')
+    deepEqual(
+      res.json(),
+      {
+        data: {
+          savePage: {
+            id: 1,
+            title: 'Hello'
+          }
+        }
+      },
+      'savePage response'
+    )
+  }
+
+  // The wildcard rule denies access to the other entities
+  {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: {
+        query: `
+          mutation {
+            saveCategory(input: { name: "News" }) {
+              id
+              name
+            }
+          }
+        `
+      }
+    })
+    equal(res.statusCode, 200, 'saveCategory status code')
+    deepEqual(res.json().data.saveCategory, null, 'saveCategory is denied')
+    equal(res.json().errors[0].message, 'operation not allowed', 'saveCategory error message')
+  }
+
+  // The anonymous wildcard rule denies access to every entity
+  for (const url of ['/pages', '/categories']) {
+    const res = await app.inject({
+      method: 'GET',
+      url
+    })
+    equal(res.statusCode, 403, `GET ${url} status code (anonymous)`)
+  }
+})
+
+test('an unknown entity in a rule still fails', async () => {
+  const app = fastify()
+  app.register(core, {
+    ...connInfo,
+    events: false,
+    async onDatabaseLoad (db, sql) {
+      ok('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await db.query(sql`DROP TABLE IF EXISTS categories`)
+      await createPagesAndCategories(db, sql)
+    }
+  })
+  app.register(auth, {
+    roleKey: 'X-PLATFORMATIC-ROLE',
+    anonymousRole: 'anonymous',
+    rules: [
+      {
+        role: 'anonymous',
+        entities: ['*', 'missing'],
+        find: false,
+        delete: false,
+        save: false
+      }
+    ]
+  })
+  test.after(() => {
+    app.close()
+  })
+
+  let error
+  try {
+    await app.ready()
+  } catch (err) {
+    error = err
+  }
+  equal(error.message.includes("Unknown entity 'missing'"), true, 'unknown entity error')
+})

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -329,7 +329,7 @@ export interface PlatformaticDatabaseConfig {
     rules?: (
       | {
           /**
-           * the DB entity type to which the rule applies
+           * the DB entity type to which the rule applies, use '*' to apply the rule to all entities
            */
           entity?: string;
           /**
@@ -349,7 +349,7 @@ export interface PlatformaticDatabaseConfig {
         }
       | {
           /**
-           * the DB entity types to which the rule applies
+           * the DB entity types to which the rule applies, use '*' to apply the rule to all entities
            */
           entities?: string[];
           /**

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -352,7 +352,7 @@ export const authorization = {
             properties: {
               entity: {
                 type: 'string',
-                description: 'the DB entity type to which the rule applies'
+                description: "the DB entity type to which the rule applies, use '*' to apply the rule to all entities"
               },
               ...sharedAuthorizationRule
             },
@@ -364,7 +364,7 @@ export const authorization = {
             properties: {
               entities: {
                 type: 'array',
-                description: 'the DB entity types to which the rule applies',
+                description: "the DB entity types to which the rule applies, use '*' to apply the rule to all entities",
                 items: {
                   type: 'string'
                 }

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -940,7 +940,7 @@
                 "properties": {
                   "entity": {
                     "type": "string",
-                    "description": "the DB entity type to which the rule applies"
+                    "description": "the DB entity type to which the rule applies, use '*' to apply the rule to all entities"
                   },
                   "role": {
                     "type": "string",
@@ -976,7 +976,7 @@
                 "properties": {
                   "entities": {
                     "type": "array",
-                    "description": "the DB entity types to which the rule applies",
+                    "description": "the DB entity types to which the rule applies, use '*' to apply the rule to all entities",
                     "items": {
                       "type": "string"
                     }


### PR DESCRIPTION
## Summary

Blocking a role from every entity required listing all entities in the rule and remembering to update the list whenever a new entity was created. A rule can now use the `'*'` wildcard:

```json
{
  "role": "anonymous",
  "entity": "*",
  "find": false,
  "save": false,
  "delete": false
}
```

- `'*'` works in both `entity` and `entities` and expands to all known entities (union with any explicitly listed names, so unknown names still raise the existing error).
- Rules are evaluated in order (`first-match`), so more specific rules for the same role win when defined **before** the wildcard one — documented in the rules reference.
- `schema.json` regenerated with the updated descriptions.

Fixes #1414

## Test plan

New `packages/db-authorization/test/wildcard-entities.test.js`: wildcard denies across multiple entities (GraphQL and REST), a specific rule defined before the wildcard wins, and unknown entities mixed with the wildcard still fail at startup. Full `db-authorization` suite passes (72/72).

> Stacked on #4895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF