### PR TITLE
ci: make runtime matrix resilient to one-off flaky failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,8 @@ jobs:
           max_attempts: 2
           timeout_minutes: 25
           retry_on: error
+          # The default shell on Windows is PowerShell 5.1, which does not support &&
+          shell: bash
           command: cd packages/runtime && pnpm run test:${{ matrix.suite }}
 
   service:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,8 +291,12 @@ jobs:
     needs: setup
     if: ${{ !inputs.job || inputs.job == 'runtime' }}
     runs-on: ${{matrix.os}}
-    timeout-minutes: 30
+    timeout-minutes: 55
     strategy:
+      # Do not cancel the other 29 matrix jobs when a single job hits a flaky
+      # failure (e.g. one-off V8 crashes in worker threads), so that reruns
+      # only need to repeat the failed job.
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2025]
         node: [22, 24, 26]
@@ -312,7 +316,12 @@ jobs:
           retry_on: error
           command: pnpm install --frozen-lockfile
       - name: Run runtime package test suite
-        run: cd packages/runtime && pnpm run test:${{ matrix.suite }}
+        uses: nick-fields/retry@v3.0.2
+        with:
+          max_attempts: 2
+          timeout_minutes: 25
+          retry_on: error
+          command: cd packages/runtime && pnpm run test:${{ matrix.suite }}
 
   service:
     name: 'service - ${{ matrix.os }} - ${{ matrix.node }}'


### PR DESCRIPTION
## Problem

The runtime test suite occasionally fails for reasons unrelated to the code under test. The latest instance (run [29703993963](https://github.com/platformatic/platformatic/actions/runs/29703993963), job `runtime - ubuntu-24.04 - 24 - main` on PR #4976) was a fatal V8 crash in Node.js 24.18.0:

```
FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal
 3: node::cjs_lexer::Parse(v8::FunctionCallbackInfo<v8::Value> const&)
...
1: cjsPreparseModuleExports (node:internal/modules/esm/translators:432:44)
```

The crash happened ~3 seconds into `worker-scaler-1.test.js`, while a runtime worker thread was preparsing CJS modules during `app.start()`. A fatal V8 error in any worker thread aborts the whole test process, so the file fails with no usable test output. This is [nodejs/node#63323](https://github.com/nodejs/node/issues/63323) — a race in the native CJS lexer introduced in Node 24.14.0 (when `cjs-module-lexer` WASM was replaced with the native implementation in nodejs/node#61456), triggered probabilistically by multiple worker threads concurrently doing ESM→CJS preparse. It was fixed by [nodejs/node#63885](https://github.com/nodejs/node/pull/63885) and released in **Node 26.4.0**, but the fix is **not yet in any 24.x LTS release** (24.18.0, which CI uses, was cut on 2026-06-23 from before the backport) — which is exactly why the Node 24 job crashed while 22 (no native lexer) and 26 (fix released) passed. Once the 24.x backport ships, CI picks it up automatically via `node-version: 24`.

It is not a defect in the test: the same file passed on Node 22/26 and on rerun, and the historical ELU-timing flakiness of this test was already addressed by #4806 and #4904 (recent `main` failures are in other suites).

The cost of one such crash is currently amplified by CI structure: the runtime matrix uses default `fail-fast: true`, so a single flaky job cancels the other 29 matrix jobs and the whole matrix has to be rerun manually.

## Changes

- **`fail-fast: false`** for the runtime matrix: a single flaky job no longer cancels the healthy ones, and `gh run rerun --failed` only repeats the job that actually failed.
- **Retry the test step once** using the same `nick-fields/retry` action already used for `pnpm install` in every job. This automates the current practice of rerunning failed runtime jobs before investigating. Persistent failures still fail the job (and now do so twice, making a real failure easier to distinguish from a flake).
- **Job timeout raised from 30 to 55 minutes** to fit a second attempt; each individual attempt is capped at 25 minutes, above the ~20 minutes the slowest (Windows `main`) suite currently takes.

No test code changes: the worker-scaler tests were already hardened against ELU-timing flakiness, and the V8 crash cannot be mitigated from test code since it kills the entire process.
