### PR TITLE
fix(sql-mapper): return PostgreSQL DATE columns as strings

### DIFF
--- a/packages/sql-mapper/index.js
+++ b/packages/sql-mapper/index.js
@@ -88,6 +88,13 @@ async function registerPostgreSQLExtensionTypes (db) {
   try {
     await db.registerTypeParser('_vector', value => db.parseArray(value, parseVector))
   } catch {}
+
+  // Return DATE columns as 'YYYY-MM-DD' strings: parsing them into local-time
+  // JS Dates shifts the value by the process time zone offset, changing the
+  // day. 1082 is the PostgreSQL oid for the DATE type.
+  try {
+    await db.registerTypeParser(1082, value => value)
+  } catch {}
 }
 
 // Provide a developer friendly error instead of the bare SQLITE_CANTOPEN

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -1384,3 +1384,35 @@ test('array support (PG)', { skip: !isPg }, async () => {
     ]
   )
 })
+
+test('date columns are returned as YYYY-MM-DD strings', { skip: !isPg }, async () => {
+  /* https://github.com/platformatic/platformatic/issues/1451 */
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+    await db.query(sql`CREATE TABLE pages (
+      id SERIAL PRIMARY KEY,
+      publish_date DATE
+    );`)
+  }
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {}
+  })
+  const pageEntity = mapper.entities.page
+
+  const [page] = await pageEntity.insert({
+    inputs: [{ publishDate: '2023-06-01' }]
+  })
+  // No time zone dependent Date parsing: the value must be the exact date
+  equal(page.publishDate, '2023-06-01')
+
+  const [found] = await pageEntity.find({ where: { publishDate: { eq: '2023-06-01' } } })
+  equal(found.publishDate, '2023-06-01')
+})


### PR DESCRIPTION
## Summary

Reading a PostgreSQL `DATE` column like `2023-06-01` returned a local-time JS `Date` — e.g. `2023-05-31T22:00:00.000Z` in a UTC+2 process — shifting the value into a different day (or month) depending on the machine's time zone.

`DATE` values (oid 1082) are now returned as plain `'YYYY-MM-DD'` strings, which:

- can't shift, regardless of `TZ`
- match the OpenAPI schema for date fields (`string`/`format: date`)
- serialize correctly through the GraphQL `Date` scalar

`timestamp`/`timestamptz` are unchanged (they represent absolute instants).

Fixes #1451

## Test plan

- New regression test in `packages/sql-mapper/test/entity.test.js`: inserting and finding a `DATE` value returns the exact `'2023-06-01'` string.
- Full `sql-mapper`, `sql-openapi`, `sql-graphql` and `sql-events` suites pass on PostgreSQL locally.

> Stacked on #4899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF