### PR TITLE
fix(gateway): preserve security configuration when composing OpenAPI

### DIFF
--- a/packages/gateway/lib/openapi-composer.js
+++ b/packages/gateway/lib/openapi-composer.js
@@ -34,6 +34,8 @@ function namespaceSchemaOperationIds (apiPrefix, schema) {
   }
 }
 
+const OPENAPI_HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
+
 export function composeOpenApi (apis, options = {}) {
   const mergedPaths = {}
   const mergedPathOwners = {}
@@ -41,10 +43,20 @@ export function composeOpenApi (apis, options = {}) {
   const mergedSecuritySchemes = {}
 
   for (const { id, prefix, schema } of apis) {
-    const { paths, components } = clone(schema)
+    const { paths, components, security: defaultSecurity } = clone(schema)
 
     const apiPrefix = generateOperationIdApiPrefix(id)
     for (const [path, pathSchema] of Object.entries(paths)) {
+      // The document-level security of the application applies to every operation
+      // which does not define its own
+      if (defaultSecurity) {
+        for (const method of OPENAPI_HTTP_METHODS) {
+          if (pathSchema[method] && !pathSchema[method].security) {
+            pathSchema[method].security = clone(defaultSecurity)
+          }
+        }
+      }
+
       namespaceSchemaRefs(apiPrefix, pathSchema)
       namespaceSchemaOperationIds(apiPrefix, pathSchema)
 
@@ -88,7 +100,12 @@ export function composeOpenApi (apis, options = {}) {
     }
   }
 
-  return {
+  // Gateway-level security schemes and requirements from the configuration
+  if (options.components?.securitySchemes) {
+    Object.assign(mergedSecuritySchemes, clone(options.components.securitySchemes))
+  }
+
+  const composed = {
     openapi: '3.0.0',
     info: {
       title: options.title || 'Platformatic Gateway',
@@ -100,4 +117,10 @@ export function composeOpenApi (apis, options = {}) {
     },
     paths: mergedPaths
   }
+
+  if (options.security) {
+    composed.security = clone(options.security)
+  }
+
+  return composed
 }

--- a/packages/gateway/lib/openapi-generator.js
+++ b/packages/gateway/lib/openapi-generator.js
@@ -180,16 +180,22 @@ export async function openApiGenerator (app, opts) {
   app.decorate('openApiSchemas', openApiSchemas)
   app.decorate('composedOpenApiSchema', composedOpenApiSchema)
 
+  const swaggerOpenApi = {
+    info: {
+      title: opts.openapi?.title || 'Platformatic Gateway',
+      version: opts.openapi?.version || '1.0.0'
+    },
+    servers: [{ url: getRuntimeBasePath({ throwOnMissing: false }) ?? '/' }],
+    components: app.composedOpenApiSchema.components
+  }
+
+  if (app.composedOpenApiSchema.security) {
+    swaggerOpenApi.security = app.composedOpenApiSchema.security
+  }
+
   await app.register(fastifySwagger, {
     exposeRoute: true,
-    openapi: {
-      info: {
-        title: opts.openapi?.title || 'Platformatic Gateway',
-        version: opts.openapi?.version || '1.0.0'
-      },
-      servers: [{ url: getRuntimeBasePath({ throwOnMissing: false }) ?? '/' }],
-      components: app.composedOpenApiSchema.components
-    },
+    openapi: swaggerOpenApi,
     transform ({ schema, url }) {
       for (const application of opts.applications) {
         if (!application.proxy) continue

--- a/packages/gateway/test/openapi/routes-composition.test.js
+++ b/packages/gateway/test/openapi/routes-composition.test.js
@@ -751,6 +751,7 @@ test('should proxy custom content types via config in OpenAPI composition', asyn
   assert.equal(response.bodyLength, customData.length)
 })
 
+
 test('should normalize prefixes without leading slash or with trailing slash', async t => {
   /* https://github.com/platformatic/platformatic/issues/1242 */
   const api1 = await createOpenApiApplication(t, ['users'])
@@ -804,4 +805,124 @@ test('should normalize prefixes without leading slash or with trailing slash', a
   }
 
   await testEntityRoutes(gatewayOrigin, ['/api1/users', '/api2/posts'])
+})
+
+test('should apply the application document-level security to composed operations', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1495 */
+  const api = await createBasicApplication(t, {
+    openapi: {
+      components: {
+        securitySchemes: {
+          openId: {
+            type: 'openIdConnect',
+            openIdConnectUrl: 'https://example.com/.well-known/openid-configuration'
+          }
+        }
+      },
+      security: [{ openId: [] }]
+    }
+  })
+
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'api1',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json',
+            prefix: '/api'
+          }
+        }
+      ],
+      addEmptySchema: true
+    }
+  })
+
+  await gateway.start({ listen: true })
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  })
+  assert.equal(statusCode, 200)
+
+  const openApiSchema = JSON.parse(body)
+  openApiValidator.validate(openApiSchema)
+
+  assert.deepStrictEqual(openApiSchema.components.securitySchemes, {
+    api1_openId: {
+      type: 'openIdConnect',
+      openIdConnectUrl: 'https://example.com/.well-known/openid-configuration'
+    }
+  })
+
+  // Every composed operation inherits the document-level security of its application
+  assert.deepStrictEqual(openApiSchema.paths['/api/text'].get.security, [{ api1_openId: [] }])
+  assert.deepStrictEqual(openApiSchema.paths['/api/error'].get.security, [{ api1_openId: [] }])
+})
+
+test('should include the gateway-level security configuration in the composed spec', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1495 */
+  const api = await createBasicApplication(t)
+
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'api1',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json',
+            prefix: '/api'
+          }
+        }
+      ],
+      openapi: {
+        components: {
+          securitySchemes: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+              bearerFormat: 'JWT'
+            }
+          }
+        },
+        security: [{ bearerAuth: [] }]
+      },
+      addEmptySchema: true
+    }
+  })
+
+  await gateway.start({ listen: true })
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  })
+  assert.equal(statusCode, 200)
+
+  const openApiSchema = JSON.parse(body)
+  openApiValidator.validate(openApiSchema)
+
+  assert.deepStrictEqual(openApiSchema.components.securitySchemes.bearerAuth, {
+    type: 'http',
+    scheme: 'bearer',
+    bearerFormat: 'JWT'
+  })
+  assert.deepStrictEqual(openApiSchema.security, [{ bearerAuth: [] }])
 })

