### PR TITLE
docs(sql-openapi): fill remaining API reference gaps

### DIFF
--- a/docs/reference/sql-openapi/api.md
+++ b/docs/reference/sql-openapi/api.md
@@ -90,6 +90,8 @@ You can define the ordering of the returned rows within your REST API calls with
 - **Field**: One of the fields found in the schema.
 - **Value**: can be `asc` or `desc`.
 
+Multiple `orderby.[field]` parameters can be combined, and the rows are sorted by each of them in the order they appear in the query string, e.g. `?orderby.year=desc&orderby.title=asc`.
+
 **Example**
 
 To get the `pages` ordered alphabetically by their `titles`, make an HTTP request like this:
@@ -328,7 +330,18 @@ This returns the entity in the "join table", e.g. `GET /editors/page/1/user/1`.
 
 ### `POST [P_ENTITY]/[S_REL_1]/[KEY_REL_1]/[S_REL_2]/[KEY_REL_2]`
 
-Creates a new entity in the "join table", e.g. `POST /editors/page/1/user/1`.
+Creates a new entity in the "join table", e.g. `POST /editors/page/1/user/1`. The body contains the remaining fields of the join table (the two keys come from the URL):
+
+```bash
+$ curl -X 'POST' \
+  'http://localhost:3042/editors/page/1/user/1' \
+  -H 'Content-Type: application/json' \
+  -d '{ "role": "admin" }'
+
+{ "pageId": 1, "userId": 1, "role": "admin" }
+```
+
+`PUT` accepts the same body.
 
 ### `PUT [P_ENTITY]/[S_REL_1]/[KEY_REL_1]/[S_REL_2]/[KEY_REL_2]`
 
@@ -532,3 +545,22 @@ $ curl -X 'POST' \
   "body": "Welcome to Platformatic"
 }
 ```
+
+
+## Standalone Usage
+
+`@platformatic/sql-openapi` can also be used directly in any Fastify application, together with `@platformatic/sql-mapper`:
+
+```js
+import fastify from 'fastify'
+import sqlMapper from '@platformatic/sql-mapper'
+import sqlOpenAPI from '@platformatic/sql-openapi'
+
+const app = fastify()
+await app.register(sqlMapper, { connectionString: 'postgres://...' })
+await app.register(sqlOpenAPI)
+
+await app.listen({ port: 3042 })
+```
+
+All the options described on this page (`prefix`, `ignore`, `ignoreRoutes`, `allowPrimaryKeysInInput`, ...) can be passed to the plugin registration.


### PR DESCRIPTION
## Summary

Addresses the remaining unchecked items from the issue's checklist:

- **multiple `orderby.[field]` parameters** — now documented with an example
- **many-to-many POST/PUT example bodies** — added a cURL example showing the body shape (keys in the URL, remaining fields in the body)
- **standalone usage** — new section showing `@platformatic/sql-openapi` + `@platformatic/sql-mapper` in a plain Fastify app

Already resolved since the issue was filed: the Fields section markdown renders correctly, the default limit is documented as configurable (`db.limit`), `like`/`ilike` were added to the where-operator table in #4894, and pagination has its own section.

Fixes #1234

> Stacked on #4917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF