### PR TITLE
test(node): stabilize the reusePort https test

### DIFF
--- a/packages/node/test/https.test.js
+++ b/packages/node/test/https.test.js
@@ -11,8 +11,9 @@ setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const repoRoot = resolve(import.meta.dirname, '../../..')
 
-function createDispatcher (t) {
+function createDispatcher (t, options = {}) {
   const dispatcher = new Agent({
+    ...options,
     connect: {
       rejectUnauthorized: false
     }
@@ -53,7 +54,11 @@ test('supports https server options', async t => {
 })
 
 test('supports reusePort with https server options', async t => {
-  const dispatcher = createDispatcher(t)
+  // The kernel balances SO_REUSEPORT sockets by hashing the connection 4-tuple,
+  // so requests riding a kept-alive connection always hit the same worker.
+  // Disable keep-alive to open a fresh connection (and get a new hash) on
+  // every request.
+  const dispatcher = createDispatcher(t, { pipelining: 0 })
   const port = await getPort()
 
   const { runtime } = await prepareRuntime(t, 'node-https-standalone', false, null, async (root, config) => {
@@ -76,7 +81,9 @@ test('supports reusePort with https server options', async t => {
   let attempts = 0
   const usedWorkers = new Set(Array.from(Array(workers)).map((_, i) => i.toString()))
 
-  while (usedWorkers.size > 0 && attempts++ < workers * 5) {
+  // The kernel hashing is not a strict round-robin: give it plenty of
+  // attempts to eventually hit every worker at least once.
+  while (usedWorkers.size > 0 && attempts++ < workers * 40) {
     const res = await request(url + '/', { dispatcher })
     const json = await res.body.json()
 
@@ -85,5 +92,5 @@ test('supports reusePort with https server options', async t => {
     usedWorkers.delete(res.headers['x-plt-worker-id'])
   }
 
-  deepStrictEqual(usedWorkers.size, 0)
+  deepStrictEqual(usedWorkers.size, 0, `workers never hit after ${attempts} requests: ${Array.from(usedWorkers).join(', ')}`)
 })


### PR DESCRIPTION
## What

Fixes the `supports reusePort with https server options` flake that hit two PR branches today (`fix/1805`, `fix/3522`) with `usedWorkers.size` = 1.

## Why it flaked

The kernel balances `SO_REUSEPORT` sockets by hashing the connection 4-tuple:

1. Requests riding a kept-alive undici connection always land on the same worker, so progress relied on connections getting rotated as a side effect.
2. Even with a fresh connection per request, 25 attempts leave a ~2% chance (`5 × (4/5)^25`) that one of the 5 workers is never hit — matching the observed flake rate.

## Fix

- `pipelining: 0` on the test dispatcher: every request opens a fresh connection, so each one gets a new hash.
- Attempt budget raised to `workers * 40` (miss probability ~1e-19); the loop still exits as soon as all workers are seen (~10-15 requests typically).
- The final assertion now names the workers that were never hit.

Ran 5× locally, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tmiLsoTzkwP7bcnBStjPF