### PR TITLE
fix(wattpm): handle worker-specific heap snapshot errors

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -170,7 +170,7 @@
 
 ### PLT_RUNTIME_WORKER_NOT_FOUND
 
-**Message:** Worker %s of service %s not found. Available services are: %s
+**Message:** Worker %s of application %s not found. Available workers are: %s
 
 ### PLT_RUNTIME_SERVICE_NOT_STARTED
 

--- a/packages/control/lib/index.js
+++ b/packages/control/lib/index.js
@@ -229,7 +229,7 @@ export class RuntimeApiClient {
 
       if (
         jsonError?.code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' ||
-        jsonError?.code === 'PLT_RUNTIME_APPLICATION_WORKER_NOT_FOUND'
+        jsonError?.code === 'PLT_RUNTIME_WORKER_NOT_FOUND'
       ) {
         throw new ApplicationNotFound(error)
       }
@@ -294,7 +294,7 @@ export class RuntimeApiClient {
 
       if (
         jsonError?.code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' ||
-        jsonError?.code === 'PLT_RUNTIME_APPLICATION_WORKER_NOT_FOUND'
+        jsonError?.code === 'PLT_RUNTIME_WORKER_NOT_FOUND'
       ) {
         throw new ApplicationNotFound(error)
       }
@@ -330,7 +330,7 @@ export class RuntimeApiClient {
       const message = jsonError?.message || error
       const code = jsonError?.code
 
-      if (code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' || code === 'PLT_RUNTIME_APPLICATION_WORKER_NOT_FOUND') {
+      if (code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' || code === 'PLT_RUNTIME_WORKER_NOT_FOUND') {
         throw new ApplicationNotFound(message)
       }
 
@@ -368,7 +368,7 @@ export class RuntimeApiClient {
       const message = jsonError?.message || error
       const code = jsonError?.code
 
-      if (code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' || code === 'PLT_RUNTIME_APPLICATION_WORKER_NOT_FOUND') {
+      if (code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' || code === 'PLT_RUNTIME_WORKER_NOT_FOUND') {
         throw new ApplicationNotFound(message)
       }
 
@@ -403,7 +403,7 @@ export class RuntimeApiClient {
       const message = jsonError?.message || error
       const code = jsonError?.code
 
-      if (code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' || code === 'PLT_RUNTIME_APPLICATION_WORKER_NOT_FOUND') {
+      if (code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' || code === 'PLT_RUNTIME_WORKER_NOT_FOUND') {
         throw new ApplicationNotFound(message)
       }
 

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -39,7 +39,7 @@ export const ApplicationNotFoundError = createError(
 )
 export const WorkerNotFoundError = createError(
   `${ERROR_PREFIX}_WORKER_NOT_FOUND`,
-  'Worker %s of application %s not found. Available applications are: %s'
+  'Worker %s of application %s not found. Available workers are: %s'
 )
 export const ApplicationNotStartedError = createError(
   `${ERROR_PREFIX}_APPLICATION_NOT_STARTED`,

--- a/packages/wattpm/lib/commands/inject.js
+++ b/packages/wattpm/lib/commands/inject.js
@@ -118,7 +118,7 @@ export async function injectCommand (logger, args) {
       /* c8 ignore next 4 - else */
       if (
         json?.code === 'PLT_RUNTIME_APPLICATION_NOT_FOUND' ||
-        json?.code === 'PLT_RUNTIME_APPLICATION_WORKER_NOT_FOUND'
+        json?.code === 'PLT_RUNTIME_WORKER_NOT_FOUND'
       ) {
         const error = new Error('Cannot find an application.')
         error.code = 'PLT_CTR_APPLICATION_NOT_FOUND'

--- a/packages/wattpm/lib/commands/snapshot.js
+++ b/packages/wattpm/lib/commands/snapshot.js
@@ -25,7 +25,8 @@ export async function heapSnapshotCommand (logger, args) {
     const outputDir = values.dir || process.cwd()
 
     if (applicationId) {
-      const application = runtimeApplications.find(s => s.id === applicationId)
+      const applicationIdWithoutWorker = applicationId.match(/^(.+):\d+$/)?.[1] ?? applicationId
+      const application = runtimeApplications.find(s => s.id === applicationIdWithoutWorker)
       if (!application) {
         return logFatalError(logger, `Application not found: ${applicationId}`)
       }
@@ -53,7 +54,7 @@ export async function heapSnapshotCommand (logger, args) {
   } catch (error) {
     if (error.code === 'PLT_CTR_RUNTIME_NOT_FOUND') {
       return logFatalError(logger, 'Cannot find a matching runtime.')
-    } else if (error.message && error.message.includes('Application not found')) {
+    } else if (error.code === 'PLT_CTR_APPLICATION_NOT_FOUND' || error.message?.includes('Application not found')) {
       return logFatalError(logger, error.message)
     } else {
       return logFatalError(

--- a/packages/wattpm/test/snapshot.test.js
+++ b/packages/wattpm/test/snapshot.test.js
@@ -147,6 +147,34 @@ test('heap-snapshot - should fail with non-existent application', async t => {
   ok(snapshotProcess.stdout.includes('Application not found'), 'Should report application not found')
 })
 
+test('heap-snapshot - should fail with non-existent worker', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+
+  t.after(async () => {
+    startProcess.kill('SIGINT')
+    startProcess.catch(() => {})
+  })
+
+  const startProcess = wattpm('start', rootDir)
+
+  for await (const log of on(startProcess.stdout.pipe(split2()), 'data')) {
+    const parsed = JSON.parse(log.toString())
+
+    if (parsed.msg.startsWith('Platformatic is now listening')) {
+      break
+    }
+  }
+
+  const snapshotProcess = await wattpm('heap-snapshot', 'main', 'main:999').catch(e => e)
+
+  strictEqual(snapshotProcess.exitCode, 1, 'Should exit with code 1')
+  ok(
+    snapshotProcess.stdout.includes('Worker 999 of application main not found'),
+    'Should report worker not found'
+  )
+  ok(snapshotProcess.stdout.includes('Available workers are: 0'), 'Should report available workers')
+})
+
 test('heap-snapshot - should fail with non-existent runtime', async t => {
   const snapshotProcess = await wattpm('heap-snapshot', '999999').catch(e => e)
 


### PR DESCRIPTION
Replace `PLT_RUNTIME_APPLICATION_WORKER_NOT_FOUND` with `PLT_RUNTIME_WORKER_NOT_FOUND`:

It seems code was renamed in #4208 by mistake as a large refactor. It was listening an error which is never thrown. 

Update message of `PLT_RUNTIME_WORKER_NOT_FOUND` to reflect workers, not applications as intended. Probably a copy paste from the application specific error. 

Heap snapshot falls back to generic case instead of returning worker not found when the worker isn't found (wrong id, restarted, etc). Fix it and cover with a regression test.