### PR TITLE
feat(foundation): configure the request-validation Ajv instance via `server.ajv`

### DIFF
--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -70,6 +70,7 @@ An object with the following settings:
 - **`disableRequestLogging`** (`boolean`) -- if `true`, the request logger will be disabled
 - **`exposeHeadRoutes`** (`boolean`) -- if `true`, the router will expose HEAD routes
 - **`serializerOpts`** (`object`) -- the [serializer options](https://www.fastify.io/docs/latest/Reference/Server/#serializeropts)
+- **`ajv`** (`object`) -- options for the [request-validation Ajv instance](https://www.fastify.io/docs/latest/Reference/Server/#ajv). Only `customOptions` is configurable from the configuration file (Ajv `plugins` take functions, which cannot be expressed in a configuration file).
 - **`requestIdHeader`** (`string` or `false`) -- the name of the header that will contain the request id
 - **`requestIdLogLabel`** (`string`) -- Defines the label used for the request identifier when logging the request. default: `'reqId'`
 - **`jsonShorthand`** (`boolean`) -- default: `true` -- visit [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#jsonshorthand) for more details
@@ -78,6 +79,18 @@ An object with the following settings:
 :::tip
 
 See the [fastify docs](https://www.fastify.io/docs/latest/Reference/Server) for more details.
+
+:::
+
+:::note
+
+Fastify enables Ajv type coercion (`coerceTypes: 'array'`) for request validation by
+default. On a body/query field that allows the `null` type alongside a non-string type
+(for example `number | null`), an empty string, `0` or `false` is coerced to `null`
+before validation runs, so such a value is accepted as `null` instead of being rejected
+(string-only fields are unaffected, because an empty string is already a valid string).
+Set `server.ajv.customOptions.coerceTypes` to `false` to opt out of this coercion for the
+whole service.
 
 :::
 

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -102,6 +102,14 @@ export interface PlatformaticComposerConfig {
       largeArrayMechanism?: "default" | "json-stringify";
       [k: string]: unknown;
     };
+    /**
+     * Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.
+     */
+    ajv?: {
+      customOptions?: {
+        [k: string]: unknown;
+      };
+    };
     caseSensitive?: boolean;
     requestIdHeader?: string | false;
     requestIdLogLabel?: string;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -317,6 +317,17 @@
             }
           }
         },
+        "ajv": {
+          "type": "object",
+          "description": "Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.",
+          "properties": {
+            "customOptions": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
         "caseSensitive": {
           "type": "boolean"
         },

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -119,6 +119,14 @@ export interface PlatformaticDatabaseConfig {
       largeArrayMechanism?: "default" | "json-stringify";
       [k: string]: unknown;
     };
+    /**
+     * Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.
+     */
+    ajv?: {
+      customOptions?: {
+        [k: string]: unknown;
+      };
+    };
     caseSensitive?: boolean;
     requestIdHeader?: string | false;
     requestIdLogLabel?: string;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -318,6 +318,17 @@
             }
           }
         },
+        "ajv": {
+          "type": "object",
+          "description": "Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.",
+          "properties": {
+            "customOptions": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
         "caseSensitive": {
           "type": "boolean"
         },

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -595,6 +595,18 @@ export const fastifyServer = {
         }
       }
     },
+    ajv: {
+      type: 'object',
+      description:
+        'Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.',
+      properties: {
+        customOptions: {
+          type: 'object',
+          additionalProperties: true
+        }
+      },
+      additionalProperties: false
+    },
     caseSensitive: {
       type: 'boolean'
     },

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -102,6 +102,14 @@ export interface PlatformaticGatewayConfig {
       largeArrayMechanism?: "default" | "json-stringify";
       [k: string]: unknown;
     };
+    /**
+     * Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.
+     */
+    ajv?: {
+      customOptions?: {
+        [k: string]: unknown;
+      };
+    };
     caseSensitive?: boolean;
     requestIdHeader?: string | false;
     requestIdLogLabel?: string;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -317,6 +317,17 @@
             }
           }
         },
+        "ajv": {
+          "type": "object",
+          "description": "Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.",
+          "properties": {
+            "customOptions": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
         "caseSensitive": {
           "type": "boolean"
         },

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -102,6 +102,14 @@ export interface PlatformaticServiceConfig {
       largeArrayMechanism?: "default" | "json-stringify";
       [k: string]: unknown;
     };
+    /**
+     * Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.
+     */
+    ajv?: {
+      customOptions?: {
+        [k: string]: unknown;
+      };
+    };
     caseSensitive?: boolean;
     requestIdHeader?: string | false;
     requestIdLogLabel?: string;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -317,6 +317,17 @@
             }
           }
         },
+        "ajv": {
+          "type": "object",
+          "description": "Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; for example set `customOptions.coerceTypes` to `false` to reject empty strings on fields that allow the `null` type instead of coercing them to `null`.",
+          "properties": {
+            "customOptions": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
         "caseSensitive": {
           "type": "boolean"
         },

--- a/packages/service/test/ajv-server-option.test.js
+++ b/packages/service/test/ajv-server-option.test.js
@@ -1,0 +1,85 @@
+import assert from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { buildConfig, createFromConfig } from './helper.js'
+
+const plugins = { paths: [join(import.meta.dirname, 'fixtures', 'ajv-coercion-plugin.js')] }
+
+test('server.ajv.customOptions configures the request-validation Ajv instance (coerceTypes off)', async t => {
+  const app = await createFromConfig(
+    t,
+    buildConfig({
+      server: {
+        hostname: '127.0.0.1',
+        port: 0,
+        logger: { level: 'fatal' },
+        ajv: { customOptions: { coerceTypes: false } }
+      },
+      plugins
+    })
+  )
+
+  t.after(async () => {
+    await app.stop()
+  })
+  await app.start({ listen: true })
+
+  const res = await request(`${app.url}/echo`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ capacity: '' })
+  })
+
+  // Without coercion the empty string is not a valid number and is rejected.
+  assert.strictEqual(res.statusCode, 400)
+})
+
+test('by default an empty string is coerced to null on a number|null field', async t => {
+  const app = await createFromConfig(
+    t,
+    buildConfig({
+      server: {
+        hostname: '127.0.0.1',
+        port: 0,
+        logger: { level: 'fatal' }
+      },
+      plugins
+    })
+  )
+
+  t.after(async () => {
+    await app.stop()
+  })
+  await app.start({ listen: true })
+
+  const res = await request(`${app.url}/echo`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ capacity: '' })
+  })
+
+  // Locks in (and documents) the current default: Fastify's Ajv coerces '' to
+  // null on a field that allows the null type, so validation passes as null.
+  assert.strictEqual(res.statusCode, 200)
+  const body = await res.body.json()
+  assert.strictEqual(body.capacity, null)
+})
+
+test('server.ajv rejects unknown keys at config-load time (additionalProperties: false)', async t => {
+  await assert.rejects(
+    createFromConfig(
+      t,
+      buildConfig({
+        server: {
+          hostname: '127.0.0.1',
+          port: 0,
+          logger: { level: 'fatal' },
+          ajv: { unknownKey: true }
+        }
+      }),
+      undefined,
+      { skipCleanup: true }
+    )
+  )
+})

--- a/packages/service/test/fixtures/ajv-coercion-plugin.js
+++ b/packages/service/test/fixtures/ajv-coercion-plugin.js
@@ -1,0 +1,19 @@
+export default async function (app) {
+  // `capacity` allows `number | null`. With Fastify's default Ajv coercion an
+  // empty string (which is not a valid number) is coerced to `null` before
+  // validation, so `{ "capacity": "" }` is silently accepted as `null`.
+  app.post(
+    '/echo',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            capacity: { type: ['number', 'null'] }
+          }
+        }
+      }
+    },
+    async request => ({ capacity: request.body.capacity })
+  )
+}


### PR DESCRIPTION
## Problem

Fastify's default request-validation Ajv options (from `@fastify/ajv-compiler`) enable type coercion:

https://github.com/fastify/ajv-compiler/blob/v4.0.5/lib/default-ajv-options.js#L5-L14

```js
module.exports = Object.freeze({
  coerceTypes: 'array',
  ...
})
```

