### PR TITLE
fix: pin npm 11 in release workflow

### DIFF
--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      - run: npm install npm@11 -g
+      - run: npm install npm@11.18.0 -g
       - name: pnpm install
         uses: nick-fields/retry@v3.0.2
         with:

--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      - run: npm install npm -g
+      - run: npm install npm@11 -g
       - name: pnpm install
         uses: nick-fields/retry@v3.0.2
         with:

--- a/packages/wattpm-utils/test/configuration-less.test.js
+++ b/packages/wattpm-utils/test/configuration-less.test.js
@@ -53,6 +53,8 @@ server.listen(3000)
     'utf-8'
   )
 
+  await writeFile(resolve(rootDir, '.npmrc'), 'dry-run=true\n', 'utf-8')
+
   changeWorkingDirectory(t, rootDir)
   const wattProcess = await wattpmUtils('import', '-P', 'pnpm')
 
@@ -70,6 +72,7 @@ server.listen(3000)
 
   // Replace some dependences with symlinks to local packages
   const modulesDir = resolve(rootDir, 'node_modules/@platformatic')
+  await createDirectory(modulesDir)
   await safeRemove(resolve(modulesDir, 'basic'))
   await safeRemove(resolve(modulesDir, 'node'))
   await symlink(resolve(import.meta.dirname, '../../basic'), resolve(modulesDir, 'basic'), 'dir')

--- a/packages/wattpm-utils/test/create.test.js
+++ b/packages/wattpm-utils/test/create.test.js
@@ -9,7 +9,10 @@ import { createTemporaryDirectory, executeCommand, wattpmUtils } from './helper.
 
 const createEnv = {
   NO_COLOR: 'true',
-  PLT_MODULES_PATHS: JSON.stringify({ '@platformatic/vite': resolve(import.meta.dirname, '../../vite') })
+  PLT_MODULES_PATHS: JSON.stringify({
+    '@platformatic/next': resolve(import.meta.dirname, '../../next'),
+    '@platformatic/vite': resolve(import.meta.dirname, '../../vite')
+  })
 }
 
 test('create - should create a new project using watt.json by default', async t => {

--- a/packages/wattpm-utils/test/import.test.js
+++ b/packages/wattpm-utils/test/import.test.js
@@ -14,14 +14,6 @@ import { prepareRuntime } from '../../basic/test/helper.js'
 import { version } from '../lib/version.js'
 import { changeWorkingDirectory, createTemporaryDirectory, executeCommand, wattpmUtils } from './helper.js'
 
-// These tests perform real npm installs: make npm resilient to transient
-// registry network failures (like ECONNRESET) by retrying more aggressively.
-// The variables are inherited by the package manager processes spawned by
-// the import command.
-process.env.npm_config_fetch_retries = '5'
-process.env.npm_config_fetch_retry_factor = '4'
-process.env.npm_config_fetch_retry_mintimeout = '1000'
-
 const autodetect = {
   astro: 'astro',
   node: null,
@@ -436,6 +428,8 @@ test('import - when launched without arguments, should fix the configuration of 
 
   const configurationFile = resolve(rootDir, 'watt.json')
   const originalFileContents = await loadRawConfigurationFile(configurationFile)
+
+  await writeFile(resolve(rootDir, '.npmrc'), 'dry-run=true\n', 'utf-8')
 
   changeWorkingDirectory(t, rootDir)
   const importProcess = await wattpmUtils('import')


### PR DESCRIPTION
## Summary

- pin the release workflow's global npm install to npm 11.18.0
- prevent npm 12 from being selected during releases
- make `wattpm-utils` tests use local Platformatic capabilities and dry-run dependency installation instead of requiring the current repository version to already exist on npm

Revert the npm pin after https://github.com/npm/cli/issues/9722 lands.

## Context

The failed 3.62.0 release pushed the version bump, then npm 12 failed before publishing with `Cannot find module 'sigstore'`. This exposed `wattpm-utils` tests that attempted to install unpublished `@platformatic/*@^3.62.0` packages.

## Validation

- `npm view npm@11.18.0 version`
- `cd packages/wattpm-utils && pnpm test` — 86 tests passed
- `cd packages/wattpm-utils && pnpm run lint`
- `git diff --check`
- pre-commit checks passed
