### PR TITLE
test(runtime): validate per-worker port ranges

### DIFF
--- a/packages/runtime/test/multiple-workers/helper.js
+++ b/packages/runtime/test/multiple-workers/helper.js
@@ -1,6 +1,7 @@
 import { createDirectory, features, safeRemove } from '@platformatic/foundation'
 import { deepStrictEqual } from 'node:assert'
 import { cp, symlink } from 'node:fs/promises'
+import { createServer } from 'node:net'
 import { join, resolve } from 'node:path'
 import { request } from 'undici'
 
@@ -8,6 +9,79 @@ export const fixturesDir = join(import.meta.dirname, '..', '..', 'fixtures')
 export const tmpDir = resolve(import.meta.dirname, '../../tmp')
 
 const WAIT_TIMEOUT = process.env.CI ? 20_000 : 10_000
+const MAX_PORT = 65_535
+
+function listen (server, host, port) {
+  return new Promise((resolve, reject) => {
+    function onError (error) {
+      server.off('listening', onListening)
+      reject(error)
+    }
+
+    function onListening () {
+      server.off('error', onError)
+      resolve()
+    }
+
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen({ host, port, exclusive: true })
+  })
+}
+
+function closeServer (server) {
+  if (!server.listening) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()))
+  })
+}
+
+export async function findAvailablePortRange ({ host, size, startPort }) {
+  if (!Number.isInteger(size) || size < 1 || size > MAX_PORT) {
+    throw new RangeError('size must be an integer between 1 and 65535')
+  }
+
+  if (startPort !== undefined && (!Number.isInteger(startPort) || startPort < 1 || startPort > MAX_PORT)) {
+    throw new RangeError('startPort must be an integer between 1 and 65535')
+  }
+
+  while (true) {
+    const servers = []
+
+    try {
+      const firstServer = createServer()
+      servers.push(firstServer)
+      await listen(firstServer, host, startPort ?? 0)
+      startPort = undefined
+
+      const address = firstServer.address()
+      const basePort = address.port
+
+      if (basePort + size - 1 > MAX_PORT) {
+        continue
+      }
+
+      for (let offset = 1; offset < size; offset++) {
+        const server = createServer()
+        servers.push(server)
+        await listen(server, host, basePort + offset)
+      }
+
+      return basePort
+    } catch (error) {
+      startPort = undefined
+
+      if (error.code !== 'EACCES' && error.code !== 'EADDRINUSE') {
+        throw error
+      }
+    } finally {
+      await Promise.all(servers.map(closeServer))
+    }
+  }
+}
 
 export async function prepareRuntime (t, name, dependencies) {
   const root = resolve(tmpDir, `plt-multiple-workers-${Date.now()}`)

--- a/packages/runtime/test/multiple-workers/per-worker-port.test.js
+++ b/packages/runtime/test/multiple-workers/per-worker-port.test.js
@@ -1,22 +1,56 @@
-import { deepStrictEqual, strictEqual } from 'node:assert'
+import { deepStrictEqual, notStrictEqual, strictEqual } from 'node:assert'
+import { once } from 'node:events'
+import { createServer } from 'node:net'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { request } from 'undici'
 import { createRuntime, updateConfigFile } from '../helpers.js'
-import { prepareRuntime, waitForEvents } from './helper.js'
+import { findAvailablePortRange, prepareRuntime, waitForEvents } from './helper.js'
 
 const HOST = '127.0.0.1'
 
-async function getBasePort () {
-  const getPort = await import('get-port')
-  return getPort.default({ host: HOST })
+async function listen (server, port = 0) {
+  server.listen({ host: HOST, port, exclusive: true })
+  await once(server, 'listening')
 }
 
-async function preparePerWorkerPortRuntime (t, { application = 'node', workerCount = 5 } = {}) {
+function closeServer (server) {
+  if (!server.listening) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()))
+  })
+}
+
+async function getOccupiedPortWithAvailablePreviousPort () {
+  while (true) {
+    const occupiedServer = createServer()
+    await listen(occupiedServer)
+    const occupiedPort = occupiedServer.address().port
+    const candidatePort = occupiedPort - 1
+    const probeServer = createServer()
+
+    try {
+      await listen(probeServer, candidatePort)
+      return { candidatePort, occupiedPort, occupiedServer }
+    } catch {
+      await closeServer(occupiedServer)
+    } finally {
+      await closeServer(probeServer)
+    }
+  }
+}
+
+async function preparePerWorkerPortRuntime (
+  t,
+  { application = 'node', workerCount = 5, maxWorkerCount = workerCount } = {}
+) {
   const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
   const configFile = resolve(root, './platformatic.json')
-  const basePort = await getBasePort()
+  const basePort = await findAvailablePortRange({ host: HOST, size: maxWorkerCount })
 
   await updateConfigFile(configFile, contents => {
     contents.server = {
@@ -112,6 +146,32 @@ async function assertPortClosed (port) {
   throw new Error(`Port ${port} is still accepting requests`)
 }
 
+test('findAvailablePortRange retries when a port inside the candidate range is unavailable', async t => {
+  const { candidatePort, occupiedServer } = await getOccupiedPortWithAvailablePreviousPort()
+  t.after(() => closeServer(occupiedServer))
+
+  const basePort = await findAvailablePortRange({ host: HOST, size: 2, startPort: candidatePort })
+  notStrictEqual(basePort, candidatePort)
+
+  const probeServers = []
+  try {
+    for (let offset = 0; offset < 2; offset++) {
+      const server = createServer()
+      probeServers.push(server)
+      await listen(server, basePort + offset)
+    }
+  } finally {
+    await Promise.all(probeServers.map(closeServer))
+  }
+
+  const candidateServer = createServer()
+  try {
+    await listen(candidateServer, candidatePort)
+  } finally {
+    await closeServer(candidateServer)
+  }
+})
+
 test('assigns one incremental port per entrypoint worker', async t => {
   const { app, basePort } = await preparePerWorkerPortRuntime(t)
 
@@ -123,7 +183,7 @@ test('assigns one incremental port per entrypoint worker', async t => {
 })
 
 test('assigns new incremental ports when scaling up and stops highest ports when scaling down', async t => {
-  const { app, basePort } = await preparePerWorkerPortRuntime(t)
+  const { app, basePort } = await preparePerWorkerPortRuntime(t, { maxWorkerCount: 7 })
 
   await app.start()
 


### PR DESCRIPTION
## Summary

- add a helper that probes and releases complete consecutive TCP port ranges
- retry range selection when Windows reports `EACCES` or `EADDRINUSE`
- reserve all seven ports used by the scale-up test and cover retry/cleanup behavior

## Testing

- `pnpm --filter @platformatic/runtime run lint`
- focused port-range test, repeated 10 times

Fixes #4939
