### PR TITLE
fix(node): skip asyncDispose on unbound HTTP servers

### DIFF
--- a/packages/node/lib/capability.js
+++ b/packages/node/lib/capability.js
@@ -313,6 +313,12 @@ export class NodeCapability extends BaseCapability {
     }
 
     if (this.#app?.[Symbol.asyncDispose]) {
+      // node:http.Server implements Symbol.asyncDispose(), but rejects with
+      // ERR_SERVER_NOT_RUNNING when a non-entrypoint server was never bound.
+      if (this.#app instanceof Server && !this.#server.listening) {
+        return
+      }
+
       return this.#app[Symbol.asyncDispose]()
     }
 

--- a/packages/node/test/closing.test.js
+++ b/packages/node/test/closing.test.js
@@ -83,6 +83,26 @@ test('should close a non-listening raw HTTP server', async t => {
   ok(!events.find(m => m.event === 'application:worker:exit:timeout'))
 })
 
+test('should log stop errors without hanging runtime close', async t => {
+  const { root, runtime } = await prepareRuntime(t, 'close-throws')
+  const eventsPromise = collectEvents(runtime)
+
+  await startRuntime(t, runtime)
+  await runtime.close()
+
+  const events = await eventsPromise
+  ok(events.find(m => m.event === 'application:worker:stop:error'))
+  ok(!events.find(m => m.event === 'application:worker:exit:timeout'))
+
+  const logs = await getLogsFromFile(root)
+  const stopErrorLog = logs.find(
+    m => m.level === 50 && m.msg?.includes('Failed to stop worker 0 of the application "frontend"')
+  )
+  ok(stopErrorLog)
+  strictEqual(stopErrorLog.err?.code, 'TEST_CLOSE_FAILED')
+  strictEqual(stopErrorLog.err?.message, 'boom while closing')
+})
+
 test('should invoke Symbol.asyncDispose for custom objects returned by create', async t => {
   const { root, runtime } = await prepareRuntime(t, 'close-standalone-with-custom-object-async-dispose')
   const url = await startRuntime(t, runtime)

--- a/packages/node/test/closing.test.js
+++ b/packages/node/test/closing.test.js
@@ -71,6 +71,18 @@ test('should invoke Symbol.asyncDispose on the app if defined', async t => {
   await checkWarningEmitted(root, false)
 })
 
+test('should close a non-listening raw HTTP server', async t => {
+  const { runtime } = await prepareRuntime(t, 'close-non-listening-server')
+  const eventsPromise = collectEvents(runtime)
+
+  await startRuntime(t, runtime)
+  await runtime.close()
+
+  const events = await eventsPromise
+  ok(!events.find(m => m.event === 'application:worker:stop:error'))
+  ok(!events.find(m => m.event === 'application:worker:exit:timeout'))
+})
+
 test('should invoke Symbol.asyncDispose for custom objects returned by create', async t => {
   const { root, runtime } = await prepareRuntime(t, 'close-standalone-with-custom-object-async-dispose')
   const url = await startRuntime(t, runtime)

--- a/packages/node/test/fixtures/close-non-listening-server/package.json
+++ b/packages/node/test/fixtures/close-non-listening-server/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "close-non-listening-server",
+  "private": true,
+  "workspaces": [
+    "services/*"
+  ]
+}

--- a/packages/node/test/fixtures/close-non-listening-server/platformatic.runtime.json
+++ b/packages/node/test/fixtures/close-non-listening-server/platformatic.runtime.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.62.2.json",
+  "entrypoint": "frontend",
+  "server": {
+    "port": 0
+  },
+  "gracefulShutdown": {
+    "application": 100
+  },
+  "services": [
+    {
+      "id": "frontend",
+      "path": "./services/frontend"
+    },
+    {
+      "id": "backend",
+      "path": "./services/backend"
+    }
+  ]
+}

--- a/packages/node/test/fixtures/close-non-listening-server/services/backend/index.js
+++ b/packages/node/test/fixtures/close-non-listening-server/services/backend/index.js
@@ -1,0 +1,11 @@
+import { getLogger } from '@platformatic/globals'
+import { createServer } from 'node:http'
+
+export function create () {
+  const logger = getLogger()
+
+  return createServer((_, res) => {
+    logger.debug('Serving request.')
+    res.end('ok')
+  })
+}

--- a/packages/node/test/fixtures/close-non-listening-server/services/backend/package.json
+++ b/packages/node/test/fixtures/close-non-listening-server/services/backend/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "@platformatic/globals": ">=3.0.0",
+    "@platformatic/node": ">=3.0.0"
+  }
+}

--- a/packages/node/test/fixtures/close-non-listening-server/services/backend/platformatic.application.json
+++ b/packages/node/test/fixtures/close-non-listening-server/services/backend/platformatic.application.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.62.2.json"
+}

--- a/packages/node/test/fixtures/close-non-listening-server/services/frontend/index.js
+++ b/packages/node/test/fixtures/close-non-listening-server/services/frontend/index.js
@@ -1,0 +1,7 @@
+import { createServer } from 'node:http'
+
+export function create () {
+  return createServer((_, res) => {
+    res.end('ok')
+  })
+}

--- a/packages/node/test/fixtures/close-non-listening-server/services/frontend/package.json
+++ b/packages/node/test/fixtures/close-non-listening-server/services/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "@platformatic/node": ">=3.0.0"
+  }
+}

--- a/packages/node/test/fixtures/close-non-listening-server/services/frontend/platformatic.application.json
+++ b/packages/node/test/fixtures/close-non-listening-server/services/frontend/platformatic.application.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.62.2.json"
+}

--- a/packages/node/test/fixtures/close-throws/package.json
+++ b/packages/node/test/fixtures/close-throws/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "close-throws",
+  "private": true,
+  "workspaces": [
+    "services/*"
+  ]
+}

--- a/packages/node/test/fixtures/close-throws/platformatic.runtime.json
+++ b/packages/node/test/fixtures/close-throws/platformatic.runtime.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.62.2.json",
+  "entrypoint": "frontend",
+  "server": {
+    "port": 0
+  },
+  "gracefulShutdown": {
+    "runtime": 2000,
+    "application": 1000
+  },
+  "logger": {
+    "level": "error"
+  },
+  "services": [
+    {
+      "id": "frontend",
+      "path": "./services/frontend"
+    }
+  ]
+}

--- a/packages/node/test/fixtures/close-throws/services/frontend/index.js
+++ b/packages/node/test/fixtures/close-throws/services/frontend/index.js
@@ -1,0 +1,23 @@
+import { createServer } from 'node:http'
+
+let server
+
+export function create () {
+  server = createServer((_, res) => {
+    res.end('ok')
+  })
+
+  return server
+}
+
+export async function close () {
+  // Close the bound server first so the worker can exit, then throw so the
+  // runtime stop path must log the error instead of swallowing it.
+  await new Promise((resolve, reject) => {
+    server.close(err => (err ? reject(err) : resolve()))
+  })
+
+  const error = new Error('boom while closing')
+  error.code = 'TEST_CLOSE_FAILED'
+  throw error
+}

--- a/packages/node/test/fixtures/close-throws/services/frontend/package.json
+++ b/packages/node/test/fixtures/close-throws/services/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "@platformatic/node": ">=3.0.0"
+  }
+}

--- a/packages/node/test/fixtures/close-throws/services/frontend/platformatic.application.json
+++ b/packages/node/test/fixtures/close-throws/services/frontend/platformatic.application.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.62.2.json"
+}

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -3003,7 +3003,7 @@ export class Runtime extends EventEmitter {
       await executeWithTimeout(sendViaITC(worker, 'stop', { force: !!this.error, dependents }), exitTimeout)
     } catch (error) {
       this.emitAndNotify('application:worker:stop:error', eventPayload)
-      this.logger.info({ error: ensureLoggableError(error) }, `Failed to stop ${label}. Killing a worker thread.`)
+      this.logger.error({ err: ensureLoggableError(error) }, `Failed to stop ${label}. Killing a worker thread.`)
     } finally {
       worker[kITC].notify('application:worker:stop:processed')
       // Wait for the processed message to be received

--- a/packages/runtime/lib/worker/itc.js
+++ b/packages/runtime/lib/worker/itc.js
@@ -183,7 +183,12 @@ export async function setupITC (controller, application, dispatcher, sharedConte
 
             // Reply to the runtime that the start failed, so it can cleanup
             once(itc, 'application:worker:start:processed').then(() => {
-              closeITC(dispatcher, itc, messaging).catch(() => {})
+              closeITC(dispatcher, itc, messaging).catch(err => {
+                logger.error(
+                  { err: ensureLoggableError(err) },
+                  'Failed to close the worker ITC after a failed start.'
+                )
+              })
             })
 
             throw ensureLoggableError(e)
@@ -199,23 +204,32 @@ export async function setupITC (controller, application, dispatcher, sharedConte
       },
 
       async stop ({ force, dependents }) {
-        const status = controller.getStatus()
+        try {
+          const status = controller.getStatus()
 
-        if (!force && status === 'starting') {
-          await once(controller, 'start')
+          if (!force && status === 'starting') {
+            await once(controller, 'start')
+          }
+
+          if (force || status.startsWith('start')) {
+            // This gives a chance to a capability to perform custom logic
+            const events = getEvents()
+            events.emit('stop')
+
+            await controller.stop(force, dependents)
+          }
+        } finally {
+          // Always schedule cleanup, even when stop throws. Otherwise the worker
+          // keeps open handles and runtime shutdown hangs until the grace timeout.
+          once(itc, 'application:worker:stop:processed').then(() => {
+            closeITC(dispatcher, itc, messaging).catch(err => {
+              logger.error(
+                { err: ensureLoggableError(err) },
+                'Failed to close the worker ITC after stop.'
+              )
+            })
+          })
         }
-
-        if (force || status.startsWith('start')) {
-          // This gives a chance to a capability to perform custom logic
-          const events = getEvents()
-          events.emit('stop')
-
-          await controller.stop(force, dependents)
-        }
-
-        once(itc, 'application:worker:stop:processed').then(() => {
-          closeITC(dispatcher, itc, messaging).catch(() => {})
-        })
       },
 
       async getDependencies () {


### PR DESCRIPTION
## Summary

- Non-entrypoint Node apps that return a raw `node:http.Server` are never bound.
- On Node 24, `Server[Symbol.asyncDispose]()` calls `close()` and rejects with `ERR_SERVER_NOT_RUNNING`.
- That rejection failed worker stop and left runtime shutdown hanging until `close-with-grace` timed out (`Could not close the runtime in 10000 ms`).

This skips `Symbol.asyncDispose()` when the app is an unbound HTTP `Server`, and adds a regression fixture/test covering start+close for that multi-app case.

## Test plan

- [x] Added `packages/node/test/fixtures/close-non-listening-server`
- [x] Added regression test asserting no `application:worker:stop:error` / exit timeout
- [x] Confirmed the new test fails without the guard and passes with it
- [x] Ran `packages/node/test/closing.test.js` (13 passing)
- [x] Reproduced original Ctrl-C failure against a wattpm sample app
