### PR TITLE
fix(runtime): allow removing applications without a live worker

### DIFF
--- a/packages/runtime/fixtures/dynamic-applications/application-2/index.mjs
+++ b/packages/runtime/fixtures/dynamic-applications/application-2/index.mjs
@@ -26,5 +26,13 @@ export function create () {
     return { ok: true }
   })
 
+  app.get('/crash', () => {
+    setImmediate(() => {
+      process.exit(1)
+    })
+
+    return { ok: true }
+  })
+
   return app
 }

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -651,7 +651,13 @@ export class Runtime extends EventEmitter {
 
     const removed = []
     for (const application of applications) {
-      const details = await this.getApplicationDetails(application)
+      if (!this.#applications.has(application)) {
+        throw new ApplicationNotFoundError(application, this.getApplicationsIds().join(', '))
+      }
+
+      // Use allowUnloaded so that applications without a live worker
+      // (stopped or crashed with restartOnError: 0) can still be removed.
+      const details = await this.getApplicationDetails(application, true)
       details.status = 'removed'
       removed.push(details)
     }

--- a/packages/runtime/test/dynamic-applications.test.js
+++ b/packages/runtime/test/dynamic-applications.test.js
@@ -366,3 +366,64 @@ test('vertical autoscaler should work properly when adding and removing applicat
   // Wait for few cycles of vertical autoscaler
   await sleep(10000)
 })
+
+test('should be able to remove a stopped application', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  await runtime.stopApplication('application-1')
+
+  const removed = await runtime.removeApplications(['application-1'])
+  deepStrictEqual(removed[0].id, 'application-1')
+  deepStrictEqual(removed[0].status, 'removed')
+  ok(!runtime.getApplicationsIds().includes('application-1'))
+
+  await rejects(
+    () => runtime.removeApplications(['application-1']),
+    /Application application-1 not found./
+  )
+})
+
+test('should be able to remove an application whose worker crashed and was not restarted', async t => {
+  const configFile = join(fixturesDir, 'dynamic-applications')
+  const runtime = await createRuntime(configFile, null)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  // Add application-2 with restartOnError disabled so that it stays down after crashing
+  const restartPromise = once(runtime, 'application:restarted')
+  await runtime.addApplications(
+    [
+      await prepareApplication(runtime.getRuntimeConfig(true), {
+        id: 'application-2',
+        path: './application-2',
+        restartOnError: 0
+      })
+    ],
+    true
+  )
+  await restartPromise
+
+  const url = runtime.getUrl()
+
+  // Crash the application and wait for the runtime to mark it as unavailable
+  const unavailablePromise = once(runtime, 'application:worker:unvailable')
+  await request(url + '/application-2/crash')
+  await unavailablePromise
+
+  // Removing the application must succeed even though it has no live worker
+  const removed = await runtime.removeApplications(['application-2'])
+  deepStrictEqual(removed[0].id, 'application-2')
+  deepStrictEqual(removed[0].status, 'removed')
+  ok(!runtime.getApplicationsIds().includes('application-2'))
+})


### PR DESCRIPTION
## Problem

Fixes #4959.

`Runtime.removeApplications()` required a live worker for every application it removed: the initial `getApplicationDetails` call used the default `allowUnloaded: false`, which throws `PLT_RUNTIME_WORKER_NOT_FOUND` when the application is registered but has no worker in the pool.

An application reaches that state on its own when its worker crashes with `restartOnError: 0` (the exit handler removes the worker from the pool and correctly does not restart it), or when it is stopped via `stopApplication()`. From then on the application could never be removed — the registration leaked until the whole runtime restarted and its id could not be reused.

## Fix

Pass `allowUnloaded: true` in the details lookup inside `removeApplications`, with an explicit registration check first so removing an unknown application still throws `ApplicationNotFoundError`. The rest of the method already handles the zero-worker case: `stopApplication` iterates `#workers.getKeys(id)` (a no-op with zero workers), and the registry cleanup and `application:removed` notification run as before.

## Tests

Two new tests in `test/dynamic-applications.test.js`:

- removing a stopped application (plus verifying a second removal now throws `ApplicationNotFoundError`),
- removing an application whose worker crashed with `restartOnError: 0` and was not restarted (via a new `/crash` route in the `dynamic-applications/application-2` fixture).

Both fail with `PLT_RUNTIME_WORKER_NOT_FOUND` without the fix (verified by running them against the unpatched `runtime.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWCqGV3AEoWnshy19oYsFe