### PR TITLE
docs(sql-graphql): state explicitly that delete mutations remove multiple entities

### DIFF
--- a/docs/reference/sql-graphql/mutations.md
+++ b/docs/reference/sql-graphql/mutations.md
@@ -104,7 +104,19 @@ main()
 ## `delete[ENTITIES]`
 
 Deletes one or more entities from the database, based on the `where` clause
-passed as an input to the mutation.
+passed as an input to the mutation. All the rows matching the clause are
+deleted in a single mutation and returned in the response, e.g.:
+
+```graphql
+mutation {
+  deletePages(where: { status: { eq: "draft" } }) {
+    id
+    title
+  }
+}
+```
+
+deletes every draft page and returns them.
 
 ### Example
 


### PR DESCRIPTION
## Summary

The `delete[ENTITIES]` mutation documentation only showed a single-row deletion example. It now states explicitly that all rows matching the `where` clause are deleted in a single mutation and returned, with a multi-row example.

Fixes #250

> Stacked on #4907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF