### PR TITLE
fix(sql-openapi): do not rename reverse relation routes for unrelated foreign keys

### DIFF
--- a/packages/sql-openapi/lib/entity-to-routes.js
+++ b/packages/sql-openapi/lib/entity-to-routes.js
@@ -180,8 +180,13 @@ export async function entityPlugin (app, opts) {
     // e.g. getQuotesForMovie
     const operationId = `get${capitalize(targetEntity.pluralName)}For${capitalize(entity.singularName)}`
 
+    // Only disambiguate the route name when the target entity has more than
+    // one relation pointing to this entity, not just any relation
+    const relationsToThisEntity = targetEntity.relations.filter(
+      relation => relation.foreignEntityName === entity.singularName
+    )
     let routePathName =
-      targetEntity.relations.length > 1
+      relationsToThisEntity.length > 1
         ? camelcase([reverseRelationship.sourceEntity, targetForeignKeyCamelcase])
         : targetEntity.pluralName
 

--- a/packages/sql-openapi/test/multiple-fk.test.js
+++ b/packages/sql-openapi/test/multiple-fk.test.js
@@ -225,3 +225,74 @@ test('multiple foreign keys pointing the same table', { skip: isSQLite }, async 
     equal(res.statusCode, 500, 'POST /editors status code')
   }
 })
+
+test('foreign keys pointing to different tables do not change the route name', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1491 */
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    await db.query(sql`DROP TABLE IF EXISTS translations`)
+    await db.query(sql`DROP TABLE IF EXISTS text_content`)
+    await db.query(sql`DROP TABLE IF EXISTS languages`)
+
+    if (isSQLite) {
+      await db.query(sql`CREATE TABLE languages (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL
+      );`)
+      await db.query(sql`CREATE TABLE text_content (
+        id INTEGER PRIMARY KEY,
+        key TEXT NOT NULL
+      );`)
+      await db.query(sql`CREATE TABLE translations (
+        id INTEGER PRIMARY KEY,
+        text TEXT NOT NULL,
+        language_id INTEGER NOT NULL,
+        text_content_id INTEGER NOT NULL,
+        CONSTRAINT fk_translations_language FOREIGN KEY (language_id) REFERENCES languages(id),
+        CONSTRAINT fk_translations_text_content FOREIGN KEY (text_content_id) REFERENCES text_content(id)
+      );`)
+    } else {
+      await db.query(sql`CREATE TABLE languages (
+        id SERIAL PRIMARY KEY,
+        name TEXT NOT NULL
+      );`)
+      await db.query(sql`CREATE TABLE text_content (
+        id SERIAL PRIMARY KEY,
+        key TEXT NOT NULL
+      );`)
+      await db.query(sql`CREATE TABLE translations (
+        id SERIAL PRIMARY KEY,
+        text TEXT NOT NULL,
+        language_id INTEGER NOT NULL,
+        text_content_id INTEGER NOT NULL,
+        CONSTRAINT fk_translations_language FOREIGN KEY (language_id) REFERENCES languages(id),
+        CONSTRAINT fk_translations_text_content FOREIGN KEY (text_content_id) REFERENCES text_content(id)
+      );`)
+    }
+  }
+
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    onDatabaseLoad
+  })
+  app.register(sqlOpenAPI)
+  t.after(async () => {
+    const { db, sql } = app.platformatic
+    await db.query(sql`DROP TABLE IF EXISTS translations`)
+    await db.query(sql`DROP TABLE IF EXISTS text_content`)
+    await db.query(sql`DROP TABLE IF EXISTS languages`)
+    await app.close()
+  })
+
+  await app.ready()
+
+  const res = await app.inject({ method: 'GET', url: '/documentation/json' })
+  const openapi = res.json()
+
+  // Each entity has a single relation per target table, so the plural
+  // route names must be used
+  equal(openapi.paths['/textContent/{id}/translations'] !== undefined, true, '/textContent/{id}/translations exists')
+  equal(openapi.paths['/languages/{id}/translations'] !== undefined, true, '/languages/{id}/translations exists')
+  equal(openapi.paths['/textContent/{id}/translationTextContentId'], undefined, 'no disambiguated route')
+})

--- a/packages/sql-openapi/test/multiple-fk.test.js
+++ b/packages/sql-openapi/test/multiple-fk.test.js
@@ -3,7 +3,7 @@ import fastify from 'fastify'
 import { equal, deepEqual as same } from 'node:assert/strict'
 import { test } from 'node:test'
 import sqlOpenAPI from '../index.js'
-import { clear, connInfo, isPg, isSQLite } from './helper.js'
+import { clear, connInfo, isMysql, isPg, isSQLite } from './helper.js'
 
 test('multiple foreign keys pointing the same table', { skip: isSQLite }, async t => {
   async function onDatabaseLoad (db, sql) {
@@ -241,13 +241,30 @@ test('foreign keys pointing to different tables do not change the route name', a
       );`)
       await db.query(sql`CREATE TABLE text_content (
         id INTEGER PRIMARY KEY,
-        key TEXT NOT NULL
+        content_key TEXT NOT NULL
       );`)
       await db.query(sql`CREATE TABLE translations (
         id INTEGER PRIMARY KEY,
         text TEXT NOT NULL,
         language_id INTEGER NOT NULL,
         text_content_id INTEGER NOT NULL,
+        CONSTRAINT fk_translations_language FOREIGN KEY (language_id) REFERENCES languages(id),
+        CONSTRAINT fk_translations_text_content FOREIGN KEY (text_content_id) REFERENCES text_content(id)
+      );`)
+    } else if (isMysql) {
+      await db.query(sql`CREATE TABLE languages (
+        id SERIAL PRIMARY KEY,
+        name TEXT NOT NULL
+      );`)
+      await db.query(sql`CREATE TABLE text_content (
+        id SERIAL PRIMARY KEY,
+        content_key TEXT NOT NULL
+      );`)
+      await db.query(sql`CREATE TABLE translations (
+        id SERIAL PRIMARY KEY,
+        text TEXT NOT NULL,
+        language_id BIGINT UNSIGNED NOT NULL,
+        text_content_id BIGINT UNSIGNED NOT NULL,
         CONSTRAINT fk_translations_language FOREIGN KEY (language_id) REFERENCES languages(id),
         CONSTRAINT fk_translations_text_content FOREIGN KEY (text_content_id) REFERENCES text_content(id)
       );`)
@@ -258,7 +275,7 @@ test('foreign keys pointing to different tables do not change the route name', a
       );`)
       await db.query(sql`CREATE TABLE text_content (
         id SERIAL PRIMARY KEY,
-        key TEXT NOT NULL
+        content_key TEXT NOT NULL
       );`)
       await db.query(sql`CREATE TABLE translations (
         id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary

Given `translations` with foreign keys to **both** `languages` and `text_content`, the reverse route for text content was generated as `/textContent/{id}/translationTextContentId` instead of `/textContent/{id}/translations`.

The disambiguation logic triggered whenever the target entity had more than one relation (`targetEntity.relations.length > 1`), regardless of where those relations point. It now only counts relations referencing the current entity, so the disambiguated name is used exactly when two or more foreign keys point to the **same** table (the case it was designed for — that behavior is unchanged and covered by the existing `multiple-fk` tests).

This is the fix suggested by @mbrunjadze-crocobet in the issue.

Fixes #1491

## Test plan

New regression test in `packages/sql-openapi/test/multiple-fk.test.js` with the issue's exact schema, asserting the plural route names and the absence of the disambiguated one — fails without the fix, passes with it. Full sql-openapi suites pass on SQLite and PostgreSQL.

> Stacked on #4901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF