### PR TITLE
chore: update descriptions in package.json in packages

### DIFF
--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/basic",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic Basic",
   "main": "index.js",
   "types": "index.d.ts",
   "type": "module",

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/composer",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic Composer",
   "main": "index.js",
   "types": "index.d.ts",
   "type": "module",

--- a/packages/db-authorization/package.json
+++ b/packages/db-authorization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/db-authorization",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic DB authorization",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/packages/db-core/package.json
+++ b/packages/db-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/db-core",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic DB core",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/db",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic DB",
   "main": "index.js",
   "types": "index.d.ts",
   "type": "module",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/gateway",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic Gateway",
   "main": "index.js",
   "types": "index.d.ts",
   "type": "module",

--- a/packages/itc/package.json
+++ b/packages/itc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/itc",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic ITC",
   "main": "lib/index.js",
   "type": "module",
   "types": "lib/index.d.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/runtime",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic runtime",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platformatic/service",
   "version": "3.61.1",
-  "description": "",
+  "description": "Platformatic Service",
   "main": "index.js",
   "types": "index.d.ts",
   "type": "module",


### PR DESCRIPTION
Proposal:

- Populated the missing `description` fields (which were previously empty `""`) inside the `package.json` files of several workspace packages. This helps improve project documentation, making the purpose of each module clear at a glance directly from its `package.json`.

Updated Packages:
- `packages/basic`
- `packages/composer`
- `packages/db-authorization`
- `packages/db-core`
- `packages/db`
- `packages/gateway`
- `packages/itc`
- `packages/service`

Note: 
  - No functional code or dependency changes. Just adding meaningful text where it was missing. 