### PR TITLE
test(runtime): avoid Windows dynamic port range

### DIFF
--- a/packages/runtime/test/multiple-workers/helper.js
+++ b/packages/runtime/test/multiple-workers/helper.js
@@ -10,6 +10,24 @@ export const tmpDir = resolve(import.meta.dirname, '../../tmp')
 
 const WAIT_TIMEOUT = process.env.CI ? 20_000 : 10_000
 const MAX_PORT = 65_535
+const MIN_WINDOWS_TEST_PORT = 1_024
+const WINDOWS_DYNAMIC_PORT_START = 49_152
+
+function getCandidatePort (size) {
+  if (process.platform !== 'win32') {
+    return 0
+  }
+
+  // Windows can add excluded ranges while the runner is active. Those ranges
+  // normally live in the dynamic port range and fail with EACCES when bound.
+  // Pick a random non-dynamic port so the range remains usable after probing.
+  const maxBasePort = WINDOWS_DYNAMIC_PORT_START - size
+  if (maxBasePort < MIN_WINDOWS_TEST_PORT) {
+    return 0
+  }
+
+  return MIN_WINDOWS_TEST_PORT + Math.floor(Math.random() * (maxBasePort - MIN_WINDOWS_TEST_PORT + 1))
+}
 
 function listen (server, host, port) {
   return new Promise((resolve, reject) => {
@@ -54,7 +72,7 @@ export async function findAvailablePortRange ({ host, size, startPort }) {
     try {
       const firstServer = createServer()
       servers.push(firstServer)
-      await listen(firstServer, host, startPort ?? 0)
+      await listen(firstServer, host, startPort ?? getCandidatePort(size))
       startPort = undefined
 
       const address = firstServer.address()

--- a/packages/runtime/test/multiple-workers/per-worker-port.test.js
+++ b/packages/runtime/test/multiple-workers/per-worker-port.test.js
@@ -9,6 +9,7 @@ import { createRuntime, updateConfigFile } from '../helpers.js'
 import { findAvailablePortRange, prepareRuntime, waitForEvents } from './helper.js'
 
 const HOST = '127.0.0.1'
+const WINDOWS_DYNAMIC_PORT_START = 49_152
 
 async function listen (server, port = 0) {
   server.listen({ host: HOST, port, exclusive: true })
@@ -171,6 +172,17 @@ test('findAvailablePortRange retries when a port inside the candidate range is u
     await closeServer(candidateServer)
   }
 })
+
+test(
+  'findAvailablePortRange avoids the Windows dynamic port range',
+  { skip: process.platform !== 'win32' },
+  async () => {
+    const size = 2
+    const basePort = await findAvailablePortRange({ host: HOST, size })
+
+    strictEqual(basePort + size <= WINDOWS_DYNAMIC_PORT_START, true)
+  }
+)
 
 test('assigns one incremental port per entrypoint worker', async t => {
   const { app, basePort } = await preparePerWorkerPortRuntime(t)


### PR DESCRIPTION
## Summary

- select per-worker test port ranges below the Windows dynamic port range
- preserve random range selection and existing retry behavior for unavailable ports
- add a Windows regression test that verifies selected ranges remain below port 49152

## Testing

- `pnpm --filter @platformatic/runtime run lint`
- focused `findAvailablePortRange` tests, repeated 10 times

The complete `per-worker-port.test.js` suite could not run locally because `@datadog/pprof` has no native build for Windows ARM64 with Node.js 24.14.0.

Fixes #4953
