### PR TITLE
fix(runtime): make the shared tmp directories usable by every user

### DIFF
--- a/packages/basic/lib/worker/child-manager.js
+++ b/packages/basic/lib/worker/child-manager.js
@@ -1,4 +1,4 @@
-import { createDirectory, ensureLoggableError } from '@platformatic/foundation'
+import { createSharedTemporaryDirectory, ensureLoggableError } from '@platformatic/foundation'
 import { getLogger, updateGlobals } from '@platformatic/globals'
 import { ITC } from '@platformatic/itc/lib/index.js'
 import { randomBytes } from 'node:crypto'
@@ -7,7 +7,7 @@ import { rm, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { createRequire, register } from 'node:module'
 import { platform, tmpdir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { request } from 'undici'
 import { WebSocketServer } from 'ws'
@@ -85,7 +85,7 @@ export class ChildManager extends ITC {
     super.listen()
 
     if (!isWindows) {
-      await createDirectory(dirname(this.#socketPath))
+      await createSharedTemporaryDirectory('platformatic', 'runtimes')
     }
 
     this.#websocketServer = new WebSocketServer({ server: this.#server })
@@ -145,9 +145,9 @@ export class ChildManager extends ITC {
 
     // Serialize data into a JSON file for the capability to use
     this.#dataPath = resolve(tmpdir(), 'platformatic', 'runtimes', `${this.#id}.json`)
-    await createDirectory(dirname(this.#dataPath))
+    await createSharedTemporaryDirectory('platformatic', 'runtimes')
 
-    // We write all the data to a JSON file
+    // We write all the data to a JSON file, readable by the current user only
     await writeFile(
       this.#dataPath,
       JSON.stringify(
@@ -159,7 +159,7 @@ export class ChildManager extends ITC {
         null,
         2
       ),
-      'utf-8'
+      { encoding: 'utf-8', mode: 0o600 }
     )
 
     process.env.PLT_MANAGER_ID = this.#id

--- a/packages/foundation/index.d.ts
+++ b/packages/foundation/index.d.ts
@@ -197,6 +197,7 @@ export declare function generateDashedName (): string
 export declare function isFileAccessible (filename: string, directory?: string): Promise<boolean>
 export declare function createDirectory (path: string, empty?: boolean): Promise<string | undefined>
 export declare function createTemporaryDirectory (prefix: string): Promise<string>
+export declare function createSharedTemporaryDirectory (...segments: string[]): Promise<string>
 export declare function safeRemove (path: string): Promise<void>
 export declare function searchFilesWithExtensions (
   root: string,

--- a/packages/foundation/lib/file-system.js
+++ b/packages/foundation/lib/file-system.js
@@ -1,8 +1,8 @@
 import generateName from 'boring-name-generator'
 import { EventEmitter } from 'node:events'
 import { existsSync } from 'node:fs'
-import { access, glob, mkdir, rm, watch } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { access, chmod, glob, mkdir, rm, watch } from 'node:fs/promises'
+import { platform, tmpdir } from 'node:os'
 import { join, matchesGlob, resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { PathOptionRequiredError } from './errors.js'
@@ -40,6 +40,27 @@ export async function createTemporaryDirectory (prefix) {
   const directory = join(tmpdir(), `plt-utils-${prefix}-${process.pid}-${tmpCount++}`)
 
   return createDirectory(directory)
+}
+
+// Directories under os.tmpdir() shared by every user running Platformatic must be
+// writable by all of them, like os.tmpdir() itself. The mode passed to mkdir is
+// masked with the process umask, so chmod each segment explicitly; chmod failures
+// are ignored as the segment might be owned by another user.
+export async function createSharedTemporaryDirectory (...segments) {
+  let directory = tmpdir()
+
+  for (const segment of segments) {
+    directory = join(directory, segment)
+    await mkdir(directory, { recursive: true, maxRetries: 10, retryDelay: 1000 })
+
+    if (platform() !== 'win32') {
+      try {
+        await chmod(directory, 0o1777)
+      } catch {}
+    }
+  }
+
+  return directory
 }
 
 export async function safeRemove (path) {

--- a/packages/foundation/test/file-system.test.js
+++ b/packages/foundation/test/file-system.test.js
@@ -1,12 +1,13 @@
 import { deepEqual, equal, match, ok, throws } from 'node:assert'
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, stat, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import { basename, join, sep } from 'node:path'
 import { test } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
 import {
   createDirectory,
+  createSharedTemporaryDirectory,
   createTemporaryDirectory,
   FileWatcher,
   generateDashedName,
@@ -344,4 +345,30 @@ test('FileWatcher - should handle watchIgnore with duplicates', async t => {
   equal(fileWatcher.watchIgnore.length, 2)
   ok(fileWatcher.watchIgnore.includes('ignore.file'))
   ok(fileWatcher.watchIgnore.includes('ignore2.file'))
+})
+
+test('createSharedTemporaryDirectory - creates world-writable segments with the sticky bit', { skip: process.platform === 'win32' }, async t => {
+  const root = `plt-test-shared-${process.pid}-${generateDashedName()}`
+  t.after(() => safeRemove(join(os.tmpdir(), root)))
+
+  const directory = await createSharedTemporaryDirectory(root, 'nested')
+  equal(directory, join(os.tmpdir(), root, 'nested'))
+
+  const rootStat = await stat(join(os.tmpdir(), root))
+  equal(rootStat.mode & 0o7777, 0o1777)
+
+  const nestedStat = await stat(directory)
+  equal(nestedStat.mode & 0o7777, 0o1777)
+})
+
+test('createSharedTemporaryDirectory - fixes the permissions of existing directories', { skip: process.platform === 'win32' }, async t => {
+  const root = `plt-test-shared-${process.pid}-${generateDashedName()}`
+  t.after(() => safeRemove(join(os.tmpdir(), root)))
+
+  await mkdir(join(os.tmpdir(), root), { mode: 0o755 })
+
+  await createSharedTemporaryDirectory(root)
+
+  const rootStat = await stat(join(os.tmpdir(), root))
+  equal(rootStat.mode & 0o7777, 0o1777)
 })

--- a/packages/runtime/lib/management-api.js
+++ b/packages/runtime/lib/management-api.js
@@ -3,11 +3,13 @@ import fastifyWebsocket from '@fastify/websocket'
 import {
   applications as applicationSchema,
   createDirectory,
+  createSharedTemporaryDirectory,
   kMetadata,
   safeRemove,
   validate
 } from '@platformatic/foundation'
 import fastify from 'fastify'
+import { chmod } from 'node:fs/promises'
 import { platform, tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -343,7 +345,14 @@ export async function startManagementApi (runtime, config) {
 
   const runtimePIDDir = join(PLATFORMATIC_TMP_DIR, runtimePID.toString())
   if (platform() !== 'win32') {
-    await createDirectory(customSocket ? dirname(customSocket) : runtimePIDDir, typeof customSocket !== 'string')
+    if (customSocket) {
+      await createDirectory(dirname(customSocket))
+    } else {
+      await createSharedTemporaryDirectory('platformatic', 'runtimes')
+      await createDirectory(runtimePIDDir, true)
+      // The socket must only be accessible by the current user
+      await chmod(runtimePIDDir, 0o700)
+    }
   }
 
   let socketPath = null

--- a/packages/runtime/test/management-api/socket-permissions.test.js
+++ b/packages/runtime/test/management-api/socket-permissions.test.js
@@ -1,0 +1,37 @@
+import { equal } from 'node:assert'
+import { stat } from 'node:fs/promises'
+import { platform, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { createRuntime } from '../helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', '..', 'fixtures')
+
+test('shared tmp directories are world-writable while the socket directory is private', async t => {
+  /* https://github.com/platformatic/platformatic/issues/2847 */
+  if (platform() === 'win32') {
+    t.skip('Unix socket permissions test skipped on Windows')
+    return
+  }
+
+  const projectDir = join(fixturesDir, 'management-api-without-metrics')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const sharedRoot = join(tmpdir(), 'platformatic')
+  const runtimesDir = join(sharedRoot, 'runtimes')
+  const pidDir = join(runtimesDir, process.pid.toString())
+
+  // Shared directories must be writable by every user, like os.tmpdir() itself
+  equal((await stat(sharedRoot)).mode & 0o7777, 0o1777)
+  equal((await stat(runtimesDir)).mode & 0o7777, 0o1777)
+
+  // The directory containing the management API socket is only accessible by the current user
+  equal((await stat(pidDir)).mode & 0o7777, 0o700)
+})


### PR DESCRIPTION
## What

Fixes #2847.

On a multi-user system, the first user running Platformatic owned `/tmp/platformatic` (created with the default `0755 & ~umask` mode), so every other user failed with `EACCES: permission denied, mkdir '/tmp/platformatic/runtimes/<pid>'` when starting a runtime.

## Changes

Following the direction outlined in the issue:

- New `createSharedTemporaryDirectory()` helper in `@platformatic/foundation`: creates each shared segment under `os.tmpdir()` and chmods it to `1777` (world-writable + sticky bit, like `os.tmpdir()` itself). Chmod failures are ignored for segments owned by other users.
- `startManagementApi` uses it for `/tmp/platformatic/runtimes`, and restricts the per-PID directory containing the management API socket to `0700` so the socket is only accessible by the current user.
- `@platformatic/basic`'s `ChildManager` uses the helper for its socket/data paths and writes the context JSON with mode `0600`.
- Unit tests for the helper (including fixing permissions of pre-existing directories) and an integration test asserting the runtime's directory modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF