### PR TITLE
docs(db): clarify that Platformatic DB works with an existing database

### DIFF
--- a/docs/reference/db/overview.md
+++ b/docs/reference/db/overview.md
@@ -11,6 +11,17 @@ The Database Service supports PostgreSQL, MySQL, MariaDB, and SQLite, automatica
 
 For a high level overview of how Watt and its applications work, please reference the [Overview](../../Overview.md) guide.
 
+## Using an Existing Database
+
+Platformatic DB works out of the box with an **existing database**: point `db.connectionString` at it and the schema is introspected automatically — no migrations are required. The `migrations` configuration is entirely optional and only needed if you want Platformatic to manage schema changes for you.
+
+A few conventions to be aware of when mapping an existing schema:
+
+- Table names are mapped to entities: `snake_case` names are converted to camelCase, and the entity gets both a singular (`movie`) and a plural (`movies`) form. A table named `movies` is exposed as `GET /movies` and the `Movie` GraphQL type.
+- Column names are camelCased in the same way (`created_at` → `createdAt`).
+- Relationships are discovered from foreign key constraints; join tables with composite primary keys are treated as many-to-many relationships.
+- Tables can be excluded (or explicitly included) with `db.ignore` / `db.include`, and `created_at`/`updated_at` handling can be disabled or renamed with `db.autoTimestamp`.
+
 ## Features
 
 ### Automatic API Generation


### PR DESCRIPTION
## Summary

The docs never stated explicitly that Platformatic DB can be pointed at an existing database without any migrations. Added a *Using an Existing Database* section to the Database Service overview covering:

- migrations are optional — introspection is automatic from `connectionString`
- expected naming conventions (snake_case → camelCase, singular/plural entity forms)
- relationship discovery from foreign keys, many-to-many via composite-key join tables
- `include`/`ignore` and `autoTimestamp` knobs for adapting to existing schemas

Fixes #1233

> Stacked on #4914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF