### PR TITLE
fix(gateway): fetch OpenAPI schemas in parallel at startup

### DIFF
--- a/packages/gateway/lib/openapi-generator.js
+++ b/packages/gateway/lib/openapi-generator.js
@@ -140,26 +140,43 @@ export async function openApiGenerator (app, opts) {
   const openApiSchemas = []
   const apiByApiRoutes = {}
 
-  for (const { id, origin, openapi } of applications) {
-    if (!openapi) continue
+  // Fetch all the schemas in parallel, then process the results in the
+  // original applications order so that composition stays deterministic.
+  const fetchResults = await Promise.allSettled(
+    applications.map(async ({ id, origin, openapi }) => {
+      if (!openapi) return null
 
-    let openapiConfig = null
-    if (openapi.config) {
-      try {
-        openapiConfig = await loadOpenApiConfig(openapi.config)
-      } catch (error) {
-        app.log.error(error)
-        throw new CouldNotReadOpenAPIConfigError(id)
+      let openapiConfig = null
+      if (openapi.config) {
+        try {
+          openapiConfig = await loadOpenApiConfig(openapi.config)
+        } catch (error) {
+          app.log.error(error)
+          throw new CouldNotReadOpenAPIConfigError(id)
+        }
       }
-    }
 
-    let originSchema = null
-    try {
-      originSchema = await getOpenApiSchema(origin, openapi)
-    } catch (error) {
-      app.log.error(error, `failed to fetch schema for "${id} application"`)
-      continue
+      let originSchema = null
+      try {
+        originSchema = await getOpenApiSchema(origin, openapi)
+      } catch (error) {
+        app.log.error(error, `failed to fetch schema for "${id} application"`)
+        return null
+      }
+
+      return { openapiConfig, originSchema }
+    })
+  )
+
+  for (let i = 0; i < applications.length; i++) {
+    const result = fetchResults[i]
+    if (result.status === 'rejected') {
+      throw result.reason
     }
+    if (result.value === null) continue
+
+    const { id, origin, openapi } = applications[i]
+    const { openapiConfig, originSchema } = result.value
 
     const schema = modifyOpenApiSchema(app, originSchema, openapiConfig)
 

--- a/packages/gateway/test/openapi/fetch-parallelism.test.js
+++ b/packages/gateway/test/openapi/fetch-parallelism.test.js
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import fastify from 'fastify'
+
+import { createFromConfig } from '../helper.js'
+
+function buildOpenApiSchema (pathName) {
+  return {
+    openapi: '3.0.0',
+    info: { title: 'Test', version: '1.0.0' },
+    paths: {
+      [`/${pathName}`]: {
+        get: {
+          operationId: `get_${pathName}`,
+          responses: {
+            200: { description: 'OK' }
+          }
+        }
+      }
+    }
+  }
+}
+
+test('should fetch application schemas in parallel at startup', async t => {
+  const applicationsCount = 3
+
+  let inFlight = 0
+  let maxInFlight = 0
+
+  const applications = []
+  for (let i = 0; i < applicationsCount; i++) {
+    const pathName = `entities${i}`
+    const app = fastify({
+      logger: false,
+      keepAliveTimeout: 10,
+      forceCloseConnections: true
+    })
+
+    app.get('/documentation/json', async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await sleep(200)
+      inFlight--
+      return buildOpenApiSchema(pathName)
+    })
+
+    app.get(`/${pathName}`, async () => ({ ok: true }))
+
+    t.after(async () => {
+      await app.close()
+    })
+
+    await app.listen({ port: 0 })
+
+    applications.push({
+      id: `api${i}`,
+      origin: 'http://127.0.0.1:' + app.server.address().port,
+      openapi: {
+        url: '/documentation/json',
+        prefix: `/api${i}`
+      }
+    })
+  }
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: { applications }
+  })
+
+  await gateway.start({ listen: true })
+
+  assert.equal(maxInFlight, applicationsCount, 'schema fetches should overlap')
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  })
+  assert.equal(statusCode, 200)
+
+  const composedSchema = JSON.parse(body)
+  const composedPaths = Object.keys(composedSchema.paths)
+
+  // Composition must stay deterministic and follow the applications order
+  assert.deepEqual(composedPaths, ['/api0/entities0', '/api1/entities1', '/api2/entities2'])
+})


### PR DESCRIPTION
## What

At startup the gateway fetched each application's OpenAPI schema sequentially (`await` inside a `for...of` in `openApiGenerator`), so boot time grew with the *sum* of the round-trips instead of the *max*. On resource-constrained deployments this was measured at ~9.5s of cold-start time.

This PR fans the fetches out with `Promise.allSettled`, mirroring the pattern already used by the `fetch-openapi-schemas` command, and then processes the results in the original `applications` order so composition stays deterministic.

## Semantics preserved

- A failed schema fetch is still logged with the same message and the application is skipped.
- A broken OpenAPI config file still throws `CouldNotReadOpenAPIConfigError` and fails the boot (the first failing application in declaration order wins).
- `openApiSchemas` and the composed schema keep the exact same ordering as before.

## Testing

Added `test/openapi/fetch-parallelism.test.js`, which serves schemas from endpoints that track in-flight request concurrency and asserts the fetches overlap (it fails against the previous sequential implementation) and that the composed paths keep the applications order.

Fixes #4971

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5CLjHAMSxg7GoJmLkwDVE
