### PR TITLE
docs(db): document user metadata access in custom GraphQL resolvers

### DIFF
--- a/docs/reference/db/authorization/user-roles-metadata.md
+++ b/docs/reference/db/authorization/user-roles-metadata.md
@@ -110,4 +110,25 @@ await request.setupDBAuthorizationUser();
 const userRoles = request.user.roles;
 ```
 
+### Accessing user metadata in custom GraphQL resolvers
+
+In a custom [mercurius](https://mercurius.dev) resolver, the Fastify request is available under `context.reply.request`, so the same pattern applies:
+
+```javascript
+app.graphql.extendSchema(`
+  extend type Query {
+    whoami: String
+  }
+`);
+app.graphql.defineResolvers({
+  Query: {
+    whoami: async (source, args, context) => {
+      const request = context.reply.request;
+      await request.setupDBAuthorizationUser();
+      return request.user?.["X-PLATFORMATIC-USER-ID"];
+    }
+  }
+});
+```
+
 <Issues />


### PR DESCRIPTION
## Summary

Documents how to access `request.user` from a custom mercurius resolver — the Fastify request lives at `context.reply.request` in the resolver context, then `setupDBAuthorizationUser()` populates the metadata exactly as in REST routes. Added to the user-metadata page next to the existing REST example.

Fixes #1237

> Stacked on #4916.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF