### PR TITLE
feat(runtime): add main-thread extensions

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -13,6 +13,7 @@ Welcome to the Platformatic guides! These practical guides help you solve specif
 ### Caching & Performance
 - **[Cache with Platformatic Watt](./guides/cache-with-platformatic-watt.md)** - Implement caching strategies to improve application performance
 - **[Profiling with Watt](./guides/profiling-with-watt.md)** - Profile and optimize your Watt applications for better performance
+- **[Capture Flamegraphs on Health Events](./guides/capture-flamegraphs-on-health-events.md)** - Automatically capture CPU profiles when workers become unhealthy and upload them to S3
 - **[Debugging with REPL](./guides/debugging-with-repl.md)** - Debug applications interactively using the built-in REPL
 
 ### Multi-Repository & Scaling

--- a/docs/guides/capture-flamegraphs-on-health-events.md
+++ b/docs/guides/capture-flamegraphs-on-health-events.md
@@ -139,8 +139,13 @@ await itc.send('flamegraph:capture', {
 
 Instead of capturing a profile only when something goes wrong, you can keep the profiler always on. When profiling is started with the `durationMillis` option, the profiler rotates the profile window at that interval and the runtime emits [`application:worker:profile:captured`](../reference/runtime/programmatic.md#applicationworkerprofilecaptured) every time a window completes. The event only carries metadata — profiles can be big, so the runtime never moves them around unless someone asks. Retrieve the profile on demand with `getApplicationLastProfile()`:
 
+Profiling state lives inside each worker thread, so it must be enabled per worker and re-enabled whenever a worker is replaced. Subscribing to `application:worker:started` covers all the cases with a single handler: it fires for every worker after it has fully started, both on the initial runtime startup and every time a worker is restarted (after a crash, a reload or a scaling event).
+
 ```js
 export default async function setup ({ runtime, logger, options }) {
+  const { applications = ['api'], durationMillis = 60000 } = options
+
+  // Ship each completed profile window
   runtime.on('application:worker:profile:captured', async ({ id, application, worker, type }) => {
     try {
       const profile = await runtime.getApplicationLastProfile(id, { type })
@@ -153,9 +158,21 @@ export default async function setup ({ runtime, logger, options }) {
     }
   })
 
-  // Rotate a CPU profile window every minute for every worker of "api"
-  runtime.on('started', () => {
-    runtime.startApplicationProfiling('api', { type: 'cpu', durationMillis: 60000 })
+  // Enable continuous profiling on every worker as soon as it starts.
+  // This also covers replacement workers, which start with a fresh profiler.
+  runtime.on('application:worker:started', async ({ application, worker }) => {
+    if (!applications.includes(application)) {
+      return
+    }
+
+    try {
+      await runtime.startApplicationProfiling(`${application}:${worker}`, {
+        type: 'cpu',
+        durationMillis
+      })
+    } catch (err) {
+      logger.error({ err, application, worker }, 'failed to start continuous profiling')
+    }
   })
 }
 ```

--- a/docs/guides/capture-flamegraphs-on-health-events.md
+++ b/docs/guides/capture-flamegraphs-on-health-events.md
@@ -120,7 +120,7 @@ export default async function setup ({ runtime, itc, logger, options }) {
 
 The extension reacts to two triggers:
 
-- **Health metrics** - Once an extension subscribes to `application:worker:health:metrics` during its setup, the runtime collects health data (event loop utilization, heap usage and custom health signals) for every worker each second and emits this event, even when health checks are not configured.
+- **Health metrics** - Once an extension subscribes to [`application:worker:health:metrics`](../reference/runtime/programmatic.md#applicationworkerhealthmetrics) during its setup, the runtime collects health data (event loop utilization, heap usage and custom health signals) for every worker each second and emits this event, even when health checks are not configured.
 - **Custom commands** - Applications can request a capture themselves through the custom `flamegraph:capture` command. For example, from any application:
 
 ```js

--- a/docs/guides/capture-flamegraphs-on-health-events.md
+++ b/docs/guides/capture-flamegraphs-on-health-events.md
@@ -1,8 +1,8 @@
 # Capture Flamegraphs on Health Events
 
-When a production application misbehaves — event loop utilization spikes, memory grows, latency climbs — the profile you need is the one you did not capture. This guide shows how to use a [runtime extension](../reference/runtime/configuration.md#extensions) to automatically capture a CPU profile when a worker becomes unhealthy and upload it to Amazon S3, so a flamegraph of the incident is always waiting for you.
+When a production application misbehaves — event loop utilization spikes, memory grows, latency climbs — the profile you need is the one you did not capture. This guide shows how to use a [runtime extension](../reference/runtime/configuration.md#extensions) to capture a CPU profile when an application detects a problem and upload it to Amazon S3, so a flamegraph of the incident is always waiting for you.
 
-Everything runs in the runtime main thread: the extension observes health metrics for all workers, triggers the built-in pprof profiler, and ships the resulting profile with the AWS SDK from your own `node_modules`.
+Everything runs in the runtime main thread: the extension triggers the built-in pprof profiler and ships the resulting profile with the AWS SDK from your own `node_modules`. For fully automatic captures based on event loop utilization, use [continuous profiling](#continuous-profiling) below: the profiler has its own built-in ELU gating.
 
 ## Prerequisites
 
@@ -27,7 +27,6 @@ Register the extension in your `watt.json` (or `platformatic.json`) and pass its
       "options": {
         "bucket": "{PLT_FLAMEGRAPHS_BUCKET}",
         "region": "{PLT_AWS_REGION}",
-        "maxELU": 0.9,
         "profileDurationMillis": 10000,
         "cooldownMillis": 300000
       }
@@ -49,7 +48,6 @@ export default async function setup ({ runtime, itc, logger, options }) {
   const {
     bucket,
     region,
-    maxELU = 0.9,
     profileDurationMillis = 10000,
     cooldownMillis = 300000
   } = options
@@ -95,14 +93,6 @@ export default async function setup ({ runtime, itc, logger, options }) {
     }
   }
 
-  // Triggered by the runtime: health metrics are collected every second
-  // for every worker as soon as an extension subscribes to this event.
-  runtime.on('application:worker:health:metrics', ({ application, worker, currentHealth }) => {
-    if (currentHealth?.elu > maxELU) {
-      captureAndUpload(application, worker, `elu above ${maxELU}`)
-    }
-  })
-
   // Triggered by the applications: workers can explicitly request a capture,
   // for example when they detect slow requests.
   itc.handle('flamegraph:capture', async ({ application, worker, reason }) => {
@@ -118,10 +108,7 @@ export default async function setup ({ runtime, itc, logger, options }) {
 }
 ```
 
-The extension reacts to two triggers:
-
-- **Health metrics** - Once an extension subscribes to [`application:worker:health:metrics`](../reference/runtime/programmatic.md#applicationworkerhealthmetrics) during its setup, the runtime collects health data (event loop utilization, heap usage and custom health signals) for every worker each second and emits this event, even when health checks are not configured.
-- **Custom commands** - Applications can request a capture themselves through the custom `flamegraph:capture` command. For example, from any application:
+Applications request a capture through the custom `flamegraph:capture` command whenever they detect a problem — a slow request, a saturated queue, a failed health signal. For example, from any application:
 
 ```js
 import { getApplicationId, getITC, getWorkerId } from '@platformatic/globals'
@@ -177,7 +164,7 @@ export default async function setup ({ runtime, logger, options }) {
 }
 ```
 
-To keep the overhead down when nothing is wrong, combine `durationMillis` with the `eluThreshold` option: the profiler only records while the worker's event loop utilization is above the threshold, and completed windows are still announced via the same event.
+To keep the overhead down when nothing is wrong, combine `durationMillis` with the `eluThreshold` option: the profiler only records while the worker's event loop utilization is above the threshold, and completed windows are still announced via the same event. This check runs inside the worker itself and uses hysteresis to avoid rapid toggling, so prefer it over starting and stopping captures from the main thread based on external ELU readings.
 
 ## Analyze the flamegraphs
 

--- a/docs/guides/capture-flamegraphs-on-health-events.md
+++ b/docs/guides/capture-flamegraphs-on-health-events.md
@@ -1,0 +1,151 @@
+# Capture Flamegraphs on Health Events
+
+When a production application misbehaves — event loop utilization spikes, memory grows, latency climbs — the profile you need is the one you did not capture. This guide shows how to use a [runtime extension](../reference/runtime/configuration.md#extensions) to automatically capture a CPU profile when a worker becomes unhealthy and upload it to Amazon S3, so a flamegraph of the incident is always waiting for you.
+
+Everything runs in the runtime main thread: the extension observes health metrics for all workers, triggers the built-in pprof profiler, and ships the resulting profile with the AWS SDK from your own `node_modules`.
+
+## Prerequisites
+
+1. A Watt application (see the [quick start](../getting-started/quick-start-watt.md))
+2. The profiler preload package and the AWS SDK:
+
+```bash
+npm install @platformatic/wattpm-pprof-capture @aws-sdk/client-s3
+```
+
+`@platformatic/wattpm-pprof-capture` is automatically added to the runtime `preload` when it is installed, so no extra configuration is needed for profiling itself.
+
+## Configure the extension
+
+Register the extension in your `watt.json` (or `platformatic.json`) and pass its settings via `options`:
+
+```json
+{
+  "extensions": [
+    {
+      "path": "./flamegraph-extension.js",
+      "options": {
+        "bucket": "{PLT_FLAMEGRAPHS_BUCKET}",
+        "region": "{PLT_AWS_REGION}",
+        "maxELU": 0.9,
+        "profileDurationMillis": 10000,
+        "cooldownMillis": 300000
+      }
+    }
+  ]
+}
+```
+
+The environment variable placeholders are resolved from the runtime environment, so the bucket and region never need to be hardcoded.
+
+## The extension
+
+Create `flamegraph-extension.js` next to your configuration file:
+
+```js
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+
+export default async function setup ({ runtime, itc, logger, options }) {
+  const {
+    bucket,
+    region,
+    maxELU = 0.9,
+    profileDurationMillis = 10000,
+    cooldownMillis = 300000
+  } = options
+
+  const s3 = new S3Client({ region })
+  const capturing = new Set()
+  const lastCapture = new Map()
+
+  async function captureAndUpload (application, worker, reason) {
+    const target = `${application}:${worker}`
+
+    // Never run two captures for the same worker and honor the cooldown,
+    // otherwise a sustained spike would trigger a capture every second.
+    const last = lastCapture.get(target) ?? 0
+    if (capturing.has(target) || Date.now() - last < cooldownMillis) {
+      return
+    }
+
+    capturing.add(target)
+
+    try {
+      logger.warn({ application, worker, reason }, 'health event detected, capturing CPU profile')
+
+      await runtime.startApplicationProfiling(target, { type: 'cpu' })
+      await new Promise(resolve => setTimeout(resolve, profileDurationMillis))
+      const profile = await runtime.stopApplicationProfiling(target, { type: 'cpu' })
+
+      const key = `flamegraphs/${application}/${worker}/${new Date().toISOString()}.pb`
+
+      await s3.send(new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: Buffer.from(profile),
+        ContentType: 'application/octet-stream'
+      }))
+
+      lastCapture.set(target, Date.now())
+      logger.info({ application, worker, key }, 'CPU profile uploaded')
+    } catch (err) {
+      logger.error({ err, application, worker }, 'failed to capture or upload the CPU profile')
+    } finally {
+      capturing.delete(target)
+    }
+  }
+
+  // Triggered by the runtime: health metrics are collected every second
+  // for every worker as soon as an extension subscribes to this event.
+  runtime.on('application:worker:health:metrics', ({ application, worker, currentHealth }) => {
+    if (currentHealth?.elu > maxELU) {
+      captureAndUpload(application, worker, `elu above ${maxELU}`)
+    }
+  })
+
+  // Triggered by the applications: workers can explicitly request a capture,
+  // for example when they detect slow requests.
+  itc.handle('flamegraph:capture', async ({ application, worker, reason }) => {
+    captureAndUpload(application, worker, reason)
+    return { scheduled: true }
+  })
+
+  return {
+    async close () {
+      s3.destroy()
+    }
+  }
+}
+```
+
+The extension reacts to two triggers:
+
+- **Health metrics** - Once an extension subscribes to `application:worker:health:metrics` during its setup, the runtime collects health data (event loop utilization, heap usage and custom health signals) for every worker each second and emits this event, even when health checks are not configured.
+- **Custom commands** - Applications can request a capture themselves through the custom `flamegraph:capture` command. For example, from any application:
+
+```js
+import { getApplicationId, getITC, getWorkerId } from '@platformatic/globals'
+
+const itc = getITC()
+
+await itc.send('flamegraph:capture', {
+  application: getApplicationId(),
+  worker: getWorkerId(),
+  reason: 'slow request detected'
+})
+```
+
+## Analyze the flamegraphs
+
+The uploaded files are standard [pprof](https://github.com/google/pprof) profiles. Download one and turn it into a flamegraph:
+
+```bash
+aws s3 cp s3://my-bucket/flamegraphs/api/0/2026-07-13T10:00:00.000Z.pb profile.pb
+npx flame profile.pb
+```
+
+See [Profiling with Watt](./profiling-with-watt.md) for more details on reading flamegraphs and on the other profiling workflows (heap profiles, manual captures via the CLI, and continuous profiling).
+
+## Beyond S3
+
+The same pattern works for any destination or trigger: upload to Google Cloud Storage or Azure Blob Storage, notify a Slack channel with a link to the profile, or capture a [heap snapshot](./heap-snapshots.md) instead of a CPU profile when memory is the concern. The extension has full access to the [Runtime API](../reference/runtime/programmatic.md), so anything the runtime can do, an extension can automate.

--- a/docs/guides/capture-flamegraphs-on-health-events.md
+++ b/docs/guides/capture-flamegraphs-on-health-events.md
@@ -135,6 +135,33 @@ await itc.send('flamegraph:capture', {
 })
 ```
 
+## Continuous profiling
+
+Instead of capturing a profile only when something goes wrong, you can keep the profiler always on. When profiling is started with the `durationMillis` option, the profiler rotates the profile window at that interval and the runtime emits [`application:worker:profile:captured`](../reference/runtime/programmatic.md#applicationworkerprofilecaptured) every time a window completes. The event only carries metadata — profiles can be big, so the runtime never moves them around unless someone asks. Retrieve the profile on demand with `getApplicationLastProfile()`:
+
+```js
+export default async function setup ({ runtime, logger, options }) {
+  runtime.on('application:worker:profile:captured', async ({ id, application, worker, type }) => {
+    try {
+      const profile = await runtime.getApplicationLastProfile(id, { type })
+
+      // Upload the profile, as shown above, or hand it to a continuous
+      // profiling backend of your choice.
+      await upload(`flamegraphs/${application}/${worker}/${new Date().toISOString()}.pb`, profile)
+    } catch (err) {
+      logger.error({ err, id }, 'failed to collect the captured profile')
+    }
+  })
+
+  // Rotate a CPU profile window every minute for every worker of "api"
+  runtime.on('started', () => {
+    runtime.startApplicationProfiling('api', { type: 'cpu', durationMillis: 60000 })
+  })
+}
+```
+
+To keep the overhead down when nothing is wrong, combine `durationMillis` with the `eluThreshold` option: the profiler only records while the worker's event loop utilization is above the threshold, and completed windows are still announced via the same event.
+
 ## Analyze the flamegraphs
 
 The uploaded files are standard [pprof](https://github.com/google/pprof) profiles. Download one and turn it into a flamegraph:

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -73,7 +73,7 @@ export default async function setup ({ runtime, itc, logger, options, root }) {
   })
 
   // Register a custom command that applications can invoke via
-  // globalThis.platformatic.itc.send('acme:hello', payload)
+  // getITC().send('acme:hello', payload)
   itc.handle('acme:hello', async payload => {
     return { hello: payload.name }
   })
@@ -92,13 +92,14 @@ The setup function receives a context object with the following properties:
   subscribe to all [runtime events](./programmatic.md#events) and invoke any public method.
 - **`itc`** - A facade over the runtime ITC:
   - **`handle(name, handler)`** - Registers a custom command invocable from any application via
-    `globalThis.platformatic.itc.send(name, payload)`. The name must not clash with the commands
-    reserved by the runtime or with a command registered by another extension.
+    the [ITC API](./globals.md#communicating-with-runtime-extensions) returned by `getITC()` from
+    `@platformatic/globals`. The name must not clash with the commands reserved by the runtime or
+    with a command registered by another extension.
   - **`send(target, name, payload)`** - Sends a request to a worker and awaits its response. `target` is
     an application ID (a worker is chosen in round-robin) or `application:worker-index` for a specific worker.
   - **`notify(target, name, payload)`** - Sends a fire-and-forget notification. When `target` is an
     application ID, all its running workers are notified; use `application:worker-index` to target a
-    specific worker. Workers receive notifications via `globalThis.platformatic.itc.on(name, handler)`.
+    specific worker. Workers receive notifications via `getITC().on(name, handler)`.
 - **`logger`** - A child of the runtime logger.
 - **`options`** - The `options` object specified in the configuration, if any.
 - **`root`** - The runtime project root directory.

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -109,6 +109,10 @@ in reverse order.
 
 Extensions are not loaded when building the applications (for example via `wattpm build`).
 
+For a complete worked example — enabling continuous profiling on every worker when it starts (or is
+restarted) and shipping the captured profiles — see the
+[Capture Flamegraphs on Health Events](../../guides/capture-flamegraphs-on-health-events.md) guide.
+
 ### `applications`
 
 `applications` is an array of objects that defines the applications managed by the

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -39,6 +39,76 @@ Application Performance Monitoring (APM) agents. `preload` should contain
 a path or a list of paths pointing to a CommonJS or ES module that is loaded at the start of
 the app worker thread.
 
+### `extensions`
+
+While `preload` injects code in each application worker thread, `extensions` loads custom code
+in the **runtime main thread**. Extensions can observe and control the whole runtime: they receive
+the `Runtime` object and an ITC (Inter-Thread Communication) facade which allows them to register
+custom commands that applications can invoke from their worker threads.
+
+`extensions` can be a path, an object with `path` and `options` properties, or an array of either:
+
+```json
+{
+  "extensions": [
+    {
+      "path": "./runtime-extension.js",
+      "options": {
+        "bucket": "{S3_BUCKET}"
+      }
+    }
+  ]
+}
+```
+
+Each file must default-export a setup function, which is invoked during the runtime initialization,
+before any application is started. TypeScript files are supported out of the box via
+[Node.js type stripping](https://nodejs.org/api/typescript.html#type-stripping).
+
+```js
+export default async function setup ({ runtime, itc, logger, options, root }) {
+  // React to runtime events
+  runtime.on('application:worker:started', payload => {
+    logger.info({ payload }, 'worker started')
+  })
+
+  // Register a custom command that applications can invoke via
+  // globalThis.platformatic.itc.send('acme:hello', payload)
+  itc.handle('acme:hello', async payload => {
+    return { hello: payload.name }
+  })
+
+  return {
+    async close () {
+      // Invoked when the runtime is closed
+    }
+  }
+}
+```
+
+The setup function receives a context object with the following properties:
+
+- **`runtime`** - The [Runtime](./programmatic.md) instance. It is an `EventEmitter`, so extensions can
+  subscribe to all runtime events and invoke any public method.
+- **`itc`** - A facade over the runtime ITC:
+  - **`handle(name, handler)`** - Registers a custom command invocable from any application via
+    `globalThis.platformatic.itc.send(name, payload)`. The name must not clash with the commands
+    reserved by the runtime or with a command registered by another extension.
+  - **`send(target, name, payload)`** - Sends a request to a worker and awaits its response. `target` is
+    an application ID (a worker is chosen in round-robin) or `application:worker-index` for a specific worker.
+  - **`notify(target, name, payload)`** - Sends a fire-and-forget notification. When `target` is an
+    application ID, all its running workers are notified; use `application:worker-index` to target a
+    specific worker. Workers receive notifications via `globalThis.platformatic.itc.on(name, handler)`.
+- **`logger`** - A child of the runtime logger.
+- **`options`** - The `options` object specified in the configuration, if any.
+- **`root`** - The runtime project root directory.
+
+The setup function can optionally return an object with a `close` method, which is invoked when the
+runtime is being closed. When multiple extensions are configured, they are loaded in order and closed
+in reverse order.
+
+Extensions are not loaded when building the applications (for example via `wattpm build`).
+
 ### `applications`
 
 `applications` is an array of objects that defines the applications managed by the

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -89,7 +89,7 @@ export default async function setup ({ runtime, itc, logger, options, root }) {
 The setup function receives a context object with the following properties:
 
 - **`runtime`** - The [Runtime](./programmatic.md) instance. It is an `EventEmitter`, so extensions can
-  subscribe to all runtime events and invoke any public method.
+  subscribe to all [runtime events](./programmatic.md#events) and invoke any public method.
 - **`itc`** - A facade over the runtime ITC:
   - **`handle(name, handler)`** - Registers a custom command invocable from any application via
     `globalThis.platformatic.itc.send(name, payload)`. The name must not clash with the commands

--- a/docs/reference/runtime/globals.md
+++ b/docs/reference/runtime/globals.md
@@ -177,6 +177,25 @@ const { port1 } = new MessageChannel()
 await messaging.send('service', 'connect', { port: port1 }, { transferList: [port1] })
 ```
 
+### Communicating with runtime extensions
+
+When the runtime is configured with [`extensions`](./configuration.md#extensions), applications can invoke
+the custom commands registered by the extensions in the main thread using the ITC API returned by `getITC()`:
+
+```js
+import { getITC } from '@platformatic/globals'
+
+const itc = getITC()
+
+// Invoke a custom command registered by an extension via itc.handle()
+const response = await itc.send('acme:hello', { name: 'world' })
+
+// Receive notifications sent by an extension via itc.notify()
+itc.on('acme:ping', payload => {
+  console.log('received', payload)
+})
+```
+
 ### Shared context API
 
 The shared context API stores context that is shared between all runtime applications:

--- a/docs/reference/runtime/programmatic.md
+++ b/docs/reference/runtime/programmatic.md
@@ -187,6 +187,14 @@ test('handles ping messages', async t => {
 
 These act on a single application by `id`. If an entrypoint exists, it can be restarted but cannot be removed (see below).
 
+### Profiling
+
+These methods require [`@platformatic/wattpm-pprof-capture`](../../guides/profiling-with-watt.md) to be installed. The `id` can be an application ID (a worker is chosen in round-robin) or `application:worker-index` for a specific worker.
+
+- **`runtime.startApplicationProfiling(id, options?): Promise<void>`** — Starts profiling a worker. `options.type` is `cpu` (default) or `heap`. Passing `options.durationMillis` enables continuous profiling: the profile window is rotated at that interval and each completed window emits the [`application:worker:profile:captured`](#applicationworkerprofilecaptured) event.
+- **`runtime.stopApplicationProfiling(id, options?): Promise<Buffer>`** — Stops profiling and returns the last captured profile in pprof format.
+- **`runtime.getApplicationLastProfile(id, options?): Promise<Buffer>`** — Returns the last profile window captured by the continuous profiler without stopping it.
+
 ### Events
 
 The `Runtime` instance is an `EventEmitter`. Programmatic users and [extensions](./configuration.md#extensions) can subscribe to the following events with `runtime.on(event, listener)`.
@@ -219,6 +227,18 @@ The payload is an object with the following properties:
 - **`healthSignals`** (`array`) - The custom health signals sent by the worker via `sendHealthSignals` since the last collection, if any.
 
 A related event, `application:worker:unhealthy` (with a `{ application, worker }` payload), is emitted when a worker with health checks enabled exceeds the configured thresholds and is about to be restarted.
+
+#### `application:worker:profile:captured`
+
+Emitted when the continuous profiler completes a profile window in a worker, that is when profiling was started with the `durationMillis` option and a rotation happened. The payload is an object with the following properties:
+
+- **`id`** (`string`) - The full worker ID (`application:index`).
+- **`application`** (`string`) - The application ID.
+- **`worker`** (`number`) - The zero-based worker index.
+- **`type`** (`string`) - The profile type, either `cpu` or `heap`.
+- **`timestamp`** (`number`) - When the profile window was completed, in milliseconds since the epoch.
+
+The event purposely does not carry the profile, since it can be big and there might be no consumer. Retrieve it on demand with `runtime.getApplicationLastProfile(id, { type })`, before the next window completes.
 
 #### Custom worker events
 

--- a/docs/reference/runtime/programmatic.md
+++ b/docs/reference/runtime/programmatic.md
@@ -187,6 +187,43 @@ test('handles ping messages', async t => {
 
 These act on a single application by `id`. If an entrypoint exists, it can be restarted but cannot be removed (see below).
 
+### Events
+
+The `Runtime` instance is an `EventEmitter`. Programmatic users and [extensions](./configuration.md#extensions) can subscribe to the following events with `runtime.on(event, listener)`.
+
+#### Runtime status events
+
+Emitted when the runtime changes status, with no payload: `init`, `starting`, `started`, `stopping`, `stopped`, `closing`, `closed`, `errored` (receives the error), `restarting`, `restarted`.
+
+#### Application lifecycle events
+
+All these events receive the application ID as payload: `application:init`, `application:starting`, `application:started`, `application:stopping`, `application:stopped`, `application:restarting`, `application:restarted`, `application:building`, `application:built`. `application:added` and `application:removed` receive the application details object instead.
+
+#### Worker lifecycle events
+
+All these events receive a `{ application, worker, workersCount }` payload, where `worker` is the zero-based worker index: `application:worker:init`, `application:worker:starting`, `application:worker:started`, `application:worker:stopping`, `application:worker:stopped`, `application:worker:changed`, `application:worker:reloaded`, `application:worker:exited`, `application:worker:unvailable`. Failure variants carry additional context: `application:worker:error` (adds `code`), `application:worker:start:error`, `application:worker:start:failed`, `application:worker:stop:error`, `application:worker:startTimeout` and `application:worker:exit:timeout`.
+
+#### `application:worker:health:metrics`
+
+Emitted every second for each running worker while health metrics collection is active. Collection is active when at least one of the following is true: a worker has health checks enabled (with `restartOnError` greater than `0`), the dynamic workers scaler is enabled, or an extension subscribed to this event during its setup.
+
+The payload is an object with the following properties:
+
+- **`id`** (`string`) - The full worker ID (`application:index`).
+- **`application`** (`string`) - The application ID.
+- **`worker`** (`number`) - The zero-based worker index.
+- **`currentHealth`** (`object` or `null`) - `null` when the health collection failed. Otherwise:
+  - **`elu`** (`number`) - The worker event loop utilization since the previous collection, between `0` and `1`.
+  - **`heapUsed`** (`number`) - The worker used heap size, in bytes.
+  - **`heapTotal`** (`number`) - The worker total heap size, in bytes. Heap statistics are refreshed once per minute.
+- **`healthSignals`** (`array`) - The custom health signals sent by the worker via `sendHealthSignals` since the last collection, if any.
+
+A related event, `application:worker:unhealthy` (with a `{ application, worker }` payload), is emitted when a worker with health checks enabled exceeds the configured thresholds and is about to be restarted.
+
+#### Custom worker events
+
+Events emitted by application workers via the events API returned by `getEvents()` (using `emitAndNotify(name, ...args)`) are re-emitted by the runtime as `application:worker:event:<name>`, receiving the event arguments followed by the worker ID, the application ID and the worker index.
+
 ## Adding and removing applications at runtime
 
 The runtime supports adding and removing applications after `start()` has been called.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -86,6 +86,7 @@ const sidebars = {
             'guides/logging-to-elasticsearch',
             'guides/opentelemetry-logging',
             'guides/profiling-with-watt',
+            'guides/capture-flamegraphs-on-health-events',
             'guides/heap-snapshots',
             'guides/debugging-with-repl'
           ]

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticAstroConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -10,6 +10,23 @@ export interface PlatformaticBasicConfig {
   module?: string;
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -28,6 +28,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -178,6 +178,23 @@ export interface PlatformaticComposerConfig {
   application?: {};
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -701,6 +701,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -504,6 +504,23 @@ export interface PlatformaticDatabaseConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1385,6 +1385,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -96,6 +96,37 @@ export const preload = {
   ]
 }
 
+const extension = {
+  anyOf: [
+    { type: 'string', resolvePath: true },
+    {
+      type: 'object',
+      additionalProperties: false,
+      required: ['path'],
+      properties: {
+        path: {
+          type: 'string',
+          resolvePath: true
+        },
+        options: {
+          type: 'object',
+          additionalProperties: true
+        }
+      }
+    }
+  ]
+}
+
+export const extensions = {
+  anyOf: [
+    ...extension.anyOf,
+    {
+      type: 'array',
+      items: extension
+    }
+  ]
+}
+
 export const watch = {
   type: 'object',
   properties: {
@@ -997,6 +1028,7 @@ export const runtimeProperties = {
     type: 'string'
   },
   preload,
+  extensions,
   entrypoint: {
     type: 'string'
   },
@@ -1594,6 +1626,7 @@ export const schemaComponents = {
   env,
   workers,
   preload,
+  extensions,
   watch,
   cors,
   logger,

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -440,6 +440,23 @@ export interface PlatformaticGatewayConfig {
   application?: {};
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1664,6 +1664,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticNestJSConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticNextJsConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticNodeJsConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticNuxtConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticReactRouterConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticRemixConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -10,6 +10,23 @@ export type PlatformaticRuntimeConfig = {
 } & {
   $schema?: string;
   preload?: string | string[];
+  extensions?:
+    | string
+    | {
+        path: string;
+        options?: {
+          [k: string]: unknown;
+        };
+      }
+    | (
+        | string
+        | {
+            path: string;
+            options?: {
+              [k: string]: unknown;
+            };
+          }
+      )[];
   entrypoint?: string;
   basePath?: string;
   autoload?: {

--- a/packages/runtime/fixtures/extensions/extension-1.js
+++ b/packages/runtime/fixtures/extensions/extension-1.js
@@ -1,0 +1,25 @@
+export default async function setup ({ runtime, itc, logger, options, root }) {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  events.push({ event: 'setup', extension: 'first' })
+
+  // Expose the facade so that tests can drive it from the outside
+  globalThis.__pltExtensionItc = itc
+
+  itc.handle('extension:context', () => {
+    return {
+      options,
+      root,
+      hasRuntime: typeof runtime.getApplicationsIds === 'function',
+      hasLogger: typeof logger.info === 'function',
+      applications: runtime.getApplicationsIds()
+    }
+  })
+
+  itc.handle('extension:sum', ({ x, y }) => x + y)
+
+  return {
+    close () {
+      events.push({ event: 'close', extension: 'first' })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-2.js
+++ b/packages/runtime/fixtures/extensions/extension-2.js
@@ -1,0 +1,10 @@
+export default function setup () {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  events.push({ event: 'setup', extension: 'second' })
+
+  return {
+    close () {
+      events.push({ event: 'close', extension: 'second' })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-duplicate.js
+++ b/packages/runtime/fixtures/extensions/extension-duplicate.js
@@ -1,0 +1,4 @@
+export default function setup ({ itc }) {
+  itc.handle('extension:dup', () => 1)
+  itc.handle('extension:dup', () => 2)
+}

--- a/packages/runtime/fixtures/extensions/extension-health.js
+++ b/packages/runtime/fixtures/extensions/extension-health.js
@@ -1,0 +1,7 @@
+export default function setup ({ runtime }) {
+  const events = (globalThis.__pltExtensionHealthEvents ??= [])
+
+  runtime.on('application:worker:health:metrics', payload => {
+    events.push(payload)
+  })
+}

--- a/packages/runtime/fixtures/extensions/extension-invalid.js
+++ b/packages/runtime/fixtures/extensions/extension-invalid.js
@@ -1,0 +1,1 @@
+export default 42

--- a/packages/runtime/fixtures/extensions/extension-profiles.js
+++ b/packages/runtime/fixtures/extensions/extension-profiles.js
@@ -1,0 +1,7 @@
+export default function setup ({ runtime }) {
+  const events = (globalThis.__pltExtensionProfileEvents ??= [])
+
+  runtime.on('application:worker:profile:captured', payload => {
+    events.push(payload)
+  })
+}

--- a/packages/runtime/fixtures/extensions/extension-profiles.js
+++ b/packages/runtime/fixtures/extensions/extension-profiles.js
@@ -4,4 +4,14 @@ export default function setup ({ runtime }) {
   runtime.on('application:worker:profile:captured', payload => {
     events.push(payload)
   })
+
+  // Enable continuous profiling on every worker as soon as it starts,
+  // including replacement workers after a restart.
+  runtime.on('application:worker:started', async ({ application, worker }) => {
+    await runtime.startApplicationProfiling(`${application}:${worker}`, {
+      type: 'cpu',
+      intervalMicros: 1000,
+      durationMillis: 300
+    })
+  })
 }

--- a/packages/runtime/fixtures/extensions/extension-reserved.js
+++ b/packages/runtime/fixtures/extensions/extension-reserved.js
@@ -1,0 +1,3 @@
+export default function setup ({ itc }) {
+  itc.handle('getApplications', () => {})
+}

--- a/packages/runtime/fixtures/extensions/extension-ts.ts
+++ b/packages/runtime/fixtures/extensions/extension-ts.ts
@@ -1,0 +1,12 @@
+interface ExtensionContext {
+  itc: {
+    handle (name: string, handler: (payload: unknown) => unknown): void
+  }
+  options: Record<string, unknown>
+}
+
+export default async function setup ({ itc, options }: ExtensionContext): Promise<void> {
+  itc.handle('extension:ts', (): Record<string, unknown> => {
+    return { language: 'typescript', options }
+  })
+}

--- a/packages/runtime/fixtures/extensions/package.json
+++ b/packages/runtime/fixtures/extensions/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/runtime/fixtures/extensions/platformatic-duplicate.json
+++ b/packages/runtime/fixtures/extensions/platformatic-duplicate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "extension-duplicate.js",
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "extension-health.js",
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-invalid.json
+++ b/packages/runtime/fixtures/extensions/platformatic-invalid.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "extension-invalid.js",
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-missing.json
+++ b/packages/runtime/fixtures/extensions/platformatic-missing.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "missing.js",
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-profiles.json
+++ b/packages/runtime/fixtures/extensions/platformatic-profiles.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "extension-profiles.js",
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-reserved.json
+++ b/packages/runtime/fixtures/extensions/platformatic-reserved.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "extension-reserved.js",
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-ts.json
+++ b/packages/runtime/fixtures/extensions/platformatic-ts.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "extension-ts.ts",
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic.runtime.json
+++ b/packages/runtime/fixtures/extensions/platformatic.runtime.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": [
+    {
+      "path": "extension-1.js",
+      "options": {
+        "greeting": "hello"
+      }
+    },
+    "extension-2.js"
+  ],
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/services/a/platformatic.service.json
+++ b/packages/runtime/fixtures/extensions/services/a/platformatic.service.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "server": {
+    "logger": {
+      "level": "warn"
+    }
+  },
+  "plugins": {
+    "paths": [{
+      "path": "plugin.js",
+      "encapsulate": false
+    }]
+  }
+}

--- a/packages/runtime/fixtures/extensions/services/a/plugin.js
+++ b/packages/runtime/fixtures/extensions/services/a/plugin.js
@@ -1,5 +1,7 @@
+import { getITC } from '@platformatic/globals'
+
 export default async function (fastify) {
-  const itc = globalThis.platformatic.itc
+  const itc = getITC()
   const pings = []
 
   itc.on('extension:ping', payload => {

--- a/packages/runtime/fixtures/extensions/services/a/plugin.js
+++ b/packages/runtime/fixtures/extensions/services/a/plugin.js
@@ -1,0 +1,26 @@
+export default async function (fastify) {
+  const itc = globalThis.platformatic.itc
+  const pings = []
+
+  itc.on('extension:ping', payload => {
+    pings.push(payload)
+  })
+
+  fastify.get('/context', async () => {
+    return itc.send('extension:context', {})
+  })
+
+  fastify.get('/sum', async request => {
+    const { x, y } = request.query
+    const result = await itc.send('extension:sum', { x: Number(x), y: Number(y) })
+    return { result }
+  })
+
+  fastify.get('/ts', async () => {
+    return itc.send('extension:ts', {})
+  })
+
+  fastify.get('/pings', async () => {
+    return pings
+  })
+}

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -196,6 +196,7 @@ export declare class Runtime extends EventEmitter {
   removeApplications (applications: string[], silent?: boolean): Promise<ApplicationDetails[]>
   startApplicationProfiling (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<void>
   stopApplicationProfiling (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<Buffer>
+  getApplicationLastProfile (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<Buffer>
 }
 
 export function wrapInRuntimeConfig (

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -4,6 +4,7 @@ import { BaseGenerator } from '@platformatic/generators'
 import { PlatformaticGlobal } from '@platformatic/globals'
 import { JSONSchemaType } from 'ajv'
 import * as colorette from 'colorette'
+import { EventEmitter } from 'node:events'
 import { Logger } from 'pino'
 import { PlatformaticRuntimeConfig } from './config.js'
 
@@ -52,6 +53,10 @@ export namespace errors {
   export const InspectorHostError: () => FastifyError
   export const CannotMapSpecifierToAbsolutePathError: (specifier: string) => FastifyError
   export const NodeInspectorFlagsNotSupportedError: () => FastifyError
+  export const FailedToLoadExtensionError: (path: string, error: string) => FastifyError
+  export const InvalidExtensionError: (path: string) => FastifyError
+  export const ReservedITCHandlerNameError: (name: string) => FastifyError
+  export const DuplicateITCHandlerNameError: (name: string) => FastifyError
 }
 
 export namespace symbols {
@@ -148,7 +153,29 @@ export class WrappedGenerator extends BaseGenerator {}
 
 export declare const schema: JSONSchemaType<PlatformaticRuntimeConfig>
 
-export declare class Runtime {
+export interface RuntimeExtensionITC {
+  handle (name: string, handler: (payload: any) => any): void
+  send<Response = unknown> (target: string, name: string, payload?: unknown): Promise<Response>
+  notify (target: string, name: string, payload?: unknown): Promise<void>
+}
+
+export interface RuntimeExtensionContext {
+  runtime: Runtime
+  itc: RuntimeExtensionITC
+  logger: Logger
+  options: Record<string, unknown>
+  root: string
+}
+
+export interface RuntimeExtensionInstance {
+  close?: () => void | Promise<void>
+}
+
+export type RuntimeExtension = (
+  context: RuntimeExtensionContext
+) => void | RuntimeExtensionInstance | Promise<void | RuntimeExtensionInstance>
+
+export declare class Runtime extends EventEmitter {
   init (): Promise<void>
   start (silent?: boolean): Promise<string | undefined>
   stop (silent?: boolean): Promise<void>
@@ -167,6 +194,8 @@ export declare class Runtime {
   restartApplication (id: string): Promise<void>
   addApplications (applications: unknown[], start?: boolean): Promise<ApplicationDetails[]>
   removeApplications (applications: string[], silent?: boolean): Promise<ApplicationDetails[]>
+  startApplicationProfiling (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<void>
+  stopApplicationProfiling (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<Buffer>
 }
 
 export function wrapInRuntimeConfig (

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -145,6 +145,26 @@ export const MissingPprofCapture = createError(
   'Please install @platformatic/wattpm-pprof-capture'
 )
 
+export const FailedToLoadExtensionError = createError(
+  `${ERROR_PREFIX}_FAILED_TO_LOAD_EXTENSION`,
+  'Failed to load the extension "%s": %s'
+)
+
+export const InvalidExtensionError = createError(
+  `${ERROR_PREFIX}_INVALID_EXTENSION`,
+  'The extension "%s" must export a setup function as its default export'
+)
+
+export const ReservedITCHandlerNameError = createError(
+  `${ERROR_PREFIX}_RESERVED_ITC_HANDLER_NAME`,
+  'The ITC command name "%s" is reserved by the runtime'
+)
+
+export const DuplicateITCHandlerNameError = createError(
+  `${ERROR_PREFIX}_DUPLICATE_ITC_HANDLER_NAME`,
+  'The ITC command "%s" has already been registered'
+)
+
 export const FailedToSendHealthSignalsError = createError(
   `${ERROR_PREFIX}_FAILED_TO_SEND_HEALTH_SIGNALS`,
   'Cannot send health signals from application "%s": %s'

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -2779,6 +2779,11 @@ export class Runtime extends EventEmitter {
         return this.#discardWorker(newWorker)
       }
 
+      // Register the worker before starting it, like in the regular startup flow,
+      // so that it is addressable when the application:worker:started event is emitted.
+      // The discard paths below remove it from the map via #cleanupWorker.
+      this.#workers.set(newWorkerId, newWorker)
+
       // Add the worker to the mesh
       await this.#startWorker(configForNewWorker, applicationConfig, workersCount, applicationId, newIndex, false, 0, newWorker, true)
 
@@ -2786,10 +2791,13 @@ export class Runtime extends EventEmitter {
       if (this.#status !== 'started') {
         return this.#discardWorker(newWorker)
       }
-
-      this.#workers.set(newWorkerId, newWorker)
     } catch (e) {
       this.#workerPortOffsets.delete(newWorkerId)
+
+      if (this.#workers.get(newWorkerId) === newWorker) {
+        this.#workers.delete(newWorkerId)
+      }
+
       newWorker?.terminate?.()
       throw e
     }

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -23,7 +23,7 @@ import { readFile } from 'node:fs/promises'
 import { STATUS_CODES } from 'node:http'
 import { createRequire } from 'node:module'
 import { availableParallelism } from 'node:os'
-import { dirname, isAbsolute, join } from 'node:path'
+import { basename, dirname, isAbsolute, join } from 'node:path'
 import { Readable } from 'node:stream'
 import { finished } from 'node:stream/promises'
 import { setImmediate as immediate, setTimeout as sleep } from 'node:timers/promises'
@@ -39,9 +39,13 @@ import {
   ApplicationNotStartedError,
   ApplicationStartTimeoutError,
   CannotRemoveEntrypointError,
+  DuplicateITCHandlerNameError,
+  FailedToLoadExtensionError,
   InvalidArgumentError,
+  InvalidExtensionError,
   MessagingError,
   MissingPprofCapture,
+  ReservedITCHandlerNameError,
   RuntimeAbortedError,
   WorkerInterceptorJoinTimeoutError,
   WorkerNotFoundError
@@ -161,6 +165,9 @@ export class Runtime extends EventEmitter {
   #workers
   #workersBroadcastChannel
   #workerITCHandlers
+  #reservedITCHandlerNames
+  #extensions
+  #extensionsWantHealthMetrics
   #restartingApplications
   #restartingWorkers
   #dynamicWorkersScaler
@@ -232,6 +239,9 @@ export class Runtime extends EventEmitter {
       getSharedContext: this.getSharedContext.bind(this),
       sendHealthSignals: this.#processHealthSignals.bind(this)
     }
+    this.#reservedITCHandlerNames = new Set(Object.keys(this.#workerITCHandlers))
+    this.#extensions = []
+    this.#extensionsWantHealthMetrics = false
     this.#sharedContext = {}
 
     if (this.#isProduction) {
@@ -295,6 +305,10 @@ export class Runtime extends EventEmitter {
         this.#dynamicWorkersScaler = new DynamicWorkersScaler(this, this.#config.workers)
       }
     }
+
+    // Load extensions before creating any worker so that custom ITC handlers
+    // registered by the extensions are available to all workers.
+    await this.#loadExtensions()
 
     await this.addApplications(this.#config.applications)
     await this.#setDispatcher(config.undici)
@@ -425,6 +439,8 @@ export class Runtime extends EventEmitter {
 
     await this.stop(silent)
     this.#updateStatus('closing')
+
+    await this.#closeExtensions()
 
     // The management API autocloses by itself via event in management-api.js.
     // This is needed to let management API stop endpoint to reply.
@@ -2176,9 +2192,9 @@ export class Runtime extends EventEmitter {
   }
 
   #startHealthMetricsCollectionIfNeeded () {
-    // Need health metrics if dynamic workers scaler exists (for vertical scaling)
-    // or if any worker has health checks enabled
-    let needsHealthMetrics = !!this.#dynamicWorkersScaler
+    // Need health metrics if dynamic workers scaler exists (for vertical scaling),
+    // if an extension subscribed to them or if any worker has health checks enabled
+    let needsHealthMetrics = !!this.#dynamicWorkersScaler || this.#extensionsWantHealthMetrics
 
     if (!needsHealthMetrics) {
       // Check if any worker has health checks enabled
@@ -3458,6 +3474,115 @@ export class Runtime extends EventEmitter {
 
     worker[kWorkerHealthSignals] ??= new HealthSignalsQueue()
     worker[kWorkerHealthSignals].add(signals)
+  }
+
+  async #loadExtensions () {
+    let extensions = this.#config.extensions
+
+    // Do not load extensions when building applications
+    if (!extensions || this.#context.build) {
+      return
+    }
+
+    if (!Array.isArray(extensions)) {
+      extensions = [extensions]
+    }
+
+    for (const extension of extensions) {
+      const { path, options } = typeof extension === 'string' ? { path: extension } : extension
+
+      let setup
+      try {
+        setup = (await import(pathToFileURL(path))).default
+      } catch (e) {
+        throw new FailedToLoadExtensionError(path, e.message, { cause: e })
+      }
+
+      if (typeof setup !== 'function') {
+        throw new InvalidExtensionError(path)
+      }
+
+      const logger = this.logger.child({ name: `extension:${basename(path)}` })
+
+      try {
+        const instance = await setup({
+          runtime: this,
+          itc: this.#createExtensionITC(),
+          logger,
+          options: options ?? {},
+          root: this.#root
+        })
+
+        this.#extensions.push({ path, instance })
+      } catch (e) {
+        throw new FailedToLoadExtensionError(path, e.message, { cause: e })
+      }
+    }
+
+    // If any extension subscribed to health metrics during its setup, make sure
+    // the health metrics collection is started even if no health check or
+    // dynamic workers scaler is enabled. Note that this is evaluated here on
+    // purpose, before any worker health check listener is registered.
+    this.#extensionsWantHealthMetrics = this.listenerCount('application:worker:health:metrics') > 0
+  }
+
+  async #closeExtensions () {
+    // Close in reverse order, so that extensions loaded later, which might depend
+    // on earlier ones, are closed first.
+    const extensions = this.#extensions.splice(0).reverse()
+
+    for (const { path, instance } of extensions) {
+      try {
+        await instance?.close?.()
+      } catch (e) {
+        this.logger.error({ err: ensureLoggableError(e) }, `Failed to close the extension "${path}".`)
+      }
+    }
+  }
+
+  #createExtensionITC () {
+    return {
+      handle: (name, handler) => {
+        if (this.#reservedITCHandlerNames.has(name)) {
+          throw new ReservedITCHandlerNameError(name)
+        }
+
+        if (name in this.#workerITCHandlers) {
+          throw new DuplicateITCHandlerNameError(name)
+        }
+
+        this.#workerITCHandlers[name] = handler
+
+        // Workers copy the handlers when their ITC is created, so also register
+        // the handler on all running workers.
+        for (const worker of this.#workers.values()) {
+          worker[kITC]?.handle(name, handler)
+        }
+      },
+      send: async (target, name, payload) => {
+        const worker = await this.#getApplicationById(target)
+        return sendViaITC(worker, name, payload)
+      },
+      notify: async (target, name, payload) => {
+        const matched = target.match(/^(.+):(\d+)$/)
+
+        if (matched) {
+          const worker = await this.#getWorkerByIdOrNext(matched[1], matched[2])
+          worker[kITC].notify(name, payload)
+          return
+        }
+
+        if (!this.#applications.has(target)) {
+          throw new ApplicationNotFoundError(target, this.getApplicationsIds().join(', '))
+        }
+
+        for (const worker of this.#workers.values()) {
+          if (worker[kApplicationId] === target && worker[kWorkerStatus] === 'started') {
+            worker[kITC].notify(name, payload)
+          }
+        }
+      }
+    }
   }
 
   #updateLoggingPrefixes () {

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -844,6 +844,13 @@ export class Runtime extends EventEmitter {
     return sendViaITC(service, 'stopProfiling', options)
   }
 
+  async getApplicationLastProfile (id, options = {}, ensureStarted = true) {
+    const service = await this.#getApplicationById(id, ensureStarted)
+    this.#validatePprofCapturePreload()
+
+    return sendViaITC(service, 'getLastProfile', options)
+  }
+
   async takeApplicationHeapSnapshot (id, ensureStarted = true) {
     const service = await this.#getApplicationById(id, ensureStarted)
 
@@ -2102,6 +2109,20 @@ export class Runtime extends EventEmitter {
 
     worker[kITC].on(openTelemetryITCMessage, resourceMetrics => {
       this.#opentelemetryMetricsForwarder?.collect(resourceMetrics)
+    })
+
+    // The continuous profiler notifies us when a profile window is completed.
+    // The event only carries metadata: the profile can be retrieved on demand
+    // via getApplicationLastProfile. We use emit instead of emitAndNotify since
+    // other workers are not interested in this event.
+    worker[kITC].on('profile:captured', ({ type, timestamp }) => {
+      this.emit('application:worker:profile:captured', {
+        id: workerId,
+        application: applicationId,
+        worker: index,
+        type,
+        timestamp
+      })
     })
 
     worker[kITC].on('request:restart', async () => {

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -22,6 +22,59 @@
         }
       ]
     },
+    "extensions": {
+      "anyOf": [
+        {
+          "type": "string",
+          "resolvePath": true
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "path"
+          ],
+          "properties": {
+            "path": {
+              "type": "string",
+              "resolvePath": true
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "resolvePath": true
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "path"
+                ],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  "options": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
     "entrypoint": {
       "type": "string"
     },

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -164,6 +164,53 @@ test('extensions subscribed to health metrics receive them even without health c
   throw new Error('The extension never received health metrics')
 })
 
+test('extensions receive the profiles captured by the continuous profiler', async t => {
+  cleanExtensionGlobals()
+  globalThis.__pltExtensionProfileEvents = []
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-profiles.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  // Enable continuous profiling with a short rotation window
+  await app.startApplicationProfiling('a', { type: 'cpu', intervalMicros: 1000, durationMillis: 300 })
+
+  try {
+    // Wait for at least two rotations
+    for (let i = 0; i < 100; i++) {
+      const events = globalThis.__pltExtensionProfileEvents
+
+      if (events.length > 1) {
+        const event = events[0]
+        strictEqual(event.id, 'a:0')
+        strictEqual(event.application, 'a')
+        strictEqual(event.worker, 0)
+        strictEqual(event.type, 'cpu')
+        strictEqual(typeof event.timestamp, 'number')
+
+        // The event only carries metadata, the profile is retrieved on demand
+        strictEqual(event.profile, undefined)
+
+        const profile = await app.getApplicationLastProfile(event.id, { type: event.type })
+        ok(profile instanceof Uint8Array || Buffer.isBuffer(profile))
+        ok(profile.length > 0)
+        return
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 100))
+    }
+
+    throw new Error('The extension never received the captured profiles')
+  } finally {
+    await app.stopApplicationProfiling('a')
+  }
+})
+
 test('extensions cannot register reserved ITC commands', async t => {
   cleanExtensionGlobals()
   process.env.PORT = 0

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -164,11 +164,13 @@ test('extensions subscribed to health metrics receive them even without health c
   throw new Error('The extension never received health metrics')
 })
 
-test('extensions receive the profiles captured by the continuous profiler', async t => {
+test('extensions receive the profiles captured by the continuous profiler, also after a restart', async t => {
   cleanExtensionGlobals()
   globalThis.__pltExtensionProfileEvents = []
   process.env.PORT = 0
 
+  // The fixture extension enables continuous profiling on every worker via
+  // the application:worker:started event, as shown in the documentation
   const configFile = join(fixturesDir, 'extensions', 'platformatic-profiles.json')
   const app = await createRuntime(configFile)
   await app.start()
@@ -177,38 +179,44 @@ test('extensions receive the profiles captured by the continuous profiler', asyn
     return app.close()
   })
 
-  // Enable continuous profiling with a short rotation window
-  await app.startApplicationProfiling('a', { type: 'cpu', intervalMicros: 1000, durationMillis: 300 })
-
-  try {
+  async function waitForCapturedProfiles () {
     // Wait for at least two rotations
     for (let i = 0; i < 100; i++) {
       const events = globalThis.__pltExtensionProfileEvents
 
       if (events.length > 1) {
-        const event = events[0]
-        strictEqual(event.id, 'a:0')
-        strictEqual(event.application, 'a')
-        strictEqual(event.worker, 0)
-        strictEqual(event.type, 'cpu')
-        strictEqual(typeof event.timestamp, 'number')
-
-        // The event only carries metadata, the profile is retrieved on demand
-        strictEqual(event.profile, undefined)
-
-        const profile = await app.getApplicationLastProfile(event.id, { type: event.type })
-        ok(profile instanceof Uint8Array || Buffer.isBuffer(profile))
-        ok(profile.length > 0)
-        return
+        return events[0]
       }
 
       await new Promise(resolve => setTimeout(resolve, 100))
     }
 
     throw new Error('The extension never received the captured profiles')
-  } finally {
-    await app.stopApplicationProfiling('a')
   }
+
+  const event = await waitForCapturedProfiles()
+  strictEqual(event.id, 'a:0')
+  strictEqual(event.application, 'a')
+  strictEqual(event.worker, 0)
+  strictEqual(event.type, 'cpu')
+  strictEqual(typeof event.timestamp, 'number')
+
+  // The event only carries metadata, the profile is retrieved on demand
+  strictEqual(event.profile, undefined)
+
+  const profile = await app.getApplicationLastProfile(event.id, { type: event.type })
+  ok(profile instanceof Uint8Array || Buffer.isBuffer(profile))
+  ok(profile.length > 0)
+
+  // Profiling must be re-enabled on the replacement worker after a restart.
+  // Truncate the array in place since the extension captured its reference.
+  await app.restartApplication('a')
+  globalThis.__pltExtensionProfileEvents.length = 0
+
+  const eventAfterRestart = await waitForCapturedProfiles()
+  strictEqual(eventAfterRestart.application, 'a')
+
+  await app.stopApplicationProfiling(eventAfterRestart.id, { type: 'cpu' })
 })
 
 test('extensions cannot register reserved ITC commands', async t => {

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -1,0 +1,248 @@
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+function cleanExtensionGlobals () {
+  globalThis.__pltExtensionEvents = []
+  globalThis.__pltExtensionItc = undefined
+}
+
+test('extensions receive the runtime, the ITC facade, the logger, the options and the root', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile)
+  const entryUrl = await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  const res = await request(entryUrl + '/context')
+  strictEqual(res.statusCode, 200)
+
+  const context = await res.body.json()
+  deepStrictEqual(context.options, { greeting: 'hello' })
+  strictEqual(context.root, join(fixturesDir, 'extensions'))
+  strictEqual(context.hasRuntime, true)
+  strictEqual(context.hasLogger, true)
+  deepStrictEqual(context.applications, ['a'])
+})
+
+test('workers can invoke custom commands registered by extensions, also after a restart', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile)
+  const entryUrl = await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  {
+    const res = await request(entryUrl + '/sum?x=1&y=2')
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { result: 3 })
+  }
+
+  // Restarted workers must see the custom handlers as well
+  await app.restartApplication('a')
+
+  {
+    // The entrypoint may listen on a different port after the restart
+    const res = await request(app.getUrl() + '/sum?x=4&y=5')
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { result: 9 })
+  }
+})
+
+test('extensions can notify workers', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile)
+  const entryUrl = await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  await globalThis.__pltExtensionItc.notify('a', 'extension:ping', { value: 42 })
+
+  // The notification is fire-and-forget, poll for the result
+  for (let i = 0; i < 10; i++) {
+    const res = await request(entryUrl + '/pings')
+    strictEqual(res.statusCode, 200)
+    const pings = await res.body.json()
+
+    if (pings.length > 0) {
+      deepStrictEqual(pings, [{ value: 42 }])
+      return
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+
+  throw new Error('The worker never received the notification')
+})
+
+test('extensions are closed in reverse order when the runtime is closed', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  deepStrictEqual(globalThis.__pltExtensionEvents, [
+    { event: 'setup', extension: 'first' },
+    { event: 'setup', extension: 'second' }
+  ])
+
+  await app.close()
+
+  deepStrictEqual(globalThis.__pltExtensionEvents, [
+    { event: 'setup', extension: 'first' },
+    { event: 'setup', extension: 'second' },
+    { event: 'close', extension: 'second' },
+    { event: 'close', extension: 'first' }
+  ])
+})
+
+test('extensions can be written in TypeScript', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-ts.json')
+  const app = await createRuntime(configFile)
+  const entryUrl = await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  const res = await request(entryUrl + '/ts')
+  strictEqual(res.statusCode, 200)
+  deepStrictEqual(await res.body.json(), { language: 'typescript', options: {} })
+})
+
+test('extensions subscribed to health metrics receive them even without health checks enabled', async t => {
+  cleanExtensionGlobals()
+  globalThis.__pltExtensionHealthEvents = []
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  // Health metrics are collected every second, poll for the first event
+  for (let i = 0; i < 50; i++) {
+    const events = globalThis.__pltExtensionHealthEvents
+
+    if (events.length > 0) {
+      strictEqual(events[0].application, 'a')
+      strictEqual(events[0].worker, 0)
+      ok(events[0].currentHealth)
+      return
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+
+  throw new Error('The extension never received health metrics')
+})
+
+test('extensions cannot register reserved ITC commands', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-reserved.json')
+  const app = await createRuntime(configFile)
+
+  t.after(() => {
+    return app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_FAILED_TO_LOAD_EXTENSION')
+      strictEqual(err.cause.code, 'PLT_RUNTIME_RESERVED_ITC_HANDLER_NAME')
+      ok(err.message.includes('reserved'))
+      return true
+    }
+  )
+})
+
+test('extensions cannot register the same ITC command twice', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-duplicate.json')
+  const app = await createRuntime(configFile)
+
+  t.after(() => {
+    return app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_FAILED_TO_LOAD_EXTENSION')
+      strictEqual(err.cause.code, 'PLT_RUNTIME_DUPLICATE_ITC_HANDLER_NAME')
+      return true
+    }
+  )
+})
+
+test('a missing extension file fails the startup', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-missing.json')
+  const app = await createRuntime(configFile)
+
+  t.after(() => {
+    return app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_FAILED_TO_LOAD_EXTENSION')
+      return true
+    }
+  )
+})
+
+test('an extension without a default exported function fails the startup', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-invalid.json')
+  const app = await createRuntime(configFile)
+
+  t.after(() => {
+    return app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_INVALID_EXTENSION')
+      return true
+    }
+  )
+})

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'tstyche'
 import type { Configuration } from '@platformatic/foundation'
-import { create, loadConfiguration, type Runtime, type RuntimeConfiguration, type ApplicationDetails, type InjectParams, type InjectResponse, type RuntimeMetadata } from '../../index.js'
+import { create, loadConfiguration, type Runtime, type RuntimeConfiguration, type ApplicationDetails, type InjectParams, type InjectResponse, type RuntimeExtension, type RuntimeExtensionContext, type RuntimeExtensionInstance, type RuntimeMetadata } from '../../index.js'
 
 const context = {} as Configuration
 
@@ -108,4 +108,37 @@ test('Runtime.addApplications', () => {
 test('Runtime.removeApplications', () => {
   expect(runtime.removeApplications(['api'])).type.toBe<Promise<ApplicationDetails[]>>()
   expect(runtime.removeApplications(['api'], true)).type.toBe<Promise<ApplicationDetails[]>>()
+})
+
+test('Runtime.startApplicationProfiling', () => {
+  expect(runtime.startApplicationProfiling('api')).type.toBe<Promise<void>>()
+  expect(runtime.startApplicationProfiling('api', { type: 'cpu' }, true)).type.toBe<Promise<void>>()
+})
+
+test('Runtime.stopApplicationProfiling', () => {
+  expect(runtime.stopApplicationProfiling('api')).type.toBe<Promise<Buffer>>()
+  expect(runtime.stopApplicationProfiling('api', { type: 'cpu' }, true)).type.toBe<Promise<Buffer>>()
+})
+
+test('RuntimeExtension', () => {
+  const extension: RuntimeExtension = async ({ runtime, itc, logger, options, root }: RuntimeExtensionContext) => {
+    expect(runtime).type.toBe<Runtime>()
+    expect(options).type.toBe<Record<string, unknown>>()
+    expect(root).type.toBe<string>()
+
+    logger.info('loaded')
+
+    itc.handle('custom:command', payload => payload)
+    expect(itc.send<number>('api', 'custom:command', { value: 42 })).type.toBe<Promise<number>>()
+    expect(itc.notify('api', 'custom:event', { value: 42 })).type.toBe<Promise<void>>()
+
+    return {
+      async close () {}
+    }
+  }
+
+  expect(extension).type.toBe<RuntimeExtension>()
+
+  const instance: RuntimeExtensionInstance = {}
+  expect(instance.close).type.toBe<(() => void | Promise<void>) | undefined>()
 })

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -120,6 +120,11 @@ test('Runtime.stopApplicationProfiling', () => {
   expect(runtime.stopApplicationProfiling('api', { type: 'cpu' }, true)).type.toBe<Promise<Buffer>>()
 })
 
+test('Runtime.getApplicationLastProfile', () => {
+  expect(runtime.getApplicationLastProfile('api')).type.toBe<Promise<Buffer>>()
+  expect(runtime.getApplicationLastProfile('api:0', { type: 'cpu' }, true)).type.toBe<Promise<Buffer>>()
+})
+
 test('RuntimeExtension', () => {
   const extension: RuntimeExtension = async ({ runtime, itc, logger, options, root }: RuntimeExtensionContext) => {
     expect(runtime).type.toBe<Runtime>()

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -333,6 +333,23 @@ export interface PlatformaticServiceConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1070,6 +1070,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticTanStackConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -130,6 +130,23 @@ export interface PlatformaticViteConfig {
   };
   runtime?: {
     preload?: string | string[];
+    extensions?:
+      | string
+      | {
+          path: string;
+          options?: {
+            [k: string]: unknown;
+          };
+        }
+      | (
+          | string
+          | {
+              path: string;
+              options?: {
+                [k: string]: unknown;
+              };
+            }
+        )[];
     basePath?: string;
     services?: {
       [k: string]: unknown;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -427,6 +427,59 @@
             }
           ]
         },
+        "extensions": {
+          "anyOf": [
+            {
+              "type": "string",
+              "resolvePath": true
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "resolvePath": true
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "resolvePath": true
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "basePath": {
           "type": "string"
         },

--- a/packages/wattpm-pprof-capture/index.js
+++ b/packages/wattpm-pprof-capture/index.js
@@ -197,7 +197,30 @@ function rotateProfile (type) {
   const wasRunning = state.profilerStarted
 
   stopProfiler(type, state)
+
+  if (wasRunning && state.latestProfile) {
+    notifyProfileCaptured(type, state)
+  }
+
   maybeStartProfiler(type, state, wasRunning)
+}
+
+// Notify the main thread that the continuous profiler completed a profile
+// window. The profile itself is purposely not included as it can be big and
+// there might be no consumer: interested code can retrieve it on demand via
+// the getLastProfile command.
+function notifyProfileCaptured (type, state) {
+  const itc = getITC({ throwOnMissing: false })
+
+  if (!itc) {
+    return
+  }
+
+  try {
+    itc.notify('profile:captured', { type, timestamp: state.latestProfileTimestamp })
+  } catch (err) {
+    getLogger({ throwOnMissing: false })?.error({ err }, 'Failed to notify the captured profile')
+  }
 }
 
 function maybeStartProfiler (type, state, wasRunning) {

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -10,6 +10,23 @@ export type PlatformaticRuntimeConfig = {
 } & {
   $schema?: string;
   preload?: string | string[];
+  extensions?:
+    | string
+    | {
+        path: string;
+        options?: {
+          [k: string]: unknown;
+        };
+      }
+    | (
+        | string
+        | {
+            path: string;
+            options?: {
+              [k: string]: unknown;
+            };
+          }
+      )[];
   entrypoint?: string;
   basePath?: string;
   autoload?: {

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -22,6 +22,59 @@
         }
       ]
     },
+    "extensions": {
+      "anyOf": [
+        {
+          "type": "string",
+          "resolvePath": true
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "path"
+          ],
+          "properties": {
+            "path": {
+              "type": "string",
+              "resolvePath": true
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "resolvePath": true
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "path"
+                ],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "resolvePath": true
+                  },
+                  "options": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
     "entrypoint": {
       "type": "string"
     },


### PR DESCRIPTION
## Summary

Adds a new `extensions` runtime configuration property that loads custom JS/TS files in the **runtime main thread**. Extensions receive the `Runtime` object and an ITC facade, so they can observe runtime events, invoke runtime APIs, and register custom ITC commands that applications can call from their worker threads.

```json
{
  "extensions": [
    { "path": "./runtime-extension.js", "options": { "bucket": "{S3_BUCKET}" } }
  ]
}
```

```js
export default async function setup ({ runtime, itc, logger, options, root }) {
  runtime.on('application:worker:health:metrics', payload => { /* ... */ })

  // Invocable from workers via globalThis.platformatic.itc.send('acme:hello', ...)
  itc.handle('acme:hello', async payload => ({ hello: payload.name }))

  return { async close () { /* invoked on runtime close */ } }
}
```

### Extensions

- `extensions` accepts a path, `{ path, options }`, or an array of either (same `resolvePath` semantics as `preload`); available in wrapped `watt.json` configs as well.
- Extensions load in `init()` before any worker spawns, so registered commands are visible to all workers (including restarted/scaled ones); a live-worker registration path also supports lazy `handle()` calls.
- The ITC facade provides `handle(name, fn)` (with collision checks against runtime-reserved commands), `send(target, name, payload)` (round-robin or `app:index`), and `notify(target, name, payload)` (broadcast to all workers of an application).
- `close()` hooks run in reverse order when the runtime closes. Extensions are skipped during `build`.
- Health metrics collection now also starts when an extension subscribes to `application:worker:health:metrics` during setup, even without health checks or the dynamic scaler enabled.
- TypeScript extensions work out of the box via Node.js type stripping.
- New errors: `FailedToLoadExtensionError`, `InvalidExtensionError`, `ReservedITCHandlerNameError`, `DuplicateITCHandlerNameError`.

### Continuous profiler notifications

When continuous profiling is enabled (`durationMillis`), `@platformatic/wattpm-pprof-capture` now notifies the main thread every time a profile window completes, and the runtime re-emits it as the `application:worker:profile:captured` event so extensions can collect profiles as they are produced.

The notification only carries metadata (`id`, `application`, `worker`, `type`, `timestamp`): profiles can be big and there might be no consumer, so they are never moved across threads unless explicitly requested. The new `runtime.getApplicationLastProfile(id, options)` method retrieves the last captured window on demand, wrapping the existing `getLastProfile` ITC command.

Replacement workers are now registered in the workers map before they are started (matching the regular startup flow), so `application:worker:started` listeners can address them by ID — e.g. to re-enable continuous profiling after a crash, reload or scaling event. The guide and the tests cover the full pattern: enable profiling from `application:worker:started` (covers initial start and every restart) and ship each window announced by `application:worker:profile:captured`.

### Docs

- `extensions` reference in the runtime shared configuration docs.
- New **Events** reference in the runtime programmatic API docs: runtime status, application and worker lifecycle events, the `application:worker:health:metrics` and `application:worker:profile:captured` payloads, and custom worker events.
- New **Profiling** section in the programmatic API docs (`startApplicationProfiling`, `stopApplicationProfiling`, `getApplicationLastProfile`).
- Worker→runtime custom commands documented in `globals.md`.
- New guide: **Capture Flamegraphs on Health Events** — a full worked example that captures a CPU profile when an application requests it and uploads it to S3, plus a continuous-profiling variant using the new event and the profiler's built-in `eluThreshold` gating (all plumbing in the runtime, S3 specifics stay in the guide).

### Testing

- 11 integration tests in `packages/runtime/test/extensions.test.js` covering context contents, worker→extension command round-trips (including after a worker restart), extension→worker notifications, reverse-order close, TypeScript extensions, health metrics without health checks, continuous-profiler capture events with on-demand profile retrieval, and all failure modes.
- New tstyche type tests for the extension contract and the profiling methods.
- Foundation suite, runtime config/preload/pprof/management-ITC/init tests and the `wattpm-pprof-capture` suite all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wwmWs8pVTD9KhUreJ1JaY

