### PR TITLE
refactor(types): migrate from tsd to tstyche in the db-authorization package

### DIFF
--- a/packages/db-authorization/package.json
+++ b/packages/db-authorization/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
-    "test:types": "tsd",
+    "test:types": "tstyche",
     "lint": "eslint"
   },
   "types": "index.d.ts",
@@ -27,7 +27,7 @@
     "fastify": "^5.7.0",
     "get-jwks": "^11.0.0",
     "neostandard": "^0.12.0",
-    "tsd": "^0.33.0",
+    "tstyche": "^6.0.0",
     "typescript": "^5.5.4",
     "why-is-node-running": "^2.2.2",
     "ws": "^8.16.0"
@@ -39,9 +39,6 @@
     "fastify-user": "^1.0.2",
     "leven": "~3.1.0",
     "undici": "^7.27.2"
-  },
-  "tsd": {
-    "directory": "test/types"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/db-authorization/test/types/index.tst.ts
+++ b/packages/db-authorization/test/types/index.tst.ts
@@ -1,14 +1,14 @@
 import fastify, {
   type FastifyPluginAsync,
 } from 'fastify'
-import { expectType } from 'tsd'
-import auth, {
+import { expect, test } from 'tstyche'
+import auth, { errors } from '../../index.js'
+import type {
   AddRulesForRoles,
   DBAuthorizationPluginInterface,
   DBAuthorizationPluginOptions,
   SetupDBAuthorizationUserDecorator,
-  errors,
-} from '../..'
+} from '../../index.js'
 import { FastifyError } from '@fastify/error'
 
 declare module 'fastify' {
@@ -17,12 +17,16 @@ declare module 'fastify' {
   }
 }
 
-expectType<FastifyPluginAsync<DBAuthorizationPluginOptions>>(auth)
+test('auth plugin type', () => {
+  expect(auth).type.toBe<FastifyPluginAsync<DBAuthorizationPluginOptions>>()
+})
 
 const app = fastify()
 app.register(auth)
 app.register(async (instance) => {
-  expectType<AddRulesForRoles>(instance.platformatic.addRulesForRoles)
+  test('addRulesForRoles decorator type', () => {
+    expect(instance.platformatic.addRulesForRoles).type.toBe<AddRulesForRoles>()
+  })
 
   interface User {
     email: string
@@ -32,7 +36,9 @@ app.register(async (instance) => {
     role: 'role',
     entity: 'entity',
     find: ({ user, where }) => {
-      expectType<User>(user)
+      test('find rule user type', () => {
+        expect(user).type.toBe<User>()
+      })
       return where
     },
   }])
@@ -66,7 +72,9 @@ app.register(async (instance) => {
   }])
 
   instance.get('/test', (request) => {
-    expectType<SetupDBAuthorizationUserDecorator>(request.setupDBAuthorizationUser)
+    test('setupDBAuthorizationUser decorator type', () => {
+      expect(request.setupDBAuthorizationUser).type.toBe<SetupDBAuthorizationUserDecorator>()
+    })
   })
 })
 
@@ -75,6 +83,8 @@ type ErrorWithNoParams = () => FastifyError
 type ErrorWithOneParam = (param: string) => FastifyError
 type ErrorWithTwoParams = (param1: string, param2: string) => FastifyError
 
-expectType<ErrorWithNoParams>(errors.Unauthorized)
-expectType<ErrorWithOneParam>(errors.UnauthorizedField)
-expectType<ErrorWithTwoParams>(errors.MissingNotNullableError)
+test('error factories', () => {
+  expect(errors.Unauthorized).type.toBe<ErrorWithNoParams>()
+  expect(errors.UnauthorizedField).type.toBe<ErrorWithOneParam>()
+  expect(errors.MissingNotNullableError).type.toBe<ErrorWithTwoParams>()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,9 +599,9 @@ importers:
       neostandard:
         specifier: ^0.12.0
         version: 0.12.2(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      tsd:
-        specifier: ^0.33.0
-        version: 0.33.0
+      tstyche:
+        specifier: ^6.0.0
+        version: 6.2.0(typescript@5.9.3)
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
@@ -5673,8 +5673,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@react-router/dev@7.18.1':
     resolution: {integrity: sha512-1Yu5272BI8g5sl1jwmhM3aFeajXQwNbWP4qrdMYfC+ayT2khxV6KPCitLNJl+jT6DMGEKb/hmwcmKd0lFIBjxQ==}
@@ -7340,8 +7340,8 @@ packages:
   caniuse-api@4.0.0:
     resolution: {integrity: sha512-B0hQ1OLyJuHTQSOWXvwibWqM6DCoqJdvBA6X1S/53bd4XU7LJ1yurIPlrsouol3mw1jh9pGI4ivubSpmJeIqCA==}
 
-  caniuse-lite@1.0.30001800:
-    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+  caniuse-lite@1.0.30001802:
+    resolution: {integrity: sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -8770,8 +8770,8 @@ packages:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
 
-  globby@16.2.0:
-    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
+  globby@16.2.1:
+    resolution: {integrity: sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==}
     engines: {node: '>=20'}
 
   globrex@0.1.2:
@@ -16761,7 +16761,7 @@ snapshots:
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.1': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@react-router/dev@7.18.1(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.48.0)(tsx@4.23.0)(typescript@5.9.3)(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
@@ -18651,7 +18651,7 @@ snapshots:
   autoprefixer@10.5.2(postcss@8.5.16):
     dependencies:
       browserslist: 4.28.4
-      caniuse-lite: 1.0.30001800
+      caniuse-lite: 1.0.30001802
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.16
@@ -18843,7 +18843,7 @@ snapshots:
   browserslist@4.28.4:
     dependencies:
       baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001800
+      caniuse-lite: 1.0.30001802
       electron-to-chromium: 1.5.387
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
@@ -18970,9 +18970,9 @@ snapshots:
   caniuse-api@4.0.0:
     dependencies:
       browserslist: 4.28.4
-      caniuse-lite: 1.0.30001800
+      caniuse-lite: 1.0.30001802
 
-  caniuse-lite@1.0.30001800: {}
+  caniuse-lite@1.0.30001802: {}
 
   ccount@2.0.1: {}
 
@@ -20732,7 +20732,7 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.3.0
 
-  globby@16.2.0:
+  globby@16.2.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       fast-glob: 3.3.3
@@ -22950,7 +22950,7 @@ snapshots:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001800
+      caniuse-lite: 1.0.30001802
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -23051,7 +23051,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       exsolve: 1.1.0
-      globby: 16.2.0
+      globby: 16.2.1
       gzip-size: 7.0.0
       h3: 1.15.11
       hookable: 5.5.3
@@ -24395,7 +24395,7 @@ snapshots:
       '@protobufjs/float': 1.0.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 22.20.0
       long: 5.3.2
 


### PR DESCRIPTION
Proposal:

- migrate from `tsd` to `tstyche` in the control package ( `@platformatic/db-authorization` ) 🔥