### PR TITLE
docs(db): document how to access the JWT/webhook user in custom plugins

### DIFF
--- a/docs/reference/db/plugin.md
+++ b/docs/reference/db/plugin.md
@@ -45,6 +45,27 @@ app.post('/', async (req, reply) => {
 })
 ```
 
+## Accessing the Authenticated User
+
+When [authorization](./authorization/overview.md) is configured (JWT, webhook or the development headers), custom routes can access the authenticated user's metadata by populating it explicitly with `request.setupDBAuthorizationUser()`:
+
+```js
+export default async function (app) {
+  app.get('/whoami', async (req, reply) => {
+    await req.setupDBAuthorizationUser()
+
+    // req.user contains the metadata extracted from the JWT claims
+    // or returned by the webhook
+    return {
+      userId: req.user['X-PLATFORMATIC-USER-ID'],
+      roles: req.user['X-PLATFORMATIC-ROLE']
+    }
+  })
+}
+```
+
+Unauthenticated requests leave `req.user` undefined, so remember to handle that case. When accessing entities on behalf of the user, prefer passing `ctx` (see above): the authorization rules are then enforced automatically.
+
 ## Running Custom SQL Queries
 
 Besides the generated entities, plugins can run any SQL query through `app.platformatic.db` and the `app.platformatic.sql` template tag, which safely interpolates values as query parameters:


### PR DESCRIPTION
## Summary

Custom plugins can use the configured authentication (JWT/webhook) via `await req.setupDBAuthorizationUser()` + `req.user`, but this was only mentioned in passing on the user-metadata page. Added an *Accessing the Authenticated User* section to the plugin docs with a working route example, the unauthenticated caveat, and the pointer to `ctx`-based entity access for rule enforcement.

Fixes #311

> Stacked on #4913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF