### PR TITLE
fix(service): hide graphiql routes from the OpenAPI definition

### DIFF
--- a/packages/service/lib/plugins/graphql.js
+++ b/packages/service/lib/plugins/graphql.js
@@ -20,6 +20,14 @@ async function setupGraphQLPlugin (app, options) {
     options
   )
 
+  // The graphiql routes do not honor additionalRouteOptions:
+  // hide them from the OpenAPI definition
+  app.addHook('onRoute', routeOptions => {
+    if (routeOptions.url === '/graphiql' || routeOptions.url.startsWith('/graphiql/')) {
+      routeOptions.schema = { ...routeOptions.schema, hide: true }
+    }
+  })
+
   app.register(mercurius, graphqlOptions)
 }
 

--- a/packages/service/test/graphql.test.js
+++ b/packages/service/test/graphql.test.js
@@ -299,3 +299,43 @@ test('do not include /graphql in the OpenAPI schema', async t => {
   const body = await res.body.json()
   assert.strictEqual(body.paths['/graphql'], undefined)
 })
+
+test('do not include the graphiql routes in the OpenAPI schema', async t => {
+  const app = await createFromConfig(
+    t,
+    buildConfig({
+      server: {
+        hostname: '127.0.0.1',
+        port: 0,
+        logger: { level: 'fatal' },
+        forceCloseConnections: true
+      },
+      service: {
+        graphql: {
+          graphiql: true
+        },
+        openapi: true
+      },
+      plugins: {
+        paths: [join(import.meta.dirname, 'fixtures', 'hello-world-resolver.js')]
+      }
+    })
+  )
+
+  t.after(async () => {
+    await app.stop()
+  })
+  await app.start({ listen: true })
+
+  {
+    const res = await request(`${app.url}/graphiql`)
+    assert.strictEqual(res.statusCode, 200, 'graphiql is served')
+  }
+
+  const res = await request(`${app.url}/documentation/json`)
+  assert.strictEqual(res.statusCode, 200, 'status code')
+  const body = await res.body.json()
+  for (const path of Object.keys(body.paths)) {
+    assert.ok(!path.startsWith('/graphiql'), `${path} must not be in the OpenAPI schema`)
+  }
+})


### PR DESCRIPTION
## Summary

With `graphiql` enabled, its routes were exposed in the OpenAPI definition:

```
/graphiql
/graphiql/main.js
/graphiql/sw.js
/graphiql/config.js
```

The `/graphql` route was already hidden through mercurius' `additionalRouteOptions`, but the graphiql routes do not honor that option. An `onRoute` hook now marks them as hidden — they are still served, just no longer documented.

Fixes #1945

## Test plan

New test in `packages/service/test/graphql.test.js`: graphiql responds 200 while no `/graphiql*` path appears in `/documentation/json`. Full service graphql tests pass.

> Stacked on #4898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF