### PR TITLE
chore(wattpm-utils): remove dotenv dependency

### DIFF
--- a/packages/wattpm-utils/package.json
+++ b/packages/wattpm-utils/package.json
@@ -35,7 +35,6 @@
     "@platformatic/runtime": "workspace:*",
     "colorette": "^2.0.20",
     "create-wattpm": "workspace:*",
-    "dotenv": "^16.4.5",
     "execa": "^9.4.0",
     "fast-json-patch": "^3.1.1",
     "semver": "^7.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2487,9 +2487,6 @@ importers:
       create-wattpm:
         specifier: workspace:*
         version: link:../create-wattpm
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
       execa:
         specifier: ^9.4.0
         version: 9.6.1


### PR DESCRIPTION
Proposal:

- The `dotenv` dependency has been removed from the `wattpm-utils` package because as it is not used