### PR TITLE
fix(runtime): emit a single HELP/TYPE block per metric family in text metrics

### DIFF
--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -103,6 +103,16 @@ function parseOrigins (origins) {
   })
 }
 
+function formatMetricValue (value) {
+  if (Number.isNaN(value)) {
+    return 'NaN'
+  } else if (!Number.isFinite(value)) {
+    return value < 0 ? '-Inf' : '+Inf'
+  }
+
+  return `${value}`
+}
+
 // Always run operations in parallel to avoid deadlocks when services have dependencies
 const DEFAULT_CONCURRENCY = availableParallelism() * 2
 const MAX_BOOTSTRAP_ATTEMPTS = 5
@@ -1251,9 +1261,7 @@ export class Runtime extends EventEmitter {
 
     let metrics = null
 
-    const applicationRestartMetrics = format === 'json'
-      ? this.#getApplicationRestartMetricsJson()
-      : this.#formatApplicationRestartMetricsText()
+    const applicationRestartMetrics = this.#getApplicationRestartMetricsJson()
 
     // Get process-level metrics once from main thread registry (if available)
     let processMetricsJson = null
@@ -1268,16 +1276,16 @@ export class Runtime extends EventEmitter {
           continue
         }
 
-        // Get thread-specific metrics from worker
+        // Get thread-specific metrics from worker. Always collect JSON so that
+        // the text format can be serialized once with a single HELP/TYPE block
+        // per metric family, as required by the Prometheus exposition format.
         const applicationMetrics = await executeWithTimeout(
-          sendViaITC(worker, 'getMetrics', format),
+          sendViaITC(worker, 'getMetrics', 'json'),
           this.#config.metrics?.timeout ?? 10000
         )
 
         if (applicationMetrics && applicationMetrics !== kTimeout) {
-          if (metrics === null) {
-            metrics = format === 'json' ? [] : ''
-          }
+          metrics ??= []
 
           // Build worker labels including custom labels from metrics config
           const workerLabels = {
@@ -1289,21 +1297,13 @@ export class Runtime extends EventEmitter {
             workerLabels.workerId = workerId
           }
 
-          if (format === 'json') {
-            // Duplicate process metrics with worker labels and add to output
-            if (processMetricsJson) {
-              this.#applyLabelsToMetrics(processMetricsJson, workerLabels, metrics)
-            }
-            // Add worker's thread-specific metrics
-            for (let i = 0; i < applicationMetrics.length; i++) {
-              metrics.push(applicationMetrics[i])
-            }
-          } else {
-            // Text format: format process metrics with worker labels
-            if (processMetricsJson) {
-              metrics += this.#formatProcessMetricsText(processMetricsJson, workerLabels)
-            }
-            metrics += applicationMetrics
+          // Duplicate process metrics with worker labels and add to output
+          if (processMetricsJson) {
+            this.#applyLabelsToMetrics(processMetricsJson, workerLabels, metrics)
+          }
+          // Add worker's thread-specific metrics
+          for (let i = 0; i < applicationMetrics.length; i++) {
+            metrics.push(applicationMetrics[i])
           }
         }
       } catch (e) {
@@ -1321,9 +1321,11 @@ export class Runtime extends EventEmitter {
     }
 
     if (metrics !== null && applicationRestartMetrics.length > 0) {
-      metrics = format === 'json'
-        ? [...applicationRestartMetrics, ...metrics]
-        : applicationRestartMetrics + metrics
+      metrics = [...applicationRestartMetrics, ...metrics]
+    }
+
+    if (metrics !== null && format !== 'json') {
+      metrics = this.#formatMetricsAsText(metrics)
     }
 
     return { metrics }
@@ -1360,28 +1362,6 @@ export class Runtime extends EventEmitter {
     return metrics
   }
 
-  #formatApplicationRestartMetricsText () {
-    let output = ''
-
-    for (const applicationId of this.#applications.keys()) {
-      const labelParts = []
-      const labels = this.#getApplicationRestartMetricLabels(applicationId)
-
-      for (const [key, val] of Object.entries(labels)) {
-        const escapedVal = String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')
-        labelParts.push(`${key}="${escapedVal}"`)
-      }
-
-      const labelStr = labelParts.length > 0 ? `{${labelParts.join(',')}}` : ''
-
-      output += `# HELP ${kApplicationRestartsMetricName} ${kApplicationRestartsMetricHelp}\n`
-      output += `# TYPE ${kApplicationRestartsMetricName} counter\n`
-      output += `${kApplicationRestartsMetricName}${labelStr} ${this.#applicationRestartCounts.get(applicationId) ?? 0}\n`
-    }
-
-    return output
-  }
-
   // Apply labels to process metrics and push to output array (for JSON format)
   #applyLabelsToMetrics (processMetrics, labels, outputArray) {
     for (let i = 0; i < processMetrics.length; i++) {
@@ -1406,27 +1386,33 @@ export class Runtime extends EventEmitter {
     }
   }
 
-  // Format process metrics as Prometheus text format with labels
-  #formatProcessMetricsText (processMetricsJson, labels) {
+  // Serialize JSON metrics to the Prometheus text exposition format.
+  // Samples are grouped by metric family so each family is emitted as a single
+  // block with one HELP/TYPE header: the format forbids repeating them, and
+  // strict parsers (e.g. OpenMetrics-based ones like Dynatrace) would otherwise
+  // only ingest the first block for each metric name.
+  #formatMetricsAsText (metricsJson) {
+    const families = new Map()
+
+    for (const metric of metricsJson) {
+      let family = families.get(metric.name)
+      if (!family) {
+        family = { help: metric.help, type: metric.type, values: [] }
+        families.set(metric.name, family)
+      }
+      family.values.push(...metric.values)
+    }
+
     let output = ''
+    for (const [name, family] of families) {
+      const escapedHelp = String(family.help).replace(/\\/g, '\\\\').replace(/\n/g, '\\n')
+      output += `# HELP ${name} ${escapedHelp}\n`
+      output += `# TYPE ${name} ${family.type}\n`
 
-    for (let i = 0; i < processMetricsJson.length; i++) {
-      const metric = processMetricsJson[i]
-      const name = metric.name
-      const help = metric.help
-      const type = metric.type
-
-      // Add HELP and TYPE lines
-      output += `# HELP ${name} ${help}\n`
-      output += `# TYPE ${name} ${type}\n`
-
-      const values = metric.values
-      for (let j = 0; j < values.length; j++) {
-        const v = values[j]
-        const combinedLabels = { ...labels, ...v.labels }
+      for (const v of family.values) {
         const labelParts = []
 
-        for (const [key, val] of Object.entries(combinedLabels)) {
+        for (const [key, val] of Object.entries(v.labels ?? {})) {
           // Escape label values for Prometheus format
           const escapedVal = String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')
           labelParts.push(`${key}="${escapedVal}"`)
@@ -1434,7 +1420,7 @@ export class Runtime extends EventEmitter {
 
         const labelStr = labelParts.length > 0 ? `{${labelParts.join(',')}}` : ''
         const metricName = v.metricName || name
-        output += `${metricName}${labelStr} ${v.value}\n`
+        output += `${metricName}${labelStr} ${formatMetricValue(v.value)}\n`
       }
     }
 

--- a/packages/runtime/test/multiple-workers/basic.test.js
+++ b/packages/runtime/test/multiple-workers/basic.test.js
@@ -152,6 +152,43 @@ test('can collect metrics with worker label', async t => {
   ])
 })
 
+test('text metrics contain a single HELP/TYPE block per metric family across all workers', async t => {
+  const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
+  const configFile = resolve(root, './platformatic.json')
+  const app = await createRuntime(configFile, null, { isProduction: true })
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const { metrics } = await app.getMetrics('text')
+
+  // The Prometheus exposition format requires all samples of a metric family
+  // to be grouped under a single HELP/TYPE header. Strict parsers (like the
+  // Dynatrace one) only ingest the first block for each metric name.
+  const typeCounts = new Map()
+  for (const line of metrics.split('\n')) {
+    if (line.startsWith('# TYPE ')) {
+      const name = line.split(' ')[2]
+      typeCounts.set(name, (typeCounts.get(name) ?? 0) + 1)
+    }
+  }
+
+  ok(typeCounts.size > 0, 'Expected at least one metric family')
+  for (const [name, count] of typeCounts) {
+    strictEqual(count, 1, `Expected metric family ${name} to be declared exactly once, found ${count} TYPE lines`)
+  }
+
+  // Samples from multiple workers of the same application must still be present
+  const nodeWorkerIds = new Set()
+  for (const match of metrics.matchAll(/applicationId="node",workerId="(\d+)"/g)) {
+    nodeWorkerIds.add(match[1])
+  }
+  ok(nodeWorkerIds.size > 1, `Expected metrics from multiple node workers, found ${nodeWorkerIds.size}`)
+})
+
 test('worker threads have correct threadName property set', async t => {
   const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
   const configFile = resolve(root, './platformatic.json')


### PR DESCRIPTION
## Problem

The `:9090/metrics` endpoint concatenated each worker's full Prometheus text output. With multiple workers, the same metric family was declared repeatedly — one `# HELP`/`# TYPE` block per worker (and the `platformatic_application_restarts_total` counter was even declared once per application):

```
# HELP http_requests_total requests
# TYPE http_requests_total counter
http_requests_total{applicationId="app",workerId="0"} 10
# HELP http_requests_total requests   <-- duplicate family declaration
# TYPE http_requests_total counter    <-- duplicate family declaration
http_requests_total{applicationId="app",workerId="1"} 11
```

The [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/) requires all samples of a metric family to be grouped under a single `# HELP`/`# TYPE` header, and OpenMetrics forbids re-declaring a family outright. The Prometheus server's own scraper is lenient and merges the duplicate blocks, but strict OpenMetrics-based parsers — such as the Dynatrace k8s operator — only ingest the **first** block for each metric name, so only the first worker's metrics were visible.

## Fix

- `Runtime.getMetrics()` now always collects worker metrics as JSON over ITC (samples already carry distinguishing `applicationId`/`workerId` labels from each worker registry's default labels) and, for text requests, serializes once at the end.
- The new `#formatMetricsAsText()` groups samples by metric family and emits a single `# HELP`/`# TYPE` header per family, followed by all samples from every worker.
- Removed `#formatProcessMetricsText()` and `#formatApplicationRestartMetricsText()`, both of which emitted duplicate headers.
- Non-finite values are now rendered as `+Inf`/`-Inf`/`NaN` instead of the invalid `Infinity`.
- The JSON output format is unchanged.

Both consumers of the text format (the Prometheus server and the management API) go through `runtime.getMetrics`, so both are fixed.

## Testing

- New regression test asserting each metric family is declared exactly once in the text output of a multi-worker runtime, while samples from all workers remain present. It fails against the previous code (`platformatic_application_restarts_total ... found 3 TYPE lines`).
- Existing suites pass: `prom-metrics` (31), `api/metrics` (10), `management-api/metrics` (3), `v2-metrics-compatibility` (4), `dynamic-applications` metrics, `multiple-workers/basic` metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjZHDpEF84nn7EtmiBR7Ms