### PR TITLE
feat(gateway): stream the deduplication leader response to its client

### DIFF
--- a/docs/reference/gateway/deduplication.md
+++ b/docs/reference/gateway/deduplication.md
@@ -204,7 +204,7 @@ The optional `prefix` value is prepended to all gateway deduplication keys so mu
 
 ## Timeouts
 
-Deduplication buffers the leader response so it can be replayed to waiting requests.
+Deduplication retains a copy of the leader response so it can be replayed to waiting requests. The leader client receives the response streamed as it arrives from the upstream; waiting requests receive the complete response once the leader response has finished.
 
 Important options:
 
@@ -233,7 +233,7 @@ Example:
 
 If all retry attempts are exhausted, the request bypasses deduplication and is proxied normally. This keeps deduplication as an optimization instead of a source of request hangs.
 
-Gateway deduplication buffers the leader response before replaying it to waiters. For streamed or chunked responses, the final response size might not be known before the response has been read. Enforcing a hard size limit after the response starts would make duplicate requests wait and then receive no replayable result, so deduplication does not impose a response size cutoff.
+Gateway deduplication streams the leader response to its client while retaining all chunks in memory, and replays the complete response to waiters. For streamed or chunked responses, the final response size might not be known before the response has been read. Enforcing a hard size limit after the response starts would make duplicate requests wait and then receive no replayable result, so deduplication does not impose a response size cutoff.
 
 Enable deduplication only on controlled routes whose response sizes are bounded or roughly predictable. Large responses increase gateway memory usage and, when using Valkey storage, serialization and storage cost.
 

--- a/packages/gateway/lib/deduplication/index.js
+++ b/packages/gateway/lib/deduplication/index.js
@@ -4,6 +4,7 @@ import Router from 'find-my-way'
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
+import { PassThrough } from 'node:stream'
 import stringify from 'safe-stable-stringify'
 import { MemoryDeduplicationStorage } from './memory-storage.js'
 import { ValkeyDeduplicationStorage } from './valkey-storage.js'
@@ -130,10 +131,34 @@ export async function createDeduplicationHandler ({
         async function deduplicateResponse (proxiedRequest, proxiedReply, res) {
           const body = new DynamicBuffer()
 
+          // The client receives the body as it arrives from the upstream, while
+          // the same chunks accumulate for storage. Backpressure from the client
+          // is deliberately ignored: publication to the waiters must never depend
+          // on how fast the leader client consumes the response, and the chunks
+          // are retained in full for storage anyway, so this costs no extra
+          // memory. If the client goes away mid-response, the upstream is still
+          // consumed to completion so that the waiters can be served.
+          const stream = new PassThrough()
+          stream.on('error', () => {})
+
+          const sent = Promise.resolve(
+            baseOnResponse ? baseOnResponse(proxiedRequest, proxiedReply, { ...res, stream }) : proxiedReply.send(stream)
+          )
+          // The rejection is rethrown by the return below; this only prevents it
+          // from being reported as unhandled while the body is still streaming.
+          sent.catch(() => {})
+
           try {
             for await (const chunk of res.stream) {
-              body.append(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+              const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+              body.append(buffer)
+
+              if (!stream.destroyed) {
+                stream.write(buffer)
+              }
             }
+
+            stream.end()
 
             await storage.setResponse(
               responseId,
@@ -148,17 +173,19 @@ export async function createDeduplicationHandler ({
             await storage.unlock(key, token)
           } catch (error) {
             app.log.error({ err: ensureLoggableError(error) }, 'Error while deduplicating gateway response')
+
+            // Only sever the client when the body was actually truncated: a
+            // storage failure after the body completed should not abort a
+            // client which is still draining a valid response.
+            if (!stream.writableEnded) {
+              stream.destroy(error)
+            }
+
             await publishError({ storage, key, token, responseId, config, metrics })
             throw error
           }
 
-          const stream = body.asReadable()
-
-          if (baseOnResponse) {
-            return baseOnResponse(proxiedRequest, proxiedReply, { ...res, stream })
-          }
-
-          return proxiedReply.send(stream)
+          return sent
         }
 
         async function deduplicateError (proxiedReply, error) {

--- a/packages/gateway/test/deduplication.test.js
+++ b/packages/gateway/test/deduplication.test.js
@@ -525,6 +525,95 @@ test('should replay binary chunks without concatenating before storage', async (
   )
 })
 
+test('should stream the leader response while buffering it for the waiters', async () => {
+  let upstreamProducedLastChunk = false
+  let firstChunkSeenBeforeUpstreamEnd = false
+
+  async function * slowBody () {
+    yield Buffer.from('he')
+    await sleep(200)
+    upstreamProducedLastChunk = true
+    yield Buffer.from('llo')
+  }
+
+  const handler = await createDeduplicationTestHandler(
+    { enabled: true, lockTtl: 2000, ttl: 1000 },
+    async (_request, reply, _dest, options) => {
+      return options.onResponse(createRequest(), reply, {
+        statusCode: 200,
+        headers: {},
+        stream: ReadableStream.from(slowBody())
+      })
+    }
+  )
+
+  const reply = createReply()
+  reply.send = async function (payload) {
+    const chunks = []
+
+    for await (const chunk of payload) {
+      if (chunks.length === 0 && !upstreamProducedLastChunk) {
+        firstChunkSeenBeforeUpstreamEnd = true
+      }
+
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+
+    this.payload = Buffer.concat(chunks)
+  }
+
+  await handler(createRequest(), reply, '/value', {})
+
+  assert.equal(reply.payload.toString(), 'hello')
+  assert.equal(firstChunkSeenBeforeUpstreamEnd, true)
+})
+
+test('should not delay waiters when the leader client consumes slowly', async () => {
+  const order = []
+  let upstreamCalls = 0
+
+  async function * upstreamBody () {
+    yield Buffer.from('he')
+    await sleep(150)
+    yield Buffer.from('llo')
+  }
+
+  const handler = await createDeduplicationTestHandler(
+    { enabled: true, lockTtl: 2000, ttl: 1000 },
+    async (_request, reply, _dest, options) => {
+      upstreamCalls++
+      return options.onResponse(createRequest(), reply, {
+        statusCode: 200,
+        headers: {},
+        stream: ReadableStream.from(upstreamBody())
+      })
+    }
+  )
+
+  const slowReply = createReply()
+  slowReply.send = async function (payload) {
+    const chunks = []
+
+    for await (const chunk of payload) {
+      await sleep(300)
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+
+    this.payload = Buffer.concat(chunks)
+  }
+
+  const leader = handler(createRequest(), slowReply, '/value', {}).then(() => order.push('leader'))
+  await sleep(50)
+  const waiterReply = createReply()
+  await handler(createRequest(), waiterReply, '/value', {}).then(() => order.push('waiter'))
+  await leader
+
+  assert.equal(upstreamCalls, 1)
+  assert.deepEqual(order, ['waiter', 'leader'])
+  assert.equal(waiterReply.payload.toString(), 'hello')
+  assert.equal(slowReply.payload.toString(), 'hello')
+})
+
 test('should increment fallback metric', async () => {
   const metrics = createDeduplicationMetrics()
   let upstreamCalls = 0


### PR DESCRIPTION
## Problem

The deduplication handler buffered the entire upstream response before sending anything to the leader client: the leader saw the first byte only after the last byte had arrived **and** the response had been written to storage. On deduplicated routes this defeated streaming responses (e.g. SSR early flush — TTFB moved from first-chunk time to full-response time) and put the storage round-trips on the leader's critical path.

## Change

The leader client now receives the body as it arrives from the upstream, while the same chunks keep accumulating for storage:

- A `PassThrough` is handed to the reply immediately; the pump appends each upstream chunk to the storage buffer and writes it to the client stream.
- **Client backpressure is deliberately ignored**: publication to the waiters must never depend on how fast the leader client consumes the response (a naive tee would make every waiter hostage to the slowest client's download speed). The chunks are retained in full for storage anyway, so this costs no additional memory — the stream queue holds references to the same Buffers.
- If the client disconnects mid-response, the upstream is still consumed to completion so waiters can be served.
- `setResponse`/`notify`/`unlock` fire as soon as the upstream completes, off the client's critical path (previously the leader's last byte waited for the storage round-trips).

## Error semantics

- A mid-body upstream failure truncates the leader response — identical to plain `reply.from` proxying, so no regression vs. the non-deduplicated path — and publishes the error so waiters retry or fall back, as before.
- A storage failure after the body completed no longer aborts a client draining a valid response (previously the leader request failed even though its upstream call had succeeded).

## Tests

Two new tests pin the key properties: the leader observes the first chunk before the upstream has produced its last chunk (true streaming), and a waiter completes its replay while the leader's slow client is still draining (publication decoupled from client consumption). Full deduplication suite passes (25/25, memory + Valkey adapters).

Docs updated where they stated the leader response is buffered. Waiters still receive the complete response at leader-completion time; chunked replay to waiters is a possible future follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gsVZyGdMiPgtT7PxrdeSy