### PR TITLE
docs(db): webhook user metadata is returned in the response body

### DIFF
--- a/docs/reference/db/authorization/strategies.md
+++ b/docs/reference/db/authorization/strategies.md
@@ -147,12 +147,16 @@ the same body and headers, except for:
 - `host`
 - `connection`
 
-<!--
-TODO: Is this correct? Code looks like it's getting data from the response body:
-https://github.com/platformatic/platformatic/blob/main/packages/db-authorization/lib/webhook.js#L45-L46
--->
+If the webhook responds with a status code above 299, the request is rejected as unauthorized. Otherwise, the webhook must return the user metadata (including the roles) as a **JSON object in the response body**, e.g.:
 
-In the Webhook case, the HTTP response contains the roles/user information as HTTP headers.
+```json
+{
+  "X-PLATFORMATIC-USER-ID": 42,
+  "X-PLATFORMATIC-ROLE": "user"
+}
+```
+
+The returned object becomes the user metadata for the request, exactly as if it had been extracted from a JWT.
 
 ## HTTP headers (development only)
 


### PR DESCRIPTION
## Summary

The webhook authorization docs stated that *"the HTTP response contains the roles/user information as HTTP headers"* — but the implementation (`fastify-user`'s webhook strategy) reads the user metadata from the **JSON response body** (`this.user = await res.body.json()`), rejecting on status codes above 299. The docs even carried a TODO comment doubting the sentence.

The section now documents the actual contract with an example payload.

Fixes #297

> Stacked on #4908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF