### PR TITLE
feat(foundation): add strictEnv option to fail or warn on missing env variables

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -426,6 +426,10 @@
 
 **Message:** Invalid config file extension. Only yml, yaml, json, json5, toml, tml are supported.
 
+### PLT_MISSING_ENV_VARIABLES
+
+**Message:** The configuration references the following environment variables which are not set: %s
+
 ### PLT_NO_CONFIG_FILE_FOUND
 
 **Message:** no config file found

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -229,6 +229,22 @@ application, with application-level environment variables taking precedence.
 
 The path to an `.env` file to load for the runtime. By default, the `.env` file is loaded from the application directory.
 
+### `strictEnv`
+
+Controls what happens when a `{PLT_*}` environment variable placeholder references a variable which is not set:
+
+- `false` (the default): the placeholder is silently replaced with an empty string.
+- `true`: loading the configuration fails at startup with an error listing all the missing variables.
+- `"warn"`: a warning listing the missing variables is logged, but the placeholders are still replaced with an empty string.
+
+The value is also applied when loading the configuration files of the applications in the runtime.
+
+```json
+{
+  "strictEnv": true
+}
+```
+
 ### `sourceMaps`
 
 If `true`, source maps are enabled for all applications. Default: `false`. This setting can be overridden at the application level.

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -295,6 +295,17 @@ variables of the same name.
 If no environment variable is found, then the placeholder will be replaced with an empty string.
 Note that this can lead to a schema validation error.
 
+To fail at startup (or log a warning) when a placeholder references an environment variable which
+is not set, use the [`strictEnv`](../runtime/configuration.md#strictenv) runtime option:
+
+```json title="platformatic.json"
+{
+  "runtime": {
+    "strictEnv": true
+  }
+}
+```
+
 ### Setting Environment Variables
 
 If a `.env` file exists it will automatically be loaded by Platformatic using

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticAstroConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -573,6 +573,10 @@ export interface PlatformaticBasicConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -2153,6 +2153,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -741,6 +741,10 @@ export interface PlatformaticComposerConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -2826,6 +2826,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -1067,6 +1067,10 @@ export interface PlatformaticDatabaseConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -3510,6 +3510,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/foundation/index.d.ts
+++ b/packages/foundation/index.d.ts
@@ -85,6 +85,7 @@ export type ConfigurationOptions<T = {}> = Partial<{
   replaceEnv: boolean
   replaceEnvIgnore: string[]
   onMissingEnv: (key: string) => string | undefined
+  strictEnv: boolean | 'warn'
   fixPaths: boolean
   logger: Logger
   root: string
@@ -181,6 +182,7 @@ export declare const SourceMissingError: FastifyError
 export declare const RootMissingError: FastifyError
 export declare const SchemaMustBeDefinedError: FastifyError
 export declare const ConfigurationDoesNotValidateAgainstSchemaError: FastifyError
+export declare const MissingEnvVariablesError: FastifyError
 
 // Execution types
 export declare function executeWithTimeout<T> (promise: Promise<T>, timeout: number, timeoutValue?: any): Promise<T>

--- a/packages/foundation/lib/configuration.js
+++ b/packages/foundation/lib/configuration.js
@@ -12,6 +12,7 @@ import {
   CannotParseConfigFileError,
   ConfigurationDoesNotValidateAgainstSchemaError,
   InvalidConfigFileExtensionError,
+  MissingEnvVariablesError,
   RootMissingError,
   SourceMissingError
 } from './errors.js'
@@ -442,6 +443,16 @@ export function replaceEnv (config, env, onMissingEnv, ignore) {
   return config
 }
 
+function normalizeStrictEnv (value) {
+  if (value === 'warn') {
+    return 'warn'
+  } else if (value === 'false' || value === '') {
+    return false
+  }
+
+  return Boolean(value)
+}
+
 export async function loadConfiguration (source, schema, options = {}) {
   const {
     validate: shouldValidate,
@@ -453,6 +464,7 @@ export async function loadConfiguration (source, schema, options = {}) {
     replaceEnv: shouldReplaceEnv,
     replaceEnvIgnore,
     onMissingEnv,
+    strictEnv: strictEnvOption,
     fixPaths,
     logger,
     skipMetadata,
@@ -487,7 +499,42 @@ export async function loadConfiguration (source, schema, options = {}) {
   env.PLT_ROOT = root
 
   if (shouldReplaceEnv) {
-    config = replaceEnv(config, env, onMissingEnv, replaceEnvIgnore)
+    const missingEnv = new Set()
+
+    config = replaceEnv(
+      config,
+      env,
+      key => {
+        const value = onMissingEnv?.(key)
+
+        if (typeof value === 'undefined' || value === null) {
+          missingEnv.add(key)
+        }
+
+        return value
+      },
+      replaceEnvIgnore
+    )
+
+    // strictEnv can be set programmatically or in the configuration file itself, either at the top level
+    // (runtime configurations) or in the runtime property (capabilities configurations).
+    const strictEnv = normalizeStrictEnv(strictEnvOption ?? config.strictEnv ?? config.runtime?.strictEnv)
+
+    if (strictEnv && missingEnv.size > 0) {
+      const keys = Array.from(missingEnv).sort().join(', ')
+
+      if (strictEnv === 'warn') {
+        const message = `The configuration references the following environment variables which are not set: ${keys}`
+
+        if (logger) {
+          logger.warn(message)
+        } else {
+          process.emitWarning(message)
+        }
+      } else {
+        throw new MissingEnvVariablesError(keys)
+      }
+    }
   }
 
   const moduleInfo = extractModuleFromSchemaUrl(config)

--- a/packages/foundation/lib/errors.js
+++ b/packages/foundation/lib/errors.js
@@ -56,3 +56,7 @@ export const ConfigurationDoesNotValidateAgainstSchemaError = createError(
   `${ERROR_PREFIX}_CONFIGURATION_DOES_NOT_VALIDATE_AGAINST_SCHEMA`,
   'The configuration does not validate against the configuration schema'
 )
+export const MissingEnvVariablesError = createError(
+  `${ERROR_PREFIX}_MISSING_ENV_VARIABLES`,
+  'The configuration references the following environment variables which are not set: %s'
+)

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -1533,6 +1533,11 @@ export const runtimeProperties = {
   envfile: {
     type: 'string'
   },
+  strictEnv: {
+    anyOf: [{ type: 'boolean' }, { type: 'string' }],
+    description:
+      'When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.'
+  },
   sourceMaps: {
     type: 'boolean',
     default: false

--- a/packages/foundation/test/configuration.test.js
+++ b/packages/foundation/test/configuration.test.js
@@ -1593,3 +1593,196 @@ test('validate - should fail resolveModule validation for invalid module', () =>
     name: 'FastifyError'
   })
 })
+
+test('loadConfiguration - strictEnv should throw when environment variables are missing', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{TEST_HOST}', url: '{MISSING_ONE}', flag: '{MISSING_TWO}' }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  await rejects(
+    async () => {
+      await loadConfiguration(configFile, null, {
+        ignoreProcessEnv: true,
+        env: { TEST_HOST: 'custom-host' },
+        strictEnv: true
+      })
+    },
+    {
+      code: 'PLT_MISSING_ENV_VARIABLES',
+      message:
+        'The configuration references the following environment variables which are not set: MISSING_ONE, MISSING_TWO'
+    }
+  )
+})
+
+test('loadConfiguration - strictEnv should be read from the configuration file', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { strictEnv: true, host: '{MISSING_VAR}' }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  await rejects(
+    async () => {
+      await loadConfiguration(configFile, null, { ignoreProcessEnv: true })
+    },
+    {
+      code: 'PLT_MISSING_ENV_VARIABLES',
+      message: 'The configuration references the following environment variables which are not set: MISSING_VAR'
+    }
+  )
+})
+
+test('loadConfiguration - strictEnv should be read from the runtime property of the configuration file', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { runtime: { strictEnv: true }, host: '{MISSING_VAR}' }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  await rejects(
+    async () => {
+      await loadConfiguration(configFile, null, { ignoreProcessEnv: true })
+    },
+    { code: 'PLT_MISSING_ENV_VARIABLES' }
+  )
+})
+
+test('loadConfiguration - strictEnv=warn should log a warning and keep the empty string behavior', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{MISSING_VAR}' }
+  const warnings = []
+  const logger = {
+    warn (message) {
+      warnings.push(message)
+    }
+  }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  const result = await loadConfiguration(configFile, null, {
+    ignoreProcessEnv: true,
+    strictEnv: 'warn',
+    logger
+  })
+
+  equal(result.host, '')
+  deepEqual(warnings, [
+    'The configuration references the following environment variables which are not set: MISSING_VAR'
+  ])
+})
+
+test('loadConfiguration - strictEnv=warn should use process.emitWarning when no logger is provided', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{MISSING_VAR}' }
+  const warnings = []
+
+  function onWarning (warning) {
+    warnings.push(warning.message)
+  }
+
+  process.on('warning', onWarning)
+
+  t.after(async () => {
+    process.removeListener('warning', onWarning)
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  const result = await loadConfiguration(configFile, null, { ignoreProcessEnv: true, strictEnv: 'warn' })
+  equal(result.host, '')
+
+  // Warnings are emitted asynchronously
+  await new Promise(resolve => setImmediate(resolve))
+  deepEqual(warnings, [
+    'The configuration references the following environment variables which are not set: MISSING_VAR'
+  ])
+})
+
+test('loadConfiguration - strictEnv should not throw when onMissingEnv provides a value', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{MISSING_VAR}' }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  const result = await loadConfiguration(configFile, null, {
+    ignoreProcessEnv: true,
+    strictEnv: true,
+    onMissingEnv: key => `default_${key}`
+  })
+
+  equal(result.host, 'default_MISSING_VAR')
+})
+
+test('loadConfiguration - strictEnv should not throw when all variables are set', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{TEST_HOST}' }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  const result = await loadConfiguration(configFile, null, {
+    ignoreProcessEnv: true,
+    env: { TEST_HOST: 'custom-host' },
+    strictEnv: true
+  })
+
+  equal(result.host, 'custom-host')
+})
+
+test('loadConfiguration - strictEnv should support placeholders and string values', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { strictEnv: '{PLT_STRICT_ENV}', host: '{MISSING_VAR}' }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  // Resolved to "false", strict mode is disabled
+  const result = await loadConfiguration(configFile, null, {
+    ignoreProcessEnv: true,
+    env: { PLT_STRICT_ENV: 'false' }
+  })
+  equal(result.host, '')
+
+  // Resolved to "true", strict mode is enabled
+  await rejects(
+    async () => {
+      await loadConfiguration(configFile, null, { ignoreProcessEnv: true, env: { PLT_STRICT_ENV: 'true' } })
+    },
+    { code: 'PLT_MISSING_ENV_VARIABLES' }
+  )
+})

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -1008,6 +1008,10 @@ export interface PlatformaticGatewayConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -3809,6 +3809,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticNestJSConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticNextJsConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticNodeJsConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticNuxtConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticReactRouterConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticRemixConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -696,6 +696,10 @@ export type PlatformaticRuntimeConfig = {
     [k: string]: string;
   };
   envfile?: string;
+  /**
+   * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+   */
+  strictEnv?: boolean | string;
   sourceMaps?: boolean;
   nodeModulesSourceMaps?: string[];
   scheduler?: {

--- a/packages/runtime/fixtures/configs/monorepo-strict-env.json
+++ b/packages/runtime/fixtures/configs/monorepo-strict-env.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/1.52.0.json",
+  "entrypoint": "serviceApp",
+  "strictEnv": true,
+  "watch": "{PLT_STRICT_ENV_WATCH}",
+  "autoload": {
+    "path": "../monorepo",
+    "exclude": ["docs", "composerApp"],
+    "mappings": {
+      "serviceAppWithLogger": {
+        "id": "with-logger",
+        "config": "platformatic.service.json"
+      },
+      "serviceAppWithMultiplePlugins": {
+        "id": "multi-plugin-service",
+        "config": "platformatic.service.json"
+      }
+    }
+  },
+  "gracefulShutdown": {
+    "runtime": 1000,
+    "service": 1000
+  }
+}

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -95,7 +95,8 @@ export class Controller extends EventEmitter {
       worker: workerData?.worker,
       resourceLimits: workerData?.resourceLimits,
       hasManagementApi: !!runtimeConfig.managementApi,
-      fetchApplicationUrl: fetchApplicationUrl.bind(null, applicationConfig)
+      fetchApplicationUrl: fetchApplicationUrl.bind(null, applicationConfig),
+      strictEnv: runtimeConfig.strictEnv
     }
   }
 
