### PR TITLE
feat(runtime): add per-worker port assignment

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -367,7 +367,8 @@ If the entrypoint has also a `server` configured, then the runtime settings over
 An object with the following settings:
 
 - **`hostname`** — Hostname where Platformatic Service server will listen for connections.
-- **`port`** — Port where Platformatic Service server will listen for connections.
+- **`port`** — Port where Platformatic Service server will listen for connections. Provide a number or a string. When `portAssignment` is set to `perWorkerIncrement`, this is the first port assigned to worker 0.
+- **`portAssignment`** (`string`) — Sets how entrypoint server worker ports are assigned. Default: `shared`. Set it to `shared` or leave it unset to make all workers listen on the same `port`. Set it to `perWorkerIncrement` to give each worker its own incremental port, starting from `port`. Use `perWorkerIncrement` only with external load balancing, never on its own.
 - **`http2`** (`boolean`) — Enables HTTP/2 support. Default: `false`.
 - **`https`** (`object`) - Configuration for HTTPS supporting the following options. Requires `https`.
   - `allowHTTP1` (`boolean`) - If `true`, the server will also accept HTTP/1.1 connections when `http2` is enabled. Default: `false`.

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticAstroConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticAstroConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -89,6 +89,10 @@ export interface PlatformaticBasicConfig {
       hostname?: string;
       port?: number | string;
       /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
+      /**
        * The maximum length of the queue of pending connections
        */
       backlog?: number;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -683,6 +683,14 @@
                 }
               ]
             },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+            },
             "backlog": {
               "type": "integer",
               "description": "The maximum length of the queue of pending connections"

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -257,6 +257,10 @@ export interface PlatformaticComposerConfig {
       hostname?: string;
       port?: number | string;
       /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
+      /**
        * The maximum length of the queue of pending connections
        */
       backlog?: number;
@@ -314,6 +318,40 @@ export interface PlatformaticComposerConfig {
       bufferPoolSize?: number | string;
       defaultHighWaterMark?: number | string;
     };
+    healthProbes?:
+      | boolean
+      | string
+      | {
+          enabled?: boolean | string;
+          hostname?: string;
+          port?: number | string;
+          readiness?:
+            | boolean
+            | {
+                endpoint?: string;
+                success?: {
+                  statusCode?: number;
+                  body?: string;
+                };
+                fail?: {
+                  statusCode?: number;
+                  body?: string;
+                };
+              };
+          liveness?:
+            | boolean
+            | {
+                endpoint?: string;
+                success?: {
+                  statusCode?: number;
+                  body?: string;
+                };
+                fail?: {
+                  statusCode?: number;
+                  body?: string;
+                };
+              };
+        };
     undici?: {
       agentOptions?: {
         [k: string]: unknown;
@@ -472,6 +510,10 @@ export interface PlatformaticComposerConfig {
                   body?: string;
                 };
               };
+          /**
+           * @deprecated
+           * Deprecated. Health probe timeout configuration is no longer used.
+           */
           healthChecksTimeouts?: number | string;
           plugins?: string[];
           timeout?: number | string;
@@ -505,6 +547,29 @@ export interface PlatformaticComposerConfig {
              * Service version for OTLP resource attributes
              */
             serviceVersion?: string;
+          };
+          /**
+           * Configuration for forwarding user OpenTelemetry metrics to an OTLP endpoint
+           */
+          opentelemetry?: {
+            /**
+             * Enable or disable OpenTelemetry metrics forwarding
+             */
+            enabled?: boolean | string;
+            /**
+             * OTLP metrics endpoint URL (e.g., http://collector:4318/v1/metrics)
+             */
+            endpoint: string;
+            /**
+             * Interval in milliseconds between metric forwards
+             */
+            interval?: number | string;
+            /**
+             * Additional HTTP headers for authentication
+             */
+            headers?: {
+              [k: string]: string;
+            };
           };
           /**
            * Custom labels to add to HTTP metrics (http_request_all_duration_seconds). Each label extracts its value from an HTTP request header.
@@ -973,6 +1038,28 @@ export interface PlatformaticComposerConfig {
             custom?: {
               path: string;
             };
+            deduplication?: {
+              enabled?: boolean | string;
+              storage?:
+                | {
+                    adapter?: "memory";
+                  }
+                | {
+                    adapter: "valkey";
+                    url: string;
+                    prefix?: string;
+                  };
+              methods?: ("GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS" | "HEAD")[];
+              headers?: string[];
+              routes?: {
+                [k: string]: unknown;
+              }[];
+              key?: string;
+              timeout?: number;
+              retries?: number;
+              ttl?: number;
+              lockTtl?: number;
+            };
             ws?: {
               upstream?: string;
               reconnect?: {
@@ -992,6 +1079,28 @@ export interface PlatformaticComposerConfig {
           };
     }[];
     handler?: string;
+    deduplication?: {
+      enabled?: boolean | string;
+      storage?:
+        | {
+            adapter?: "memory";
+          }
+        | {
+            adapter: "valkey";
+            url: string;
+            prefix?: string;
+          };
+      methods?: ("GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS" | "HEAD")[];
+      headers?: string[];
+      routes?: {
+        [k: string]: unknown;
+      }[];
+      key?: string;
+      timeout?: number;
+      retries?: number;
+      ttl?: number;
+      lockTtl?: number;
+    };
     openapi?: {
       info?: Info;
       jsonSchemaDialect?: string;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -1356,6 +1356,14 @@
                 }
               ]
             },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+            },
             "backlog": {
               "type": "integer",
               "description": "The maximum length of the queue of pending connections"

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -583,6 +583,10 @@ export interface PlatformaticDatabaseConfig {
       hostname?: string;
       port?: number | string;
       /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
+      /**
        * The maximum length of the queue of pending connections
        */
       backlog?: number;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -2040,6 +2040,14 @@
                 }
               ]
             },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+            },
             "backlog": {
               "type": "integer",
               "description": "The maximum length of the queue of pending connections"

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -362,6 +362,11 @@ export const server = {
     port: {
       anyOf: [{ type: 'integer' }, { type: 'string' }]
     },
+    portAssignment: {
+      type: 'string',
+      enum: ['shared', 'perWorkerIncrement'],
+      description: 'Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).'
+    },
     backlog: {
       type: 'integer',
       description: 'The maximum length of the queue of pending connections'

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -519,6 +519,10 @@ export interface PlatformaticGatewayConfig {
       hostname?: string;
       port?: number | string;
       /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
+      /**
        * The maximum length of the queue of pending connections
        */
       backlog?: number;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -2317,6 +2317,14 @@
                 }
               ]
             },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+            },
             "backlog": {
               "type": "integer",
               "description": "The maximum length of the queue of pending connections"

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticNestJSConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticNestJSConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticNextJsConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticNextJsConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticNodeJsConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticNodeJsConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticNuxtConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticNuxtConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticReactRouterConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticReactRouterConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticRemixConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticRemixConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -197,6 +197,10 @@ export type PlatformaticRuntimeConfig = {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;

--- a/packages/runtime/fixtures/multiple-workers/service/crash-plugin.js
+++ b/packages/runtime/fixtures/multiple-workers/service/crash-plugin.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = async function (app) {
+  app.post('/crash', async () => {
+    setImmediate(() => {
+      throw new Error('kaboom')
+    })
+  })
+}

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -546,12 +546,19 @@ export class Runtime extends EventEmitter {
 
   async addApplications (applications, start = false) {
     const setupInvocations = []
+    // Per-worker ports do not need SO_REUSEPORT because each worker binds a different port.
+    const usesPerWorkerPorts = this.#config.server?.portAssignment === 'perWorkerIncrement'
 
     const toStart = []
     for (const application of applications) {
       const workers = application.workers
 
-      if ((workers.static > 1 || workers.minimum > 1) && application.entrypoint && !features.node.reusePort) {
+      if (
+        (workers.static > 1 || workers.minimum > 1) &&
+        application.entrypoint &&
+        !features.node.reusePort &&
+        !usesPerWorkerPorts
+      ) {
         this.logger.warn(
           `"${application.id}" is set as the entrypoint, but reusePort is not available in your OS; setting workers to 1 instead of ${workers.static}`
         )

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -155,6 +155,7 @@ export class Runtime extends EventEmitter {
   #restartingWorkers
   #dynamicWorkersScaler
   #nextWorkerIndex
+  #workerPortOffsets
 
   #sharedHttpCache
   #scheduler
@@ -196,6 +197,7 @@ export class Runtime extends EventEmitter {
     this.#restartingApplications = new Set()
     this.#restartingWorkers = new Map()
     this.#nextWorkerIndex = new Map()
+    this.#workerPortOffsets = new Map() // fullWorkerId => portOffset
     this.#sharedHttpCache = null
     this.#applicationsConfigsPatches = new Map()
 
@@ -1833,6 +1835,7 @@ export class Runtime extends EventEmitter {
     const setupInvocations = []
 
     for (let i = 0; i < workers; i++) {
+      this.#workerPortOffsets.set(`${id}:${i}`, i)
       setupInvocations.push([config, applicationConfig, workers, id, i])
     }
 
@@ -1858,6 +1861,12 @@ export class Runtime extends EventEmitter {
       }
 
       inspectorOptions.port = inspectorOptions.port + this.#workers.size + 1
+    }
+
+    let serverConfigOverride
+    if (this.#config.server?.portAssignment === 'perWorkerIncrement') {
+      const portOffset = this.#workerPortOffsets.get(workerId)
+      serverConfigOverride = { port: Number(this.#config.server.port) + portOffset }
     }
 
     if (config.telemetry) {
@@ -1923,12 +1932,21 @@ export class Runtime extends EventEmitter {
     const maxYoungGenerationSizeMb = maxYoungGeneration ? Math.floor(maxYoungGeneration / (1024 * 1024)) : undefined
     const codeRangeSizeMb = codeRangeSize ? Math.floor(codeRangeSize / (1024 * 1024)) : undefined
 
+    const workerConfig = {
+      ...config,
+      preload
+    }
+
+    if (config.server && serverConfigOverride) {
+      workerConfig.server = {
+        ...config.server,
+        ...serverConfigOverride
+      }
+    }
+
     const worker = new Worker(kWorkerFile, {
       workerData: {
-        config: {
-          ...config,
-          preload
-        },
+        config: workerConfig,
         applicationConfig: {
           ...applicationConfig,
           isProduction: this.#isProduction,
@@ -1977,6 +1995,7 @@ export class Runtime extends EventEmitter {
       worker[kWorkerStatus] = 'exited'
       this.emitAndNotify('application:worker:exited', eventPayload)
 
+      const portOffset = this.#workerPortOffsets.get(worker[kFullId]) ?? index
       this.#cleanupWorker(worker)
 
       if (this.#status === 'stopping') {
@@ -2001,7 +2020,7 @@ export class Runtime extends EventEmitter {
               this.logger.warn(`The ${errorLabel} will be restarted in ${restartOnError}ms ...`)
             }
 
-            this.#restartCrashedWorker(config, applicationConfig, workersCount, applicationId, index, false, 0).catch(
+            this.#restartCrashedWorker(config, applicationConfig, workersCount, applicationId, index, false, 0, portOffset).catch(
               err => {
                 this.logger.error({ err: ensureLoggableError(err) }, `${errorLabel} could not be restarted.`)
               }
@@ -2486,6 +2505,7 @@ export class Runtime extends EventEmitter {
     } catch (err) {
       const error = ensureError(err)
       worker[kITC].notify('application:worker:start:processed')
+      const portOffset = this.#workerPortOffsets.get(worker[kFullId]) ?? index
 
       // TODO: handle port allocation error here
       if (error.code === 'EADDRINUSE' || error.code === 'EACCES') throw error
@@ -2532,7 +2552,7 @@ export class Runtime extends EventEmitter {
         )
       }
 
-      await this.#restartCrashedWorker(config, applicationConfig, workersCount, id, index, silent, bootstrapAttempt)
+      await this.#restartCrashedWorker(config, applicationConfig, workersCount, id, index, silent, bootstrapAttempt, portOffset)
     }
   }
 
@@ -2601,6 +2621,7 @@ export class Runtime extends EventEmitter {
 
   #cleanupWorker (worker) {
     clearTimeout(worker[kHealthCheckTimer])
+    this.#workerPortOffsets.delete(worker[kFullId])
 
     const currentWorker = this.#workers.get(worker[kFullId])
 
@@ -2629,7 +2650,7 @@ export class Runtime extends EventEmitter {
     return index
   }
 
-  async #restartCrashedWorker (config, applicationConfig, workersCount, id, oldIndex, silent, bootstrapAttempt) {
+  async #restartCrashedWorker (config, applicationConfig, workersCount, id, oldIndex, silent, bootstrapAttempt, portOffset) {
     // Use oldIndex for tracking to prevent duplicate restarts of the same crashed worker
     const restartKey = `${id}:${oldIndex}`
 
@@ -2650,18 +2671,22 @@ export class Runtime extends EventEmitter {
         }
 
         // Get a new unique index for the restarted worker
-        const index = this.#getNextWorkerIndex(id)
+        const newIndex = this.#getNextWorkerIndex(id)
+        const newWorkerId = `${id}:${newIndex}`
+        this.#workerPortOffsets.set(newWorkerId, portOffset)
 
         try {
-          await this.#setupWorker(config, applicationConfig, workersCount, id, index)
-          await this.#startWorker(config, applicationConfig, workersCount, id, index, silent, bootstrapAttempt)
+          await this.#setupWorker(config, applicationConfig, workersCount, id, newIndex)
+          await this.#startWorker(config, applicationConfig, workersCount, id, newIndex, silent, bootstrapAttempt)
           this.#incrementApplicationRestartCount(id)
 
           this.logger.info(
-            `The ${this.#workerExtendedLabel(id, index, workersCount)} has been successfully restarted ...`
+            `The ${this.#workerExtendedLabel(id, newIndex, workersCount)} has been successfully restarted ...`
           )
           resolve()
         } catch (err) {
+          this.#workerPortOffsets.delete(newWorkerId)
+
           // The runtime was stopped while the restart was happening, ignore any error.
           if (!this.#status.startsWith('start')) {
             resolve()
@@ -2690,6 +2715,8 @@ export class Runtime extends EventEmitter {
     const newIndex = this.#getNextWorkerIndex(applicationId)
     const newWorkerId = `${applicationId}:${newIndex}`
     const newLabel = this.#workerExtendedLabel(applicationId, newIndex, workersCount)
+    const portOffset = this.#workerPortOffsets.get(`${applicationId}:${oldIndex}`)
+    this.#workerPortOffsets.set(newWorkerId, portOffset)
 
     const stopBeforeStart =
       applicationConfig.entrypoint &&
@@ -2705,13 +2732,13 @@ export class Runtime extends EventEmitter {
       configForNewWorker = { ...config, server: { ...config.server, port: this.#entrypointPort } }
     }
 
-    if (stopBeforeStart) {
-      await this.#removeWorker(workersCount, applicationId, oldIndex, worker, silent, oldLabel)
-    }
-
     try {
       if (!silent) {
         this.logger.debug(`Preparing to start ${newLabel} as replacement for ${oldLabel} ...`)
+      }
+
+      if (stopBeforeStart) {
+        await this.#removeWorker(workersCount, applicationId, oldIndex, worker, silent, oldLabel)
       }
 
       // Create a new worker with a new index, preserving any pinned port when stopBeforeStart is required.
@@ -2732,6 +2759,7 @@ export class Runtime extends EventEmitter {
 
       this.#workers.set(newWorkerId, newWorker)
     } catch (e) {
+      this.#workerPortOffsets.delete(newWorkerId)
       newWorker?.terminate?.()
       throw e
     }
@@ -3286,16 +3314,25 @@ export class Runtime extends EventEmitter {
 
     if (currentWorkers < workers) {
       report.started = []
+      let pendingWorkerId
+
       try {
         for (let i = currentWorkers; i < workers; i++) {
           const newIndex = this.#getNextWorkerIndex(applicationId)
+          pendingWorkerId = `${applicationId}:${newIndex}`
+          this.#workerPortOffsets.set(pendingWorkerId, i)
+
           await this.#setupWorker(config, applicationConfig, workers, applicationId, newIndex)
           await this.#startWorker(config, applicationConfig, workers, applicationId, newIndex, false, 0)
+
+          pendingWorkerId = undefined
           report.started.push(newIndex)
           startedWorkersCount++
         }
         report.success = true
       } catch (err) {
+        pendingWorkerId && this.#workerPortOffsets.delete(pendingWorkerId)
+
         if (startedWorkersCount < 1) {
           this.logger.error({ err }, 'Cannot start application workers, no worker started')
         } else {
@@ -3310,21 +3347,32 @@ export class Runtime extends EventEmitter {
       // keep the current workers count until all the application workers are all stopped
       report.stopped = []
       try {
-        // Get actual worker keys and sort by index descending to stop most recent first (snapshot to avoid mutation during iteration)
-        const workerKeys = [...this.#workers.getKeys(applicationId)]
-        const workerIndices = workerKeys
-          .map(key => parseInt(key.split(':')[1], 10))
-          .sort((a, b) => b - a) // descending order
-
         const workersToStop = currentWorkers - workers
-        for (let i = 0; i < workersToStop && i < workerIndices.length; i++) {
-          const workerIndex = workerIndices[i]
+        const allInOnePort = this.#config.server?.portAssignment !== 'perWorkerIncrement'
+        const workerIdsToStop = this.#workers
+          .getKeys(applicationId)
+          .map(key => parseInt(key.split(':')[1], 10))
+
+        if (allInOnePort) {
+          // Stop most recent workers first.
+          workerIdsToStop.sort((a, b) => b - a)
+        } else {
+          // When port increment is enabled, disable the workers with the highest ports.
+          workerIdsToStop.sort((a, b) => {
+            const offsetA = this.#workerPortOffsets.get(`${applicationId}:${a}`) ?? a
+            const offsetB = this.#workerPortOffsets.get(`${applicationId}:${b}`) ?? b
+            return offsetB - offsetA
+          })
+        }
+
+        for (const workerIndex of workerIdsToStop.splice(0, workersToStop)) {
           const worker = this.#workers.get(`${applicationId}:${workerIndex}`)
           await sendViaITC(worker, 'removeFromMesh')
           await this.#stopWorker(currentWorkers, applicationId, workerIndex, false, worker, [])
           report.stopped.push(workerIndex)
           stoppedWorkersCount++
         }
+
         report.success = true
       } catch (err) {
         if (stoppedWorkersCount < 1) {

--- a/packages/runtime/lib/worker/round-robin-map.js
+++ b/packages/runtime/lib/worker/round-robin-map.js
@@ -43,7 +43,7 @@ export class RoundRobinMap extends Map {
   }
 
   getKeys (application) {
-    return this.#instances[application]?.keys ?? []
+    return [...(this.#instances[application]?.keys ?? [])]
   }
 
   next (application) {

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -1889,6 +1889,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"

--- a/packages/runtime/test/multiple-workers/per-worker-port.test.js
+++ b/packages/runtime/test/multiple-workers/per-worker-port.test.js
@@ -1,0 +1,192 @@
+import { ok, strictEqual } from 'node:assert'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { request } from 'undici'
+import { createRuntime, updateConfigFile } from '../helpers.js'
+import { prepareRuntime, waitForEvents } from './helper.js'
+
+const HOST = '127.0.0.1'
+
+async function getBasePort () {
+  const getPort = await import('get-port')
+  return getPort.default({ host: HOST })
+}
+
+async function preparePerWorkerPortRuntime (t, { application = 'node', workerCount = 5 } = {}) {
+  const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
+  const configFile = resolve(root, './platformatic.json')
+  const basePort = await getBasePort()
+
+  await updateConfigFile(configFile, contents => {
+    contents.server = {
+      hostname: HOST,
+      port: basePort,
+      portAssignment: 'perWorkerIncrement'
+    }
+    contents.autoload = undefined
+    contents.entrypoint = application
+
+    let applicationConfig = contents.services.find(service => service.id === application)
+    if (!applicationConfig) {
+      applicationConfig = {
+        id: application,
+        path: `./${application}`,
+        config: 'platformatic.json'
+      }
+      contents.services.push(applicationConfig)
+    }
+
+    applicationConfig.workers = workerCount
+  })
+
+  if (application === 'service') {
+    await updateConfigFile(resolve(root, 'service/platformatic.json'), contents => {
+      contents.plugins.paths.push('./crash-plugin.js')
+    })
+  }
+
+  const app = await createRuntime(configFile, null, { isProduction: true })
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  return { app, basePort }
+}
+
+async function requestWorkerPort (port, expectedFrom = 'node') {
+  const res = await request(`http://${HOST}:${port}/hello`, {
+    headersTimeout: 2000,
+    bodyTimeout: 2000
+  })
+  const json = await res.body.json()
+
+  strictEqual(res.statusCode, 200)
+  strictEqual(json.from, expectedFrom)
+  strictEqual(res.headers['x-plt-port'], port.toString())
+
+  return Number(res.headers['x-plt-worker-id'])
+}
+
+async function assertPortsRespond (basePort, offsets, expectedFrom = 'node') {
+  const workerIds = []
+
+  for (const offset of offsets) {
+    workerIds.push(await requestWorkerPort(basePort + offset, expectedFrom))
+  }
+
+  return workerIds
+}
+
+async function waitForDifferentWorkerOnPort (port, previousWorkerId, expectedFrom = 'node') {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      const workerId = await requestWorkerPort(port, expectedFrom)
+      if (workerId !== previousWorkerId) {
+        return workerId
+      }
+    } catch {}
+
+    await sleep(100)
+  }
+
+  throw new Error(`Port ${port} did not switch from worker ${previousWorkerId}`)
+}
+
+async function assertPortClosed (port) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      const res = await request(`http://${HOST}:${port}/hello`, {
+        headersTimeout: 200,
+        bodyTimeout: 200
+      })
+      await res.body.text()
+    } catch {
+      return
+    }
+
+    await sleep(100)
+  }
+
+  throw new Error(`Port ${port} is still accepting requests`)
+}
+
+test('assigns one incremental port per entrypoint worker', async t => {
+  const { app, basePort } = await preparePerWorkerPortRuntime(t)
+
+  await app.start()
+
+  for (let offset = 0; offset < 5; offset++) {
+    strictEqual(await requestWorkerPort(basePort + offset), offset)
+  }
+})
+
+test('assigns new incremental ports when scaling up and stops highest ports when scaling down', async t => {
+  const { app, basePort } = await preparePerWorkerPortRuntime(t)
+
+  await app.start()
+
+  await assertPortsRespond(basePort, [0, 4])
+
+  let report = await app.updateApplicationsResources([{ application: 'node', workers: 7 }])
+  strictEqual(report.length, 1)
+  await assertPortsRespond(basePort, [0, 5, 6])
+
+  report = await app.updateApplicationsResources([{ application: 'node', workers: 3 }])
+  strictEqual(report.length, 1)
+  await assertPortsRespond(basePort, [0, 2])
+
+  await assertPortClosed(basePort + 3)
+})
+
+test('preserves incremental ports when restarting an application', async t => {
+  const { app, basePort } = await preparePerWorkerPortRuntime(t)
+
+  await app.start()
+  await assertPortsRespond(basePort, [0, 4])
+
+  await app.restartApplication('node')
+
+  await assertPortsRespond(basePort, [0, 4])
+})
+
+test('preserves incremental ports when replacing workers after a health update', async t => {
+  const { app, basePort } = await preparePerWorkerPortRuntime(t)
+
+  await app.start()
+  await assertPortsRespond(basePort, [0, 4])
+
+  await app.updateApplicationsResources([
+    {
+      application: 'node',
+      workers: 5,
+      health: { maxHeapTotal: '512MB' }
+    }
+  ])
+
+  const workerIds = await assertPortsRespond(basePort, [0, 4])
+  for (const workerId of workerIds) {
+    ok(workerId >= 5)
+  }
+})
+
+test('preserves incremental port when restarting a crashed worker', async t => {
+  const { app, basePort } = await preparePerWorkerPortRuntime(t, { application: 'service', workerCount: 3 })
+
+  await app.start()
+  strictEqual(await requestWorkerPort(basePort, 'service'), 0)
+
+  const eventsPromise = waitForEvents(
+    app,
+    { event: 'application:worker:error', application: 'service', worker: 0 },
+    20_000
+  )
+
+  const res = await request(`http://${HOST}:${basePort}/crash`, { method: 'POST' })
+  await res.body.text()
+  await eventsPromise
+
+  const replacementWorkerId = await waitForDifferentWorkerOnPort(basePort, 0, 'service')
+  ok(replacementWorkerId > 0)
+})

--- a/packages/runtime/test/multiple-workers/per-worker-port.test.js
+++ b/packages/runtime/test/multiple-workers/per-worker-port.test.js
@@ -1,4 +1,4 @@
-import { ok, strictEqual } from 'node:assert'
+import { deepStrictEqual, strictEqual } from 'node:assert'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -79,11 +79,11 @@ async function assertPortsRespond (basePort, offsets, expectedFrom = 'node') {
   return workerIds
 }
 
-async function waitForDifferentWorkerOnPort (port, previousWorkerId, expectedFrom = 'node') {
+async function waitForWorkerOnPort (port, expectedWorkerId, expectedFrom = 'node') {
   for (let attempt = 0; attempt < 50; attempt++) {
     try {
       const workerId = await requestWorkerPort(port, expectedFrom)
-      if (workerId !== previousWorkerId) {
+      if (workerId === expectedWorkerId) {
         return workerId
       }
     } catch {}
@@ -91,7 +91,7 @@ async function waitForDifferentWorkerOnPort (port, previousWorkerId, expectedFro
     await sleep(100)
   }
 
-  throw new Error(`Port ${port} did not switch from worker ${previousWorkerId}`)
+  throw new Error(`Port ${port} did not switch to worker ${expectedWorkerId}`)
 }
 
 async function assertPortClosed (port) {
@@ -127,35 +127,38 @@ test('assigns new incremental ports when scaling up and stops highest ports when
 
   await app.start()
 
-  await assertPortsRespond(basePort, [0, 4])
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2, 3, 4]), [0, 1, 2, 3, 4])
 
   let report = await app.updateApplicationsResources([{ application: 'node', workers: 7 }])
   strictEqual(report.length, 1)
-  await assertPortsRespond(basePort, [0, 5, 6])
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2, 3, 4, 5, 6]), [0, 1, 2, 3, 4, 5, 6])
 
   report = await app.updateApplicationsResources([{ application: 'node', workers: 3 }])
   strictEqual(report.length, 1)
-  await assertPortsRespond(basePort, [0, 2])
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2]), [0, 1, 2])
 
   await assertPortClosed(basePort + 3)
+  await assertPortClosed(basePort + 4)
+  await assertPortClosed(basePort + 5)
+  await assertPortClosed(basePort + 6)
 })
 
 test('preserves incremental ports when restarting an application', async t => {
   const { app, basePort } = await preparePerWorkerPortRuntime(t)
 
   await app.start()
-  await assertPortsRespond(basePort, [0, 4])
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2, 3, 4]), [0, 1, 2, 3, 4])
 
   await app.restartApplication('node')
 
-  await assertPortsRespond(basePort, [0, 4])
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2, 3, 4]), [5, 6, 7, 8, 9])
 })
 
 test('preserves incremental ports when replacing workers after a health update', async t => {
   const { app, basePort } = await preparePerWorkerPortRuntime(t)
 
   await app.start()
-  await assertPortsRespond(basePort, [0, 4])
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2, 3, 4]), [0, 1, 2, 3, 4])
 
   await app.updateApplicationsResources([
     {
@@ -165,17 +168,14 @@ test('preserves incremental ports when replacing workers after a health update',
     }
   ])
 
-  const workerIds = await assertPortsRespond(basePort, [0, 4])
-  for (const workerId of workerIds) {
-    ok(workerId >= 5)
-  }
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2, 3, 4]), [5, 6, 7, 8, 9])
 })
 
 test('preserves incremental port when restarting a crashed worker', async t => {
   const { app, basePort } = await preparePerWorkerPortRuntime(t, { application: 'service', workerCount: 3 })
 
   await app.start()
-  strictEqual(await requestWorkerPort(basePort, 'service'), 0)
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2], 'service'), [0, 1, 2])
 
   const eventsPromise = waitForEvents(
     app,
@@ -187,6 +187,6 @@ test('preserves incremental port when restarting a crashed worker', async t => {
   await res.body.text()
   await eventsPromise
 
-  const replacementWorkerId = await waitForDifferentWorkerOnPort(basePort, 0, 'service')
-  ok(replacementWorkerId > 0)
+  await waitForWorkerOnPort(basePort, 3, 'service')
+  deepStrictEqual(await assertPortsRespond(basePort, [0, 1, 2], 'service'), [3, 1, 2])
 })

--- a/packages/runtime/test/start/restart-runtime.test.js
+++ b/packages/runtime/test/start/restart-runtime.test.js
@@ -5,6 +5,7 @@ import { test } from 'node:test'
 import { request } from 'undici'
 import { transform } from '../../lib/config.js'
 import { createRuntime, getTempDir } from '../helpers.js'
+import { prepareRuntime } from '../multiple-workers/helper.js'
 
 const fixturesDir = join(import.meta.dirname, '..', '..', 'fixtures')
 
@@ -135,4 +136,36 @@ test('will restart applications in parallel', async t => {
     events.findLastIndex(e => e[0] === 'application:restarting') <
       events.findIndex(e => e[0] === 'application:restarted')
   )
+})
+
+test('restartApplication restarts each original worker exactly once', async t => {
+  const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
+  const configFile = join(root, './platformatic.json')
+  const app = await createRuntime(configFile, null, { isProduction: true })
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const started = []
+  const stopped = []
+
+  app.on('application:worker:started', ({ application, worker }) => {
+    if (application === 'node') {
+      started.push(worker)
+    }
+  })
+
+  app.on('application:worker:stopped', ({ application, worker }) => {
+    if (application === 'node') {
+      stopped.push(worker)
+    }
+  })
+
+  await app.restartApplication('node')
+
+  deepStrictEqual(started, [5, 6, 7, 8, 9])
+  deepStrictEqual(stopped, [0, 1, 2, 3, 4])
 })

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -412,6 +412,10 @@ export interface PlatformaticServiceConfig {
       hostname?: string;
       port?: number | string;
       /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
+      /**
        * The maximum length of the queue of pending connections
        */
       backlog?: number;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1725,6 +1725,14 @@
                 }
               ]
             },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+            },
             "backlog": {
               "type": "integer",
               "description": "The maximum length of the queue of pending connections"

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticTanStackConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticTanStackConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -66,6 +66,10 @@ export interface PlatformaticViteConfig {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;
@@ -204,6 +208,10 @@ export interface PlatformaticViteConfig {
     server?: {
       hostname?: string;
       port?: number | string;
+      /**
+       * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+       */
+      portAssignment?: "shared" | "perWorkerIncrement";
       /**
        * The maximum length of the queue of pending connections
        */

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -196,6 +196,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"
@@ -1073,6 +1081,14 @@
                   "type": "string"
                 }
               ]
+            },
+            "portAssignment": {
+              "type": "string",
+              "enum": [
+                "shared",
+                "perWorkerIncrement"
+              ],
+              "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
             },
             "backlog": {
               "type": "integer",

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -197,6 +197,10 @@ export type PlatformaticRuntimeConfig = {
     hostname?: string;
     port?: number | string;
     /**
+     * Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0).
+     */
+    portAssignment?: "shared" | "perWorkerIncrement";
+    /**
      * The maximum length of the queue of pending connections
      */
     backlog?: number;

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -1889,6 +1889,14 @@
             }
           ]
         },
+        "portAssignment": {
+          "type": "string",
+          "enum": [
+            "shared",
+            "perWorkerIncrement"
+          ],
+          "description": "Configures how entrypoint server worker ports are assigned. When set to shared, all workers listen on the same port. When set to perWorkerIncrement, each worker will use its own port, starting from port (worker 0)."
+        },
         "backlog": {
           "type": "integer",
           "description": "The maximum length of the queue of pending connections"


### PR DESCRIPTION
## Why

`SO_REUSEPORT` can split traffic unevenly in some nginx setups, especially with reused connections and `net.ipv4.tcp_tw_reuse=2`.

This PR adds an option to let each worker listen on a different port and let custom load balancer decide how to route traffic between the workers (also without eBPF if the environment is limited).

## What

This PR adds `server.portAssignment: "perWorkerIncrement"` config option.

When it is enabled:
- worker 0 uses `server.port`
- worker 1 uses `server.port + 1`
- worker N uses `server.port + N`

If any of them is crashed/restarted, the new worker keeps the same port.

The default behavior is unchanged. If `portAssignment` is unset or set to `shared`, all workers keep listening on `server.port`.

Since #4596, restarted or crashed workers get new worker IDs. To keep ports stable, the runtime now tracks the port offset for each worker.

A replacement worker keeps the same offset as the worker it replaces. Scaling up adds higher offsets, and scaling down removes the highest offsets first. We also keep `TCP_REUSEPORT` enabled to ensure gapless restarts.