### PR TITLE
fix(db): support triggers and comments in SQLite migrations

### DIFF
--- a/packages/db/lib/migrator.js
+++ b/packages/db/lib/migrator.js
@@ -3,6 +3,7 @@ import { readdir, stat } from 'node:fs/promises'
 import { basename } from 'node:path'
 import Postgrator from 'postgrator'
 import { ApplyMigrationError, MigrateMissingMigrationsDirError, MigrateMissingMigrationsError } from './errors.js'
+import { splitSQLiteStatements } from './split-sqlite-statements.js'
 
 export class Migrator {
   constructor (migrationConfig, coreConfig, logger) {
@@ -16,6 +17,7 @@ export class Migrator {
     this.logger = logger
 
     this.db = null
+    this.sqliteDb = null
     this.postgrator = null
     this.appliedMigrationsCount = 0
     this.lastStartedMigration = null
@@ -49,6 +51,15 @@ export class Migrator {
 
     this.db = db
 
+    /* c8 ignore next 6 */
+    if (driver === 'sqlite3') {
+      const { DatabaseSync } = await import('node:sqlite')
+      const connectionString = this.coreConfig.connectionString
+      this.sqliteDb = new DatabaseSync(
+        connectionString === 'sqlite://:memory:' ? ':memory:' : connectionString.replace('sqlite://', '')
+      )
+    }
+
     // Glob patterns should always use / as a path separator, even on Windows systems, as \ is used to escape glob characters.
     const migrationPattern = this.migrationDir + '/*'
     this.logger.debug(`Migrating from ${migrationPattern}`)
@@ -59,6 +70,19 @@ export class Migrator {
       database,
       schemaTable: this.migrationsTable || 'versions',
       execQuery: async query => {
+        // The SQLite pool splits scripts with a generic splitter which
+        // breaks on the semicolons inside CREATE TRIGGER bodies and fails
+        // on scripts only containing comments. Split the script with a
+        // SQLite aware splitter and run each statement on a raw connection,
+        // whose prepare() handles trigger bodies correctly.
+        if (driver === 'sqlite3') {
+          let rows = []
+          for (const statement of splitSQLiteStatements(query)) {
+            rows = this.runSQLiteStatement(statement)
+          }
+          return { rows }
+        }
+
         const res = await db.query(sql`${sql.__dangerous__rawValue(query)}`)
         return { rows: res }
       },
@@ -85,6 +109,10 @@ export class Migrator {
       const migrationName = basename(migration.filename)
       this.logger.debug(`completed ${migrationName}`)
     })
+  }
+
+  runSQLiteStatement (text) {
+    return this.sqliteDb.prepare(text).all()
   }
 
   async checkMigrationsDirectoryExists () {
@@ -189,6 +217,10 @@ export class Migrator {
   }
 
   async close () {
+    if (this.sqliteDb !== null) {
+      this.sqliteDb.close()
+      this.sqliteDb = null
+    }
     if (this.db !== null) {
       await this.db.dispose()
       this.db = null

--- a/packages/db/lib/split-sqlite-statements.js
+++ b/packages/db/lib/split-sqlite-statements.js
@@ -1,0 +1,138 @@
+const TRANSACTION_MODIFIERS = new Set(['TRANSACTION', 'DEFERRED', 'IMMEDIATE', 'EXCLUSIVE'])
+
+function nextWord (script, from) {
+  let i = from
+  while (i < script.length && /\s/.test(script[i])) {
+    i++
+  }
+  let j = i
+  while (j < script.length && /[A-Za-z_0-9]/.test(script[j])) {
+    j++
+  }
+  return { word: script.slice(i, j).toUpperCase(), index: i }
+}
+
+/**
+ * Split a SQLite script into single statements.
+ *
+ * Generic SQL splitters break on the semicolons inside CREATE TRIGGER
+ * BEGIN ... END bodies, so this one tracks strings, quoted identifiers,
+ * comments and BEGIN/CASE ... END nesting and only splits on top level
+ * semicolons.
+ */
+export function splitSQLiteStatements (script) {
+  const statements = []
+  let current = ''
+  let depth = 0
+  let i = 0
+  const len = script.length
+
+  while (i < len) {
+    const ch = script[i]
+    const two = script.slice(i, i + 2)
+
+    // Strings and quoted identifiers: quotes are escaped by doubling them
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch
+      current += ch
+      i++
+      while (i < len) {
+        current += script[i]
+        if (script[i] === quote) {
+          if (script[i + 1] === quote) {
+            current += script[i + 1]
+            i += 2
+            continue
+          }
+          i++
+          break
+        }
+        i++
+      }
+      continue
+    }
+
+    // Bracket quoted identifiers
+    if (ch === '[') {
+      while (i < len && script[i] !== ']') {
+        current += script[i]
+        i++
+      }
+      if (i < len) {
+        current += ']'
+        i++
+      }
+      continue
+    }
+
+    // Line comments
+    if (two === '--') {
+      while (i < len && script[i] !== '\n') {
+        current += script[i]
+        i++
+      }
+      continue
+    }
+
+    // Block comments
+    if (two === '/*') {
+      while (i < len && script.slice(i, i + 2) !== '*/') {
+        current += script[i]
+        i++
+      }
+      if (i < len) {
+        current += '*/'
+        i += 2
+      }
+      continue
+    }
+
+    // Keywords: track BEGIN/CASE ... END nesting
+    if (/[A-Za-z_]/.test(ch)) {
+      let j = i
+      while (j < len && /[A-Za-z_0-9]/.test(script[j])) {
+        j++
+      }
+      const word = script.slice(i, j).toUpperCase()
+
+      if (word === 'BEGIN') {
+        // BEGIN [TRANSACTION|DEFERRED|IMMEDIATE|EXCLUSIVE|;] starts a
+        // transaction, not a block
+        const following = nextWord(script, j)
+        if (script[following.index] !== ';' && !TRANSACTION_MODIFIERS.has(following.word)) {
+          depth++
+        }
+      } else if (word === 'CASE') {
+        depth++
+      } else if (word === 'END') {
+        depth = Math.max(0, depth - 1)
+      }
+
+      current += script.slice(i, j)
+      i = j
+      continue
+    }
+
+    if (ch === ';' && depth === 0) {
+      statements.push(current)
+      current = ''
+      i++
+      continue
+    }
+
+    current += ch
+    i++
+  }
+  statements.push(current)
+
+  return statements
+    .map(statement => statement.trim())
+    .filter(statement => {
+      // Skip empty chunks and comment only chunks
+      const withoutComments = statement
+        .replace(/--[^\n]*/g, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .trim()
+      return withoutComments.length > 0
+    })
+}

--- a/packages/db/test/migrate/sqlite-statements.test.js
+++ b/packages/db/test/migrate/sqlite-statements.test.js
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { createConnectionPool } from '@platformatic/sql-mapper'
+import { applyMigrations } from '../../lib/commands/migrations-apply.js'
+import { splitSQLiteStatements } from '../../lib/split-sqlite-statements.js'
+import { createCapturingLogger, createTestContext } from '../cli/test-utilities.js'
+import { createDirectory } from '@platformatic/foundation'
+
+test('splitSQLiteStatements', () => {
+  // Plain statements
+  assert.deepEqual(splitSQLiteStatements('CREATE TABLE a (id INTEGER);\nCREATE TABLE b (id INTEGER);'), [
+    'CREATE TABLE a (id INTEGER)',
+    'CREATE TABLE b (id INTEGER)'
+  ])
+
+  // Semicolons inside strings
+  assert.deepEqual(splitSQLiteStatements("INSERT INTO a (name) VALUES ('foo;bar');"), [
+    "INSERT INTO a (name) VALUES ('foo;bar')"
+  ])
+
+  // Semicolons inside comments, including commented out statements
+  assert.deepEqual(
+    splitSQLiteStatements(`-- A comment that contains a ;
+-- CREATE TABLE IF NOT EXISTS movies (
+--   id INTEGER PRIMARY KEY,
+--   title TEXT NOT NULL
+-- );
+CREATE TABLE movies (id INTEGER PRIMARY KEY);`),
+    [
+      `-- A comment that contains a ;
+-- CREATE TABLE IF NOT EXISTS movies (
+--   id INTEGER PRIMARY KEY,
+--   title TEXT NOT NULL
+-- );
+CREATE TABLE movies (id INTEGER PRIMARY KEY)`
+    ]
+  )
+
+  // Comment only scripts produce no statements
+  assert.deepEqual(splitSQLiteStatements('-- only a comment with a ;\n/* and a block; comment */'), [])
+
+  // Triggers keep their BEGIN ... END body together
+  const trigger = `CREATE TRIGGER tg_users_updated_at AFTER UPDATE ON users FOR EACH ROW
+BEGIN
+  UPDATE users SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END`
+  assert.deepEqual(splitSQLiteStatements(`CREATE TABLE users (id INTEGER PRIMARY KEY);\n${trigger};`), [
+    'CREATE TABLE users (id INTEGER PRIMARY KEY)',
+    trigger
+  ])
+
+  // CASE ... END does not confuse the nesting
+  assert.deepEqual(
+    splitSQLiteStatements("SELECT CASE WHEN a = 1 THEN 'one' ELSE 'other' END FROM t; SELECT 2;"),
+    ["SELECT CASE WHEN a = 1 THEN 'one' ELSE 'other' END FROM t", 'SELECT 2']
+  )
+
+  // BEGIN as transaction start does not open a block
+  assert.deepEqual(splitSQLiteStatements('BEGIN;\nCREATE TABLE a (id INTEGER);\nCOMMIT;'), [
+    'BEGIN',
+    'CREATE TABLE a (id INTEGER)',
+    'COMMIT'
+  ])
+  assert.deepEqual(splitSQLiteStatements('BEGIN TRANSACTION;\nCREATE TABLE a (id INTEGER);\nCOMMIT;'), [
+    'BEGIN TRANSACTION',
+    'CREATE TABLE a (id INTEGER)',
+    'COMMIT'
+  ])
+})
+
+test('migrations with triggers and comments apply on SQLite', async t => {
+  /*
+   * https://github.com/platformatic/platformatic/issues/932
+   * https://github.com/platformatic/platformatic/issues/125
+   */
+  const cwd = await mkdtemp(join(tmpdir(), 'sqlite-trigger-migration-'))
+  const configFilePath = join(cwd, 'platformatic.db.json')
+  const migrationsDirPath = join(cwd, 'migrations')
+  const dbPath = join(cwd, 'db.sqlite')
+
+  const config = {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' }
+    },
+    db: {
+      connectionString: `sqlite://${dbPath}`
+    },
+    migrations: {
+      dir: migrationsDirPath
+    }
+  }
+
+  await writeFile(configFilePath, JSON.stringify(config))
+  await createDirectory(migrationsDirPath)
+  await writeFile(
+    join(migrationsDirPath, '001.do.sql'),
+    `-- A comment that contains a ;
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY,
+  firstname TEXT NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER tg_users_updated_at AFTER UPDATE ON users FOR EACH ROW
+BEGIN
+  UPDATE users SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END;
+`
+  )
+  await writeFile(join(migrationsDirPath, '001.undo.sql'), 'DROP TRIGGER tg_users_updated_at;\nDROP TABLE users;\n')
+
+  const logger = createCapturingLogger()
+  const context = createTestContext()
+
+  await applyMigrations(logger, configFilePath, [], context)
+
+  const output = logger.getCaptured()
+  assert.match(output, /running 001\.do\.sql/)
+  assert.doesNotMatch(output, /incomplete input/)
+
+  // The trigger is in place and works
+  const { db, sql } = await createConnectionPool({
+    connectionString: `sqlite://${dbPath}`,
+    log: logger
+  })
+  t.after(() => db.dispose())
+
+  await db.query(sql`INSERT INTO users (firstname, updated_at) VALUES ('foo', '2020-01-01 00:00:00')`)
+  await db.query(sql`UPDATE users SET firstname = 'bar' WHERE id = 1`)
+  const [user] = await db.query(sql`SELECT firstname, updated_at FROM users`)
+  assert.equal(user.firstname, 'bar')
+  assert.notEqual(user.updated_at, '2020-01-01 00:00:00', 'the trigger updated updated_at')
+
+  // The migration was recorded exactly once
+  const versions = await db.query(sql`SELECT version FROM versions ORDER BY version DESC`)
+  assert.equal(versions[0].version, 1)
+
+  await readFile(join(migrationsDirPath, '001.do.sql'))
+})


### PR DESCRIPTION
## Summary

Two long-standing SQLite migration failures, same root cause:

- **#932**: a migration containing `CREATE TRIGGER ... BEGIN ... END;` failed with `SQLITE_ERROR: incomplete input`
- **#125**: comments containing semicolons (e.g. commented-out statements) failed with `SQLITE_MISUSE: not an error`

Migration scripts were split into statements by a generic splitter that breaks on any top-level-looking `;` — including the ones inside trigger bodies — and produced empty/comment-only statements.

The migrator now:

- splits SQLite scripts with a SQLite-aware splitter that tracks strings, quoted identifiers, line/block comments, and `BEGIN`/`CASE` … `END` nesting (distinguishing `BEGIN TRANSACTION` from trigger blocks), and drops comment-only chunks
- runs each statement on a raw `node:sqlite` connection, whose native parser handles trigger bodies with internal semicolons (the pooled connection re-splits internally so it cannot be used for this)

Other databases are unchanged. Note the migrator has always used its own dedicated connection, so using a separate raw connection for SQLite preserves existing semantics (including for `:memory:`).

Fixes #932
Fixes #125

## Test plan

New `packages/db/test/migrate/sqlite-statements.test.js`:
- unit tests for the splitter (strings, comments with `;`, commented-out statements, comment-only scripts, triggers, `CASE...END`, `BEGIN`/`BEGIN TRANSACTION`)
- integration test applying the exact migration from #932 (+ #125-style comment), verifying the trigger actually fires and the migration is recorded

Full `db` package suite passes locally (108 tests), as do the migrate/migrator/runtime migration-error tests.

> Stacked on #4902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF