### PR TITLE
feat(gateway): document and test the proxy.custom extension contract

### DIFF
--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -60,14 +60,26 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
         - **`logs`** (`boolean`) - Enable logging for WebSocket reconnection events.
       - **`hooks`** (`object`) - WebSocket hooks configuration:
         - **`path`** (`string`) - Path to a JavaScript/TypeScript file that exports WebSocket lifecycle hooks (e.g., `onConnect`, `onReconnect`, `onDisconnect`, `onIncomingMessage`, `onOutgoingMessage`, `onPong`).
-    - **`custom`** (`object`) - Custom proxy logic configuration:
-      - **`path`** (`string`) - Path to a JavaScript/TypeScript file that exports custom proxy functions. The file should export an object with:
-        - **`preRewrite`** (`function`) - A function `(url, params, prefix) => string` that can be used to modify the request URL. See [@fastify/http-proxy](https://github.com/fastify/fastify-http-proxy?tab=readme-ov-file#prerewrite).
-        - **`preValidation`** (`function`) - A function that runs before proxying. Can be either:
-          - An async function: `(request, reply) => Promise<boolean>` - Return `false` to stop the request proxying and return an error. Return `true` or `undefined` to continue.
-          - A callback function: `(request, reply, done) => void` - Call `done()` to continue or `done(error)` to stop with an error.
-            See [fastify preValidation hook](https://fastify.dev/docs/latest/Reference/Hooks/#prevalidation) for further information.
-        - **`getUpstream`** (`function`) - A function `(request, base) => string` that dynamically determines the upstream URL based on the request. Receives the request object and the base upstream URL. Note: `request.body` is a readable stream by default. If you need to access the body content as JSON or string in `getUpstream`, use `preValidation` to parse the body first. See [@fastify/fastify-reply-from](https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#getupstreamrequest-base) for further information.
+    - **`custom`** (`object`) - Custom proxy logic configuration. This is a supported public API: external modules and addons can rely on this contract to implement per-request routing, for example to route requests to different versions of the same application based on a header or a cookie. Supports the following options:
+      - **`path`** (**required**, `string`) - Path to a JavaScript/TypeScript file that exports the custom proxy hooks. The module can either export the hooks object directly (as the default export) or export a factory function `(options) => hooks` (synchronous or asynchronous) which receives the `options` value below and returns the hooks object.
+      - **`options`** (`object`) - An arbitrary JSON object which is passed to the factory function exported by the module referenced in `path`. It is ignored when the module exports the hooks object directly.
+
+      The hooks object supports the following properties, all optional:
+
+      - **`preRewrite`** (`function`) - A function `(url, params, prefix) => string` that can be used to modify the request URL. See [@fastify/http-proxy](https://github.com/fastify/fastify-http-proxy?tab=readme-ov-file#prerewrite).
+      - **`preValidation`** (`function`) - A function that runs before proxying. Can be either:
+        - An async function: `(request, reply) => Promise<boolean>` - Return `false` to stop the request proxying and return an error. Return `true` or `undefined` to continue.
+        - A callback function: `(request, reply, done) => void` - Call `done()` to continue or `done(error)` to stop with an error.
+          See [fastify preValidation hook](https://fastify.dev/docs/latest/Reference/Hooks/#prevalidation) for further information.
+      - **`getUpstream`** (`function`) - A function `(request, base) => string` that dynamically determines the upstream URL for each request. Receives the request object and the base upstream URL. Note: `request.body` is a readable stream by default. If you need to access the body content as JSON or string in `getUpstream`, use `preValidation` to parse the body first. See [@fastify/fastify-reply-from](https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#getupstreamrequest-base) for further information.
+
+        When `getUpstream` is provided, the following guarantees apply:
+
+        - The `upstream` setting is ignored and `base` may be `undefined`, so the function must always return a full origin (for example `http://127.0.0.1:3042` or `http://my-application.plt.local`).
+        - When running inside Platformatic Runtime or Watt, the returned origin can be the internal mesh address `http://<application-id>.plt.local` of **any** application in the runtime, including applications which are **not** listed in the gateway `applications` configuration. Such requests are routed through the runtime mesh network. This makes it possible to keep a single logical entry in the gateway configuration and dispatch each request to one of several runtime applications (for example several versions of the same application) at runtime.
+        - When no `ws.upstream` is configured, `getUpstream` also selects the upstream for WebSocket connections. It is invoked once per connection with the upgrade request at upgrade time.
+      - **`rewriteHeaders`** (`function`) - A function `(headers, request) => headers` invoked with the response headers received from the upstream (after the gateway performed its internal `Location` header rewriting) and the original request. It must return the headers object to send back to the client. Use it, for example, to add a `Set-Cookie` header which pins a client to the upstream selected by `getUpstream`. Since both hooks receive the same request object, `getUpstream` can attach data to it (e.g. `request.selectedUpstream = ...`) and `rewriteHeaders` can read it back.
+      - **`onError`** (`function`) - A function `(reply, { error }) => void` invoked when proxying a request fails. The gateway first logs the error, then invokes this hook instead of its default handler (which forwards the error to the client). Use `reply` to send a custom response. See [@fastify/fastify-reply-from](https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#onerrorreply-error) for further information.
 
     :::note
     If the prefix is not explicitly set, the gateway and the application will try to find the best prefix for the application.
@@ -137,7 +149,6 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
       "id": "dynamic-router",
       "proxy": {
         "prefix": "/",
-        "upstream": "http://default-service.com",
         "custom": {
           "path": "./custom-proxy.js"
         }
@@ -165,7 +176,78 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
         if (request.url.startsWith('/v2')) {
           return 'http://api-v2.example.com'
         }
-        return base
+        return 'http://api-v1.example.com'
+      }
+    }
+    ```
+
+    **Example: Per-Request Version Routing (header or cookie based)**
+
+    A single logical application is listed in the gateway configuration, while the requests
+    are dispatched at runtime to several applications running in the same runtime
+    (for example several versions of the same application). The target applications
+    do not need to be listed in the gateway configuration: any `http://<application-id>.plt.local`
+    origin is routed through the runtime mesh network.
+
+    ```json
+    {
+      "id": "main",
+      "proxy": {
+        "prefix": "/",
+        "custom": {
+          "path": "./version-router.js",
+          "options": {
+            "header": "x-app-version",
+            "cookie": "app-version",
+            "fallback": "main"
+          }
+        }
+      }
+    }
+    ```
+
+    Where `version-router.js` exports a factory function receiving `custom.options`:
+
+    ```javascript
+    function parseCookies (header) {
+      const cookies = {}
+
+      for (const part of (header ?? '').split(';')) {
+        const index = part.indexOf('=')
+
+        if (index !== -1) {
+          cookies[part.slice(0, index).trim()] = decodeURIComponent(part.slice(index + 1).trim())
+        }
+      }
+
+      return cookies
+    }
+
+    export default function createVersionRouter (options) {
+      return {
+        getUpstream (request) {
+          // Select the version via a request header or a cookie
+          const version =
+            request.headers[options.header] ?? parseCookies(request.headers.cookie)[options.cookie]
+
+          if (version) {
+            request.selectedVersion = version
+            return `http://${version}.plt.local`
+          }
+
+          return `http://${options.fallback}.plt.local`
+        },
+        rewriteHeaders (headers, request) {
+          // Pin the client to the selected version on subsequent requests
+          if (request.selectedVersion) {
+            headers['set-cookie'] = `${options.cookie}=${request.selectedVersion}; Path=/`
+          }
+
+          return headers
+        },
+        onError (reply, { error }) {
+          reply.code(503).send({ error: 'Selected version is unavailable' })
+        }
       }
     }
     ```

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -1037,6 +1037,9 @@ export interface PlatformaticComposerConfig {
             hostname?: string;
             custom?: {
               path: string;
+              options?: {
+                [k: string]: unknown;
+              };
             };
             deduplication?: {
               enabled?: boolean | string;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -3679,6 +3679,10 @@
                         "properties": {
                           "path": {
                             "type": "string"
+                          },
+                          "options": {
+                            "type": "object",
+                            "additionalProperties": true
                           }
                         },
                         "required": [

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -257,6 +257,9 @@ export interface PlatformaticGatewayConfig {
             hostname?: string;
             custom?: {
               path: string;
+              options?: {
+                [k: string]: unknown;
+              };
             };
             deduplication?: {
               enabled?: boolean | string;

--- a/packages/gateway/lib/proxy.js
+++ b/packages/gateway/lib/proxy.js
@@ -59,7 +59,15 @@ async function resolveApplicationProxyParameters (application, root) {
   const require = createRequire(import.meta.filename)
 
   if (application.proxy?.custom) {
-    const custom = await loadModule(require, resolve(root, application.proxy.custom.path))
+    const { path, options } = application.proxy.custom
+    let custom = await loadModule(require, resolve(root, path))
+
+    // When the module exports a function, it is used as a factory which receives
+    // the options defined in the configuration and returns the hooks object.
+    if (typeof custom === 'function') {
+      custom = await custom(options ?? {})
+    }
+
     application.proxy.custom = custom
   }
 
@@ -199,6 +207,8 @@ async function proxyPlugin (app, opts) {
     }
 
     const getUpstream = application.proxy?.custom?.getUpstream
+    const customRewriteHeaders = application.proxy?.custom?.rewriteHeaders
+    const customOnError = application.proxy?.custom?.onError
     // When getUpstream is provided, upstream ust be undefined, otherwise the getUpstream will be ignored
     const upstream = getUpstream ? undefined : (application.proxy?.upstream ?? origin)
 
@@ -224,7 +234,9 @@ async function proxyPlugin (app, opts) {
       preValidation: application.proxy?.custom?.preValidation,
 
       websocket: true,
-      wsUpstream: ws?.upstream ?? url ?? origin,
+      // When getUpstream is provided and no explicit WebSocket upstream is configured,
+      // leave wsUpstream undefined so that getUpstream is used to select the upstream per-connection
+      wsUpstream: ws?.upstream ?? (getUpstream ? undefined : (url ?? origin)),
       wsReconnect: ws?.reconnect,
       wsHooks: {
         onConnect: (...args) => {
@@ -251,7 +263,7 @@ async function proxyPlugin (app, opts) {
       routes,
       internalRewriteLocationHeader: false,
       replyOptions: {
-        rewriteHeaders: headers => {
+        rewriteHeaders: (headers, request) => {
           let location = headers.location
           if (location) {
             if (toReplace) {
@@ -262,6 +274,11 @@ async function proxyPlugin (app, opts) {
             }
             headers.location = location
           }
+
+          if (customRewriteHeaders) {
+            headers = customRewriteHeaders(headers, request) ?? headers
+          }
+
           return headers
         },
         rewriteRequestHeaders: (request, headers) => {
@@ -300,6 +317,11 @@ async function proxyPlugin (app, opts) {
         },
         onError: (reply, { error }) => {
           app.log.error({ error: ensureLoggableError(error) }, 'Error while proxying request to another application')
+
+          if (customOnError) {
+            return customOnError(reply, { error })
+          }
+
           return reply.send(error)
         },
         getUpstream

--- a/packages/gateway/lib/schema.js
+++ b/packages/gateway/lib/schema.js
@@ -222,7 +222,11 @@ export const gateway = {
                   custom: {
                     type: 'object',
                     properties: {
-                      path: { type: 'string' }
+                      path: { type: 'string' },
+                      options: {
+                        type: 'object',
+                        additionalProperties: true
+                      }
                     },
                     required: ['path'],
                     additionalProperties: false

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -851,6 +851,10 @@
                         "properties": {
                           "path": {
                             "type": "string"
+                          },
+                          "options": {
+                            "type": "object",
+                            "additionalProperties": true
                           }
                         },
                         "required": [

--- a/packages/gateway/test/proxy-custom.test.js
+++ b/packages/gateway/test/proxy-custom.test.js
@@ -1,0 +1,295 @@
+import { createDirectory, safeRemove } from '@platformatic/foundation'
+import assert from 'assert/strict'
+import { once } from 'node:events'
+import { symlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { WebSocket } from 'ws'
+import {
+  createApplication,
+  createFromConfig,
+  createGatewayInRuntime,
+  createWebsocketApplication,
+  REFRESH_TIMEOUT
+} from './helper.js'
+
+function ensureCleanup (t, folders) {
+  function cleanup () {
+    return Promise.all(folders.map(safeRemove))
+  }
+
+  t.after(cleanup)
+  return cleanup()
+}
+
+async function createNamedApplication (t, name) {
+  const app = await createApplication(t, [
+    {
+      method: 'GET',
+      path: '/whoami',
+      handler: async (_req, res) => {
+        return res.send({ from: name })
+      }
+    }
+  ])
+
+  const origin = await app.listen({ port: 0 })
+  return origin
+}
+
+test('should select the upstream via custom getUpstream using a request header or a cookie and pass custom.options to the module', async t => {
+  const oneOrigin = await createNamedApplication(t, 'one')
+  const twoOrigin = await createNamedApplication(t, 'two')
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'the-proxy',
+          proxy: {
+            prefix: '/',
+            custom: {
+              path: resolve(import.meta.dirname, './proxy/fixtures/custom-header-cookie.js'),
+              options: {
+                header: 'x-plt-version',
+                cookie: 'plt-version',
+                upstreams: { one: oneOrigin, two: twoOrigin },
+                fallback: oneOrigin
+              }
+            }
+          }
+        }
+      ]
+    }
+  })
+
+  const gatewayOrigin = await gateway.start({ listen: true })
+
+  {
+    // Select the upstream via a request header
+    const { statusCode, headers, body: rawBody } = await request(gatewayOrigin, {
+      method: 'GET',
+      path: '/whoami',
+      headers: { 'x-plt-version': 'two' }
+    })
+
+    assert.equal(statusCode, 200)
+    assert.deepStrictEqual(await rawBody.json(), { from: 'two' })
+
+    // The custom rewriteHeaders hook added a Set-Cookie header to the proxied response
+    assert.ok(headers['set-cookie'].includes('plt-version=two'))
+  }
+
+  {
+    // Select the upstream via a cookie
+    const { statusCode, headers, body: rawBody } = await request(gatewayOrigin, {
+      method: 'GET',
+      path: '/whoami',
+      headers: { cookie: 'foo=bar; plt-version=two' }
+    })
+
+    assert.equal(statusCode, 200)
+    assert.deepStrictEqual(await rawBody.json(), { from: 'two' })
+    assert.ok(headers['set-cookie'].includes('plt-version=two'))
+  }
+
+  {
+    // No header and no cookie - use the fallback from custom.options
+    const { statusCode, headers, body: rawBody } = await request(gatewayOrigin, {
+      method: 'GET',
+      path: '/whoami'
+    })
+
+    assert.equal(statusCode, 200)
+    assert.deepStrictEqual(await rawBody.json(), { from: 'one' })
+    assert.equal(headers['set-cookie'], undefined)
+  }
+})
+
+test('should support custom onError hooks', async t => {
+  // Get a port which is guaranteed to be closed
+  const app = await createApplication(t)
+  const origin = await app.listen({ port: 0 })
+  await app.close()
+  globalThis.customProxyUnreachableUpstream = origin
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'the-proxy',
+          proxy: {
+            prefix: '/',
+            custom: {
+              path: resolve(import.meta.dirname, './proxy/fixtures/custom-on-error.js')
+            }
+          }
+        }
+      ]
+    }
+  })
+
+  const gatewayOrigin = await gateway.start({ listen: true })
+
+  const { statusCode, body: rawBody } = await request(gatewayOrigin, {
+    method: 'GET',
+    path: '/whoami'
+  })
+
+  assert.equal(statusCode, 503)
+  const body = await rawBody.json()
+  assert.equal(body.handled, true)
+})
+
+test('should route requests via the runtime mesh to applications not listed in the gateway configuration', async t => {
+  const echoModulesRoot = resolve(import.meta.dirname, './proxy/fixtures/echo/node_modules')
+
+  await ensureCleanup(t, [echoModulesRoot])
+
+  // Make sure there is @platformatic/node available in the echo application.
+  // We can't simply specify it in the package.json due to circular dependencies.
+  await createDirectory(resolve(echoModulesRoot, '@platformatic'))
+  await symlink(resolve(import.meta.dirname, '../../node'), resolve(echoModulesRoot, '@platformatic/node'), 'dir')
+
+  const runtime = await createGatewayInRuntime(
+    t,
+    'gateway-custom-mesh',
+    {
+      gateway: {
+        // Note: only "main" is listed here, "version-one" and "version-two" are not
+        applications: [
+          {
+            id: 'main',
+            proxy: {
+              prefix: '/',
+              custom: {
+                path: resolve(import.meta.dirname, './proxy/fixtures/custom-mesh.js'),
+                options: {
+                  header: 'x-plt-version',
+                  cookie: 'plt-version',
+                  fallback: 'main'
+                }
+              }
+            }
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'main',
+        path: resolve(import.meta.dirname, './proxy/fixtures/echo')
+      },
+      {
+        id: 'version-one',
+        path: resolve(import.meta.dirname, './proxy/fixtures/echo')
+      },
+      {
+        id: 'version-two',
+        path: resolve(import.meta.dirname, './proxy/fixtures/echo')
+      }
+    ]
+  )
+
+  const address = await runtime.start()
+
+  {
+    // No header and no cookie - use the fallback from custom.options
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/'
+    })
+
+    assert.equal(statusCode, 200)
+    assert.deepStrictEqual(await rawBody.json(), { service: 'main' })
+  }
+
+  {
+    // Select an application not listed in the gateway configuration via a request header
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/',
+      headers: { 'x-plt-version': 'version-one' }
+    })
+
+    assert.equal(statusCode, 200)
+    assert.deepStrictEqual(await rawBody.json(), { service: 'version-one' })
+  }
+
+  {
+    // Select an application not listed in the gateway configuration via a cookie
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/',
+      headers: { cookie: 'plt-version=version-two' }
+    })
+
+    assert.equal(statusCode, 200)
+    assert.deepStrictEqual(await rawBody.json(), { service: 'version-two' })
+  }
+})
+
+test('should select the WebSocket upstream per-connection via custom getUpstream', async t => {
+  const { application: wsApplicationOne, wsServer: wsServerOne } = await createWebsocketApplication(t)
+  wsServerOne.on('connection', socket => {
+    socket.send('ws-one')
+  })
+
+  const { application: wsApplicationTwo, wsServer: wsServerTwo } = await createWebsocketApplication(t)
+  wsServerTwo.on('connection', socket => {
+    socket.send('ws-two')
+  })
+
+  const oneOrigin = `http://127.0.0.1:${wsApplicationOne.address().port}`
+  const twoOrigin = `http://127.0.0.1:${wsApplicationTwo.address().port}`
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'the-proxy',
+          proxy: {
+            prefix: '/',
+            custom: {
+              path: resolve(import.meta.dirname, './proxy/fixtures/custom-ws.js'),
+              options: {
+                header: 'x-plt-version',
+                upstreams: { one: oneOrigin, two: twoOrigin, default: oneOrigin }
+              }
+            }
+          }
+        }
+      ]
+    }
+  })
+
+  const gatewayOrigin = await gateway.start({ listen: true })
+
+  async function firstMessage (headers) {
+    const client = new WebSocket(gatewayOrigin.replace('http://', 'ws://'), { headers })
+    const [message] = await once(client, 'message')
+    client.close()
+    return message.toString()
+  }
+
+  assert.equal(await firstMessage({ 'x-plt-version': 'one' }), 'ws-one')
+  assert.equal(await firstMessage({ 'x-plt-version': 'two' }), 'ws-two')
+  assert.equal(await firstMessage({}), 'ws-one')
+})

