### PR TITLE
feat(runtime): per-application restartOnError override

### DIFF
--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticAstroConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -620,6 +620,10 @@ export interface PlatformaticBasicConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -258,6 +258,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2343,6 +2355,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -788,6 +788,10 @@ export interface PlatformaticComposerConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -931,6 +931,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -3016,6 +3028,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -1114,6 +1114,10 @@ export interface PlatformaticDatabaseConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1615,6 +1615,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -3700,6 +3712,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -873,6 +873,17 @@ export const application = {
       ]
     },
     health: { ...healthWithoutDefaults },
+    restartOnError: {
+      description:
+        'Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.',
+      anyOf: [
+        { type: 'boolean' },
+        {
+          type: 'number',
+          minimum: 0
+        }
+      ]
+    },
     dependencies: {
       type: 'array',
       items: {

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -1050,6 +1050,10 @@ export interface PlatformaticGatewayConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1894,6 +1894,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -3979,6 +3991,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticNestJSConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticNextJsConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticNodeJsConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticNuxtConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticReactRouterConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticRemixConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -51,6 +51,10 @@ export type PlatformaticRuntimeConfig = {
           bufferPoolSize?: number | string;
           defaultHighWaterMark?: number | string;
         };
+        /**
+         * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+         */
+        restartOnError?: boolean | number;
         dependencies?: string[];
         arguments?: string[];
         env?: {

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -118,6 +118,7 @@ const DEFAULT_CONCURRENCY = availableParallelism() * 2
 const MAX_BOOTSTRAP_ATTEMPTS = 5
 const IMMEDIATE_RESTART_MAX_THRESHOLD = 10
 const MAX_WORKERS = 100
+const DEFAULT_RESTART_ON_ERROR_DELAY = 5000
 
 export class Runtime extends EventEmitter {
   logger
@@ -1842,7 +1843,7 @@ export class Runtime extends EventEmitter {
   }
 
   async #setupWorker (config, applicationConfig, workersCount, applicationId, index, enabled = true, attempt = 0) {
-    const { restartOnError } = config
+    const restartOnError = this.#getApplicationRestartOnError(config, applicationConfig)
     const workerId = `${applicationId}:${index}`
 
     // Handle inspector
@@ -2184,7 +2185,7 @@ export class Runtime extends EventEmitter {
       // Check if any worker has health checks enabled
       for (const worker of this.#workers.values()) {
         const healthConfig = worker[kConfig]?.health
-        if (healthConfig?.enabled && this.#config.restartOnError > 0) {
+        if (healthConfig?.enabled && this.#getApplicationRestartOnError(this.#config, worker[kConfig]) > 0) {
           needsHealthMetrics = true
           break
         }
@@ -2485,7 +2486,7 @@ export class Runtime extends EventEmitter {
       }
 
       const { enabled, gracePeriod } = worker[kConfig].health
-      if (enabled && config.restartOnError > 0) {
+      if (enabled && this.#getApplicationRestartOnError(config, applicationConfig) > 0) {
         // if gracePeriod is 0, it will be set to 1 to start health checks immediately
         // however, the health event will start when the worker is started
         setTimeout(
@@ -2523,7 +2524,7 @@ export class Runtime extends EventEmitter {
         this.logger.error({ err: ensureLoggableError(error) }, `Failed to start ${label}: ${error.message}`)
       }
 
-      const restartOnError = config.restartOnError
+      const restartOnError = this.#getApplicationRestartOnError(config, applicationConfig)
 
       if (disableRestartAttempts || !restartOnError) {
         throw error
@@ -2643,7 +2644,25 @@ export class Runtime extends EventEmitter {
     return index
   }
 
+  // Returns the effective restartOnError value for an application: the application-level
+  // value, when defined, takes precedence over the runtime-level one.
+  // The value is normalized to a number: false becomes 0 (never restart),
+  // true becomes the default delay.
+  #getApplicationRestartOnError (config, applicationConfig) {
+    let restartOnError = applicationConfig?.restartOnError ?? config.restartOnError
+
+    if (restartOnError === true) {
+      restartOnError = DEFAULT_RESTART_ON_ERROR_DELAY
+    } else if (restartOnError === false || restartOnError < 0) {
+      restartOnError = 0
+    }
+
+    return restartOnError
+  }
+
   async #restartCrashedWorker (config, applicationConfig, workersCount, id, oldIndex, silent, bootstrapAttempt, portOffset) {
+    const restartOnError = this.#getApplicationRestartOnError(config, applicationConfig)
+
     // Use oldIndex for tracking to prevent duplicate restarts of the same crashed worker
     const restartKey = `${id}:${oldIndex}`
 
@@ -2689,10 +2708,10 @@ export class Runtime extends EventEmitter {
         }
       }
 
-      if (config.restartOnError < IMMEDIATE_RESTART_MAX_THRESHOLD) {
+      if (restartOnError < IMMEDIATE_RESTART_MAX_THRESHOLD) {
         process.nextTick(restart.bind(this))
       } else {
-        setTimeout(restart.bind(this), config.restartOnError)
+        setTimeout(restart.bind(this), restartOnError)
       }
     })
 

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -251,6 +251,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -649,6 +661,18 @@
             },
             "additionalProperties": false
           },
+          "restartOnError": {
+            "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number",
+                "minimum": 0
+              }
+            ]
+          },
           "dependencies": {
             "type": "array",
             "items": {
@@ -1045,6 +1069,18 @@
             },
             "additionalProperties": false
           },
+          "restartOnError": {
+            "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number",
+                "minimum": 0
+              }
+            ]
+          },
           "dependencies": {
             "type": "array",
             "items": {
@@ -1440,6 +1476,18 @@
               }
             },
             "additionalProperties": false
+          },
+          "restartOnError": {
+            "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number",
+                "minimum": 0
+              }
+            ]
           },
           "dependencies": {
             "type": "array",

--- a/packages/runtime/test/multiple-workers/per-application-restart-on-error.test.js
+++ b/packages/runtime/test/multiple-workers/per-application-restart-on-error.test.js
@@ -1,0 +1,157 @@
+import { deepStrictEqual, ok } from 'node:assert'
+import { readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { Client } from 'undici'
+import { createRuntime, updateFile } from '../helpers.js'
+import { prepareRuntime, waitForEvents } from './helper.js'
+
+async function prepareCrashableRuntime (t, { runtimeRestartOnError, applicationRestartOnError }) {
+  const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
+  const configFile = resolve(root, './platformatic.json')
+
+  const config = JSON.parse(await readFile(configFile, 'utf-8'))
+  config.workers = 1
+  config.restartOnError = runtimeRestartOnError
+  config.services[0].workers = 1
+
+  if (typeof applicationRestartOnError !== 'undefined') {
+    config.services[0].restartOnError = applicationRestartOnError
+  }
+
+  await writeFile(configFile, JSON.stringify(config, null, 2))
+
+  // Add a route which crashes the worker when invoked
+  await updateFile(resolve(root, 'node/index.mjs'), contents => {
+    return contents.replace(
+      "app.get('/hello'",
+      `app.get('/crash', async () => {
+    setImmediate(() => {
+      throw new Error('kaboom')
+    })
+
+    return { ok: true }
+  })
+
+  app.get('/hello'`
+    )
+  })
+
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const client = new Client(
+    {
+      hostname: 'localhost',
+      protocol: 'http:'
+    },
+    {
+      socketPath: app.getManagementApiUrl(),
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10
+    }
+  )
+
+  t.after(async () => {
+    await client.close()
+  })
+
+  return { root, app, client }
+}
+
+test('per-application restartOnError=0 quarantines a crashed application while the runtime keeps running', async t => {
+  const { app, client } = await prepareCrashableRuntime(t, {
+    runtimeRestartOnError: 500,
+    applicationRestartOnError: 0
+  })
+
+  const started = []
+  app.on('application:worker:started', payload => {
+    started.push(payload)
+  })
+
+  const eventsPromise = waitForEvents(
+    app,
+    { event: 'application:worker:error', application: 'node', worker: 0 },
+    { event: 'application:worker:unvailable', application: 'node', worker: 0 }
+  )
+
+  // Crash the only worker of the "node" application
+  {
+    const res = await client.request({ method: 'GET', path: '/api/v1/applications/node/proxy/crash' })
+    await res.body.dump()
+    deepStrictEqual(res.statusCode, 200)
+  }
+
+  await eventsPromise
+
+  // Give a potential (unwanted) restart the time to happen, then verify it did not
+  await sleep(2000)
+  deepStrictEqual(
+    started.filter(e => e.application === 'node'),
+    [],
+    'the crashed application should not be restarted'
+  )
+
+  // The runtime and the sibling applications must still serve requests
+  const res = await client.request({ method: 'GET', path: '/api/v1/applications/service/proxy/hello' })
+  deepStrictEqual(res.statusCode, 200)
+  deepStrictEqual(await res.body.json(), { from: 'service' })
+})
+
+test('per-application restartOnError overrides a runtime which disabled restarts', async t => {
+  const { app, client } = await prepareCrashableRuntime(t, {
+    runtimeRestartOnError: 0,
+    applicationRestartOnError: 100
+  })
+
+  const eventsPromise = waitForEvents(
+    app,
+    { event: 'application:worker:error', application: 'node', worker: 0 },
+    // Restarted workers get a new unique index
+    { event: 'application:worker:started', application: 'node', worker: 1 }
+  )
+
+  const res = await client.request({ method: 'GET', path: '/api/v1/applications/node/proxy/crash' })
+  await res.body.dump()
+  deepStrictEqual(res.statusCode, 200)
+
+  await eventsPromise
+
+  // The restarted application must serve requests again
+  const verify = await client.request({ method: 'GET', path: '/api/v1/applications/node/proxy/hello' })
+  deepStrictEqual(verify.statusCode, 200)
+  deepStrictEqual(await verify.body.json(), { from: 'node' })
+})
+
+test('the runtime-level restartOnError is used when the application does not define one', async t => {
+  const { app, client } = await prepareCrashableRuntime(t, {
+    runtimeRestartOnError: 0
+  })
+
+  const started = []
+  app.on('application:worker:started', payload => {
+    started.push(payload)
+  })
+
+  const eventsPromise = waitForEvents(
+    app,
+    { event: 'application:worker:error', application: 'node', worker: 0 },
+    { event: 'application:worker:unvailable', application: 'node', worker: 0 }
+  )
+
+  const res = await client.request({ method: 'GET', path: '/api/v1/applications/node/proxy/crash' })
+  await res.body.dump()
+  deepStrictEqual(res.statusCode, 200)
+
+  await eventsPromise
+
+  await sleep(2000)
+  ok(!started.some(e => e.application === 'node'), 'the crashed application should not be restarted')
+})

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -943,6 +943,10 @@ export interface PlatformaticServiceConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1300,6 +1300,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -3385,6 +3397,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticTanStackConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -740,6 +740,10 @@ export interface PlatformaticViteConfig {
         bufferPoolSize?: number | string;
         defaultHighWaterMark?: number | string;
       };
+      /**
+       * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+       */
+      restartOnError?: boolean | number;
       arguments?: string[];
       env?: {
         [k: string]: string;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -657,6 +657,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -2742,6 +2754,18 @@
                 }
               },
               "additionalProperties": false
+            },
+            "restartOnError": {
+              "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                }
+              ]
             },
             "arguments": {
               "type": "array",

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -51,6 +51,10 @@ export type PlatformaticRuntimeConfig = {
           bufferPoolSize?: number | string;
           defaultHighWaterMark?: number | string;
         };
+        /**
+         * Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.
+         */
+        restartOnError?: boolean | number;
         dependencies?: string[];
         arguments?: string[];
         env?: {

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -251,6 +251,18 @@
                 },
                 "additionalProperties": false
               },
