### PR TITLE
fix(db): make schema.lock deterministic and add read-only mode

### DIFF
--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -360,6 +360,22 @@ postgres://user:password@my-database:5432/db-name
 
   Starting Platformatic DB or running a migration will automatically create the schemalock file.
 
+  Set `readOnly` to `true` to load the schema lock without ever writing it back, e.g. when the file is checked into version control and must not be rewritten at runtime:
+
+  ```json title="Example Read-Only Object"
+  {
+    "db": {
+      ...
+      "schemalock": {
+        "path": "./schema.lock",
+        "readOnly": true
+      }
+    }
+  }
+  ```
+
+  In read-only mode the file is never created or updated, not even when migrations are applied automatically.
+
 ### `migrations`
 
 Configures [Postgrator](https://github.com/rickbergfalk/postgrator) to run migrations against the database.

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -189,6 +189,10 @@ export interface PlatformaticDatabaseConfig {
       | boolean
       | {
           path?: string;
+          /**
+           * Never write the schema lock file at runtime, only read it.
+           */
+          readOnly?: boolean;
           [k: string]: unknown;
         };
     poolSize?: number;

--- a/packages/db/lib/application.js
+++ b/packages/db/lib/application.js
@@ -6,7 +6,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { execute as applyMigrations } from './migrator.js'
 import { root } from './root.js'
 import { execute as generateTypes } from './types.js'
-import { locateSchemaLock, updateSchemaLock, validateSchemaLockFormat } from './utils.js'
+import { isSchemaLockReadOnly, locateSchemaLock, serializeDbschema, updateSchemaLock, validateSchemaLockFormat } from './utils.js'
 
 async function healthCheck (app) {
   const { db, sql } = app.platformatic
@@ -38,8 +38,13 @@ export async function platformaticDatabase (app, capability) {
         createSchemaLock = false
       } catch (err) {
         app.log.trace({ err }, 'failed to load schema lock')
-        app.log.info('no schema lock found, will create one')
-        createSchemaLock = true
+
+        if (isSchemaLockReadOnly(config)) {
+          app.log.warn('no schema lock found, the schema lock is read-only so it will not be created')
+        } else {
+          app.log.info('no schema lock found, will create one')
+          createSchemaLock = true
+        }
       }
     }
   }
@@ -78,7 +83,7 @@ export async function platformaticDatabase (app, capability) {
   if (createSchemaLock) {
     try {
       const path = locateSchemaLock(config)
-      await writeFile(path, JSON.stringify(app.platformatic.dbschema, null, 2))
+      await writeFile(path, serializeDbschema(app.platformatic.dbschema))
       app.log.info({ path }, 'created schema lock')
     } catch (err) {
       app.log.trace({ err }, 'unable to save schema lock')

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -40,6 +40,11 @@ export const db = {
             path: {
               type: 'string',
               resolvePath: true
+            },
+            readOnly: {
+              type: 'boolean',
+              default: false,
+              description: 'Never write the schema lock file at runtime, only read it.'
             }
           }
         }

--- a/packages/db/lib/utils.js
+++ b/packages/db/lib/utils.js
@@ -24,11 +24,23 @@ export function locateSchemaLock (config) {
   return config.db.schemalock.path ?? join(config[kMetadata].root, 'schema.lock')
 }
 
+export function isSchemaLockReadOnly (config) {
+  return config.db.schemalock?.readOnly === true
+}
+
+// The information_schema queries used for introspection include *_catalog
+// columns, which contain the name of the database the schema was introspected
+// against. They are not used to build the entities, so they are stripped to
+// keep the lock file deterministic across database names.
+export function serializeDbschema (dbschema) {
+  return JSON.stringify(dbschema, (key, value) => (/_catalog$/i.test(key) ? undefined : value), 2)
+}
+
 export async function updateSchemaLock (logger, config) {
-  if (config.db.schemalock) {
+  if (config.db.schemalock && !isSchemaLockReadOnly(config)) {
     const conn = await setupDB(logger, { ...config.db, dbschema: null })
     const schemaLockPath = locateSchemaLock(config)
-    await fs.writeFile(schemaLockPath, JSON.stringify(conn.dbschema, null, 2))
+    await fs.writeFile(schemaLockPath, serializeDbschema(conn.dbschema))
 
     await conn.db.dispose()
   }
@@ -41,7 +53,10 @@ export function validateSchemaLockFormat (schemaLock) {
   if (!isBoolean && !isObject) {
     throw new InvalidSchemaLockError()
   }
-  if (isObject && typeof schemaLock.path !== 'string') {
+  if (isObject && typeof schemaLock.path !== 'string' && typeof schemaLock.readOnly !== 'boolean') {
+    throw new InvalidSchemaLockError()
+  }
+  if (isObject && schemaLock.path !== undefined && typeof schemaLock.path !== 'string') {
     throw new InvalidSchemaLockError()
   }
 }

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -579,6 +579,11 @@
                 "path": {
                   "type": "string",
                   "resolvePath": true
+                },
+                "readOnly": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Never write the schema lock file at runtime, only read it."
                 }
               }
             }

--- a/packages/db/test/schemalock-boot.test.js
+++ b/packages/db/test/schemalock-boot.test.js
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict'
-import { readFile, mkdtemp } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { readFile, mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { test } from 'node:test'
-import { createBasicPages, createFromConfig, getConnectionInfo } from './helper.js'
+import { createBasicPages, createFromConfig, getConnectionInfo, isMysql } from './helper.js'
 
 test('creates the schema.lock file at boot when it does not exist', async t => {
   /* https://github.com/platformatic/platformatic/issues/4035 */
@@ -40,4 +41,161 @@ test('creates the schema.lock file at boot when it does not exist', async t => {
     dbschema.some(table => table.table === 'pages'),
     'schema.lock contains the pages table'
   )
+})
+
+function findCatalogKeys (value, found = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      findCatalogKeys(item, found)
+    }
+  } else if (value !== null && typeof value === 'object') {
+    for (const key of Object.keys(value)) {
+      if (/_catalog$/i.test(key)) {
+        found.push(key)
+      }
+      findCatalogKeys(value[key], found)
+    }
+  }
+  return found
+}
+
+async function startWithSchemaLock (t, schemaLockPath, connectionInfo) {
+  const app = await createFromConfig(t, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' }
+    },
+    db: {
+      ...connectionInfo,
+      schemalock: {
+        path: schemaLockPath
+      },
+      async onDatabaseLoad (db, sql) {
+        await createBasicPages(db, sql)
+      }
+    }
+  })
+
+  await app.start({ listen: true })
+  return app
+}
+
+test('schema.lock does not embed the database catalog name', async t => {
+  /* https://github.com/platformatic/platformatic/issues/4969 */
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+  const directory = await mkdtemp(join(tmpdir(), 'schemalock-boot-'))
+  const schemaLockPath = join(directory, 'schema.lock')
+
+  const app = await startWithSchemaLock(t, schemaLockPath, connectionInfo)
+
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+
+  const dbschema = JSON.parse(await readFile(schemaLockPath, 'utf-8'))
+  assert.deepEqual(findCatalogKeys(dbschema), [], 'schema.lock contains no *_catalog fields')
+})
+
+test('schema.lock is deterministic across database names', { skip: isMysql }, async t => {
+  /* https://github.com/platformatic/platformatic/issues/4969
+     Skipped on MySQL/MariaDB because there the schema name is the database
+     name, so the lock legitimately embeds it. */
+  const first = await getConnectionInfo()
+  const second = await getConnectionInfo()
+  const directory = await mkdtemp(join(tmpdir(), 'schemalock-boot-'))
+  const firstLockPath = join(directory, 'first.schema.lock')
+  const secondLockPath = join(directory, 'second.schema.lock')
+
+  t.after(async () => {
+    await first.dropTestDB()
+    await second.dropTestDB()
+  })
+
+  const firstApp = await startWithSchemaLock(t, firstLockPath, first.connectionInfo)
+  await firstApp.stop()
+
+  const secondApp = await startWithSchemaLock(t, secondLockPath, second.connectionInfo)
+  await secondApp.stop()
+
+  const firstLock = await readFile(firstLockPath, 'utf-8')
+  const secondLock = await readFile(secondLockPath, 'utf-8')
+  assert.equal(firstLock, secondLock, 'the same schema produces the same schema.lock on different databases')
+})
+
+test('does not create schema.lock at boot when the schema lock is read-only', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+  const directory = await mkdtemp(join(tmpdir(), 'schemalock-boot-'))
+  const schemaLockPath = join(directory, 'schema.lock')
+
+  const app = await createFromConfig(t, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' }
+    },
+    db: {
+      ...connectionInfo,
+      schemalock: {
+        path: schemaLockPath,
+        readOnly: true
+      },
+      async onDatabaseLoad (db, sql) {
+        await createBasicPages(db, sql)
+      }
+    }
+  })
+
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+  await app.start({ listen: true })
+
+  assert.equal(existsSync(schemaLockPath), false, 'schema.lock is not created in read-only mode')
+})
+
+test('does not rewrite schema.lock on migrations autoApply when the schema lock is read-only', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+  const directory = await mkdtemp(join(tmpdir(), 'schemalock-boot-'))
+  const schemaLockPath = join(directory, 'schema.lock')
+  const migrationsDir = join(directory, 'migrations')
+
+  await mkdir(migrationsDir)
+  await writeFile(
+    join(migrationsDir, '001.do.sql'),
+    'CREATE TABLE graphs (id INTEGER PRIMARY KEY, name VARCHAR(42));'
+  )
+
+  const sentinel = '[]'
+  await writeFile(schemaLockPath, sentinel)
+
+  const app = await createFromConfig(t, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' }
+    },
+    db: {
+      ...connectionInfo,
+      schemalock: {
+        path: schemaLockPath,
+        readOnly: true
+      }
+    },
+    migrations: {
+      dir: migrationsDir,
+      autoApply: true
+    }
+  })
+
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+  await app.start({ listen: true })
+
+  const contents = await readFile(schemaLockPath, 'utf-8')
+  assert.equal(contents, sentinel, 'schema.lock is not rewritten after applying migrations in read-only mode')
 })


### PR DESCRIPTION
Fixes #4969

## Problem

The PostgreSQL introspection queries select entire `information_schema` rows (`SELECT constraints.*, usage.*`), so the generated `schema.lock` embedded `*_catalog` fields containing the name of the database it was generated against. The exact same schema produced different lock files depending on the database name, and with `db.schemalock` enabled any boot applying migrations against a differently-named database rewrote the file, dirtying the working tree.

## Changes

- **Deterministic lock**: `*_catalog` fields are stripped when serializing the lock (both in `updateSchemaLock` and in the boot-time creation path). They are not consumed when the lock is loaded — entities are built from `table`, `schema`, `columns` and `constraints` — so the lock becomes byte-identical across database names. Existing locks that still contain the fields keep loading fine.
- **Opt-in read-only mode** (`schemalock.readOnly`): the lock is loaded but never created or rewritten at runtime, not even when migrations are applied via `autoApply`:

  ```json
  { "db": { "schemalock": { "path": "./schema.lock", "readOnly": true } } }
  ```

  `validateSchemaLockFormat` now also accepts the object form without `path` when `readOnly` is set (the default `schema.lock` location is used).

Note: on MySQL/MariaDB the schema name *is* the database name and is semantically meaningful (used to build entities), so it stays in the lock; the determinism guarantee applies to PostgreSQL and SQLite. The MySQL queries already select explicit columns, so no catalog fields leak there.

## Tests

New tests in `packages/db/test/schemalock-boot.test.js` (verified red without the fix, green with it, on sqlite, postgresql and mariadb):

- the lock contains no `*_catalog` fields
- the same schema produces byte-identical locks against two differently-named databases (skipped on MySQL/MariaDB)
- `readOnly` prevents lock creation at boot
- `readOnly` prevents lock rewrite when migrations are auto-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMWaa9w7uNEqJQns4Gneu3