### PR TITLE
fix(runtime): do not prepend base path to absolute Location headers

### DIFF
--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -717,6 +717,16 @@ export class ChildProcess extends ITC {
 
 function stripBasePath (basePath) {
   const kBasePath = Symbol('kBasePath')
+  const absoluteUrlPattern = /^https?:\/\//i
+
+  function prependBasePath (value) {
+    // Absolute and protocol-relative URLs (RFC 7231 Location) must not be rewritten
+    if (typeof value !== 'string' || absoluteUrlPattern.test(value) || value.startsWith('//') || value.startsWith(basePath)) {
+      return value
+    }
+
+    return basePath + value
+  }
 
   diagnosticChannel.subscribe('http.server.request.start', ({ request, response }) => {
     if (request.url.startsWith(basePath)) {
@@ -742,8 +752,8 @@ function stripBasePath (basePath) {
 
       if (headers) {
         for (const key in headers) {
-          if (key.toLowerCase() === 'location' && !headers[key].startsWith(basePath)) {
-            headers[key] = basePath + headers[key]
+          if (key.toLowerCase() === 'location') {
+            headers[key] = prependBasePath(headers[key])
           }
         }
       }
@@ -754,8 +764,8 @@ function stripBasePath (basePath) {
 
   ServerResponse.prototype.setHeader = function (name, value) {
     if (this[kBasePath]) {
-      if (name.toLowerCase() === 'location' && !value.startsWith(basePath)) {
-        value = basePath + value
+      if (name.toLowerCase() === 'location') {
+        value = prependBasePath(value)
       }
     }
     originSetHeader.call(this, name, value)

--- a/packages/runtime/fixtures/base-path/services/express/plugin.js
+++ b/packages/runtime/fixtures/base-path/services/express/plugin.js
@@ -12,4 +12,8 @@ app.get('/redirect', (req, res) => {
   res.redirect('/hello')
 })
 
+app.get('/redirect-external', (req, res) => {
+  res.redirect('https://example.com/oauth/authorize?client_id=123')
+})
+
 app.listen(0)

--- a/packages/runtime/fixtures/base-path/services/node-child/plugin.js
+++ b/packages/runtime/fixtures/base-path/services/node-child/plugin.js
@@ -13,6 +13,11 @@ const server = createServer((req, res) => {
     res.end()
     return
   }
+  if (req.url === '/redirect-external') {
+    res.writeHead(302, { Location: 'https://example.com/oauth/authorize?client_id=123' })
+    res.end()
+    return
+  }
   throw new Error(`Unexpected request: ${req.url}`)
 })
 

--- a/packages/runtime/fixtures/base-path/services/node/plugin.js
+++ b/packages/runtime/fixtures/base-path/services/node/plugin.js
@@ -14,6 +14,12 @@ function build () {
       res.end()
       return
     }
+    if (req.url === '/redirect-external') {
+      res.setHeader('Location', 'https://example.com/oauth/authorize?client_id=123')
+      res.writeHead(302)
+      res.end()
+      return
+    }
     throw new Error(`Unexpected request: ${req.url}`)
   })
 

--- a/packages/runtime/fixtures/base-path/services/service/plugin.js
+++ b/packages/runtime/fixtures/base-path/services/service/plugin.js
@@ -9,4 +9,8 @@ module.exports = async function (app) {
   app.get('/redirect', async (req, reply) => {
     reply.redirect('/hello')
   })
+
+  app.get('/redirect-external', async (req, reply) => {
+    reply.redirect('https://example.com/oauth/authorize?client_id=123')
+  })
 }

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -364,6 +364,16 @@ async function main () {
 
 function stripBasePath (basePath) {
   const kBasePath = Symbol('kBasePath')
+  const absoluteUrlPattern = /^https?:\/\//i
+
+  function prependBasePath (value) {
+    // Absolute and protocol-relative URLs (RFC 7231 Location) must not be rewritten
+    if (typeof value !== 'string' || absoluteUrlPattern.test(value) || value.startsWith('//') || value.startsWith(basePath)) {
+      return value
+    }
+
+    return basePath + value
+  }
 
   subscribe('http.server.request.start', ({ request, response }) => {
     if (request.url.startsWith(basePath)) {
@@ -389,8 +399,8 @@ function stripBasePath (basePath) {
 
       if (headers) {
         for (const key in headers) {
-          if (key.toLowerCase() === 'location' && !headers[key].startsWith(basePath)) {
-            headers[key] = basePath + headers[key]
+          if (key.toLowerCase() === 'location') {
+            headers[key] = prependBasePath(headers[key])
           }
         }
       }
@@ -401,8 +411,8 @@ function stripBasePath (basePath) {
 
   ServerResponse.prototype.setHeader = function (name, value) {
     if (this[kBasePath]) {
-      if (name.toLowerCase() === 'location' && !value.startsWith(basePath)) {
-        value = basePath + value
+      if (name.toLowerCase() === 'location') {
+        value = prependBasePath(value)
       }
     }
     originSetHeader.call(this, name, value)

--- a/packages/runtime/test/base-path.test.js
+++ b/packages/runtime/test/base-path.test.js
@@ -71,6 +71,17 @@ test('should strip the runtime base path for an application as an entrypoint', a
   }
 
   {
+    // Redirect to an external absolute URL is not rewritten
+    const { statusCode, headers } = await request(entryUrl, {
+      path: '/base-path/redirect-external'
+    })
+    strictEqual(statusCode, 302)
+
+    const location = headers.location
+    strictEqual(location, 'https://example.com/oauth/authorize?client_id=123')
+  }
+
+  {
     // Check the openapi base path
     const { statusCode, body } = await request(entryUrl, {
       path: '/base-path/documentation/json'
@@ -125,6 +136,17 @@ test('should strip the runtime base path for a gateway as an entrypoint', async 
 
     const location = headers.location
     strictEqual(location, '/base-path/service/hello')
+  }
+
+  {
+    // Redirect to an external absolute URL is not rewritten
+    const { statusCode, headers } = await request(entryUrl, {
+      path: '/base-path/service/redirect-external'
+    })
+    strictEqual(statusCode, 302)
+
+    const location = headers.location
+    strictEqual(location, 'https://example.com/oauth/authorize?client_id=123')
   }
 
   {
@@ -183,6 +205,17 @@ test('should strip the runtime base path for a node as an entrypoint', async t =
     const location = headers.location
     strictEqual(location, '/base-path/hello')
   }
+
+  {
+    // Redirect to an external absolute URL is not rewritten
+    const { statusCode, headers } = await request(entryUrl, {
+      path: '/base-path/redirect-external'
+    })
+    strictEqual(statusCode, 302)
+
+    const location = headers.location
+    strictEqual(location, 'https://example.com/oauth/authorize?client_id=123')
+  }
 })
 
 test('should strip the runtime base path for an express as an entrypoint', async t => {
@@ -229,6 +262,17 @@ test('should strip the runtime base path for an express as an entrypoint', async
     const location = headers.location
     strictEqual(location, '/base-path/hello')
   }
+
+  {
+    // Redirect to an external absolute URL is not rewritten
+    const { statusCode, headers } = await request(entryUrl, {
+      path: '/base-path/redirect-external'
+    })
+    strictEqual(statusCode, 302)
+
+    const location = headers.location
+    strictEqual(location, 'https://example.com/oauth/authorize?client_id=123')
+  }
 })
 
 test('should strip the runtime base path for a nodejs in a child process as an entrypoint', async t => {
@@ -274,6 +318,17 @@ test('should strip the runtime base path for a nodejs in a child process as an e
 
     const location = headers.location
     strictEqual(location, '/base-path/hello')
+  }
+
+  {
+    // Redirect to an external absolute URL is not rewritten
+    const { statusCode, headers } = await request(entryUrl, {
+      path: '/base-path/redirect-external'
+    })
+    strictEqual(statusCode, 302)
+
+    const location = headers.location
+    strictEqual(location, 'https://example.com/oauth/authorize?client_id=123')
   }
 })
 


### PR DESCRIPTION
## Description

When the runtime is configured with a `basePath`, the `stripBasePath` shim rewrote **every** `Location` response header, corrupting redirects to external absolute URLs (e.g. OAuth authorize endpoints) into broken relative paths:

```
Location: https://app.example.com/oauth/authorize?client_id=...
→ Location: /base-pathhttps://app.example.com/oauth/authorize?client_id=...
```

This applies the same guard the gateway proxy already uses in `packages/gateway/lib/proxy.js`: the base path is only prepended when the `Location` value is **not** an absolute (`https?://`) or protocol-relative (`//host`) URL. Relative redirects keep working exactly as before.

The shim is duplicated in two places, both fixed:
- `packages/runtime/lib/worker/main.js` (worker entrypoint)
- `packages/basic/lib/worker/child-process.js` (child-process capabilities)

## Tests

Added an external-redirect route to the `base-path` fixtures (service, node, express, node-child) and assertions in all five `base-path.test.js` entrypoint variants (including the gateway one) that an absolute `Location` passes through untouched. The node fixture uses `setHeader` and the others `writeHead`/framework redirects, so both monkeypatched paths are covered.

Fixes #4970

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hvGbCx7VisHY5h9kjuZyL