With coercion on, Ajv rewrites `""` (and `0`, `false`) to `null` whenever a value does not match a listed type but the schema allows type `"null"` ([ajv `dataType.ts#L122-L125`](https://github.com/ajv-validator/ajv/blob/v8.18.0/lib/compile/validate/dataType.ts#L122-L125)):

```ts
case "null":
  gen.elseIf(_`${data} === "" || ${data} === 0 || ${data} === false`)
  gen.assign(coerced, null)
```

The practical consequence on any Platformatic service: a request-body field that allows `null` alongside a **non-string** type silently accepts an empty string as `null`. A `number | null` field is the common footgun:

```js
// body schema for one field, `capacity`:
{ type: ['number', 'null'] }
// or the equivalent TypeBox spelling, Type.Union([Type.Number(), Type.Null()])
{ anyOf: [{ type: 'number' }, { type: 'null' }] }
```

```
POST /... {"capacity":""}   →  200, handler receives capacity === null
```

The empty string is not a valid number, so Ajv falls through to the `null` branch and coerces it — the caller sent `""`, the handler sees `null`, indistinguishable from an explicit `null`. (String-only fields are unaffected: `""` is already a valid string, so no coercion happens and `minLength` still fires as expected. The surprise is specifically non-string null-unions.)

This is Fastify/Ajv behavior, not a Platformatic bug — but **Platformatic gives no way to adjust it.** The service capability spreads `config.server` straight into `fastify()`:

https://github.com/platformatic/platformatic/blob/d758e865909568a312a872a541160bd02ba4ef01/packages/service/lib/capability.js#L40-L46

(and `serverConfig` is just `deepmerge(context.serverConfig, config.server)` — [`packages/basic/lib/capability.js#L89`](https://github.com/platformatic/platformatic/blob/d758e865909568a312a872a541160bd02ba4ef01/packages/basic/lib/capability.js#L89)), so Fastify's [`ajv` server option](https://fastify.dev/docs/latest/Reference/Server/#ajv) would flow through — except the config schema does not include it and the `server` object is closed with `additionalProperties: false`, so setting it fails config validation. The only Ajv knob exposed today is `server.serializerOpts.ajv`, which configures the response serializer, not request validation.

The only way to tighten coercion today is dropping to Fastify internals (a custom `setValidatorCompiler` in an encapsulated plugin) — heavyweight for what is a one-line Ajv option, and out of reach of the config file that defines everything else about the server.

## What this PR does

Exposes Fastify's request-validation `ajv` option in the shared `server` config schema (`fastifyServer` in `packages/foundation/lib/schema.js`, which every capability with a Fastify server reuses). Runtime-wise it already works — the spread in `capability.js` forwards it — so this is **schema + generated types + docs only, no behavior code**:

```js
ajv: {
  type: 'object',
  description:
    'Options for the Fastify request-validation Ajv instance (the Fastify `ajv` server option). Only `customOptions` is configurable from the config file; ...',
  properties: {
    customOptions: { type: 'object', additionalProperties: true }
  },
  additionalProperties: false
}
```

Because the schema is shared, the regenerated `schema.json` + `config.d.ts` of `service`, `db`, `composer` and `gateway` are included. Users can then choose e.g. `coerceTypes: false` (strict bodies) per service without touching code.

Scope note: Fastify's `ajv.plugins` takes functions, which are not expressible in a JSON config file — so this exposes `customOptions` only and says so in the description. (If you'd want `plugins` too, that needs a module-resolution design; happy to follow up separately.)

Independently of the knob, this also adds a short note to the service configuration docs about the `""`/`0`/`false` → `null` coercion on null-allowing non-string fields — valuable even if the knob itself is rejected.

## Test plan

Integration tests in `packages/service/test/ajv-server-option.test.js` (config-driven server, POST body field `capacity: { type: ['number','null'] }`):

1. Service configured with `server.ajv.customOptions.coerceTypes: false` → POST `{"capacity":""}` returns **400** (no coercion).
2. Same service **without** the option → POST `{"capacity":""}` returns **200** with `capacity === null` (locks in AND documents the current default).
3. Config-validation: `server.ajv.unknownKey` fails config load (`additionalProperties: false` on the new object).

## Environment

- `@platformatic/service` / `@platformatic/foundation` 3.62.2 — defect present and permalinks pinned to current `main` `d758e865`.
- `fastify` 5.7.2, `@fastify/ajv-compiler` 4.0.5, `ajv` 8.18.0, Node.js 20+.
