### PR TITLE
fix(db): support string schema lock read-only values

### DIFF
--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -360,7 +360,7 @@ postgres://user:password@my-database:5432/db-name
 
   Starting Platformatic DB or running a migration will automatically create the schemalock file.
 
-  Set `readOnly` to `true` to load the schema lock without ever writing it back, e.g. when the file is checked into version control and must not be rewritten at runtime:
+  Set `readOnly` to `true` (or the string `"true"`) to load the schema lock without ever writing it back, e.g. when the file is checked into version control and must not be rewritten at runtime:
 
   ```json title="Example Read-Only Object"
   {

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -192,7 +192,7 @@ export interface PlatformaticDatabaseConfig {
           /**
            * Never write the schema lock file at runtime, only read it.
            */
-          readOnly?: boolean;
+          readOnly?: boolean | string;
           [k: string]: unknown;
         };
     poolSize?: number;

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -42,7 +42,7 @@ export const db = {
               resolvePath: true
             },
             readOnly: {
-              type: 'boolean',
+              anyOf: [{ type: 'boolean' }, { type: 'string' }],
               default: false,
               description: 'Never write the schema lock file at runtime, only read it.'
             }

--- a/packages/db/lib/utils.js
+++ b/packages/db/lib/utils.js
@@ -25,7 +25,8 @@ export function locateSchemaLock (config) {
 }
 
 export function isSchemaLockReadOnly (config) {
-  return config.db.schemalock?.readOnly === true
+  const { readOnly } = config.db.schemalock ?? {}
+  return readOnly === true || readOnly === 'true'
 }
 
 // The information_schema queries used for introspection include *_catalog
@@ -53,7 +54,12 @@ export function validateSchemaLockFormat (schemaLock) {
   if (!isBoolean && !isObject) {
     throw new InvalidSchemaLockError()
   }
-  if (isObject && typeof schemaLock.path !== 'string' && typeof schemaLock.readOnly !== 'boolean') {
+  if (
+    isObject &&
+    typeof schemaLock.path !== 'string' &&
+    typeof schemaLock.readOnly !== 'boolean' &&
+    typeof schemaLock.readOnly !== 'string'
+  ) {
     throw new InvalidSchemaLockError()
   }
   if (isObject && schemaLock.path !== undefined && typeof schemaLock.path !== 'string') {

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -581,7 +581,14 @@
                   "resolvePath": true
                 },
                 "readOnly": {
-                  "type": "boolean",
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
                   "default": false,
                   "description": "Never write the schema lock file at runtime, only read it."
                 }

--- a/packages/db/test/schemalock-boot.test.js
+++ b/packages/db/test/schemalock-boot.test.js
@@ -124,7 +124,7 @@ test('schema.lock is deterministic across database names', { skip: isMysql }, as
   assert.equal(firstLock, secondLock, 'the same schema produces the same schema.lock on different databases')
 })
 
-test('does not create schema.lock at boot when the schema lock is read-only', async t => {
+test('does not create schema.lock at boot when the schema lock is read-only string', async t => {
   const { connectionInfo, dropTestDB } = await getConnectionInfo()
   const directory = await mkdtemp(join(tmpdir(), 'schemalock-boot-'))
   const schemaLockPath = join(directory, 'schema.lock')
@@ -139,7 +139,7 @@ test('does not create schema.lock at boot when the schema lock is read-only', as
       ...connectionInfo,
       schemalock: {
         path: schemaLockPath,
-        readOnly: true
+        readOnly: 'true'
       },
       async onDatabaseLoad (db, sql) {
         await createBasicPages(db, sql)

--- a/packages/db/test/utils.test.js
+++ b/packages/db/test/utils.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import os from 'node:os'
 import { test } from 'node:test'
-import { urlDirname } from '../lib/utils.js'
+import { isSchemaLockReadOnly, urlDirname } from '../lib/utils.js'
 
 const isWindows = os.platform() === 'win32'
 
@@ -14,4 +14,11 @@ test('urlDirname', t => {
     filePath = 'file:///path/to/file.json'
     assert.equal(urlDirname(filePath), '/path/to')
   }
+})
+
+test('isSchemaLockReadOnly accepts boolean and string configuration', () => {
+  assert.equal(isSchemaLockReadOnly({ db: { schemalock: { readOnly: true } } }), true)
+  assert.equal(isSchemaLockReadOnly({ db: { schemalock: { readOnly: 'true' } } }), true)
+  assert.equal(isSchemaLockReadOnly({ db: { schemalock: { readOnly: false } } }), false)
+  assert.equal(isSchemaLockReadOnly({ db: { schemalock: { readOnly: 'false' } } }), false)
 })


### PR DESCRIPTION
## Summary

- allow `db.schemalock.readOnly` to be configured as a boolean or string
- enable read-only mode only for `true` and `"true"`
- regenerate DB schema/types and document the string form

## Tests

- `pnpm --filter @platformatic/db run build`
- `pnpm --filter @platformatic/db exec node --test --test-reporter=spec test/utils.test.js test/schema.test.js`
- `pnpm --filter @platformatic/db exec eslint lib/schema.js lib/utils.js test/schemalock-boot.test.js test/utils.test.js`

The PostgreSQL-backed schema-lock boot tests could not run locally because PostgreSQL was unavailable at `127.0.0.1:5432`.