--- a/packages/gateway/test/openapi/schemas-composition.test.js
+++ b/packages/gateway/test/openapi/schemas-composition.test.js
@@ -656,3 +656,41 @@ test('should throw an error if there are duplicates paths with prefixes', async 
     )
   }
 })
+
+test('should apply document-level security only to operations without their own', async t => {
+  /* https://github.com/platformatic/platformatic/issues/1495 */
+  const schema = {
+    openapi: '3.0.0',
+    info: {
+      title: 'API 1',
+      version: '1.0.0'
+    },
+    security: [{ defaultAuth: [] }],
+    components: {
+      securitySchemes: {
+        defaultAuth: { type: 'http', scheme: 'bearer' },
+        customAuth: { type: 'http', scheme: 'basic' }
+      }
+    },
+    paths: {
+      '/default': {
+        get: {
+          operationId: 'getDefault',
+          responses: {}
+        }
+      },
+      '/custom': {
+        get: {
+          operationId: 'getCustom',
+          security: [{ customAuth: [] }],
+          responses: {}
+        }
+      }
+    }
+  }
+
+  const composed = composeOpenApi([{ id: 'api1', schema }])
+
+  assert.deepEqual(composed.paths['/default'].get.security, [{ api1_defaultAuth: [] }])
+  assert.deepEqual(composed.paths['/custom'].get.security, [{ api1_customAuth: [] }])
+})


### PR DESCRIPTION
## What

Fixes #1495.

A composed application exposing a spec with `components.securitySchemes` **and a document-level `security` requirement** (exactly the configuration from the issue) lost all authentication information in the composed document: per-operation `security` was already namespaced and preserved, but the document-level default was silently dropped.

## Changes

- `composeOpenApi` now applies each application's document-level `security` to every operation of that application which does not define its own (per the OpenAPI spec semantics), before the usual namespacing.
- The gateway-level `openapi.security` and `openapi.components.securitySchemes` configuration (already allowed by the config schema, previously ignored) is now included in the composed spec, and the served document exposes the top-level `security` accordingly.
- Unit test for override semantics (operation-level security wins over the document default) and integration tests for both the application-level and gateway-level cases. Full gateway OpenAPI suite passes (52/52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF