### PR TITLE
refactor(types): migrate from tsd to tstyche in the generators package

### DIFF
--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "lint": "eslint",
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
-    "test:types": "tsd"
+    "test:types": "tstyche"
   },
   "keywords": [],
   "dependencies": {
@@ -36,11 +36,8 @@
     "cleaner-spec-reporter": "^0.5.0",
     "eslint": "9",
     "neostandard": "^0.12.0",
-    "tsd": "^0.33.0",
+    "tstyche": "^6.0.0",
     "typescript": "^5.5.4"
-  },
-  "tsd": {
-    "directory": "test/types"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/generators/test/types/index.tst.ts
+++ b/packages/generators/test/types/index.tst.ts
@@ -1,16 +1,16 @@
-import { expectAssignable } from 'tsd'
+import { expect } from 'tstyche'
 import { ConfigField, ConfigFieldDefinition } from '../../index.js'
 
-expectAssignable<ConfigFieldDefinition>({
+expect({
   label: 'PLT_TESTING',
   var: 'testing',
   default: 'hello world',
-  type: 'string',
+  type: 'string' as const,
   configValue: 'someConfigValue'
-})
+}).type.toBeAssignableTo<ConfigFieldDefinition>()
 
-expectAssignable<ConfigField>({
+expect({
   var: 'testing',
   configValue: 'someConfigValue',
   value: 'asd123'
-})
+}).type.toBeAssignableTo<ConfigField>()

--- a/packages/generators/tsconfig.json
+++ b/packages/generators/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "lib": ["es2022"],
     "target": "esnext",
@@ -10,6 +11,7 @@
     "incremental": true,
     "strict": true,
     "outDir": "dist",
+    "rootDir": ".",
     "skipLibCheck": true
   },
   "watchOptions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -942,9 +942,9 @@ importers:
       neostandard:
         specifier: ^0.12.0
         version: 0.12.2(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      tsd:
-        specifier: ^0.33.0
-        version: 0.33.0
+      tstyche:
+        specifier: ^6.0.0
+        version: 6.2.0(typescript@5.9.3)
       typescript:
         specifier: ^5.5.4
         version: 5.9.3


### PR DESCRIPTION
Proposal: 

- migrate from `tsd` to `tstyche` in the generators package ( `@platformatic/generators` ) 🔥