+              "restartOnError": {
+                "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                ]
+              },
               "dependencies": {
                 "type": "array",
                 "items": {
@@ -649,6 +661,18 @@
             },
             "additionalProperties": false
           },
+          "restartOnError": {
+            "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number",
+                "minimum": 0
+              }
+            ]
+          },
           "dependencies": {
             "type": "array",
             "items": {
@@ -1045,6 +1069,18 @@
             },
             "additionalProperties": false
           },
+          "restartOnError": {
+            "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number",
+                "minimum": 0
+              }
+            ]
+          },
           "dependencies": {
             "type": "array",
             "items": {
@@ -1440,6 +1476,18 @@
               }
             },
             "additionalProperties": false
+          },
+          "restartOnError": {
+            "description": "Overrides the runtime-level restartOnError for this application. Set to false or 0 to never restart the application when it crashes, a positive number to wait that amount of milliseconds between restarts, or true to use the default delay.",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number",
+                "minimum": 0
+              }
+            ]
           },
           "dependencies": {
             "type": "array",


### PR DESCRIPTION
## What

Adds `restartOnError` as a per-application property in the runtime configuration. It has the same type and semantics as the existing runtime-level property: `false`/`0` means the application is never restarted when it crashes, a positive number is the delay in milliseconds between restarts, and `true` uses the default delay (5000ms).

Motivation: allows quarantining a crash-looping application without affecting the rest of the runtime — needed when running multiple versions of the same application in one runtime (skew protection).

## Semantics

- **Precedence**: the application-level value, when defined, takes precedence over the runtime-level one. When absent, the runtime-level value applies, exactly as before.
- **Quarantine**: with `restartOnError: 0` (or `false`) on a non-entrypoint application, a crashed worker is not restarted: the exit is logged, `application:worker:error` and `application:worker:unvailable` are emitted, and the runtime and all sibling applications keep running and serving requests.
- The effective value is used everywhere the runtime-level one was used: the crash/restart decision on worker exit, the bootstrap retry logic in `#startWorker`, the restart delay in `#restartCrashedWorker`, and the health-check gating (health-driven restarts are disabled for an application which opted out of restarts).
- Notably, this also makes it possible to disable restarts for a single application in production, where the runtime-level value is force-normalized to an immediate restart.
- The property is part of the applications schema, so it is validated and accepted by `addApplications` (management API / ITC) as well, and can also be set through the wrapped `runtime.application` property of an application's own config.

## Backward compatibility

No behavior change when the per-application property is absent: the runtime-level `restartOnError` (including its production normalization and defaults) is untouched, and the existing "stay up, emit `application:worker:unvailable`" behavior for globally disabled restarts is unchanged.

## Tests

New tests in `packages/runtime/test/multiple-workers/per-application-restart-on-error.test.js`:
- per-app `restartOnError: 0` with runtime-level restarts enabled: the crashed app stays down, the event is emitted, siblings still serve requests
- per-app positive value with runtime-level `0`: the app is restarted
- no per-app value: falls back to the runtime-level behavior

Schemas and types regenerated (`gen-schema` / `gen-types`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Nq4eqbifqTuBJCDGf3D5U