### PR TITLE
fix(gateway): include accept-encoding in default deduplication headers

### DIFF
--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -268,7 +268,7 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
     ```
 
   - **`methods`** (`array of string`, default: `['GET', 'HEAD']`) - Methods eligible for deduplication when `routes` is not specified.
-  - **`headers`** (`array of string`, default: `['authorization', 'cookie', 'accept', 'accept-language']`) - Request headers included in the default deduplication key.
+  - **`headers`** (`array of string`, default: `['authorization', 'cookie', 'accept', 'accept-encoding', 'accept-language']`) - Request headers included in the default deduplication key.
   - **`routes`** (`array`) - Optional route whitelist. When specified, routes decide whether deduplication applies instead of `methods` alone. Routes use `find-my-way` syntax and accept either `method` or `methods` plus `path`.
   - **`key`** (`string`) - Path to a JavaScript or TypeScript module exporting a synchronous `computeDeduplicationKey(request, context)` function to customize key computation.
   - **`timeout`** (`number`, default: `1000`) - Milliseconds a duplicate request waits for the leader response before retrying lock acquisition.

--- a/docs/reference/gateway/deduplication.md
+++ b/docs/reference/gateway/deduplication.md
@@ -71,7 +71,7 @@ The default deduplication key is computed from:
 The default headers are:
 
 ```json
-["authorization", "cookie", "accept", "accept-language"]
+["authorization", "cookie", "accept", "accept-encoding", "accept-language"]
 ```
 
 Customize the headers included in the key with `headers`:

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -3762,6 +3762,7 @@
                               "authorization",
                               "cookie",
                               "accept",
+                              "accept-encoding",
                               "accept-language"
                             ]
                           },
@@ -3986,6 +3987,7 @@
                 "authorization",
                 "cookie",
                 "accept",
+                "accept-encoding",
                 "accept-language"
               ]
             },

--- a/packages/gateway/lib/deduplication/index.js
+++ b/packages/gateway/lib/deduplication/index.js
@@ -9,7 +9,7 @@ import { MemoryDeduplicationStorage } from './memory-storage.js'
 import { ValkeyDeduplicationStorage } from './valkey-storage.js'
 
 const require = createRequire(import.meta.url)
-const defaultDeduplicationHeaders = ['authorization', 'cookie', 'accept', 'accept-language']
+const defaultDeduplicationHeaders = ['authorization', 'cookie', 'accept', 'accept-encoding', 'accept-language']
 const defaultDeduplicationMethods = ['GET', 'HEAD']
 
 async function publishError ({ storage, key, token, responseId, config, metrics }) {

--- a/packages/gateway/lib/schema.js
+++ b/packages/gateway/lib/schema.js
@@ -170,7 +170,7 @@ export const deduplication = {
     headers: {
       type: 'array',
       items: { type: 'string' },
-      default: ['authorization', 'cookie', 'accept', 'accept-language']
+      default: ['authorization', 'cookie', 'accept', 'accept-encoding', 'accept-language']
     },
     routes: {
       type: 'array',

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -934,6 +934,7 @@
                               "authorization",
                               "cookie",
                               "accept",
+                              "accept-encoding",
                               "accept-language"
                             ]
                           },
@@ -1158,6 +1159,7 @@
                 "authorization",
                 "cookie",
                 "accept",
+                "accept-encoding",
                 "accept-language"
               ]
             },

--- a/packages/gateway/test/deduplication.test.js
+++ b/packages/gateway/test/deduplication.test.js
@@ -298,6 +298,52 @@ test('should deduplicate configured headers regardless of insertion order', asyn
   assert.equal(upstreamCalls, 1)
 })
 
+test('should not deduplicate concurrent requests with different accept-encoding headers', async () => {
+  let upstreamCalls = 0
+  const handler = await createDeduplicationTestHandler(
+    { enabled: true, lockTtl: 2000, ttl: 1000 },
+    async (_request, reply, _dest, options) => {
+      upstreamCalls++
+      await sleep(100)
+      return options.onResponse(createRequest(), reply, {
+        statusCode: 200,
+        headers: {},
+        stream: ReadableStream.from([Buffer.from('ok')])
+      })
+    }
+  )
+
+  const gzipRequest = { ...createRequest(), headers: { 'accept-encoding': 'gzip' } }
+  const brotliRequest = { ...createRequest(), headers: { 'accept-encoding': 'br' } }
+
+  await Promise.all([handler(gzipRequest, createReply(), '/value', {}), handler(brotliRequest, createReply(), '/value', {})])
+
+  assert.equal(upstreamCalls, 2)
+})
+
+test('should deduplicate concurrent requests with the same accept-encoding header', async () => {
+  let upstreamCalls = 0
+  const handler = await createDeduplicationTestHandler(
+    { enabled: true, lockTtl: 2000, ttl: 1000 },
+    async (_request, reply, _dest, options) => {
+      upstreamCalls++
+      await sleep(100)
+      return options.onResponse(createRequest(), reply, {
+        statusCode: 200,
+        headers: {},
+        stream: ReadableStream.from([Buffer.from('ok')])
+      })
+    }
+  )
+
+  const firstRequest = { ...createRequest(), headers: { 'accept-encoding': 'gzip' } }
+  const secondRequest = { ...createRequest(), headers: { 'accept-encoding': 'gzip' } }
+
+  await Promise.all([handler(firstRequest, createReply(), '/value', {}), handler(secondRequest, createReply(), '/value', {})])
+
+  assert.equal(upstreamCalls, 1)
+})
+
 test('should not deduplicate methods outside of the configured methods', async t => {
   const upstream = await createCountingApplication(t)
   const origin = await upstream.application.listen({ port: 0 })


### PR DESCRIPTION
## Problem

The gateway request-deduplication key is computed from `origin`, `method`, `url`, and a configurable set of request headers, defaulting to `authorization`, `cookie`, `accept`, and `accept-language`. `accept-encoding` is missing from that list.

The deduplication handler stores the leader's proxied response verbatim — including its `content-encoding` response header and the encoded body — and replays it to all waiters that coalesced on the same key. Without `accept-encoding` in the key, a response encoded for a gzip-negotiating client can be replayed to a client that negotiated brotli or identity: the waiter receives a `content-encoding` it never offered, and potentially a body it cannot decode.

## Fix

Add `accept-encoding` to the default deduplication headers, in the handler defaults and the config schema (regenerated `schema.json` for `@platformatic/gateway` and `@platformatic/composer`, which re-exports the schema). Documentation defaults updated to match.

The cost is key fragmentation by encoding — in practice 2–3 variants per URL — which is the correct trade-off; users who normalize `accept-encoding` upstream can still override the `headers` list explicitly.

## Tests

Two new handler-level tests:
- concurrent requests with **different** `accept-encoding` values are not deduplicated (2 upstream calls);
- concurrent requests with the **same** `accept-encoding` are deduplicated (1 upstream call).

Full deduplication suite passes (25/25, memory + Valkey adapters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gsVZyGdMiPgtT7PxrdeSy