### PR TITLE
docs(sql-mapper): document client-generated primary keys

### DIFF
--- a/docs/reference/sql-mapper/entities/api.md
+++ b/docs/reference/sql-mapper/entities/api.md
@@ -286,6 +286,20 @@ async function main() {
 main()
 ```
 
+#### Client-generated primary keys
+
+The primary key does not have to be database-generated: to build idempotent services, provide the primary key value in the input and it will be used as-is. This works with every supported primary key type, including UUIDs:
+
+```js
+await mapper.entities.page.insert({
+  inputs: [
+    { id: '00000000-0000-0000-0000-000000000042', title: 'Foobar' }
+  ]
+})
+```
+
+The same applies to the generated REST (`POST /pages`) and GraphQL (`savePage`/`insertPages`) APIs. To reject client-provided primary keys in the REST API instead, set `db.openapi.allowPrimaryKeysInInput` to `false`.
+
 ### `save`
 
 Create a new entity row in the database or update an existing one.


### PR DESCRIPTION
## Summary

The issue asked to verify and document that clients can generate primary key values themselves (for idempotent services) instead of relying on autogenerated ones.

Verified: explicit primary key values work on insert/save for every supported key type — covered by the `insert with explicit integer PK value` / `insert with explicit uuid PK value` tests in sql-mapper (and extended to NUMBER/NUMERIC/BIGINT/TEXT keys by #4890). This adds a *Client-generated primary keys* section to the entities API docs, including the REST/GraphQL angle and the `allowPrimaryKeysInInput: false` opt-out.

Fixes #536

> Stacked on #4910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF