### PR TITLE
fix(gateway,db): honour openapi.swaggerPrefix in the root page links

### DIFF
--- a/packages/db/lib/root.js
+++ b/packages/db/lib/root.js
@@ -1,21 +1,38 @@
 import fastifyStatic from '@fastify/static'
 import userAgentParser from 'my-ua-parser'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-export async function root (app) {
+export async function root (app, config) {
   app.register(fastifyStatic, {
     root: path.join(import.meta.dirname, '../public')
   })
+
+  const swaggerPrefix = config.db?.openapi?.swaggerPrefix
+  let indexPage
+
+  async function loadIndexPage () {
+    if (!indexPage) {
+      const html = await readFile(path.join(import.meta.dirname, '../public/index.html'), 'utf8')
+      const openapiRoute = JSON.stringify(swaggerPrefix.replace(/^\/+/, ''))
+      indexPage = html.replace('</head>', `<script>window.PLT_OPENAPI_ROUTE = ${openapiRoute}</script></head>`)
+    }
+    return indexPage
+  }
+
   // root endpoint
   app.route({
     method: 'GET',
     path: '/',
     schema: { hide: true },
-    handler: (req, reply) => {
+    handler: async (req, reply) => {
       const uaString = req.headers['user-agent']
       if (uaString) {
         const parsed = userAgentParser(uaString)
         if (parsed.browser.name !== undefined) {
+          if (swaggerPrefix) {
+            return reply.type('text/html').send(await loadIndexPage())
+          }
           return reply.sendFile('./index.html')
         }
       }

--- a/packages/db/public/index.html
+++ b/packages/db/public/index.html
@@ -199,7 +199,7 @@
       }
     
       const openApiLink = document.getElementById('openapi-link')
-      openApiLink.href = currentPath + 'documentation'
+      openApiLink.href = currentPath + (window.PLT_OPENAPI_ROUTE || 'documentation')
 
       const graphqlLink = document.getElementById('graphql-link')
       graphqlLink.href = currentPath + 'graphiql'

--- a/packages/db/test/routes.test.js
+++ b/packages/db/test/routes.test.js
@@ -149,3 +149,42 @@ test('should not overwrite a plugin which uses @fastify/static on root', async t
   const expected = await readFile(join(import.meta.dirname, 'fixtures', 'hello', 'index.html'), 'utf8')
   assert.equal(body, expected)
 })
+
+test('the root page uses the configured openapi.swaggerPrefix', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1924 */
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+
+  const app = await createFromConfig(t, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' }
+    },
+    db: {
+      ...connectionInfo,
+      openapi: {
+        swaggerPrefix: '/custom-docs'
+      }
+    }
+  })
+
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+  await app.start({ listen: true })
+
+  const res = await request(`${app.url}/`, {
+    headers: {
+      'user-agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36'
+    }
+  })
+  const html = await res.body.text()
+  assert.equal(res.statusCode, 200)
+  assert.ok(html.includes('window.PLT_OPENAPI_ROUTE = "custom-docs"'))
+
+  // the OpenAPI documentation is actually served under the custom prefix
+  const docs = await request(`${app.url}/custom-docs/json`)
+  assert.equal(docs.statusCode, 200)
+})

--- a/packages/gateway/lib/openapi-scalar.js
+++ b/packages/gateway/lib/openapi-scalar.js
@@ -4,11 +4,11 @@ async function openApiScalarPlugin (app, opts) {
   const { default: scalarTheme } = await import('@platformatic/scalar-theme')
   const { default: scalarApiReference } = await import('@scalar/fastify-api-reference')
 
-  /** Serve spec file in yaml and json */
-  app.get('/documentation/json', { schema: { hide: true } }, async () => app.swagger())
-  app.get('/documentation/yaml', { schema: { hide: true } }, async () => app.swagger({ yaml: true }))
-
   const routePrefix = opts.openapi?.swaggerPrefix || '/documentation'
+
+  /** Serve spec file in yaml and json */
+  app.get(`${routePrefix}/json`, { schema: { hide: true } }, async () => app.swagger())
+  app.get(`${routePrefix}/yaml`, { schema: { hide: true } }, async () => app.swagger({ yaml: true }))
 
   await app.register(scalarApiReference, {
     logLevel: 'warn',

--- a/packages/gateway/lib/root.js
+++ b/packages/gateway/lib/root.js
@@ -61,9 +61,12 @@ export default function root (app) {
             }
           })
 
+          const swaggerPrefix = app.platformatic.config.gateway.openapi?.swaggerPrefix || '/documentation'
+
           return reply.view('index.njk', {
             hasGraphQLServices,
             hasOpenAPIServices,
+            openapiRoute: swaggerPrefix.replace(/^\/+/, ''),
             services: serviceTypes
           })
         }

--- a/packages/gateway/public/index.njk
+++ b/packages/gateway/public/index.njk
@@ -19,7 +19,7 @@
         <p class="text-desktop-display"><span>Welcome to</span><br/><span class="text-main-green">Platformatic Gateway</span></p>
         <div class="button-container">
           {% if hasOpenAPIServices %}
-          <a id="openapi-link" target="_blank" class="button-link" href="documentation">
+          <a id="openapi-link" target="_blank" class="button-link" href="{{ openapiRoute }}">
             <img src="./images/openapi.svg" />
             OpenAPI Documentation
           </a>

--- a/packages/gateway/test/openapi/root-endpoint.test.js
+++ b/packages/gateway/test/openapi/root-endpoint.test.js
@@ -215,3 +215,58 @@ test('should have links to composed applications', async t => {
 
   assert.ok(content.includes("const href = window.location.href.replace(/\\/$/, '')"))
 })
+
+test('should honour openapi.swaggerPrefix in the root page and spec routes', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1924 */
+  const api = await createOpenApiApplication(t, ['users'])
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'api1',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json'
+          }
+        }
+      ],
+      openapi: {
+        swaggerPrefix: '/custom-docs'
+      }
+    }
+  })
+
+  {
+    // The root page links to the configured prefix
+    const { statusCode, body } = await gateway.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36'
+      }
+    })
+    assert.equal(statusCode, 200)
+    assert.ok(body.includes('href="custom-docs"'))
+    assert.ok(!body.includes('href="documentation"'))
+  }
+
+  {
+    // The spec routes follow the configured prefix
+    const { statusCode, body } = await gateway.inject({ method: 'GET', url: '/custom-docs/json' })
+    assert.equal(statusCode, 200)
+    assert.ok(JSON.parse(body).openapi)
+  }
+
+  {
+    const { statusCode } = await gateway.inject({ method: 'GET', url: '/custom-docs/yaml' })
+    assert.equal(statusCode, 200)
+  }
+})


### PR DESCRIPTION
## What

Fixes #1924.

The welcome pages of Platformatic DB and Gateway hardcoded the `documentation` link, so configuring a custom `openapi.swaggerPrefix` left the root page pointing at a 404. Additionally, the gateway served the JSON/YAML spec routes at `/documentation/{json,yaml}` regardless of the configured prefix, while the Scalar UI itself moved to the custom prefix.

## Changes

- **gateway**: the root page template now receives the configured `openapi.swaggerPrefix` and links to it; the `/json` and `/yaml` spec routes follow the prefix too (`openapi-scalar.js`).
- **db**: when a custom `swaggerPrefix` is configured, the served welcome page injects `window.PLT_OPENAPI_ROUTE` and the page script uses it (falling back to `documentation`, so the static file keeps working standalone). `sql-openapi` already honoured the prefix for the docs routes.
- Regression tests in both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF