### PR TITLE
fix(sql-mapper): align foreign key output types

### DIFF
--- a/docs/guides/build-modular-monolith.md
+++ b/docs/guides/build-modular-monolith.md
@@ -201,12 +201,12 @@ We should receive a response like this:
 
 ```json
 [
-  { "id": 1, "name": "Stephen King", "createdAt": "1687827965773", "updatedAt": "1687827965773" },
-  { "id": 2, "name": "Miranda July", "createdAt": "1687827965778", "updatedAt": "1687827965778" },
-  { "id": 3, "name": "Lewis Carroll", "createdAt": "1687827965780", "updatedAt": "1687827965780" },
-  { "id": 4, "name": "Martha Schumacher", "createdAt": "1687827965782", "updatedAt": "1687827965782" },
-  { "id": 5, "name": "Mick Garris", "createdAt": "1687827965784", "updatedAt": "1687827965784" },
-  { "id": 6, "name": "Dede Gardner", "createdAt": "1687827965786", "updatedAt": "1687827965786" }
+  { "id": "1", "name": "Stephen King", "createdAt": "1687827965773", "updatedAt": "1687827965773" },
+  { "id": "2", "name": "Miranda July", "createdAt": "1687827965778", "updatedAt": "1687827965778" },
+  { "id": "3", "name": "Lewis Carroll", "createdAt": "1687827965780", "updatedAt": "1687827965780" },
+  { "id": "4", "name": "Martha Schumacher", "createdAt": "1687827965782", "updatedAt": "1687827965782" },
+  { "id": "5", "name": "Mick Garris", "createdAt": "1687827965784", "updatedAt": "1687827965784" },
+  { "id": "6", "name": "Dede Gardner", "createdAt": "1687827965786", "updatedAt": "1687827965786" }
 ]
 ```
 
@@ -360,25 +360,25 @@ The response should look like this:
 ```json
 [
   {
-    "id": 1,
+    "id": "1",
     "title": "Fairy Tale",
-    "authorId": 1,
+    "authorId": "1",
     "publishedYear": 2022,
     "createdAt": "1687893211326",
     "updatedAt": "1687893211326"
   },
   {
-    "id": 2,
+    "id": "2",
     "title": "No One Belongs Here More Than You",
-    "authorId": 2,
+    "authorId": "2",
     "publishedYear": 2007,
     "createdAt": "1687893211333",
     "updatedAt": "1687893211333"
   },
   {
-    "id": 3,
+    "id": "3",
     "title": "Alice's Adventures in Wonderland",
-    "authorId": 3,
+    "authorId": "3",
     "publishedYear": 1865,
     "createdAt": "1687893211336",
     "updatedAt": "1687893211336"
@@ -546,28 +546,28 @@ And we should then receive a response like this:
 ```json
 [
   {
-    "id": 1,
+    "id": "1",
     "title": "Maximum Overdrive",
-    "directorId": 1,
-    "producerId": 4,
+    "directorId": "1",
+    "producerId": "4",
     "releasedYear": 1986,
     "createdAt": "1687895004362",
     "updatedAt": "1687895004362"
   },
   {
-    "id": 2,
+    "id": "2",
     "title": "The Shining",
-    "directorId": 5,
-    "producerId": 1,
+    "directorId": "5",
+    "producerId": "1",
     "releasedYear": 1980,
     "createdAt": "1687895004369",
     "updatedAt": "1687895004369"
   },
   {
-    "id": 3,
+    "id": "3",
     "title": "Kajillionaire",
-    "directorId": 2,
-    "producerId": 6,
+    "directorId": "2",
+    "producerId": "6",
     "releasedYear": 2020,
     "createdAt": "1687895004372",
     "updatedAt": "1687895004372"
@@ -686,25 +686,25 @@ We should receive a response like this:
 ```json
 [
   {
-    "id": 1,
+    "id": "1",
     "title": "Fairy Tale",
-    "authorId": 1,
+    "authorId": "1",
     "publishedYear": 2022,
     "createdAt": "1687893211326",
     "updatedAt": "1687893211326"
   },
   {
-    "id": 2,
+    "id": "2",
     "title": "No One Belongs Here More Than You",
-    "authorId": 2,
+    "authorId": "2",
     "publishedYear": 2007,
     "createdAt": "1687893211333",
     "updatedAt": "1687893211333"
   },
   {
-    "id": 3,
+    "id": "3",
     "title": "Alice's Adventures in Wonderland",
-    "authorId": 3,
+    "authorId": "3",
     "publishedYear": 1865,
     "createdAt": "1687893211336",
     "updatedAt": "1687893211336"
@@ -723,28 +723,28 @@ We should receive a response like this:
 ```json
 [
   {
-    "id": 1,
+    "id": "1",
     "title": "Maximum Overdrive",
-    "directorId": 1,
-    "producerId": 4,
+    "directorId": "1",
+    "producerId": "4",
     "releasedYear": 1986,
     "createdAt": "1687895004362",
     "updatedAt": "1687895004362"
   },
   {
-    "id": 2,
+    "id": "2",
     "title": "The Shining",
-    "directorId": 5,
-    "producerId": 1,
+    "directorId": "5",
+    "producerId": "1",
     "releasedYear": 1980,
     "createdAt": "1687895004369",
     "updatedAt": "1687895004369"
   },
   {
-    "id": 3,
+    "id": "3",
     "title": "Kajillionaire",
-    "directorId": 2,
-    "producerId": 6,
+    "directorId": "2",
+    "producerId": "6",
     "releasedYear": 2020,
     "createdAt": "1687895004372",
     "updatedAt": "1687895004372"
@@ -1102,12 +1102,12 @@ We should receive a response like this from the People application's `/people` r
 
 ```json
 [
-  { "id": 1, "name": "Stephen King", "createdAt": "1687891503369", "updatedAt": "1687891503369" },
-  { "id": 2, "name": "Miranda July", "createdAt": "1687891503375", "updatedAt": "1687891503375" },
-  { "id": 3, "name": "Lewis Carroll", "createdAt": "1687891503377", "updatedAt": "1687891503377" },
-  { "id": 4, "name": "Martha Schumacher", "createdAt": "1687891503379", "updatedAt": "1687891503379" },
-  { "id": 5, "name": "Mick Garris", "createdAt": "1687891503381", "updatedAt": "1687891503381" },
-  { "id": 6, "name": "Dede Gardner", "createdAt": "1687891503383", "updatedAt": "1687891503383" }
+  { "id": "1", "name": "Stephen King", "createdAt": "1687891503369", "updatedAt": "1687891503369" },
+  { "id": "2", "name": "Miranda July", "createdAt": "1687891503375", "updatedAt": "1687891503375" },
+  { "id": "3", "name": "Lewis Carroll", "createdAt": "1687891503377", "updatedAt": "1687891503377" },
+  { "id": "4", "name": "Martha Schumacher", "createdAt": "1687891503379", "updatedAt": "1687891503379" },
+  { "id": "5", "name": "Mick Garris", "createdAt": "1687891503381", "updatedAt": "1687891503381" },
+  { "id": "6", "name": "Dede Gardner", "createdAt": "1687891503383", "updatedAt": "1687891503383" }
 ]
 ```
 

--- a/docs/reference/sql-mapper/entities/fields.md
+++ b/docs/reference/sql-mapper/entities/fields.md
@@ -15,6 +15,8 @@ These objects contain the following properties:
 - `sqlType`: The original field type. It may vary depending on the underlying DB Engine
 - `isNullable`: Whether the field can be `null` or not
 - `primaryKey`: Whether the field is the primary key or not
+- `foreignKey`: Whether the field is a foreign key or not
+- `stringifyOutput`: Whether the field is converted to a string in mapper output because it references a primary key
 - `camelcase`: The _camel cased_ value of the field
 
 ## Example

--- a/docs/reference/sql-openapi/api.md
+++ b/docs/reference/sql-openapi/api.md
@@ -19,6 +19,8 @@ CREATE TABLE pages (
 - `[PRIMARY_KEY]` is `id`
 - `fields` are `id`, `title`, `body`
 
+Numeric primary keys and foreign keys that reference them are serialized as strings in response bodies. Request bodies, path parameters, and query filters retain their native numeric types.
+
 ## GET and POST parameters
 
 Some APIs need the `GET` method, where parameters must be defined in the URL, or `POST/PUT` methods, where parameters can be defined in the `HTTP` request payload.
@@ -119,7 +121,7 @@ $ curl -v -X 'GET' \
 > x-total-count: 18
  (...)
 
-[{"id":1,"title":"Movie1"},{"id":2,"title":"Movie2"}]%
+[{"id":"1","title":"Movie1"},{"id":"2","title":"Movie2"}]%
 ```
 
 
@@ -140,7 +142,7 @@ $ curl -X 'POST' \
 }'
 
 {
-  "id": 1,
+  "id": "1",
   "title": "Hello World",
   "body": "Welcome to Platformatic"
 }
@@ -178,7 +180,7 @@ $ curl -X 'POST' \
 }'
 
 {
-  "id": 1,
+  "id": "1",
   "title": "Hello Platformatic!",
   "body": "Welcome to Platformatic"
 }
@@ -206,11 +208,11 @@ $ curl -X 'PUT' \
 }'
 
 [{
-  "id": 1,
+  "id": "1",
   "title": "Updated title!",
   "body": "Updated body!"
 },{
-  "id": 2,
+  "id": "2",
   "title": "Updated title!",
   "body": "Updated body!"
 }]
@@ -341,7 +343,7 @@ $ curl -X 'POST' \
   -H 'Content-Type: application/json' \
   -d '{ "role": "admin" }'
 
-{ "pageId": 1, "userId": 1, "role": "admin" }
+{ "pageId": "1", "userId": "1", "role": "admin" }
 ```
 
 `PUT` accepts the same body.
@@ -431,12 +433,12 @@ $ curl -X 'GET' 'http://localhost:3042/movies?limit=5&cursor=true&orderby.id=asc
 [
   {
     "title": "Terminator",
-    "id": 1
+    "id": "1"
   },
   ...
   {
     "title": "Star Trek",
-    "id": 5
+    "id": "5"
   }
 ]
 ```
@@ -452,7 +454,7 @@ $ curl -X 'GET' 'http://localhost:3042/movies?limit=5&startAfter=eyJpZCI6NX0=&or
 [
   {
     "title": "Star Wars",
-    "id": 6
+    "id": "6"
   },
   ...
 ]
@@ -519,7 +521,7 @@ $ curl -X 'POST' \
 }'
 
 {
-  "id": 1,
+  "id": "1",
   "title": "Hello Platformatic!",
   "body": "Welcome to Platformatic"
   "statusCode": 400,
@@ -543,7 +545,7 @@ $ curl -X 'POST' \
 }'
 
 {
-  "id": 42,
+  "id": "42",
   "title": "Hello Platformatic!",
   "body": "Welcome to Platformatic"
 }

--- a/packages/db/test/fixtures/auto-gen-types/index.tst.ts
+++ b/packages/db/test/fixtures/auto-gen-types/index.tst.ts
@@ -13,7 +13,7 @@ expect(aggregateRatings).type.toBe<Partial<AggregateRating>[]>()
 const aggregateRating = aggregateRatings[0] as AggregateRating
 expect(aggregateRating).type.toBe<{
   id?: string
-  movieId: number
+  movieId: string
   rating: number
   ratingType: string
 }>()

--- a/packages/sql-json-schema-mapper/index.js
+++ b/packages/sql-json-schema-mapper/index.js
@@ -58,7 +58,7 @@ export function mapSQLTypeToOpenAPIType (sqlType) {
   }
 }
 
-function mapSQLTypeToOpenAPISchema (field) {
+function mapSQLTypeToOpenAPISchema (field, output) {
   if (field.sqlType === 'vector') {
     const schema = {
       type: 'array',
@@ -75,10 +75,16 @@ function mapSQLTypeToOpenAPISchema (field) {
     return schema
   }
 
-  return { type: mapSQLTypeToOpenAPIType(field.sqlType) }
+  let type = mapSQLTypeToOpenAPIType(field.sqlType)
+  if (output && (field.primaryKey || field.stringifyOutput) && (type === 'integer' || type === 'number')) {
+    type = 'string'
+  }
+
+  return { type }
 }
 
-export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = false) {
+export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = false, options = {}) {
+  const { output = false } = options
   const fields = entity.camelCasedFields
   const properties = {}
   const required = []
@@ -103,7 +109,7 @@ export function mapSQLEntityToJSONSchema (entity, ignore = {}, noRequired = fals
         additionalProperties: true
       }
     } else {
-      properties[field.camelcase] = mapSQLTypeToOpenAPISchema(field)
+      properties[field.camelcase] = mapSQLTypeToOpenAPISchema(field, output)
     }
     if (field.isNullable || noRequired || field.autoTimestamp) {
       properties[field.camelcase].nullable = true
@@ -188,8 +194,8 @@ function renderProperties (
       types = [type]
     }
 
-    // The mapper always returns primary keys as strings
-    if (fieldDefinitions[name]?.primaryKey) {
+    // The mapper returns primary keys and marked foreign keys as strings
+    if (fieldDefinitions[name]?.primaryKey || fieldDefinitions[name]?.stringifyOutput) {
       types = Array.from(new Set(types.map(t => (t === 'integer' || t === 'number' ? 'string' : t))))
     }
 

--- a/packages/sql-json-schema-mapper/test/simple.test.js
+++ b/packages/sql-json-schema-mapper/test/simple.test.js
@@ -121,6 +121,43 @@ test('simple db, simple rest API', async t => {
   }
 })
 
+test('output schemas stringify numeric primary and referencing foreign keys', () => {
+  const entity = {
+    name: 'Registration',
+    camelCasedFields: {
+      id: {
+        camelcase: 'id',
+        sqlType: 'integer',
+        isNullable: false,
+        primaryKey: true
+      },
+      contactId: {
+        camelcase: 'contactId',
+        sqlType: 'integer',
+        isNullable: false,
+        foreignKey: true,
+        stringifyOutput: true
+      },
+      externalCode: {
+        camelcase: 'externalCode',
+        sqlType: 'integer',
+        isNullable: false,
+        foreignKey: true
+      }
+    }
+  }
+
+  const inputSchema = mapSQLEntityToJSONSchema(entity)
+  same(inputSchema.properties.id, { type: 'integer' })
+  same(inputSchema.properties.contactId, { type: 'integer' })
+  same(inputSchema.properties.externalCode, { type: 'integer' })
+
+  const outputSchema = mapSQLEntityToJSONSchema(entity, {}, true, { output: true })
+  same(outputSchema.properties.id, { type: 'string', nullable: true })
+  same(outputSchema.properties.contactId, { type: 'string', nullable: true })
+  same(outputSchema.properties.externalCode, { type: 'integer', nullable: true })
+})
+
 test('noRequired = true', async t => {
   const app = fastify()
   app.register(sqlMapper, {

--- a/packages/sql-json-schema-mapper/test/types.test.js
+++ b/packages/sql-json-schema-mapper/test/types.test.js
@@ -255,6 +255,12 @@ test('numeric primary keys are mapped to string type', async t => {
       age: {
         type: 'integer'
       },
+      contactId: {
+        type: 'integer'
+      },
+      externalCode: {
+        type: 'integer'
+      },
       name: {
         type: 'string'
       }
@@ -265,12 +271,16 @@ test('numeric primary keys are mapped to string type', async t => {
   const fieldDefinitions = {
     id: { primaryKey: true, sqlType: 'integer' },
     age: { sqlType: 'integer' },
+    contactId: { foreignKey: true, stringifyOutput: true, sqlType: 'integer' },
+    externalCode: { foreignKey: true, sqlType: 'integer' },
     name: { sqlType: 'varchar' }
   }
 
   const result = mapOpenAPItoTypes(schema, fieldDefinitions)
 
   same(result.includes('id: string;'), true, 'the primary key is typed as string, like the mapper returns it')
+  same(result.includes('contactId?: string;'), true, 'a foreign key to a primary key is typed as string')
+  same(result.includes('externalCode?: number;'), true, 'other foreign keys keep the number type')
   same(result.includes('age?: number;'), true, 'other numeric fields keep the number type')
   same(result.includes('name?: string;'), true, 'string fields keep the string type')
 })

--- a/packages/sql-mapper/index.d.ts
+++ b/packages/sql-mapper/index.d.ts
@@ -60,6 +60,11 @@ export interface DBEntityField {
    */
   foreignKey?: boolean,
   /**
+   * An option that is true if a foreign key field is stringified in mapper output
+   * because it references a primary key.
+   */
+  stringifyOutput?: boolean,
+  /**
    * An option that is true if field is nullable.
    */
   isNullable: boolean,

--- a/packages/sql-mapper/index.js
+++ b/packages/sql-mapper/index.js
@@ -80,6 +80,29 @@ const defaultAutoTimestampFields = {
   updatedAt: 'updated_at'
 }
 
+function physicalEntityKey (schema, table) {
+  return `${schema ?? ''}\0${table}`
+}
+
+function markForeignKeysReferencingPrimaryKeys (entities) {
+  const entitiesByTable = new Map()
+
+  for (const entity of Object.values(entities)) {
+    entitiesByTable.set(physicalEntityKey(entity.schema, entity.table), entity)
+  }
+
+  for (const entity of Object.values(entities)) {
+    for (const relation of entity.relations) {
+      const foreignSchema = relation.foreign_table_schema ?? entity.schema
+      const foreignEntity = entitiesByTable.get(physicalEntityKey(foreignSchema, relation.foreign_table_name))
+
+      if (foreignEntity?.primaryKeys.has(relation.foreign_column_name)) {
+        entity.fields[relation.column_name].stringifyOutput = true
+      }
+    }
+  }
+}
+
 async function registerPostgreSQLExtensionTypes (db) {
   try {
     await db.registerTypeParser('vector', parseVector)
@@ -374,6 +397,8 @@ export async function connect ({
         addEntityHooks(entity.singularName, hooks[entity.singularName])
       }
     }
+
+    markForeignKeysReferencingPrimaryKeys(entities)
 
     const res = {
       db,

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -104,8 +104,13 @@ function createMapper (
       let value = output[key]
       const newKey = fieldMapToRetrieve[key]
       // Do not convert Date objects: they are serialized according to the
-      // schema of the field, like non primary key columns
-      if (primaryKeys.has(key) && value !== null && value !== undefined && !(value instanceof Date)) {
+      // schema of the field, like other non-stringified columns
+      if (
+        (primaryKeys.has(key) || fields[key]?.stringifyOutput) &&
+        value !== null &&
+        value !== undefined &&
+        !(value instanceof Date)
+      ) {
         value = value.toString()
       }
       if (newKey && isVectorType(fields[key].sqlType)) {

--- a/packages/sql-mapper/lib/queries/pg.js
+++ b/packages/sql-mapper/lib/queries/pg.js
@@ -80,16 +80,27 @@ export async function listColumns (db, sql, table, schema) {
 
 export async function listConstraints (db, sql, table, schema) {
   const query = sql`
-    SELECT constraints.*, usage.*, usage2.table_name AS foreign_table_name, usage2.column_name AS foreign_column_name, usage2.table_schema AS foreign_table_schema
+    SELECT constraints.*, usage.*, foreign_usage.table_name AS foreign_table_name,
+      foreign_usage.column_name AS foreign_column_name, foreign_usage.table_schema AS foreign_table_schema
     FROM information_schema.table_constraints constraints
       JOIN information_schema.key_column_usage usage
-        ON constraints.constraint_name = usage.constraint_name
-        AND constraints.table_name = ${table}
-      JOIN information_schema.constraint_column_usage usage2
-        ON usage.constraint_name = usage2.constraint_name
-        AND ( usage.table_name = ${table}
-        AND usage.table_schema = ${schema} )
-    ORDER BY usage.constraint_name, usage.ordinal_position, usage2.table_name, usage2.column_name
+        ON constraints.constraint_catalog = usage.constraint_catalog
+        AND constraints.constraint_schema = usage.constraint_schema
+        AND constraints.constraint_name = usage.constraint_name
+        AND constraints.table_schema = usage.table_schema
+        AND constraints.table_name = usage.table_name
+      LEFT JOIN information_schema.referential_constraints referential
+        ON constraints.constraint_catalog = referential.constraint_catalog
+        AND constraints.constraint_schema = referential.constraint_schema
+        AND constraints.constraint_name = referential.constraint_name
+      LEFT JOIN information_schema.key_column_usage foreign_usage
+        ON referential.unique_constraint_catalog = foreign_usage.constraint_catalog
+        AND referential.unique_constraint_schema = foreign_usage.constraint_schema
+        AND referential.unique_constraint_name = foreign_usage.constraint_name
+        AND usage.position_in_unique_constraint = foreign_usage.ordinal_position
+    WHERE constraints.table_name = ${table}
+      AND constraints.table_schema = ${schema}
+    ORDER BY usage.constraint_name, usage.ordinal_position
   `
   const constraintsList = await db.query(query)
   return constraintsList

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -1,4 +1,4 @@
-import { deepEqual, equal, notEqual, ok, rejects } from 'node:assert'
+import { deepEqual, equal, notEqual, ok, rejects, strictEqual } from 'node:assert'
 import { test } from 'node:test'
 import { connect } from '../index.js'
 import { clear, connInfo, isMysql, isMysql8, isPg, isSQLite } from './helper.js'
@@ -561,6 +561,8 @@ test('mixing snake and camel case', async () => {
   const pageEntity = mapper.entities.page
   const categoryEntity = mapper.entities.category
 
+  strictEqual(pageEntity.fields.category_id.stringifyOutput, true)
+
   const [newCategory] = await categoryEntity.insert({
     fields: ['id', 'name'],
     inputs: [{ name: 'fiction' }]
@@ -594,6 +596,8 @@ test('mixing snake and camel case', async () => {
         categoryId: newCategory.id
       }
     ])
+    strictEqual(res[0].categoryId, newCategory.id)
+    strictEqual(typeof res[0].categoryId, 'string')
   }
 
   {
@@ -610,7 +614,142 @@ test('mixing snake and camel case', async () => {
       title: 'A fiction',
       categoryId: newCategory.id
     })
+    strictEqual(res.categoryId, newCategory.id)
+    strictEqual(typeof res.categoryId, 'string')
   }
+})
+
+test('only foreign keys referencing primary keys are stringified', async t => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    t.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+
+    if (isMysql) {
+      await db.query(sql`
+        CREATE TABLE categories (
+          id INTEGER PRIMARY KEY AUTO_INCREMENT,
+          external_code INTEGER NOT NULL UNIQUE
+        );
+        CREATE TABLE pages (
+          id INTEGER PRIMARY KEY AUTO_INCREMENT,
+          category_id INTEGER,
+          category_code INTEGER,
+          FOREIGN KEY (category_id) REFERENCES categories(id),
+          FOREIGN KEY (category_code) REFERENCES categories(external_code)
+        );
+      `)
+    } else if (isSQLite) {
+      await db.query(sql`
+        CREATE TABLE categories (
+          id INTEGER PRIMARY KEY,
+          external_code INTEGER NOT NULL UNIQUE
+        );
+        CREATE TABLE pages (
+          id INTEGER PRIMARY KEY,
+          category_id INTEGER REFERENCES categories(id),
+          category_code INTEGER REFERENCES categories(external_code)
+        );
+      `)
+    } else {
+      await db.query(sql`
+        CREATE TABLE categories (
+          id SERIAL PRIMARY KEY,
+          external_code INTEGER NOT NULL UNIQUE
+        );
+        CREATE TABLE pages (
+          id SERIAL PRIMARY KEY,
+          category_id INTEGER REFERENCES categories(id),
+          category_code INTEGER REFERENCES categories(external_code)
+        );
+      `)
+    }
+  }
+
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {}
+  })
+
+  const categoryEntity = mapper.entities.category
+  const pageEntity = mapper.entities.page
+  strictEqual(pageEntity.fields.category_id.stringifyOutput, true)
+  strictEqual(pageEntity.fields.category_code.stringifyOutput, undefined)
+
+  const [category] = await categoryEntity.insert({
+    inputs: [{ externalCode: 42 }]
+  })
+  const pages = await pageEntity.insert({
+    inputs: [
+      { categoryId: category.id, categoryCode: category.externalCode },
+      { categoryId: null, categoryCode: null }
+    ]
+  })
+
+  strictEqual(typeof category.id, 'string')
+  strictEqual(pages[0].categoryId, category.id)
+  strictEqual(typeof pages[0].categoryId, 'string')
+  strictEqual(pages[0].categoryCode, 42)
+  strictEqual(typeof pages[0].categoryCode, 'number')
+  strictEqual(pages[1].categoryId, null)
+  strictEqual(pages[1].categoryCode, null)
+
+  const found = await pageEntity.find({ orderBy: [{ field: 'id', direction: 'asc' }] })
+  strictEqual(found[0].categoryId, category.id)
+  strictEqual(typeof found[0].categoryId, 'string')
+  strictEqual(found[0].categoryCode, 42)
+  strictEqual(typeof found[0].categoryCode, 'number')
+  strictEqual(found[1].categoryId, null)
+  strictEqual(found[1].categoryCode, null)
+})
+
+test('composite foreign keys inherit each referenced column output type', { skip: !isPg }, async t => {
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      t.after(async () => {
+        await clear(db, sql)
+        db.dispose()
+      })
+
+      await db.query(sql`
+        CREATE TABLE accounts (
+          tenant_id INTEGER PRIMARY KEY,
+          code INTEGER NOT NULL,
+          UNIQUE (tenant_id, code)
+        );
+        CREATE TABLE registrations (
+          id SERIAL PRIMARY KEY,
+          tenant_id INTEGER NOT NULL,
+          code INTEGER NOT NULL,
+          FOREIGN KEY (tenant_id, code) REFERENCES accounts (tenant_id, code)
+        );
+      `)
+    },
+    ignore: {},
+    hooks: {}
+  })
+
+  const accountEntity = mapper.entities.account
+  const registrationEntity = mapper.entities.registration
+
+  strictEqual(registrationEntity.fields.tenant_id.stringifyOutput, true)
+  strictEqual(registrationEntity.fields.code.stringifyOutput, undefined)
+
+  const account = await accountEntity.save({ input: { tenantId: 1, code: 42 } })
+  const registration = await registrationEntity.save({ input: { tenantId: account.tenantId, code: account.code } })
+
+  strictEqual(registration.tenantId, account.tenantId)
+  strictEqual(typeof registration.tenantId, 'string')
+  strictEqual(registration.code, 42)
+  strictEqual(typeof registration.code, 'number')
 })
 
 test('only include wanted fields - with foreign', async () => {

--- a/packages/sql-mapper/test/schema.test.js
+++ b/packages/sql-mapper/test/schema.test.js
@@ -476,6 +476,7 @@ test('uses tables from different schemas with FK', { skip: isSQLite }, async () 
   equal(userEntity.pluralName, 'test2Users')
   equal(userEntity.schema, 'test2')
   equal(userEntity.relations.length, 1)
+  equal(userEntity.fields.page_id.stringifyOutput, true)
   const userRelation = userEntity.relations[0]
   equal(userRelation.foreignEntityName, 'test1Page')
   equal(userRelation.entityName, 'test2User')

--- a/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/0.json
+++ b/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/1.json
+++ b/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/1.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "name": {
@@ -44,7 +44,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {
@@ -60,7 +60,7 @@
             "nullable": true
           },
           "ownerId": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           }
         },

--- a/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/2.json
+++ b/packages/sql-openapi/.snapshots/0903e8f446135fccd3b4382196bc77e2/2.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/21ca681e6081425b45eee7a661271ef7/0.json
+++ b/packages/sql-openapi/.snapshots/21ca681e6081425b45eee7a661271ef7/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/0.json
+++ b/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/1.json
+++ b/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/1.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/2.json
+++ b/packages/sql-openapi/.snapshots/2b2a7f15772e1fb0e084e9f5c0d74ee6/2.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/a2201917da7f38b2633837c006be92ea/0.json
+++ b/packages/sql-openapi/.snapshots/a2201917da7f38b2633837c006be92ea/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/0.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/1.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/1.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/2.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/2.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/3.json
+++ b/packages/sql-openapi/.snapshots/af9b0817988ce8131329f46740321f03/3.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/0.json
+++ b/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "name": {
@@ -44,7 +44,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {
@@ -60,7 +60,7 @@
             "nullable": true
           },
           "ownerId": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           }
         },

--- a/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/1.json
+++ b/packages/sql-openapi/.snapshots/be3d9376dd44dba954cfbe246063a0ff/1.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "name": {
@@ -21,7 +21,7 @@
             "nullable": true
           },
           "parentId": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           }
         },

--- a/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/0.json
+++ b/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/1.json
+++ b/packages/sql-openapi/.snapshots/d5e5acecfccc1e310df23a91a4c764ad/1.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "name": {

--- a/packages/sql-openapi/.snapshots/e68742984434a6b3af32e10666135459/0.json
+++ b/packages/sql-openapi/.snapshots/e68742984434a6b3af32e10666135459/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
+++ b/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
@@ -13,7 +13,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           },
           "title": {

--- a/packages/sql-openapi/index.js
+++ b/packages/sql-openapi/index.js
@@ -74,7 +74,7 @@ async function setupOpenAPI (app, opts) {
         ignore[entity.singularName] = true
       }
     }
-    const entitySchema = mapSQLEntityToJSONSchema(entity, ignore[entity.singularName], true)
+    const entitySchema = mapSQLEntityToJSONSchema(entity, ignore[entity.singularName], true, { output: true })
     // TODO remove reverseRelationships from the entity
     /* istanbul ignore next */
     entity.reverseRelationships = entity.reverseRelationships || []

--- a/packages/sql-openapi/lib/cursor.js
+++ b/packages/sql-openapi/lib/cursor.js
@@ -1,3 +1,4 @@
+import { mapSQLEntityToJSONSchema } from '@platformatic/sql-json-schema-mapper'
 import Ajv from 'ajv'
 import camelCase from 'camelcase'
 import fjs from 'fast-json-stringify'
@@ -20,13 +21,17 @@ const ajvOptions = {
 const ajv = new Ajv(ajvOptions)
 
 export function buildCursorUtils (app, entity) {
-  const entitySchema = app.getSchema(entity.name)
+  const responseSchema = app.getSchema(entity.name)
+  const nativeSchema = mapSQLEntityToJSONSchema(entity, {}, true)
+  const properties = Object.fromEntries(
+    Object.keys(responseSchema.properties).map(name => [name, nativeSchema.properties[name]])
+  )
   const cursorSchema = {
     $id: entity.name + 'Cursor',
-    title: entitySchema.title + ' Cursor',
-    description: entitySchema.description + ' cursor',
+    title: responseSchema.title + ' Cursor',
+    description: responseSchema.description + ' cursor',
     type: 'object',
-    properties: entitySchema.properties,
+    properties,
     additionalProperties: false
   }
   const validateCursor = ajv.compile(cursorSchema)

--- a/packages/sql-openapi/test/allow-primary-keys-in-input.test.js
+++ b/packages/sql-openapi/test/allow-primary-keys-in-input.test.js
@@ -90,7 +90,7 @@ test('allowPrimaryKeysInInput: false', async t => {
     same(
       res.json(),
       {
-        id: 1, // The passed in id is ignored
+        id: '1', // The passed in id is ignored
         title: 'Hello'
       },
       'POST /pages response'
@@ -140,7 +140,7 @@ test('allowPrimaryKeysInInput: true', async t => {
     same(
       res.json(),
       {
-        id: 42, // The passed in id is used
+        id: '42', // The passed in id is used
         title: 'Hello'
       },
       'POST /pages response'
@@ -188,7 +188,7 @@ test('allowPrimaryKeysInInput default', async t => {
     same(
       res.json(),
       {
-        id: 42, // The passed in id is used
+        id: '42', // The passed in id is used
         title: 'Hello'
       },
       'POST /pages response'

--- a/packages/sql-openapi/test/arrays.test.js
+++ b/packages/sql-openapi/test/arrays.test.js
@@ -50,7 +50,7 @@ test('expose arrays', { skip: !isPg }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello',
         tags: ['foo', 'bar']
       },
@@ -67,7 +67,7 @@ test('expose arrays', { skip: !isPg }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello',
         tags: ['foo', 'bar']
       },
@@ -85,7 +85,7 @@ test('expose arrays', { skip: !isPg }, async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Hello',
           tags: ['foo', 'bar']
         }
@@ -122,7 +122,7 @@ test('expose arrays', { skip: !isPg }, async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Hello',
           tags: ['foo', 'bar']
         }
@@ -141,7 +141,7 @@ test('expose arrays', { skip: !isPg }, async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Hello',
           tags: ['foo', 'bar']
         }
@@ -160,7 +160,7 @@ test('expose arrays', { skip: !isPg }, async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Hello',
           tags: ['foo', 'bar']
         }
@@ -182,7 +182,7 @@ test('expose arrays', { skip: !isPg }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello World',
         tags: ['foo', 'bar', 'baz']
       },
@@ -199,7 +199,7 @@ test('expose arrays', { skip: !isPg }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello World',
         tags: ['foo', 'bar', 'baz']
       },

--- a/packages/sql-openapi/test/composite.test.js
+++ b/packages/sql-openapi/test/composite.test.js
@@ -92,7 +92,7 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         theTitle: 'foobar'
       },
       'POST /pages response'
@@ -111,7 +111,7 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         username: 'mcollina'
       },
       'POST /users response'
@@ -130,7 +130,7 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        id: 2,
+        id: '2',
         username: 'lucamaraschi'
       },
       'POST /users response'
@@ -149,8 +149,8 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        userId: 1,
-        pageId: 1,
+        userId: '1',
+        pageId: '1',
         role: 'admin'
       },
       'POST /editors/page/1/user/1 response'
@@ -169,8 +169,8 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        userId: 2,
-        pageId: 1,
+        userId: '2',
+        pageId: '1',
         role: 'author'
       },
       'POST /editors/page/1/user/2 response'
@@ -187,8 +187,8 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        userId: 2,
-        pageId: 1,
+        userId: '2',
+        pageId: '1',
         role: 'author'
       },
       'GET /editors/page/1/user/2 response'
@@ -215,8 +215,8 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        userId: 1,
-        pageId: 1,
+        userId: '1',
+        pageId: '1',
         role: 'captain'
       },
       'POST /editors/page/1/user/1 response'
@@ -233,13 +233,13 @@ test('composite primary keys', async t => {
       res.json(),
       [
         {
-          userId: 1,
-          pageId: 1,
+          userId: '1',
+          pageId: '1',
           role: 'captain'
         },
         {
-          userId: 2,
-          pageId: 1,
+          userId: '2',
+          pageId: '1',
           role: 'author'
         }
       ],
@@ -257,8 +257,8 @@ test('composite primary keys', async t => {
       res.json(),
       [
         {
-          userId: 2,
-          pageId: 1,
+          userId: '2',
+          pageId: '1',
           role: 'author'
         }
       ],
@@ -275,8 +275,8 @@ test('composite primary keys', async t => {
     same(
       res.json(),
       {
-        userId: 2,
-        pageId: 1,
+        userId: '2',
+        pageId: '1',
         role: 'author'
       },
       'DELETE /editors/page/1/user/2 response'
@@ -351,8 +351,8 @@ test('composite primary keys withour relations', async t => {
     same(
       res.json(),
       {
-        userId: 1,
-        pageId: 1,
+        userId: '1',
+        pageId: '1',
         role: 'admin'
       },
       'POST /editors/pageId/1/userId/1 response'
@@ -371,8 +371,8 @@ test('composite primary keys withour relations', async t => {
     same(
       res.json(),
       {
-        userId: 2,
-        pageId: 1,
+        userId: '2',
+        pageId: '1',
         role: 'author'
       },
       'POST /editors/pageId/1/userId/2 response'
@@ -389,8 +389,8 @@ test('composite primary keys withour relations', async t => {
     same(
       res.json(),
       {
-        userId: 2,
-        pageId: 1,
+        userId: '2',
+        pageId: '1',
         role: 'author'
       },
       'GET /editors/pageId/1/userId/2 response'
@@ -417,8 +417,8 @@ test('composite primary keys withour relations', async t => {
     same(
       res.json(),
       {
-        userId: 1,
-        pageId: 1,
+        userId: '1',
+        pageId: '1',
         role: 'captain'
       },
       'POST /editors/pageId/1/userId/1 response'
@@ -435,13 +435,13 @@ test('composite primary keys withour relations', async t => {
       res.json(),
       [
         {
-          userId: 1,
-          pageId: 1,
+          userId: '1',
+          pageId: '1',
           role: 'captain'
         },
         {
-          userId: 2,
-          pageId: 1,
+          userId: '2',
+          pageId: '1',
           role: 'author'
         }
       ],
@@ -459,8 +459,8 @@ test('composite primary keys withour relations', async t => {
       res.json(),
       [
         {
-          userId: 2,
-          pageId: 1,
+          userId: '2',
+          pageId: '1',
           role: 'author'
         }
       ],
@@ -477,8 +477,8 @@ test('composite primary keys withour relations', async t => {
     same(
       res.json(),
       {
-        userId: 2,
-        pageId: 1,
+        userId: '2',
+        pageId: '1',
         role: 'author'
       },
       'DELETE /editors/pageId/1/userId/2 response'

--- a/packages/sql-openapi/test/cursor-pagination.test.js
+++ b/packages/sql-openapi/test/cursor-pagination.test.js
@@ -91,7 +91,7 @@ test('cursor pagination basics', async t => {
     })
     equal(res2.statusCode, 200, 'GET next page status code')
     same(res2.json().length, 3, 'Next page has 3 items')
-    same(res2.json()[0].id, 4, 'Next page starts with correct item')
+    same(res2.json()[0].id, '4', 'Next page starts with correct item')
 
     const res3 = await app.inject({
       method: 'GET',
@@ -153,7 +153,7 @@ test('cursor pagination basics', async t => {
     })
     equal(res2.statusCode, 200, 'GET next page with where condition status code')
     same(res2.json().length, 2, 'Next page has 2 items')
-    same(res2.json()[0].id, 3, 'Next page starts with correct item')
+    same(res2.json()[0].id, '3', 'Next page starts with correct item')
   }
 })
 
@@ -231,8 +231,8 @@ test('cursor pagination edge cases', async t => {
 
     equal(res1.json()[0].category, 'A', 'First item is category A')
     equal(res1.json()[1].category, 'A', 'Second item is category A')
-    equal(res1.json()[0].id, 2, 'First item ID is 2')
-    equal(res1.json()[1].id, 1, 'Second item ID is 1')
+    equal(res1.json()[0].id, '2', 'First item ID is 2')
+    equal(res1.json()[1].id, '1', 'Second item ID is 1')
 
     const startAfter = res1.headers['x-start-after']
     const res2 = await app.inject({
@@ -242,8 +242,8 @@ test('cursor pagination edge cases', async t => {
     equal(res2.statusCode, 200, 'Second page with category ordering')
     equal(res2.json()[0].category, 'B', 'First item is category B')
     equal(res2.json()[1].category, 'B', 'Second item is category B')
-    equal(res2.json()[0].id, 4, 'First item ID is 4')
-    equal(res2.json()[1].id, 3, 'Second item ID is 3')
+    equal(res2.json()[0].id, '4', 'First item ID is 4')
+    equal(res2.json()[1].id, '3', 'Second item ID is 3')
   }
 
   {
@@ -346,14 +346,14 @@ test('cursor pagination edge cases', async t => {
       url: `/items?limit=1&startAfter=${encodedCursor}&orderby.id=asc&&orderby.name=asc&orderby.category=asc`
     })
     equal(res.statusCode, 200, 'Valid cursor should return 200')
-    same(res.json()[0].id, wierdCursor.id + 1, 'Returned correct item')
+    same(res.json()[0].id, String(Number(wierdCursor.id) + 1), 'Returned correct item')
 
     const res1 = await app.inject({
       method: 'GET',
       url: `/items?limit=1&endBefore=${encodedCursor}&orderby.id=asc&&orderby.name=asc&orderby.category=asc`
     })
     equal(res1.statusCode, 200, 'Valid cursor should return 200')
-    same(res1.json()[0].id, wierdCursor.id - 1, 'Returned correct item')
+    same(res1.json()[0].id, String(Number(wierdCursor.id) - 1), 'Returned correct item')
   }
 
   // Both startAfter and endBefore provided. (startAfter should be used)
@@ -372,6 +372,6 @@ test('cursor pagination edge cases', async t => {
       url: `/items?limit=1&startAfter=${startAfter}&endBefore=${endBefore}&orderby.id=asc`
     })
     equal(res1.statusCode, 200)
-    same(res1.json()[0].id, lastItem.id + 1, 'Returned correct item')
+    same(res1.json()[0].id, String(Number(lastItem.id) + 1), 'Returned correct item')
   }
 })

--- a/packages/sql-openapi/test/explicit-include-2.test.js
+++ b/packages/sql-openapi/test/explicit-include-2.test.js
@@ -153,7 +153,7 @@ test('entity responds to traffic an entity in OpenAPI', async t => {
     deepEqual(
       res.json(),
       {
-        id: 123
+        id: '123'
       },
       'POST /categories response'
     )
@@ -172,6 +172,6 @@ test('entity responds to traffic an entity in OpenAPI', async t => {
       method: 'GET',
       url: '/categories/123'
     })
-    deepEqual(res.json(), { id: 123 })
+    deepEqual(res.json(), { id: '123' })
   }
 })

--- a/packages/sql-openapi/test/foreign-key-types.test.js
+++ b/packages/sql-openapi/test/foreign-key-types.test.js
@@ -1,0 +1,93 @@
+import sqlMapper from '@platformatic/sql-mapper'
+import fastify from 'fastify'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { test } from 'node:test'
+import sqlOpenAPI from '../index.js'
+import { clear, connInfo, isMysql, isSQLite } from './helper.js'
+
+test('numeric primary and referencing foreign keys are strings in REST output', async t => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+
+      if (isMysql) {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            contact_id INTEGER NOT NULL,
+            contact_code INTEGER NOT NULL,
+            FOREIGN KEY (contact_id) REFERENCES contacts(id),
+            FOREIGN KEY (contact_code) REFERENCES contacts(external_code)
+          );
+        `)
+      } else if (isSQLite) {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id INTEGER PRIMARY KEY,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id INTEGER PRIMARY KEY,
+            contact_id INTEGER NOT NULL REFERENCES contacts(id),
+            contact_code INTEGER NOT NULL REFERENCES contacts(external_code)
+          );
+        `)
+      } else {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id SERIAL PRIMARY KEY,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id SERIAL PRIMARY KEY,
+            contact_id INTEGER NOT NULL REFERENCES contacts(id),
+            contact_code INTEGER NOT NULL REFERENCES contacts(external_code)
+          );
+        `)
+      }
+    }
+  })
+  app.register(sqlOpenAPI)
+  t.after(() => app.close())
+
+  await app.ready()
+
+  const openapi = app.swagger()
+  strictEqual(openapi.components.schemas.Contact.properties.id.type, 'string')
+  strictEqual(openapi.components.schemas.ContactInput.properties.id.type, 'integer')
+  strictEqual(openapi.components.schemas.Registration.properties.id.type, 'string')
+  strictEqual(openapi.components.schemas.Registration.properties.contactId.type, 'string')
+  strictEqual(openapi.components.schemas.Registration.properties.contactCode.type, 'integer')
+  strictEqual(openapi.components.schemas.RegistrationInput.properties.id.type, 'integer')
+  strictEqual(openapi.components.schemas.RegistrationInput.properties.contactId.type, 'integer')
+  strictEqual(openapi.components.schemas.RegistrationInput.properties.contactCode.type, 'integer')
+
+  const contactResponse = await app.inject({
+    method: 'POST',
+    url: '/contacts',
+    body: { externalCode: 42 }
+  })
+  strictEqual(contactResponse.statusCode, 200, contactResponse.body)
+  deepStrictEqual(contactResponse.json(), { id: '1', externalCode: 42 })
+
+  const registrationResponse = await app.inject({
+    method: 'POST',
+    url: '/registrations',
+    body: { contactId: 1, contactCode: 42 }
+  })
+  strictEqual(registrationResponse.statusCode, 200, registrationResponse.body)
+  deepStrictEqual(registrationResponse.json(), { id: '1', contactId: '1', contactCode: 42 })
+
+  const getResponse = await app.inject({
+    method: 'GET',
+    url: '/registrations/1'
+  })
+  strictEqual(getResponse.statusCode, 200, getResponse.body)
+  deepStrictEqual(getResponse.json(), { id: '1', contactId: '1', contactCode: 42 })
+})

