### PR TITLE
fix(sql-json-schema-mapper): type numeric primary keys as strings

### DIFF
--- a/packages/db/test/fixtures/auto-gen-types-dir/index.tst.ts
+++ b/packages/db/test/fixtures/auto-gen-types-dir/index.tst.ts
@@ -10,5 +10,5 @@ const graphs = await app.platformatic.entities.graph.find()
 expect(graphs).type.toBe<Graph[]>()
 
 const graph = graphs[0]
-expect(graph?.id).type.toBe<number | undefined>()
+expect(graph?.id).type.toBe<string | undefined>()
 expect(graph?.name).type.toBe<string | null | undefined>()

--- a/packages/db/test/fixtures/auto-gen-types-no-plugin/index.tst.ts
+++ b/packages/db/test/fixtures/auto-gen-types-no-plugin/index.tst.ts
@@ -10,5 +10,5 @@ const graphs = await app.platformatic.entities.graph.find()
 expect(graphs).type.toBe<Graph[]>()
 
 const graph = graphs[0]
-expect(graph?.id).type.toBe<number | undefined>()
+expect(graph?.id).type.toBe<string | undefined>()
 expect(graph?.name).type.toBe<string | null | undefined>()

--- a/packages/db/test/fixtures/auto-gen-types/index.tst.ts
+++ b/packages/db/test/fixtures/auto-gen-types/index.tst.ts
@@ -12,7 +12,7 @@ expect(aggregateRatings).type.toBe<Partial<AggregateRating>[]>()
 
 const aggregateRating = aggregateRatings[0] as AggregateRating
 expect(aggregateRating).type.toBe<{
-  id?: number
+  id?: string
   movieId: number
   rating: number
   ratingType: string
@@ -23,7 +23,7 @@ expect(movies).type.toBe<Partial<Movie>[]>()
 
 const movie = movies[0] as Movie
 expect(movie).type.toBe<{
-  id?: number
+  id?: string
   title: string
   boxOffice?: number | null
   year: number

--- a/packages/db/test/fixtures/chars-gen-types/index.tst.ts
+++ b/packages/db/test/fixtures/chars-gen-types/index.tst.ts
@@ -10,5 +10,5 @@ const graphs = await app.platformatic.entities.pltDb.find()
 expect(graphs).type.toBe<PltDb[]>()
 
 const graph = graphs[0]
-expect(graph?.id).type.toBe<number | undefined>()
+expect(graph?.id).type.toBe<string | undefined>()
 expect(graph?.name).type.toBe<string | null | undefined>()

--- a/packages/db/test/fixtures/gen-types-dir/index.tst.ts
+++ b/packages/db/test/fixtures/gen-types-dir/index.tst.ts
@@ -10,5 +10,5 @@ const graphs = await app.platformatic.entities.graph.find()
 expect(graphs).type.toBe<Graph[]>()
 
 const graph = graphs[0]
-expect(graph?.id).type.toBe<number | undefined>()
+expect(graph?.id).type.toBe<string | undefined>()
 expect(graph?.name).type.toBe<string | null | undefined>()

--- a/packages/db/test/fixtures/gen-types/index.tst.ts
+++ b/packages/db/test/fixtures/gen-types/index.tst.ts
@@ -10,7 +10,7 @@ const graphs = await app.platformatic.entities.graph.find()
 expect(graphs).type.toBe<Graph[]>()
 
 const graph = graphs[0]
-expect(graph?.id).type.toBe<number | undefined>()
+expect(graph?.id).type.toBe<string | undefined>()
 expect(graph?.name).type.toBe<string | null | undefined>()
 
 app.platformatic.addEntityHooks('graph', {
@@ -20,7 +20,7 @@ app.platformatic.addEntityHooks('graph', {
 
     return [
       {
-        id: 42
+        id: '42'
       }
     ]
   }

--- a/packages/sql-json-schema-mapper/index.js
+++ b/packages/sql-json-schema-mapper/index.js
@@ -188,6 +188,11 @@ function renderProperties (
       types = [type]
     }
 
+    // The mapper always returns primary keys as strings
+    if (fieldDefinitions[name]?.primaryKey) {
+      types = Array.from(new Set(types.map(t => (t === 'integer' || t === 'number' ? 'string' : t))))
+    }
+
     if (nullable && types.indexOf('null') === -1) {
       types.push('null')
     }

--- a/packages/sql-json-schema-mapper/test/types.test.js
+++ b/packages/sql-json-schema-mapper/test/types.test.js
@@ -11,7 +11,13 @@ if (structuredClone === undefined) {
 function referenceTest (name, obj, opts = {}) {
   const { only } = opts
   test(name, { only }, async t => {
-    const reference = await dtsgenerator.default({ contents: [parseSchema(structuredClone(obj))] })
+    let reference = await dtsgenerator.default({ contents: [parseSchema(structuredClone(obj))] })
+    // Unlike dtsgenerator, numeric primary keys are intentionally rendered as
+    // strings, because that is what the mapper returns at runtime
+    reference = reference.replace(/^(\s*id\??): (.+);$/m, (_, prefix, union) => {
+      const members = Array.from(new Set(union.split(' | ').map(t => (t === 'number' ? 'string' : t))))
+      return `${prefix}: ${members.join(' | ')};`
+    })
     const cloned = structuredClone(obj)
     const ours = mapOpenAPItoTypes(cloned, { id: { primaryKey: true } })
     notEqual(cloned, obj)
@@ -231,5 +237,40 @@ test('bytea fields are mapped to Buffer type', async t => {
   same(result.includes('content?: Buffer;'), true, 'bytea field should be mapped to Buffer type')
   // Verify that non-bytea fields are mapped normally
   same(result.includes('metadata?: string;'), true, 'non-bytea string field should be mapped to string type')
-  same(result.includes('id: number;'), true, 'id field should be mapped to number type')
+  // The mapper always returns primary keys as strings
+  same(result.includes('id: string;'), true, 'primary key field should be mapped to string type')
+})
+
+test('numeric primary keys are mapped to string type', async t => {
+  /* https://github.com/platformatic/platformatic/issues/3862 */
+  const schema = {
+    id: 'User',
+    title: 'User',
+    description: 'A User',
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer'
+      },
+      age: {
+        type: 'integer'
+      },
+      name: {
+        type: 'string'
+      }
+    },
+    required: ['id']
+  }
+
+  const fieldDefinitions = {
+    id: { primaryKey: true, sqlType: 'integer' },
+    age: { sqlType: 'integer' },
+    name: { sqlType: 'varchar' }
+  }
+
+  const result = mapOpenAPItoTypes(schema, fieldDefinitions)
+
+  same(result.includes('id: string;'), true, 'the primary key is typed as string, like the mapper returns it')
+  same(result.includes('age?: number;'), true, 'other numeric fields keep the number type')
+  same(result.includes('name?: string;'), true, 'string fields keep the string type')
 })


### PR DESCRIPTION
## Summary

The mapper always returns primary keys as **strings** (`fixOutput` casts them for GraphQL `ID` compatibility), but the generated TypeScript entity interfaces declared numeric primary keys as `number`. The result — exactly the failure mode reported in the issue:

```ts
users.find(u => u.id === 1)   // type-checks, always undefined at runtime
users.find(u => u.id === '1') // works at runtime, but doesn't match the declared type
```

Numeric primary keys are now typed as `string` in the generated entity interfaces, matching what the runtime actually returns — so the broken comparison above becomes a compile-time error.

Notes:
- Only the **TypeScript generation** changes (`mapOpenAPItoTypes`); the JSON/OpenAPI schemas are untouched, so REST responses are unaffected.
- Union types (`['integer','string']`) are mapped and deduplicated.
- The dtsgenerator parity tests document the intentional deviation.

Fixes #3862

## Test plan

- New dedicated test in `sql-json-schema-mapper` (PK → string, other numerics unchanged); full package suite passes (16/16).
- `packages/db` gen-types suite updated (fixtures asserted the buggy `number` typing, including a hook returning `{id: 42}`) and passes 11/11 — the failures before updating the fixtures were TS correctly rejecting numeric ids, demonstrating the fix.

> Stacked on #4905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF