### PR TITLE
test: stabilize flaky tests (ELU scaler, logger options, import, mesh network)

### DIFF
--- a/packages/runtime/test/multiple-workers/helper.js
+++ b/packages/runtime/test/multiple-workers/helper.js
@@ -49,7 +49,34 @@ export async function verifyInject (client, application, expectedWorker, additio
   additionalChecks?.(res, json)
 }
 
+// Right after startup the mesh routes might not be fully registered yet and
+// requests can get a 404: wait for every service to be reachable first. The
+// warm up requests do not affect the round robin verification, which is
+// insensitive to the starting worker.
+async function waitForServices (baseUrl, services, { timeoutMs = WAIT_TIMEOUT, intervalMs = 250 } = {}) {
+  const start = Date.now()
+
+  for (const service of services) {
+    while (true) {
+      try {
+        const res = await request(baseUrl + `/${service.name}/hello`)
+        await res.body.dump()
+        if (res.statusCode === 200) {
+          break
+        }
+      } catch {}
+
+      if (Date.now() - start > timeoutMs) {
+        break
+      }
+      await new Promise(resolve => setTimeout(resolve, intervalMs))
+    }
+  }
+}
+
 export async function testRoundRobin (baseUrl, services) {
+  await waitForServices(baseUrl, services)
+
   // Calculate iterations needed to check all sequences at least twice
   // For a service with N workers, we need at least 2*N requests to verify 2 complete cycles
   const maxWorkerCount = Math.max(...services.map(s => s.workerCount))

--- a/packages/runtime/test/worker-scaler-1.test.js
+++ b/packages/runtime/test/worker-scaler-1.test.js
@@ -57,33 +57,19 @@ for (const [name, file] of Object.entries(configurations)) {
 
     t.after(() => app.close())
 
-    const { statusCode } = await request(entryUrl + '/service-2/cpu-intensive', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ timeout: 1000 })
+    // Drive sustained load instead of a single burst and poll for the new
+    // worker instead of sleeping a fixed amount of time: a single burst can
+    // be missed by the ELU sampling window on slow CI runners.
+    const ac = new AbortController()
+    const load = driveLoad(entryUrl, ac.signal)
+    t.after(async () => {
+      ac.abort()
+      await load
     })
-    assert.strictEqual(statusCode, 200)
 
-    await sleep(10000)
-
-    const workers = await app.getWorkers()
-
-    const service1Workers = []
-    const service2Workers = []
-
-    for (const worker of Object.values(workers)) {
-      if (worker.application === 'service-1') {
-        service1Workers.push(worker)
-      }
-      if (worker.application === 'service-2') {
-        service2Workers.push(worker)
-      }
-    }
-
-    assert.strictEqual(service1Workers.length, 1)
-    assert.strictEqual(service2Workers.length, 2)
+    const workers = await waitForWorkers(app, 'service-2', 2)
+    assert.strictEqual(countWorkers(workers, 'service-1'), 1)
+    assert.strictEqual(countWorkers(workers, 'service-2'), 2)
   })
 
   test(`should not scale an application when the scaler is the cooldown(configuration ${name})`, async t => {

--- a/packages/service/test/logger.test.js
+++ b/packages/service/test/logger.test.js
@@ -7,6 +7,39 @@ import { setTimeout as wait } from 'node:timers/promises'
 import { request } from 'undici'
 import { create } from '../index.js'
 
+// The file transport flushes asynchronously, so poll for the expected line
+// instead of waiting a fixed amount of time
+async function waitForLogLine (file, predicate, { timeoutMs = 30000, intervalMs = 250 } = {}) {
+  const start = Date.now()
+
+  while (true) {
+    const logs = []
+    try {
+      for (const line of readFileSync(file, 'utf8').split('\n')) {
+        if (line.trim() === '') {
+          continue
+        }
+        try {
+          logs.push(JSON.parse(line))
+        } catch {
+          // The line has been partially written, it will be retried at the next iteration
+        }
+      }
+    } catch {
+      // The file has not been created yet
+    }
+
+    const found = logs.find(predicate)
+    if (found) {
+      return found
+    }
+    if (Date.now() - start > timeoutMs) {
+      return undefined
+    }
+    await wait(intervalMs)
+  }
+}
+
 test('logger options', async t => {
   process.env.LOG_DIR = path.join(tmpdir(), 'test-logs', Date.now().toString())
   const file = path.join(process.env.LOG_DIR, 'service.log')
@@ -19,23 +52,16 @@ test('logger options', async t => {
   await app.start({ listen: true })
 
   await request(app.url, { path: '/logs' })
-  // wait for logger flush
-  await wait(500)
 
-  const content = readFileSync(file, 'utf8')
-  const logs = content
-    .split('\n')
-    .filter(line => line.trim() !== '')
-    .map(line => JSON.parse(line))
-
-  assert.ok(
-    logs.find(
-      log =>
-        log.level === 'DEBUG' &&
-        log.time.length === 24 && // isotime
-        log.secret === '***HIDDEN***' &&
-        log.name === 'service' &&
-        log.msg === 'call route /logs'
-    )
+  const log = await waitForLogLine(
+    file,
+    log =>
+      log.level === 'DEBUG' &&
+      log.time.length === 24 && // isotime
+      log.secret === '***HIDDEN***' &&
+      log.name === 'service' &&
+      log.msg === 'call route /logs'
   )
+
+  assert.ok(log)
 })

--- a/packages/wattpm-utils/test/import.test.js
+++ b/packages/wattpm-utils/test/import.test.js
@@ -14,6 +14,14 @@ import { prepareRuntime } from '../../basic/test/helper.js'
 import { version } from '../lib/version.js'
 import { changeWorkingDirectory, createTemporaryDirectory, executeCommand, wattpmUtils } from './helper.js'
 
+// These tests perform real npm installs: make npm resilient to transient
+// registry network failures (like ECONNRESET) by retrying more aggressively.
+// The variables are inherited by the package manager processes spawned by
+// the import command.
+process.env.npm_config_fetch_retries = '5'
+process.env.npm_config_fetch_retry_factor = '4'
+process.env.npm_config_fetch_retry_mintimeout = '1000'
+
 const autodetect = {
   astro: 'astro',
   node: null,


### PR DESCRIPTION
## Summary

Four tests produced spurious CI failures across recent runs (observed six times while iterating on the DB fixes stack). All four share the same class of root cause — fixed sleeps or missing resilience against slow/flaky CI environments:

1. **runtime `worker-scaler-1` ELU scale-up** (3 failures: ubuntu + windows): fired a single one-second CPU burst and slept a fixed 10s before asserting the scaler added a worker. On slow runners the burst can be missed by the ELU sampling window or the scale-up lands after the sleep. Now drives sustained load and polls for the expected worker count, reusing the file's existing `driveLoad`/`waitForWorkers` helpers.

2. **service `logger options`** (2 failures: windows): waited a fixed 500ms for the pino file transport to flush. Now polls for the expected log line (30s budget), tolerating a not-yet-created file and partially written lines.

3. **wattpm-utils `import`** (1 failure: `ECONNRESET` from registry.npmjs.org mid-install): these tests run real `npm install`s. npm is now configured (via `npm_config_fetch_retries` etc., inherited by the spawned package managers) to retry transient network failures aggressively.

4. **runtime `multiple-workers` mesh networking** (1 failure: `404 !== 200` right after startup): requests immediately after `app.start()` can race the mesh route registration. `testRoundRobin` now waits for every service to respond 200 before measuring; the warm-up requests don't affect the verification, which is insensitive to the starting worker.

## Test plan

- ELU test: 3 consecutive local runs + whole `worker-scaler-1.test.js` file (15/15).
- `logger.test.js`, `import.test.js` (both no-arg variants), `networking.test.js` (4/4) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF