### PR TITLE
fix(runtime): report process-level metrics only once per runtime

### DIFF
--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -894,7 +894,8 @@ export class BaseCapability extends EventEmitter {
     }
 
     // Use thread-specific metrics collection - process-level metrics are collected
-    // by the main runtime thread and duplicated with worker labels
+    // and reported only once by the main runtime thread, without application labels.
+    // See https://github.com/platformatic/platformatic/issues/3332.
     await collectThreadMetrics(this.applicationId, this.workerId, metricsConfig, this.metricsRegistry)
   }
 

--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -26,7 +26,13 @@ import {
   updateGlobals
 } from '@platformatic/globals'
 import { ITC } from '@platformatic/itc/lib/index.js'
-import { clearRegistry, client, collectThreadMetrics, setupOtlpExporter } from '@platformatic/metrics'
+import {
+  clearRegistry,
+  client,
+  collectProcessMetrics,
+  collectThreadMetrics,
+  setupOtlpExporter
+} from '@platformatic/metrics'
 import diagnosticChannel, { tracingChannel } from 'node:diagnostics_channel'
 import { EventEmitter, once } from 'node:events'
 import { readFile } from 'node:fs/promises'
@@ -285,9 +291,17 @@ export class ChildProcess extends ITC {
   }
 
   async #collectMetrics ({ applicationId, workerId, metricsConfig }) {
-    // Use thread-specific metrics collection - process-level metrics are collected
-    // by the main runtime thread and duplicated with worker labels
     await collectThreadMetrics(applicationId, workerId, metricsConfig, this.#metricsRegistry)
+
+    // This application runs as a separate OS process, so process-level metrics
+    // (e.g. process_resident_memory_bytes) are specific to this application and
+    // are reported with its labels. Applications running in worker threads share
+    // the process-level metrics reported once by the main runtime thread.
+    // See https://github.com/platformatic/platformatic/issues/3332.
+    if (metricsConfig.defaultMetrics) {
+      collectProcessMetrics(this.#metricsRegistry)
+    }
+
     this.#setHttpCacheMetrics()
     await this.#setupOtlpExporter(applicationId, metricsConfig)
   }
@@ -301,9 +315,14 @@ export class ChildProcess extends ITC {
     }
 
     if (metricsConfig.enabled !== false) {
-      // Use thread-specific metrics collection - process-level metrics are collected
-      // by the main runtime thread and duplicated with worker labels
       await collectThreadMetrics(applicationId, workerId, metricsConfig, this.#metricsRegistry)
+
+      // See the comment in #collectMetrics: this is a separate OS process, so
+      // process-level metrics are reported here with the application labels.
+      if (metricsConfig.defaultMetrics) {
+        collectProcessMetrics(this.#metricsRegistry)
+      }
+
       this.#setHttpCacheMetrics()
       await this.#setupOtlpExporter(applicationId, metricsConfig)
     }

--- a/packages/node/test/metrics.test.js
+++ b/packages/node/test/metrics.test.js
@@ -88,6 +88,10 @@ test('should configure metrics correctly with both node and http metrics', async
   const labels = []
   for (const line of lines) {
     if (!line || line.startsWith('#')) continue
+    // Process-level metrics (e.g. process_resident_memory_bytes) are reported once
+    // for the whole runtime, without labels, so their lines have no `{...}` block.
+    // See https://github.com/platformatic/platformatic/issues/3332.
+    if (!line.includes('{')) continue
     labels.push(line.split('{')[1].split('}')[0].split(','))
   }
   const applications = labels

--- a/packages/runtime/fixtures/metrics-command/platformatic.json
+++ b/packages/runtime/fixtures/metrics-command/platformatic.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.48.0.json",
+  "entrypoint": "main",
+  "watch": false,
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "logger": {
+    "level": "silent"
+  },
+  "metrics": {
+    "labels": {
+      "custom_label": "custom-value"
+    }
+  }
+}

--- a/packages/runtime/fixtures/metrics-command/services/main/index.mjs
+++ b/packages/runtime/fixtures/metrics-command/services/main/index.mjs
@@ -1,0 +1,10 @@
+import { createServer } from 'node:http'
+
+// This service runs as a command (`node index.mjs`), so it is executed in a child
+// process through the childManager and reports its own process-level metrics.
+const server = createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify({ hello: 'world' }))
+})
+
+server.listen({ host: '127.0.0.1', port: 0 })

--- a/packages/runtime/fixtures/metrics-command/services/main/package.json
+++ b/packages/runtime/fixtures/metrics-command/services/main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "metrics-command-main",
+  "main": "index.mjs"
+}

--- a/packages/runtime/fixtures/metrics-command/services/main/platformatic.json
+++ b/packages/runtime/fixtures/metrics-command/services/main/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.48.0.json",
+  "logger": {
+    "level": "silent"
+  },
+  "application": {
+    "commands": {
+      "development": "node index.mjs"
+    }
+  }
+}

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -1421,20 +1421,6 @@ export class Runtime extends EventEmitter {
         if (applicationMetrics && applicationMetrics !== kTimeout) {
           metrics ??= []
 
-          // Build worker labels including custom labels from metrics config
-          const workerLabels = {
-            ...this.#config.metrics?.labels,
-            [this.#metricsLabelName]: worker[kApplicationId]
-          }
-          const workerId = worker[kWorkerId]
-          if (workerId >= 0) {
-            workerLabels.workerId = workerId
-          }
-
-          // Duplicate process metrics with worker labels and add to output
-          if (processMetricsJson) {
-            this.#applyLabelsToMetrics(processMetricsJson, workerLabels, metrics)
-          }
           // Add worker's thread-specific metrics
           for (let i = 0; i < applicationMetrics.length; i++) {
             metrics.push(applicationMetrics[i])
@@ -1452,6 +1438,18 @@ export class Runtime extends EventEmitter {
 
         throw e
       }
+    }
+
+    // Report process-level metrics (e.g. process_resident_memory_bytes) only once:
+    // they describe the whole runtime process, so replicating them for each
+    // application running in a worker thread would just duplicate the same value.
+    // Applications running as separate OS processes report their own process-level
+    // metrics, with their own labels, as part of their thread metrics above.
+    // See https://github.com/platformatic/platformatic/issues/3332.
+    if (metrics !== null && processMetricsJson) {
+      const processMetrics = []
+      this.#applyLabelsToMetrics(processMetricsJson, { ...this.#config.metrics?.labels }, processMetrics)
+      metrics = [...processMetrics, ...metrics]
     }
 
     if (metrics !== null && applicationRestartMetrics.length > 0) {
@@ -1581,6 +1579,13 @@ export class Runtime extends EventEmitter {
 
       const applicationsMetrics = {}
 
+      // Process-level metrics are reported only once for the whole runtime, without
+      // an application label, since they are shared by all the applications running
+      // in worker threads (see issue #3332). Applications running as separate OS
+      // processes report their own labeled values, which take precedence below.
+      const runtimeProcessMetrics = {}
+      const applicationProcessMetrics = new Set()
+
       for (const metric of metrics) {
         const { name, values } = metric
 
@@ -1592,7 +1597,20 @@ export class Runtime extends EventEmitter {
         const applicationId = labels?.[this.#metricsLabelName]
 
         if (!applicationId) {
+          if (name === 'process_cpu_percent_usage') {
+            runtimeProcessMetrics.cpu = values[0].value
+            continue
+          }
+          if (name === 'process_resident_memory_bytes') {
+            runtimeProcessMetrics.rss = values[0].value
+            continue
+          }
+
           throw new Error(`Missing ${this.#metricsLabelName} label in metrics`)
+        }
+
+        if (name === 'process_cpu_percent_usage' || name === 'process_resident_memory_bytes') {
+          applicationProcessMetrics.add(`${applicationId}:${name}`)
         }
 
         let applicationMetrics = applicationsMetrics[applicationId]
@@ -1616,6 +1634,24 @@ export class Runtime extends EventEmitter {
         }
 
         parsePromMetric(applicationMetrics, metric)
+      }
+
+      // Apply the runtime-wide process-level values to every application that did
+      // not report its own (i.e. every application running in a worker thread).
+      for (const [applicationId, applicationMetrics] of Object.entries(applicationsMetrics)) {
+        if (
+          runtimeProcessMetrics.cpu !== undefined &&
+          !applicationProcessMetrics.has(`${applicationId}:process_cpu_percent_usage`)
+        ) {
+          applicationMetrics.cpu = runtimeProcessMetrics.cpu
+        }
+
+        if (
+          runtimeProcessMetrics.rss !== undefined &&
+          !applicationProcessMetrics.has(`${applicationId}:process_resident_memory_bytes`)
+        ) {
+          applicationMetrics.rss = runtimeProcessMetrics.rss
+        }
       }
 
       function parsePromMetric (applicationMetrics, promMetric) {

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -1448,7 +1448,13 @@ export class Runtime extends EventEmitter {
     // See https://github.com/platformatic/platformatic/issues/3332.
     if (metrics !== null && processMetricsJson) {
       const processMetrics = []
-      this.#applyLabelsToMetrics(processMetricsJson, { ...this.#config.metrics?.labels }, processMetrics)
+      // Drop any configured custom label that shares the name of the application
+      // label (a config can set both `applicationLabel: 'serviceId'` and a static
+      // `serviceId` label): keeping it would make these runtime-wide metrics look
+      // like they belong to an application, both here and in getFormattedMetrics().
+      const processLabels = { ...this.#config.metrics?.labels }
+      delete processLabels[this.#metricsLabelName]
+      this.#applyLabelsToMetrics(processMetricsJson, processLabels, processMetrics)
       metrics = [...processMetrics, ...metrics]
     }
 

--- a/packages/runtime/test/api/metrics-label-collision.test.js
+++ b/packages/runtime/test/api/metrics-label-collision.test.js
@@ -1,0 +1,66 @@
+import { ok, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { transform } from '../../index.js'
+import { createRuntime } from '../helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', '..', 'fixtures')
+
+function createRuntimeWithCollidingLabels (t) {
+  const configFile = join(fixturesDir, 'management-api', 'platformatic.json')
+
+  return createRuntime(configFile, null, {
+    async transform (config, ...args) {
+      config = await transform(config, ...args)
+      config.metrics = {
+        ...config.metrics,
+        // Bind the metrics server to a random free port: the default 9090 is a
+        // common local port (Prometheus, Docker desktops) and would make the
+        // runtime fail to start on developer machines.
+        hostname: '127.0.0.1',
+        port: 0,
+        applicationLabel: 'serviceId',
+        labels: { serviceId: 'main', instanceId: 'pod-1', applicationId: 'icc-app-id' }
+      }
+      return config
+    }
+  })
+}
+
+test('formatted metrics report cpu and rss for every application when a custom label collides with applicationLabel', async t => {
+  const app = await createRuntimeWithCollidingLabels(t)
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const { applications } = await app.getFormattedMetrics()
+
+  for (const applicationId of ['service-1', 'service-2', 'service-db']) {
+    const applicationMetrics = applications[applicationId]
+    ok(applicationMetrics, `Expected formatted metrics for ${applicationId}`)
+    ok(applicationMetrics.cpu > 0, `Expected cpu > 0 for ${applicationId}, got ${applicationMetrics.cpu}`)
+    ok(applicationMetrics.rss > 0, `Expected rss > 0 for ${applicationId}, got ${applicationMetrics.rss}`)
+  }
+
+  strictEqual(applications.main, undefined, 'Expected no phantom "main" application from the static serviceId label')
+})
+
+test('runtime-wide process metrics are not attributed to a service when a custom label collides with applicationLabel', async t => {
+  const app = await createRuntimeWithCollidingLabels(t)
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const { metrics } = await app.getMetrics('text')
+  const rssLines = metrics.split('\n').filter(line => line.startsWith('process_resident_memory_bytes'))
+
+  strictEqual(rssLines.length, 1, 'Expected process_resident_memory_bytes to be reported only once')
+  ok(
+    !rssLines[0].includes('serviceId='),
+    `Expected the runtime-wide process_resident_memory_bytes to have no serviceId label, got: ${rssLines[0]}`
+  )
+})

--- a/packages/runtime/test/api/metrics.test.js
+++ b/packages/runtime/test/api/metrics.test.js
@@ -43,7 +43,7 @@ test('should get runtime metrics in a json format', async t => {
 
   const { metrics } = await app.getMetrics()
 
-  const expectedMetricNames = [
+  const perApplicationMetricNames = [
     'nodejs_active_handles',
     'nodejs_active_handles_total',
     'nodejs_active_requests',
@@ -66,13 +66,6 @@ test('should get runtime metrics in a json format', async t => {
     'nodejs_heap_space_size_available_bytes',
     'nodejs_heap_space_size_total_bytes',
     'nodejs_heap_space_size_used_bytes',
-    'nodejs_version_info',
-    'process_cpu_percent_usage',
-    'process_cpu_seconds_total',
-    'process_cpu_system_seconds_total',
-    'process_cpu_user_seconds_total',
-    'process_resident_memory_bytes',
-    'process_start_time_seconds',
     'http_request_all_summary_seconds',
     'http_client_request_duration_seconds',
     'http_client_stats_free',
@@ -85,9 +78,21 @@ test('should get runtime metrics in a json format', async t => {
     'platformatic_application_restarts_total'
   ]
 
+  // These describe the whole runtime process and are reported only once,
+  // without application labels. See issue #3332.
+  const processLevelMetricNames = [
+    'nodejs_version_info',
+    'process_cpu_percent_usage',
+    'process_cpu_seconds_total',
+    'process_cpu_system_seconds_total',
+    'process_cpu_user_seconds_total',
+    'process_resident_memory_bytes',
+    'process_start_time_seconds'
+  ]
+
   const applications = ['service-1', 'service-2', 'service-db']
 
-  for (const metricName of expectedMetricNames) {
+  for (const metricName of perApplicationMetricNames) {
     const foundMetrics = metrics.filter(m => m.name === metricName)
     ok(foundMetrics.length > 0, `Missing metric: ${metricName}`)
     strictEqual(foundMetrics.length, applications.length)
@@ -107,6 +112,17 @@ test('should get runtime metrics in a json format', async t => {
         strictEqual(labels.applicationId, applicationId)
         strictEqual(labels.custom_label, 'custom-value')
       }
+    }
+  }
+
+  for (const metricName of processLevelMetricNames) {
+    const foundMetrics = metrics.filter(m => m.name === metricName)
+    strictEqual(foundMetrics.length, 1, `Expected metric ${metricName} to be reported only once`)
+
+    for (const { labels } of foundMetrics[0].values) {
+      strictEqual(labels.applicationId, undefined, `Expected metric ${metricName} to have no applicationId label`)
+      strictEqual(labels.workerId, undefined, `Expected metric ${metricName} to have no workerId label`)
+      strictEqual(labels.custom_label, 'custom-value')
     }
   }
 })
@@ -229,6 +245,42 @@ test('should get runtime metrics in a text format', async t => {
 
   // We call service-1 and service-2, so we expect metrcis for these
   deepEqual(applicationIds, ['service-1', 'service-2'])
+
+  // Process-level metrics describe the whole runtime process, so they must be
+  // reported only once and without application labels. See issue #3332.
+  const rssLines = findPrometheusLinesForMetric('process_resident_memory_bytes', metrics.metrics)
+  strictEqual(rssLines.length, 1, 'Expected process_resident_memory_bytes to be reported only once')
+  ok(!rssLines[0].includes('applicationId='), 'Expected process_resident_memory_bytes to have no applicationId label')
+  ok(!rssLines[0].includes('workerId='), 'Expected process_resident_memory_bytes to have no workerId label')
+})
+
+test('should report process-level metrics for applications running as separate processes', async t => {
+  const projectDir = join(fixturesDir, 'metrics-command')
+  const configFile = join(projectDir, 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const { metrics } = await app.getMetrics()
+
+  const rssMetrics = metrics.filter(m => m.name === 'process_resident_memory_bytes')
+
+  // The runtime process reports its own RSS once, without application labels ...
+  const runtimeRss = rssMetrics.filter(m => m.values.every(v => v.labels.applicationId === undefined))
+  strictEqual(runtimeRss.length, 1, 'Expected a single runtime-wide process_resident_memory_bytes metric')
+  ok(runtimeRss[0].values[0].value > 0)
+
+  // ... while the application running as a separate OS process reports its own RSS,
+  // with its own labels. See issue #3332.
+  const applicationRss = rssMetrics.filter(m => m.values.every(v => v.labels.applicationId === 'main'))
+  strictEqual(applicationRss.length, 1, 'Expected a process_resident_memory_bytes metric for the "main" application')
+  ok(applicationRss[0].values[0].value > 0)
+
+  strictEqual(rssMetrics.length, 2)
 })
 
 function getMetricsLines (metrics) {


### PR DESCRIPTION
# fix(runtime): report process-level metrics only once per runtime

Fixes #3332

## Problem

`process_resident_memory_bytes` (and the other process-level metrics: `process_cpu_*`, `process_start_time_seconds`, `process_open_fds`, `process_max_fds`, `nodejs_version_info`, `process_cpu_percent_usage`) were reported once **per application**, each time with `applicationId`/`workerId` (or `serviceId` in v2-compatibility mode) labels — even though all applications running in worker threads live in the same OS process, so every sample carried the exact same value.

For a runtime with N applications, scraping `/metrics` produced N identical RSS samples that only differed by label. Anyone summing `process_resident_memory_bytes` across labels (a common Prometheus pattern) got N× the real memory usage of the runtime.

#4539 removed the redundant *collection* of these metrics (they are now collected once in the main thread), but intentionally kept the duplicated *reporting*: the single collected value was still re-labeled and emitted once per worker.

## Root cause

In `Runtime#getMetrics()` (`packages/runtime/lib/runtime.js`), the process-level metrics snapshot was re-labeled with each worker's `applicationId`/`workerId` labels inside the per-worker loop ("Duplicate process metrics with worker labels") and appended to the output once per started worker.

## Fix

Following the direction outlined in #3332:

- **Applications running in worker threads** (the default): process-level metrics are now emitted **once per runtime**, with no `applicationId`/`workerId` label (configured custom labels are preserved). They describe the runtime process, not any single application.
- **Applications running as separate OS processes** (command-based, via `childManager`): the child process now collects its own process-level metrics (`collectProcessMetrics`) into its registry, so its RSS/CPU/fds are reported **with its own `applicationId`/`workerId` labels**. Previously these applications had the *main* process RSS attributed to them, which was doubly misleading (wrong process, duplicated value).

Changes:

- `packages/runtime/lib/runtime.js`
  - `getMetrics()`: the process-level snapshot is no longer duplicated inside the worker loop; it is appended exactly once (with only the configured custom labels) after the worker metrics are gathered.
  - `getFormattedMetrics()`: runtime-wide (unlabeled) process metrics no longer trigger the `Missing applicationId label` error. They are parsed separately and applied to every application that did not report its own process metrics, so the formatted output shape (`applications[id].cpu` / `.rss`) — used by the management API — is unchanged. Applications running as separate processes keep their own (now accurate) values.
- `packages/basic/lib/worker/child-process.js`: command-based (subprocess) applications collect process-level metrics into the child registry (both on initial collection and on `updateMetricsConfig`), guarded by `defaultMetrics`.
- `packages/basic/lib/capability.js`: comment update only.

### Wire format: before / after

Before (3 thread-based applications — three identical values):

```
process_resident_memory_bytes{applicationId="service-1",workerId="0"} 123456789
process_resident_memory_bytes{applicationId="service-2",workerId="0"} 123456789
process_resident_memory_bytes{applicationId="service-db",workerId="0"} 123456789
```

After:

```
process_resident_memory_bytes 123456789
```

And with an application running as a separate process:

```
process_resident_memory_bytes 123456789
process_resident_memory_bytes{applicationId="external",workerId="0"} 45678901
```

## Compatibility notes

- The per-application series for process-level metrics disappear for thread-based applications (that is the point of #3332). Dashboards that queried `process_resident_memory_bytes{applicationId="..."}` for thread-based applications should query the unlabeled runtime series instead.
- `getFormattedMetrics()` (management API / `watt-admin` live metrics) keeps the exact same output shape and, for thread-based applications, the exact same values as before. For subprocess applications the reported `rss`/`cpu` are now those of their own process instead of the runtime's.
- The `metrics.labels` custom labels are still applied to every sample, including the runtime-wide process metrics.

## Tests

- `packages/runtime/test/api/metrics.test.js`
  - JSON format: process-level families are asserted to appear **exactly once**, with no `applicationId`/`workerId` labels and with custom labels preserved; per-application families keep the previous assertions.
  - Text format: `process_resident_memory_bytes` is asserted to appear as a **single sample line** without `applicationId`/`workerId`.
  - New test + new `metrics-command` fixture: an application started via `application.commands` (child process) reports its own labeled `process_resident_memory_bytes` alongside the single runtime-wide sample.
  - The existing `getFormattedMetrics` tests (shape and multi-poll) pass unchanged, covering the management API path.