@@ -141,7 +142,8 @@ export class Controller extends EventEmitter {
       if (appConfig.config) {
         // Parse the configuration file the first time to obtain the schema
         const unvalidatedConfig = await loadConfiguration(appConfig.config, null, {
-          onMissingEnv: this.#context.fetchApplicationUrl
+          onMissingEnv: this.#context.fetchApplicationUrl,
+          strictEnv: this.#context.strictEnv
         })
         const pkg = await loadConfigurationModule(appConfig.path, unvalidatedConfig)
         this.capability = await pkg.create(appConfig.path, appConfig.config, this.#context)

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -3492,6 +3492,17 @@
     "envfile": {
       "type": "string"
     },
+    "strictEnv": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+    },
     "sourceMaps": {
       "type": "boolean",
       "default": false

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -132,6 +132,34 @@ test('correctly loads the watch value from a string', async () => {
   strictEqual((await runtime.getRuntimeConfig()).watch, false)
 })
 
+test('strictEnv should fail loading the configuration when environment variables are missing', async t => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo-strict-env.json')
+  delete process.env.PLT_STRICT_ENV_WATCH
+
+  await rejects(
+    async () => {
+      await createRuntime(configFile)
+    },
+    {
+      code: 'PLT_MISSING_ENV_VARIABLES',
+      message:
+        'The configuration references the following environment variables which are not set: PLT_STRICT_ENV_WATCH'
+    }
+  )
+})
+
+test('strictEnv should not fail loading the configuration when all environment variables are set', async t => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo-strict-env.json')
+  process.env.PLT_STRICT_ENV_WATCH = 'false'
+
+  t.after(() => {
+    delete process.env.PLT_STRICT_ENV_WATCH
+  })
+
+  const runtime = await createRuntime(configFile)
+  strictEqual((await runtime.getRuntimeConfig()).watch, false)
+})
+
 test('defaults the application name to `main` if there is no package.json', async t => {
   const configFile = join(fixturesDir, 'dbAppNoPackageJson', 'platformatic.db.json')
   const config = await databaseLoadConfiguration(configFile)

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -896,6 +896,10 @@ export interface PlatformaticServiceConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -3195,6 +3195,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticTanStackConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -693,6 +693,10 @@ export interface PlatformaticViteConfig {
       [k: string]: string;
     };
     envfile?: string;
+    /**
+     * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+     */
+    strictEnv?: boolean | string;
     sourceMaps?: boolean;
     nodeModulesSourceMaps?: string[];
     scheduler?: {

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -2552,6 +2552,17 @@
         "envfile": {
           "type": "string"
         },
+        "strictEnv": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+        },
         "sourceMaps": {
           "type": "boolean",
           "default": false

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -696,6 +696,10 @@ export type PlatformaticRuntimeConfig = {
     [k: string]: string;
   };
   envfile?: string;
+  /**
+   * When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to "warn", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false.
+   */
+  strictEnv?: boolean | string;
   sourceMaps?: boolean;
   nodeModulesSourceMaps?: string[];
   scheduler?: {

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -3492,6 +3492,17 @@
     "envfile": {
       "type": "string"
     },
+    "strictEnv": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "When set to true, the configuration loading fails if a {PLT_*} placeholder references an environment variable which is not set. When set to \"warn\", a warning listing the missing variables is logged but the placeholders are still replaced with an empty string. Defaults to false."
+    },
     "sourceMaps": {
       "type": "boolean",
       "default": false


### PR DESCRIPTION
Fixes #4968

When a configuration placeholder references an environment variable that is not set, `replaceEnv` silently falls back to an empty string — no log line, no warning. Since `''` is a valid-looking value for most options (booleans parse falsy, URLs turn into "feature disabled"), a typo in a variable name or a variable missing from one deployment environment degrades silently instead of failing fast.

## Changes

- **`@platformatic/foundation`**: `loadConfiguration` now accepts a `strictEnv` option, which can also be set in the configuration file itself — at the top level for runtime configurations, or under the `runtime` property for capability configurations:
  - `true` → configuration loading fails with the new `PLT_MISSING_ENV_VARIABLES` error, listing all missing variable names at once
  - `"warn"` → a warning listing the missing variables is logged (via the provided logger, falling back to `process.emitWarning`), while keeping the empty-string replacement
  - Missing variables are only those not resolved by `env` nor by the `onMissingEnv` hook, so application URL placeholders keep working
  - The value is resolved after env replacement, so `"strictEnv": "{PLT_STRICT_ENV}"` placeholders work too
- **`@platformatic/runtime`**: the runtime propagates its `strictEnv` value to the configuration loading of its applications via the worker context
- `strictEnv` added to the runtime schema (and therefore to the wrapped `runtime` property of all capability schemas); all `schema.json`/`config.d.ts` files regenerated
- Docs for `strictEnv` in the runtime shared configuration reference, plus a pointer from the environment variable placeholders section; new error documented in the errors reference

Default behavior is unchanged: without opting in, placeholders still resolve to `''`.

## Tests

- 8 new foundation tests covering throw/warn modes, config-file and `runtime`-property sourcing, `onMissingEnv` interaction, placeholder-based `strictEnv` values, and the no-logger fallback
- 2 new runtime tests verifying a runtime config with `strictEnv: true` fails on a missing variable and loads normally when the variable is set