--- a/packages/sql-openapi/test/hooks.test.js
+++ b/packages/sql-openapi/test/hooks.test.js
@@ -97,7 +97,7 @@ test('basic hooks', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello from hook'
       },
       'POST /pages response'
@@ -124,7 +124,7 @@ test('basic hooks', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello from hook 2'
       },
       'PUT /pages/1 response'
@@ -183,7 +183,7 @@ test('delete hook', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'POST /pages response'
@@ -199,7 +199,7 @@ test('delete hook', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'DELETE /pages response'

--- a/packages/sql-openapi/test/multiple-table.test.js
+++ b/packages/sql-openapi/test/multiple-table.test.js
@@ -59,7 +59,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 1
+        id: '1'
       },
       'POST /owners response'
     )
@@ -77,7 +77,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 2
+        id: '2'
       },
       'POST /owners response'
     )
@@ -95,7 +95,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 3
+        id: '3'
       },
       'POST /owners response'
     )
@@ -115,9 +115,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 10,
-        field1: 1,
-        field2: 2
+        id: '10',
+        field1: '1',
+        field2: '2'
       },
       'POST /editors response'
     )
@@ -137,9 +137,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 20,
-        field1: 2,
-        field2: 3
+        id: '20',
+        field1: '2',
+        field2: '3'
       },
       'POST /editors response'
     )
@@ -159,9 +159,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 30,
-        field1: 3,
-        field2: 1
+        id: '30',
+        field1: '3',
+        field2: '1'
       },
       'POST /editors response'
     )
@@ -194,9 +194,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 1000,
-        field1: 1,
-        field2: 2
+        id: '1000',
+        field1: '1',
+        field2: '2'
       },
       'POST /posts response'
     )
@@ -216,9 +216,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 2000,
-        field1: 2,
-        field2: 3
+        id: '2000',
+        field1: '2',
+        field2: '3'
       },
       'POST /posts response'
     )
@@ -238,9 +238,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     same(
       res.json(),
       {
-        id: 3000,
-        field1: 3,
-        field2: 1
+        id: '3000',
+        field1: '3',
+        field2: '1'
       },
       'POST /posts response'
     )
@@ -265,7 +265,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
       url: '/owners'
     })
     equal(res.statusCode, 200)
-    same(res.json(), [{ id: 1 }, { id: 2 }, { id: 3 }])
+    same(res.json(), [{ id: '1' }, { id: '2' }, { id: '3' }])
   }
 
   {
@@ -275,7 +275,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 1
+      id: '1'
     })
   }
 
@@ -287,9 +287,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     equal(res.statusCode, 200)
     same(res.json(), [
       {
-        id: 10,
-        field1: 1,
-        field2: 2
+        id: '10',
+        field1: '1',
+        field2: '2'
       }
     ])
   }
@@ -302,9 +302,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     equal(res.statusCode, 200)
     same(res.json(), [
       {
-        id: 1000,
-        field1: 1,
-        field2: 2
+        id: '1000',
+        field1: '1',
+        field2: '2'
       }
     ])
   }
@@ -317,19 +317,19 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     equal(res.statusCode, 200)
     same(res.json(), [
       {
-        id: 10,
-        field1: 1,
-        field2: 2
+        id: '10',
+        field1: '1',
+        field2: '2'
       },
       {
-        id: 20,
-        field1: 2,
-        field2: 3
+        id: '20',
+        field1: '2',
+        field2: '3'
       },
       {
-        id: 30,
-        field1: 3,
-        field2: 1
+        id: '30',
+        field1: '3',
+        field2: '1'
       }
     ])
   }
@@ -341,9 +341,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 20,
-      field1: 2,
-      field2: 3
+      id: '20',
+      field1: '2',
+      field2: '3'
     })
   }
 
@@ -354,7 +354,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 1
+      id: '1'
     })
   }
 
@@ -365,7 +365,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 3
+      id: '3'
     })
   }
 
@@ -377,19 +377,19 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     equal(res.statusCode, 200)
     same(res.json(), [
       {
-        id: 1000,
-        field1: 1,
-        field2: 2
+        id: '1000',
+        field1: '1',
+        field2: '2'
       },
       {
-        id: 2000,
-        field1: 2,
-        field2: 3
+        id: '2000',
+        field1: '2',
+        field2: '3'
       },
       {
-        id: 3000,
-        field1: 3,
-        field2: 1
+        id: '3000',
+        field1: '3',
+        field2: '1'
       }
     ])
   }
@@ -401,9 +401,9 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 3000,
-      field1: 3,
-      field2: 1
+      id: '3000',
+      field1: '3',
+      field2: '1'
     })
   }
 
@@ -414,7 +414,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 2
+      id: '2'
     })
   }
 
@@ -425,7 +425,7 @@ test('multiple tables have foreign keys pointing to the same primary key', async
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 3
+      id: '3'
     })
   }
 })

--- a/packages/sql-openapi/test/nested.test.js
+++ b/packages/sql-openapi/test/nested.test.js
@@ -422,14 +422,14 @@ test('nested routes with recursive FK', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           name: 'Dad',
           parentId: null
         },
         {
-          id: 2,
+          id: '2',
           name: 'Child',
-          parentId: 1
+          parentId: '1'
         }
       ],
       'GET /people response'
@@ -445,7 +445,7 @@ test('nested routes with recursive FK', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         name: 'Dad',
         parentId: null
       },

--- a/packages/sql-openapi/test/or.test.js
+++ b/packages/sql-openapi/test/or.test.js
@@ -97,8 +97,8 @@ test('list', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Dog', longText: 'Foo' },
-        { id: 2, title: 'Cat', longText: 'Bar' }
+        { id: '1', title: 'Dog', longText: 'Foo' },
+        { id: '2', title: 'Cat', longText: 'Bar' }
       ],
       'GET /posts?where.or=(title.eq=Dog|title.eq=Cat)&fields=id,title,longText response'
     )
@@ -116,7 +116,7 @@ test('list', async t => {
     )
     same(
       res.json(),
-      [{ id: 1, title: 'Dog', longText: 'Foo' }],
+      [{ id: '1', title: 'Dog', longText: 'Foo' }],
       'GET /posts?where.or=(title.eq=Dog|title.eq=Cat)&where.id.eq=1&fields=id,title,longText response'
     )
   }
@@ -134,9 +134,9 @@ test('list', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Dog', longText: 'Foo' },
-        { id: 3, title: 'Mouse', longText: 'Baz' },
-        { id: 4, title: 'Duck', longText: 'A duck tale' }
+        { id: '1', title: 'Dog', longText: 'Foo' },
+        { id: '3', title: 'Mouse', longText: 'Baz' },
+        { id: '4', title: 'Duck', longText: 'A duck tale' }
       ],
       'GET /posts?where.or=(counter.eq=10|counter.gte=30)&fields=id,title,longText response'
     )
@@ -151,8 +151,8 @@ test('list', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Dog', longText: 'Foo' },
-        { id: 4, title: 'Duck', longText: 'A duck tale' }
+        { id: '1', title: 'Dog', longText: 'Foo' },
+        { id: '4', title: 'Duck', longText: 'A duck tale' }
       ],
       'GET /posts?where.or=(title.eq=Dog|title.eq=Duck)&fields=id,title,longText response'
     )
@@ -171,8 +171,8 @@ test('list', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Dog', longText: 'Foo' },
-        { id: 3, title: 'Mouse', longText: 'Baz' }
+        { id: '1', title: 'Dog', longText: 'Foo' },
+        { id: '3', title: 'Mouse', longText: 'Baz' }
       ],
       'GET /posts?where.or=(title.eq=Dog|longText.eq=Baz)&fields=id,title,longText response'
     )
@@ -190,7 +190,7 @@ test('list', async t => {
     )
     same(
       res.json(),
-      [{ id: 1, title: 'Dog', longText: 'Foo' }],
+      [{ id: '1', title: 'Dog', longText: 'Foo' }],
       'GET /posts?where.or=(title.eq=Dog|longText.eq=Baz)&where.counter.in=10,20&fields=id,title,longText response'
     )
   }
@@ -208,9 +208,9 @@ test('list', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Dog', longText: 'Foo' },
-        { id: 2, title: 'Cat', longText: 'Bar' },
-        { id: 3, title: 'Mouse', longText: 'Baz' }
+        { id: '1', title: 'Dog', longText: 'Foo' },
+        { id: '2', title: 'Cat', longText: 'Bar' },
+        { id: '3', title: 'Mouse', longText: 'Baz' }
       ],
       'GET /posts?where.or=(counter.in=10,20|counter.in=20,30)&fields=id,title,longText response'
     )
@@ -229,9 +229,9 @@ test('list', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Dog', longText: 'Foo' },
-        { id: 2, title: 'Cat', longText: 'Bar' },
-        { id: 3, title: 'Mouse', longText: 'Baz' }
+        { id: '1', title: 'Dog', longText: 'Foo' },
+        { id: '2', title: 'Cat', longText: 'Bar' },
+        { id: '3', title: 'Mouse', longText: 'Baz' }
       ],
       'GET /posts?where.or=(longText.in=Foo,Bar|longText.in=Bar,Baz)&fields=id,title,longText response'
     )

--- a/packages/sql-openapi/test/order_by.test.js
+++ b/packages/sql-openapi/test/order_by.test.js
@@ -50,9 +50,9 @@ test('one-level order by', async t => {
       { title: 'Page 3', counter: 1 }
     ]
     const expected = [
-      { id: 1, title: 'Page 1', counter: 3 },
-      { id: 2, title: 'Page 2', counter: 2 },
-      { id: 3, title: 'Page 3', counter: 1 }
+      { id: '1', title: 'Page 1', counter: 3 },
+      { id: '2', title: 'Page 2', counter: 2 },
+      { id: '3', title: 'Page 3', counter: 1 }
     ]
 
     for (const body of pages) {
@@ -75,9 +75,9 @@ test('one-level order by', async t => {
     same(
       res.json(),
       [
-        { id: 3, title: 'Page 3', counter: 1 },
-        { id: 2, title: 'Page 2', counter: 2 },
-        { id: 1, title: 'Page 1', counter: 3 }
+        { id: '3', title: 'Page 3', counter: 1 },
+        { id: '2', title: 'Page 2', counter: 2 },
+        { id: '1', title: 'Page 1', counter: 3 }
       ],
       'GET /pages?orderby.counter=asc response'
     )
@@ -92,9 +92,9 @@ test('one-level order by', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Page 1', counter: 3 },
-        { id: 2, title: 'Page 2', counter: 2 },
-        { id: 3, title: 'Page 3', counter: 1 }
+        { id: '1', title: 'Page 1', counter: 3 },
+        { id: '2', title: 'Page 2', counter: 2 },
+        { id: '3', title: 'Page 3', counter: 1 }
       ],
       'GET /pages?orderby.counter=desc response'
     )
@@ -182,9 +182,9 @@ test('list order by', async t => {
     same(
       res.json(),
       [
-        { id: 3, counter: 1, counter2: 1 },
-        { id: 1, counter: 3, counter2: 3 },
-        { id: 2, counter: 3, counter2: 2 }
+        { id: '3', counter: 1, counter2: 1 },
+        { id: '1', counter: 3, counter2: 3 },
+        { id: '2', counter: 3, counter2: 2 }
       ],
       'GET /pages?orderby.counter=asc&orderby.counter2=desc response'
     )

--- a/packages/sql-openapi/test/same-fk-name.test.js
+++ b/packages/sql-openapi/test/same-fk-name.test.js
@@ -49,7 +49,7 @@ test('same foreign keys with different names', async t => {
     same(
       res.json(),
       {
-        id: 1
+        id: '1'
       },
       'POST /owners response'
     )
@@ -67,7 +67,7 @@ test('same foreign keys with different names', async t => {
     same(
       res.json(),
       {
-        id: 2
+        id: '2'
       },
       'POST /owners response'
     )
@@ -85,7 +85,7 @@ test('same foreign keys with different names', async t => {
     same(
       res.json(),
       {
-        id: 3
+        id: '3'
       },
       'POST /owners response'
     )
@@ -104,8 +104,8 @@ test('same foreign keys with different names', async t => {
     same(
       res.json(),
       {
-        id: 10,
-        field: 1
+        id: '10',
+        field: '1'
       },
       'POST /editors response'
     )
@@ -124,8 +124,8 @@ test('same foreign keys with different names', async t => {
     same(
       res.json(),
       {
-        id: 20,
-        field: 2
+        id: '20',
+        field: '2'
       },
       'POST /editors response'
     )
@@ -144,8 +144,8 @@ test('same foreign keys with different names', async t => {
     same(
       res.json(),
       {
-        id: 30,
-        field: 3
+        id: '30',
+        field: '3'
       },
       'POST /editors response'
     )
@@ -169,7 +169,7 @@ test('same foreign keys with different names', async t => {
       url: '/owners'
     })
     equal(res.statusCode, 200)
-    same(res.json(), [{ id: 1 }, { id: 2 }, { id: 3 }])
+    same(res.json(), [{ id: '1' }, { id: '2' }, { id: '3' }])
   }
 
   {
@@ -179,7 +179,7 @@ test('same foreign keys with different names', async t => {
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 1
+      id: '1'
     })
   }
 
@@ -191,16 +191,16 @@ test('same foreign keys with different names', async t => {
     equal(res.statusCode, 200)
     same(res.json(), [
       {
-        id: 10,
-        field: 1
+        id: '10',
+        field: '1'
       },
       {
-        id: 20,
-        field: 2
+        id: '20',
+        field: '2'
       },
       {
-        id: 30,
-        field: 3
+        id: '30',
+        field: '3'
       }
     ])
   }
@@ -212,8 +212,8 @@ test('same foreign keys with different names', async t => {
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 20,
-      field: 2
+      id: '20',
+      field: '2'
     })
   }
 
@@ -224,7 +224,7 @@ test('same foreign keys with different names', async t => {
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 1
+      id: '1'
     })
   }
 
@@ -235,7 +235,7 @@ test('same foreign keys with different names', async t => {
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 1
+      id: '1'
     })
   }
 
@@ -246,7 +246,7 @@ test('same foreign keys with different names', async t => {
     })
     equal(res.statusCode, 200, 'the foreign key is duplicated, so an index has been automatically added')
     same(res.json(), {
-      id: 1
+      id: '1'
     })
   }
 
@@ -257,7 +257,7 @@ test('same foreign keys with different names', async t => {
     })
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 2
+      id: '2'
     })
   }
 
@@ -268,7 +268,7 @@ test('same foreign keys with different names', async t => {
     })
     equal(res.statusCode, 200, 'as in the test above, same fk, same result')
     same(res.json(), {
-      id: 2
+      id: '2'
     })
   }
 
@@ -280,8 +280,8 @@ test('same foreign keys with different names', async t => {
     equal(res.statusCode, 200)
     same(res.json(), [
       {
-        id: 20,
-        field: 2
+        id: '20',
+        field: '2'
       }
     ])
   }
@@ -294,8 +294,8 @@ test('same foreign keys with different names', async t => {
     equal(res.statusCode, 200)
     same(res.json(), [
       {
-        id: 10,
-        field: 1
+        id: '10',
+        field: '1'
       }
     ])
   }

--- a/packages/sql-openapi/test/schema.test.js
+++ b/packages/sql-openapi/test/schema.test.js
@@ -75,7 +75,7 @@ test('Simple rest API with different schemas', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'POST /test1Pages response'
@@ -91,7 +91,7 @@ test('Simple rest API with different schemas', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'GET /test1Pages/1 response'
@@ -110,7 +110,7 @@ test('Simple rest API with different schemas', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello World'
       },
       'POST /test1Pages/1 response'
@@ -130,9 +130,9 @@ test('Simple rest API with different schemas', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         username: 'user1',
-        pageId: 1
+        pageId: '1'
       },
       'POST /test2Users response'
     )
@@ -151,9 +151,9 @@ test('Simple rest API with different schemas', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 2,
+        id: '2',
         username: 'user2',
-        pageId: 1
+        pageId: '1'
       },
       'POST /test2Users response'
     )
@@ -170,14 +170,14 @@ test('Simple rest API with different schemas', { skip: isSQLite }, async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           username: 'user1',
-          pageId: 1
+          pageId: '1'
         },
         {
-          id: 2,
+          id: '2',
           username: 'user2',
-          pageId: 1
+          pageId: '1'
         }
       ],
       'GET /test1Pages/1 response'
@@ -193,7 +193,7 @@ test('Simple rest API with different schemas', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello World'
       },
       'GET /test2Users/2/page response'
@@ -272,7 +272,7 @@ test('composite primary keys with schema', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         theTitle: 'foobar'
       },
       'POST /test1Pages response'
@@ -291,7 +291,7 @@ test('composite primary keys with schema', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         username: 'mcollina'
       },
       'POST /test2users response'
@@ -310,7 +310,7 @@ test('composite primary keys with schema', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 2,
+        id: '2',
         username: 'lucamaraschi'
       },
       'POST /test2Users response'
@@ -329,8 +329,8 @@ test('composite primary keys with schema', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        userId: 1,
-        pageId: 1,
+        userId: '1',
+        pageId: '1',
         role: 'admin'
       },
       'POST /test1Editors/test1Page/1/test2User/1 response'
@@ -349,8 +349,8 @@ test('composite primary keys with schema', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        userId: 2,
-        pageId: 1,
+        userId: '2',
+        pageId: '1',
         role: 'author'
       },
       'POST /test1Editors/test1page/1/test2User/2 response'

--- a/packages/sql-openapi/test/simple.test.js
+++ b/packages/sql-openapi/test/simple.test.js
@@ -65,7 +65,7 @@ test('simple db, simple rest API', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'POST /pages response'
@@ -81,7 +81,7 @@ test('simple db, simple rest API', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'GET /pages/1 response'
@@ -100,7 +100,7 @@ test('simple db, simple rest API', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello World'
       },
       'PUT /pages/1 response'
@@ -116,7 +116,7 @@ test('simple db, simple rest API', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello World'
       },
       'GET /pages/1 response'
@@ -195,7 +195,7 @@ test('simple db, simple rest API', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello fields'
       },
       'GET /pages/1?fields=title&fields=id response'
@@ -211,7 +211,7 @@ test('simple db, simple rest API', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello fields'
       },
       'GET /pages/1?fields=title,id response'
@@ -229,7 +229,7 @@ test('simple db, simple rest API', async t => {
     equal(res.statusCode, 200, 'POST /pages?fields=id status code')
     equal(res.headers.location, '/pages/2', 'POST /pages?fields=id location')
     same(res.json(), {
-      id: 2,
+      id: '2',
     }, 'POST /pages?fields=id response')
   }
 
@@ -322,7 +322,7 @@ test('nullable fields', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: null
       },
       'POST /pages response'
@@ -675,7 +675,7 @@ test('PUT with an Id', async t => {
     })
     equal(res.statusCode, 200, 'PUT /pages/1 status code')
     same(res.json(), {
-      id: 1,
+      id: '1',
       title: 'Hello World'
     })
   }
@@ -719,7 +719,7 @@ test('delete', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'POST /pages response'
@@ -735,7 +735,7 @@ test('delete', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'DELETE /pages response'
@@ -906,7 +906,7 @@ test('expose the api with a prefix, if defined', async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         title: 'Hello'
       },
       'POST /pages response'
@@ -967,7 +967,7 @@ test('JSON type', { skip: !(isPg || isMysql8) }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         config: {
           foo: 'bar'
         }
@@ -991,7 +991,7 @@ test('JSON type', { skip: !(isPg || isMysql8) }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         config: {
           foo: 'bar',
           bar: 'foo'
@@ -1039,7 +1039,7 @@ test('BIGINT', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         counter: counter.toString()
       },
       'POST /simpleTypes response'
@@ -1055,7 +1055,7 @@ test('BIGINT', { skip: isSQLite }, async t => {
     same(
       res.json(),
       {
-        id: 1,
+        id: '1',
         counter: counter.toString()
       },
       'GET /simpleTypes response'

--- a/packages/sql-openapi/test/updateMany.test.js
+++ b/packages/sql-openapi/test/updateMany.test.js
@@ -111,13 +111,13 @@ test('updateMany', async t => {
       res.json(),
       [
         {
-          id: 3,
+          id: '3',
           title: 'Updated title',
           longText: 'Baz',
           counter: 30
         },
         {
-          id: 4,
+          id: '4',
           title: 'Updated title',
           longText: 'A duck tale',
           counter: 40
@@ -140,13 +140,13 @@ test('updateMany', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Updated long text (1)',
           counter: 10
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Updated long text (1)',
           counter: 20
@@ -169,13 +169,13 @@ test('updateMany', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Updated long text (2)',
           counter: 10
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Updated long text (2)',
           counter: 20
@@ -198,7 +198,7 @@ test('updateMany', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Kitten',
           longText: 'Updated long text (2)',
           counter: 20
@@ -221,7 +221,7 @@ test('updateMany', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat'
         }
       ],
@@ -242,13 +242,13 @@ test('updateMany', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Best pet friends',
           longText: 'Updated long text (2)',
           counter: 10
         },
         {
-          id: 2,
+          id: '2',
           title: 'Best pet friends',
           longText: 'Updated long text (2)',
           counter: 20
@@ -290,13 +290,13 @@ test('updateMany', async t => {
       res.json(),
       [
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null,
           counter: 99
         },
         {
-          id: 6,
+          id: '6',
           title: 'Goat',
           longText: null,
           counter: 99
@@ -320,25 +320,25 @@ test('updateMany', async t => {
       json.sort((recordA, recordB) => recordA.id - recordB.id),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Best pet friends',
           longText: 'Updated long text (2)',
           counter: 2
         },
         {
-          id: 2,
+          id: '2',
           title: 'Best pet friends',
           longText: 'Updated long text (2)',
           counter: 2
         },
         {
-          id: 3,
+          id: '3',
           title: 'Updated title',
           longText: 'Baz',
           counter: 2
         },
         {
-          id: 4,
+          id: '4',
           title: 'Updated title',
           longText: 'A duck tale',
           counter: 2

--- a/packages/sql-openapi/test/vector.test.js
+++ b/packages/sql-openapi/test/vector.test.js
@@ -96,7 +96,7 @@ test('expose vector columns as arrays of numbers', { skip: !isPg }, async t => {
 
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 1,
+      id: '1',
       embedding: [1, 2.5, 3]
     })
   }
@@ -121,7 +121,7 @@ test('expose vector columns as arrays of numbers', { skip: !isPg }, async t => {
 
     equal(res.statusCode, 200)
     same(res.json(), {
-      id: 1,
+      id: '1',
       embedding: [1, 2.5, 3]
     })
   }

--- a/packages/sql-openapi/test/where-or-field-name.test.js
+++ b/packages/sql-openapi/test/where-or-field-name.test.js
@@ -97,7 +97,7 @@ test('where clause with field names starting with "or" should not be confused wi
     equal(res.statusCode, 200, 'GET /products?where.orange.eq=citrus status code')
     same(
       res.json(),
-      [{ id: 2, name: 'Orange', orange: 'citrus' }],
+      [{ id: '2', name: 'Orange', orange: 'citrus' }],
       'GET /products?where.orange.eq=citrus response'
     )
   }
@@ -111,7 +111,7 @@ test('where clause with field names starting with "or" should not be confused wi
     equal(res.statusCode, 200, 'GET /products?where.orderCode.eq=ORD001 status code')
     same(
       res.json(),
-      [{ id: 1, name: 'Apple', orderCode: 'ORD001' }],
+      [{ id: '1', name: 'Apple', orderCode: 'ORD001' }],
       'GET /products?where.orderCode.eq=ORD001 response'
     )
   }
@@ -126,8 +126,8 @@ test('where clause with field names starting with "or" should not be confused wi
     same(
       res.json(),
       [
-        { id: 3, name: 'Carrot', organism: 'vegetable' },
-        { id: 4, name: 'Pumpkin', organism: 'vegetable' }
+        { id: '3', name: 'Carrot', organism: 'vegetable' },
+        { id: '4', name: 'Pumpkin', organism: 'vegetable' }
       ],
       'GET /products?where.organism.eq=vegetable response'
     )
@@ -143,9 +143,9 @@ test('where clause with field names starting with "or" should not be confused wi
     same(
       res.json(),
       [
-        { id: 2, name: 'Orange', orange: 'citrus' },
-        { id: 3, name: 'Carrot', orange: 'orange-color' },
-        { id: 4, name: 'Pumpkin', orange: 'orange-color' }
+        { id: '2', name: 'Orange', orange: 'citrus' },
+        { id: '3', name: 'Carrot', orange: 'orange-color' },
+        { id: '4', name: 'Pumpkin', orange: 'orange-color' }
       ],
       'GET /products?where.orange.in=orange-color,citrus response'
     )
@@ -161,8 +161,8 @@ test('where clause with field names starting with "or" should not be confused wi
     same(
       res.json(),
       [
-        { id: 1, name: 'Apple' },
-        { id: 2, name: 'Orange' }
+        { id: '1', name: 'Apple' },
+        { id: '2', name: 'Orange' }
       ],
       'GET /products?where.or=(name.eq=Apple|name.eq=Orange) response'
     )
@@ -181,7 +181,7 @@ test('where clause with field names starting with "or" should not be confused wi
     )
     same(
       res.json(),
-      [{ id: 2, name: 'Orange', orange: 'citrus', price: 150 }],
+      [{ id: '2', name: 'Orange', orange: 'citrus', price: 150 }],
       'GET /products?where.or=(price.eq=100|price.eq=150)&where.orange.eq=citrus response'
     )
   }
@@ -200,8 +200,8 @@ test('where clause with field names starting with "or" should not be confused wi
     same(
       res.json(),
       [
-        { id: 3, name: 'Carrot', orange: 'orange-color', organism: 'vegetable' },
-        { id: 4, name: 'Pumpkin', orange: 'orange-color', organism: 'vegetable' }
+        { id: '3', name: 'Carrot', orange: 'orange-color', organism: 'vegetable' },
+        { id: '4', name: 'Pumpkin', orange: 'orange-color', organism: 'vegetable' }
       ],
       'GET /products?where.orange.eq=orange-color&where.organism.eq=vegetable response'
     )
@@ -217,8 +217,8 @@ test('where clause with field names starting with "or" should not be confused wi
     same(
       res.json(),
       [
-        { id: 1, name: 'Apple', orderCode: 'ORD001' },
-        { id: 3, name: 'Carrot', orderCode: 'ORD003' }
+        { id: '1', name: 'Apple', orderCode: 'ORD001' },
+        { id: '3', name: 'Carrot', orderCode: 'ORD003' }
       ],
       'GET /products?where.orderCode.in=ORD001,ORD003 response'
     )

--- a/packages/sql-openapi/test/where.test.js
+++ b/packages/sql-openapi/test/where.test.js
@@ -103,27 +103,27 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -142,7 +142,7 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         }
@@ -162,7 +162,7 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         }
@@ -182,7 +182,7 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -202,7 +202,7 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -221,10 +221,10 @@ test('list', async t => {
     same(
       res.json(),
       [
-        { id: 1, title: 'Dog' },
-        { id: 2, title: 'Cat' },
-        { id: 3, title: 'Mouse' },
-        { id: 4, title: 'Duck' }
+        { id: '1', title: 'Dog' },
+        { id: '2', title: 'Cat' },
+        { id: '3', title: 'Mouse' },
+        { id: '4', title: 'Duck' }
       ],
       'GET /posts?where.longText.isNull=false response'
     )
@@ -241,22 +241,22 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         }
@@ -276,12 +276,12 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -301,27 +301,27 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -340,22 +340,22 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -374,22 +374,22 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -408,17 +408,17 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -437,17 +437,17 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -466,22 +466,22 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -500,12 +500,12 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -524,17 +524,17 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -553,12 +553,12 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -577,12 +577,12 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         }
@@ -602,27 +602,27 @@ test('list', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         },
         {
-          id: 5,
+          id: '5',
           title: 'Bear',
           longText: null
         }
@@ -871,22 +871,22 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         }
@@ -905,7 +905,7 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         }
@@ -924,17 +924,17 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         }
@@ -953,17 +953,17 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         }
@@ -982,17 +982,17 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -1011,17 +1011,17 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -1040,17 +1040,17 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         }
@@ -1069,12 +1069,12 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -1093,12 +1093,12 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -1117,12 +1117,12 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         }
@@ -1141,12 +1141,12 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         }
@@ -1166,22 +1166,22 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         },
         {
-          id: 3,
+          id: '3',
           title: 'Mouse',
           longText: 'Baz'
         },
         {
-          id: 4,
+          id: '4',
           title: 'Duck',
           longText: 'A duck tale'
         }
@@ -1200,12 +1200,12 @@ test('list with NOT NULL', async t => {
       res.json(),
       [
         {
-          id: 1,
+          id: '1',
           title: 'Dog',
           longText: 'Foo'
         },
         {
-          id: 2,
+          id: '2',
           title: 'Cat',
           longText: 'Bar'
         }


### PR DESCRIPTION
## Summary

- derive foreign-key output serialization from the exact referenced primary-key component
- align mapper output, generated TypeScript types, and OpenAPI response schemas while preserving native request, filter, path, and cursor types
- pair PostgreSQL composite foreign keys by ordinal position and keep references to numeric unique non-primary columns numeric
- update REST expectations, OpenAPI snapshots, and documentation for stringified numeric identifiers

## Test plan

- `packages/sql-mapper`: full SQLite, PostgreSQL, and MySQL 8 suites; type tests; lint
- `packages/sql-json-schema-mapper`: full SQLite, PostgreSQL, and MySQL 8 suites; lint
- `packages/sql-openapi`: full SQLite, PostgreSQL, and MySQL 8 suites; type tests; lint
- `packages/db`: generated-types tests and lint
- `pnpm lint:updated-only`
- `git diff --check`

MariaDB and the separate MySQL service were not run locally.

Closes #4972