--- a/packages/gateway/test/proxy/fixtures/custom-header-cookie.js
+++ b/packages/gateway/test/proxy/fixtures/custom-header-cookie.js
@@ -1,0 +1,47 @@
+function parseCookies (header) {
+  const cookies = {}
+
+  for (const part of (header ?? '').split(';')) {
+    const index = part.indexOf('=')
+
+    if (index === -1) {
+      continue
+    }
+
+    cookies[part.slice(0, index).trim()] = decodeURIComponent(part.slice(index + 1).trim())
+  }
+
+  return cookies
+}
+
+// The module exports a factory: it receives proxy.custom.options from the
+// gateway configuration and returns the hooks object.
+export default function createProxyHooks (options) {
+  const headerName = options.header ?? 'x-upstream'
+  const cookieName = options.cookie ?? 'upstream'
+  const upstreams = options.upstreams ?? {}
+
+  return {
+    getUpstream (request, base) {
+      let selected = request.headers[headerName]
+
+      if (!selected) {
+        selected = parseCookies(request.headers.cookie)[cookieName]
+      }
+
+      if (selected && upstreams[selected]) {
+        request.selectedUpstream = selected
+        return upstreams[selected]
+      }
+
+      return options.fallback ?? base
+    },
+    rewriteHeaders (headers, request) {
+      if (request.selectedUpstream) {
+        headers['set-cookie'] = `${cookieName}=${request.selectedUpstream}; Path=/`
+      }
+
+      return headers
+    }
+  }
+}

--- a/packages/gateway/test/proxy/fixtures/custom-mesh.js
+++ b/packages/gateway/test/proxy/fixtures/custom-mesh.js
@@ -1,0 +1,36 @@
+function parseCookies (header) {
+  const cookies = {}
+
+  for (const part of (header ?? '').split(';')) {
+    const index = part.indexOf('=')
+
+    if (index === -1) {
+      continue
+    }
+
+    cookies[part.slice(0, index).trim()] = decodeURIComponent(part.slice(index + 1).trim())
+  }
+
+  return cookies
+}
+
+// Routes each request to a runtime application chosen via a request header or
+// a cookie. The returned upstreams use the runtime mesh (http://<id>.plt.local)
+// and the target applications are purposely NOT listed in the gateway
+// applications configuration.
+export default function createVersionRouter (options) {
+  const headerName = options.header ?? 'x-version'
+  const cookieName = options.cookie ?? 'version'
+
+  return {
+    getUpstream (request) {
+      const version = request.headers[headerName] ?? parseCookies(request.headers.cookie)[cookieName]
+
+      if (version) {
+        return `http://${version}.plt.local`
+      }
+
+      return `http://${options.fallback}.plt.local`
+    }
+  }
+}

--- a/packages/gateway/test/proxy/fixtures/custom-on-error.js
+++ b/packages/gateway/test/proxy/fixtures/custom-on-error.js
@@ -1,0 +1,9 @@
+export default {
+  getUpstream () {
+    // Point to a port which is guaranteed to be closed
+    return globalThis.customProxyUnreachableUpstream
+  },
+  onError (reply, { error }) {
+    reply.code(503).send({ handled: true, code: error.code ?? null })
+  }
+}

--- a/packages/gateway/test/proxy/fixtures/custom-ws.js
+++ b/packages/gateway/test/proxy/fixtures/custom-ws.js
@@ -1,0 +1,11 @@
+export default function createWsRouter (options) {
+  const headerName = options.header ?? 'x-version'
+
+  return {
+    getUpstream (request) {
+      const target = request.headers[headerName]
+
+      return options.upstreams[target] ?? options.upstreams.default
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR promotes the gateway's `proxy.custom` per-request routing mechanism from an undocumented escape hatch to a documented, tested, stable public extension API. Motivation: needed by addons that route requests across multiple versions of the same application running in one runtime (skew protection).

## The contract

An application entry in the gateway configuration can point to a module with custom proxy logic:

```json
{
  "id": "main",
  "proxy": {
    "prefix": "/",
    "custom": {
      "path": "./version-router.js",
      "options": { "header": "x-app-version", "cookie": "app-version", "fallback": "main" }
    }
  }
}
```

The module either default-exports the hooks object directly, or default-exports a factory `(options) => hooks` (sync or async) which receives `custom.options`. The hooks (all optional) are:

- `preRewrite(url, params, prefix) => string` — modify the request URL before proxying.
- `preValidation(request, reply)` — async (return `false` to stop proxying) or callback style, standard Fastify `preValidation` semantics.
- `getUpstream(request, base) => string` — select the upstream origin **per request**, e.g. based on a header or a cookie.
- `rewriteHeaders(headers, request) => headers` — rewrite the response headers from the upstream (e.g. add a `Set-Cookie` header pinning the client to the selected upstream).
- `onError(reply, { error })` — replace the default proxy error handler (the gateway still logs the error first).

## What is now guaranteed

- **Runtime mesh pass-through**: `getUpstream` may return `http://<application-id>.plt.local` for **any** application in the runtime, including applications **not listed** in the gateway `applications` configuration. Such requests are routed through the runtime mesh. This allows a single logical gateway entry to dispatch requests across several versions of an application running in the same runtime.
- When `getUpstream` is provided, `proxy.upstream` is ignored and `base` may be `undefined`: the hook must always return a full origin.
- `custom.options` is passed to the factory exported by the custom module.
- When no `ws.upstream` is configured, `getUpstream` also selects the upstream for WebSocket connections, once per connection at upgrade time.

## Changes

Docs and tests, plus the small additive wiring needed to make the documented contract real:

- `docs/reference/gateway/configuration.md`: full `proxy.custom` reference (module shape, every hook signature, `custom.options`, mesh pass-through guarantee, explicit statement that this is a supported public API) and a realistic header/cookie version-routing example.
- `packages/gateway/lib/schema.js` (+ regenerated `schema.json`/`config.d.ts` for gateway and composer): added `custom.options`.
- `packages/gateway/lib/proxy.js`:
  - support the factory module form and pass `custom.options` to it;
  - wire the custom `rewriteHeaders` and `onError` hooks into the proxy reply options (previously only `getUpstream`, `preRewrite` and `preValidation` were wired);
  - bug fix: when `getUpstream` is provided and no `ws.upstream` is configured, do not force the WebSocket upstream to the application origin, so `@fastify/http-proxy` falls back to `getUpstream` for per-connection WebSocket upstream selection (mirrors the existing handling of the HTTP `upstream`).

## Tests

New `packages/gateway/test/proxy-custom.test.js` (4 tests, all passing):

- upstream selection per request via a **header** and via a **cookie** (cookie parsed manually in the fixture), with `custom.options` driving the module (factory form) and `rewriteHeaders` adding a `Set-Cookie` header to the proxied response;
- **mesh pass-through**: a runtime with 3 applications where the gateway lists only one logical entry and the custom module routes to the two unlisted ones via `http://<id>.plt.local`;
- custom `onError` sending a custom response when the upstream is unreachable;
- per-connection **WebSocket** upstream selection via `getUpstream`.

`preRewrite` was already covered by an existing test. The full existing `test/proxy.test.js` suite passes (30/30), as do the gateway schema/type tests and the composer tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Nq4eqbifqTuBJCDGf3D5U