### PR TITLE
fix(db): create the schema.lock file at boot

### DIFF
--- a/packages/db/lib/application.js
+++ b/packages/db/lib/application.js
@@ -71,6 +71,10 @@ export async function platformaticDatabase (app, capability) {
     await capability.updateContext({ serverConfig })
   }
 
+  await app.register(core, config.db)
+
+  // This must happen after registering the core plugin, which populates
+  // app.platformatic.dbschema
   if (createSchemaLock) {
     try {
       const path = locateSchemaLock(config)
@@ -80,8 +84,6 @@ export async function platformaticDatabase (app, capability) {
       app.log.trace({ err }, 'unable to save schema lock')
     }
   }
-
-  await app.register(core, config.db)
 
   if (config.authorization) {
     await app.register(auth, config.authorization)

--- a/packages/db/test/schemalock-boot.test.js
+++ b/packages/db/test/schemalock-boot.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { readFile, mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { createBasicPages, createFromConfig, getConnectionInfo } from './helper.js'
+
+test('creates the schema.lock file at boot when it does not exist', async t => {
+  /* https://github.com/platformatic/platformatic/issues/4035 */
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+  const directory = await mkdtemp(join(tmpdir(), 'schemalock-boot-'))
+  const schemaLockPath = join(directory, 'schema.lock')
+
+  const app = await createFromConfig(t, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' }
+    },
+    db: {
+      ...connectionInfo,
+      schemalock: {
+        path: schemaLockPath
+      },
+      async onDatabaseLoad (db, sql) {
+        await createBasicPages(db, sql)
+      }
+    }
+  })
+
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+  await app.start({ listen: true })
+
+  const dbschema = JSON.parse(await readFile(schemaLockPath, 'utf-8'))
+  assert.ok(Array.isArray(dbschema), 'schema.lock contains the database schema')
+  assert.ok(
+    dbschema.some(table => table.table === 'pages'),
+    'schema.lock contains the pages table'
+  )
+})


### PR DESCRIPTION
## Summary

With `db.schemalock` enabled and no existing lock file, the boot-time creation never worked: the code ran **before** `app.register(core, ...)`, so `app.platformatic.dbschema` was `undefined` and the `writeFile` failed silently (trace-level log only). Exactly as diagnosed in the issue.

The creation block now runs right after the core plugin has populated `app.platformatic`.

Fixes #4035

## Test plan

New `packages/db/test/schemalock-boot.test.js`: boots an app with `schemalock` pointing at a temp path and asserts the file is created with the introspected schema — fails without the fix, passes with it. Existing schemalock tests (`migrate creates a schema.lock file`) and `start-and-stop` pass.

> Stacked on #4903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF