### PR TITLE
fix(gateway): name conflicting applications in the path-conflict error and normalize prefixes

### DIFF
--- a/packages/gateway/lib/errors.js
+++ b/packages/gateway/lib/errors.js
@@ -11,7 +11,10 @@ export const FailedToFetchOpenAPISchemaError = createError(
   'Failed to fetch OpenAPI schema from %s'
 )
 export const ValidationErrors = createError(`${ERROR_PREFIX}_VALIDATION_ERRORS`, 'Validation errors: %s')
-export const PathAlreadyExistsError = createError(`${ERROR_PREFIX}_PATH_ALREADY_EXISTS`, 'Path "%s" already exists')
+export const PathAlreadyExistsError = createError(
+  `${ERROR_PREFIX}_PATH_ALREADY_EXISTS`,
+  'Path "%s" is exposed by both the "%s" and the "%s" applications. Set a different openapi.prefix on one of them to resolve the conflict.'
+)
 export const CouldNotReadOpenAPIConfigError = createError(
   `${ERROR_PREFIX}_COULD_NOT_READ_OPENAPI_CONFIG`,
   'Could not read openapi config for "%s" application'

--- a/packages/gateway/lib/openapi-composer.js
+++ b/packages/gateway/lib/openapi-composer.js
@@ -36,6 +36,7 @@ function namespaceSchemaOperationIds (apiPrefix, schema) {
 
 export function composeOpenApi (apis, options = {}) {
   const mergedPaths = {}
+  const mergedPathOwners = {}
   const mergedSchemas = {}
   const mergedSecuritySchemes = {}
 
@@ -62,9 +63,10 @@ export function composeOpenApi (apis, options = {}) {
       const mergedPath = prefix ? prefix + path : path
 
       if (mergedPaths[mergedPath]) {
-        throw new PathAlreadyExistsError(mergedPath)
+        throw new PathAlreadyExistsError(mergedPath, mergedPathOwners[mergedPath], id)
       }
       mergedPaths[mergedPath] = pathSchema
+      mergedPathOwners[mergedPath] = id
     }
 
     if (components) {

--- a/packages/gateway/lib/openapi-generator.js
+++ b/packages/gateway/lib/openapi-generator.js
@@ -9,7 +9,7 @@ import { composeOpenApi } from './openapi-composer.js'
 import { loadOpenApiConfig } from './openapi-load-config.js'
 import { modifyOpenApiSchema, originPathSymbol } from './openapi-modifier.js'
 import { openApiScalar } from './openapi-scalar.js'
-import { prefixWithSlash } from './utils.js'
+import { normalizePrefix, prefixWithSlash } from './utils.js'
 
 async function fetchOpenApiSchema (openApiUrl) {
   const { body } = await request(openApiUrl)
@@ -163,7 +163,7 @@ export async function openApiGenerator (app, opts) {
 
     const schema = modifyOpenApiSchema(app, originSchema, openapiConfig)
 
-    const prefix = openapi.prefix ? prefixWithSlash(openapi.prefix) : ''
+    const prefix = normalizePrefix(openapi.prefix)
     for (const path in schema.paths) {
       apiByApiRoutes[prefix + path] = {
         origin,

--- a/packages/gateway/lib/utils.js
+++ b/packages/gateway/lib/utils.js
@@ -5,6 +5,16 @@ export function prefixWithSlash (url) {
   return ''
 }
 
+// Normalize an application prefix so that it always starts with a slash and
+// never ends with one, avoiding double slashes in the composed paths.
+export function normalizePrefix (prefix) {
+  if (typeof prefix !== 'string') {
+    return ''
+  }
+
+  return prefixWithSlash(prefix).replace(/\/+$/, '')
+}
+
 /**
  * detect if a application if fetchable, so if it has configuration to retrieve schema info (openapi or gql)
  * a application can have openapi and/or gql either from a remote application or from file

--- a/packages/gateway/test/openapi/routes-composition.test.js
+++ b/packages/gateway/test/openapi/routes-composition.test.js
@@ -750,3 +750,58 @@ test('should proxy custom content types via config in OpenAPI composition', asyn
   assert.equal(response.contentType, 'application/custom-type')
   assert.equal(response.bodyLength, customData.length)
 })
+
+test('should normalize prefixes without leading slash or with trailing slash', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1242 */
+  const api1 = await createOpenApiApplication(t, ['users'])
+  const api2 = await createOpenApiApplication(t, ['posts'])
+
+  await api1.listen({ port: 0 })
+  await api2.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'api1',
+          origin: 'http://127.0.0.1:' + api1.server.address().port,
+          openapi: {
+            url: '/documentation/json',
+            prefix: 'api1/'
+          }
+        },
+        {
+          id: 'api2',
+          origin: 'http://127.0.0.1:' + api2.server.address().port,
+          openapi: {
+            url: '/documentation/json',
+            prefix: 'api2'
+          }
+        }
+      ]
+    }
+  })
+
+  const gatewayOrigin = await gateway.start({ listen: true })
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  })
+  assert.equal(statusCode, 200)
+
+  const openApiSchema = JSON.parse(body)
+  openApiValidator.validate(openApiSchema)
+
+  for (const path of Object.keys(openApiSchema.paths)) {
+    assert.ok(path.startsWith('/api1/') || path.startsWith('/api2/'), `path ${path} is prefixed`)
+    assert.ok(!path.includes('//'), `path ${path} has no double slashes`)
+  }
+
+  await testEntityRoutes(gatewayOrigin, ['/api1/users', '/api2/posts'])
+})

--- a/packages/gateway/test/openapi/schemas-composition.test.js
+++ b/packages/gateway/test/openapi/schemas-composition.test.js
@@ -603,7 +603,10 @@ test('should throw an error if there are duplicates paths', async t => {
     ])
     assert.fail('should throw an error')
   } catch (err) {
-    assert.equal(err.message, 'Path "/books" already exists')
+    assert.equal(
+      err.message,
+      'Path "/books" is exposed by both the "api1" and the "api2" applications. Set a different openapi.prefix on one of them to resolve the conflict.'
+    )
   }
 })
 
@@ -647,6 +650,9 @@ test('should throw an error if there are duplicates paths with prefixes', async 
     ])
     assert.fail('should throw an error')
   } catch (err) {
-    assert.equal(err.message, 'Path "/api1/books" already exists')
+    assert.equal(
+      err.message,
+      'Path "/api1/books" is exposed by both the "api1" and the "api2" applications. Set a different openapi.prefix on one of them to resolve the conflict.'
+    )
   }
 })


### PR DESCRIPTION
## What

Fixes #1242.

Two problems when composing applications with conflicting routes:

1. The `Path "/" already exists` error gave no context: it didn't say which applications conflicted nor how to fix it. It now reads:
   > Path "/books" is exposed by both the "api1" and the "api2" applications. Set a different openapi.prefix on one of them to resolve the conflict.

2. An `openapi.prefix` with a trailing slash (e.g. `"tangy/"`) produced double slashes in the composed spec paths — in the original report this made `fastify-openapi-glue` reject the composed document as an invalid specification. Prefixes are now normalized to always start with a slash and never end with one (the missing-leading-slash half was already handled).

## Changes

- `PathAlreadyExistsError` takes the two application ids and suggests the fix.
- New `normalizePrefix()` used for `openapi.prefix`.
- Integration test composing applications with `api1/` and `api2` style prefixes; updated unit test message expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF