### PR TITLE
fix(db): validate migration checksums by default, aligning with Postgrator

### DIFF
--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -382,6 +382,9 @@ export interface PlatformaticDatabaseConfig {
      * Table created to track schema version.
      */
     table?: string;
+    /**
+     * Validate the checksums of already-applied migrations before running new ones. Matches the default of the underlying Postgrator library.
+     */
     validateChecksums?: boolean;
     /**
      * Whether to automatically apply migrations when running the migrate command.

--- a/packages/db/lib/migrator.js
+++ b/packages/db/lib/migrator.js
@@ -10,7 +10,10 @@ export class Migrator {
     this.coreConfig = coreConfig
     this.migrationDir = migrationConfig.dir
     this.migrationsTable = migrationConfig.table
-    this.validateChecksums = migrationConfig.validateChecksums
+    // Default to true when unset, matching Postgrator's own default. Passing an
+    // explicit `undefined` here would override that default in Postgrator's
+    // `Object.assign` merge and silently disable checksum validation.
+    this.validateChecksums = migrationConfig.validateChecksums ?? true
     this.newline = migrationConfig.newline
     this.currentSchema = migrationConfig.currentSchema
 

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -400,7 +400,10 @@ export const migrations = {
       default: 'versions'
     },
     validateChecksums: {
-      type: 'boolean'
+      type: 'boolean',
+      default: true,
+      description:
+        'Validate the checksums of already-applied migrations before running new ones. Matches the default of the underlying Postgrator library.'
     },
     autoApply: {
       description: 'Whether to automatically apply migrations when running the migrate command.',

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1042,7 +1042,9 @@
           "default": "versions"
         },
         "validateChecksums": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": true,
+          "description": "Validate the checksums of already-applied migrations before running new ones. Matches the default of the underlying Postgrator library."
         },
         "autoApply": {
           "description": "Whether to automatically apply migrations when running the migrate command.",

--- a/packages/db/test/cli/migrate.1.test.js
+++ b/packages/db/test/cli/migrate.1.test.js
@@ -85,11 +85,11 @@ test('validate migration checksums', async t => {
   assert.equal(secondFound, true)
 })
 
-test('do not validate migration checksums if not configured', async t => {
+test('do not validate migration checksums if disabled', async t => {
   const { connectionInfo, dropTestDB } = await getConnectionInfo('postgresql')
   const db = await connectDB(connectionInfo)
 
-  const firstChild = execa('node', [startPath, getFixturesConfigFileLocation('auto-apply.json')], {
+  const firstChild = execa('node', [startPath, getFixturesConfigFileLocation('auto-apply-no-checksums.json')], {
     env: {
       DATABASE_URL: connectionInfo.connectionString
     }
@@ -100,7 +100,7 @@ test('do not validate migration checksums if not configured', async t => {
   const [message] = await once(firstOutput, 'data')
   assert.match(message, /(.*)running(.*)(001\.do\.sql)/)
 
-  const secondChild = execa('node', [startPath, getFixturesConfigFileLocation('auto-apply.json')], {
+  const secondChild = execa('node', [startPath, getFixturesConfigFileLocation('auto-apply-no-checksums.json')], {
     env: {
       DATABASE_URL: connectionInfo.connectionString
     }

--- a/packages/db/test/fixtures/auto-apply-no-checksums.json
+++ b/packages/db/test/fixtures/auto-apply-no-checksums.json
@@ -1,0 +1,19 @@
+{
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0,
+    "logger": {
+      "level": "info"
+    }
+  },
+  "db": {
+    "connectionString": "{DATABASE_URL}"
+  },
+  "migrations": {
+    "dir": "./migrations",
+    "table": "versions",
+    "autoApply": true,
+    "validateChecksums": false
+  },
+  "authorization": {}
+}

--- a/packages/db/test/migrate/validate-checksums.test.js
+++ b/packages/db/test/migrate/validate-checksums.test.js
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { Migrator } from '../../lib/migrator.js'
+import { getConnectionInfo } from '../helper.js'
+
+const nullLogger = { debug () {}, info () {}, warn () {}, error () {} }
+
+async function makeMigrationsDir (files) {
+  const dir = await mkdtemp(join(tmpdir(), 'plt-db-checksums-'))
+  for (const [name, content] of Object.entries(files)) {
+    await writeFile(join(dir, name), content)
+  }
+  return dir
+}
+
+const baseMigrations = {
+  '001.do.sql': 'CREATE TABLE test1 (id INTEGER);',
+  '001.undo.sql': 'DROP TABLE test1;'
+}
+
+test('validateChecksums defaults to true (no undefined leaks into Postgrator)', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('sqlite')
+  t.after(() => dropTestDB())
+
+  const migrationDir = await makeMigrationsDir(baseMigrations)
+  const migrator = new Migrator({ dir: migrationDir }, { connectionString: connectionInfo.connectionString }, nullLogger)
+  t.after(() => migrator.close())
+
+  await migrator.setupPostgrator()
+
+  // Before the fix this was `undefined`, which overrode Postgrator's own
+  // `true` default and silently disabled checksum validation.
+  assert.equal(migrator.postgrator.config.validateChecksums, true)
+})
+
+test('validateChecksums: false is still honoured (escape hatch)', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('sqlite')
+  t.after(() => dropTestDB())
+
+  const migrationDir = await makeMigrationsDir(baseMigrations)
+  const migrator = new Migrator(
+    { dir: migrationDir, validateChecksums: false },
+    { connectionString: connectionInfo.connectionString },
+    nullLogger
+  )
+  t.after(() => migrator.close())
+
+  await migrator.setupPostgrator()
+
+  assert.equal(migrator.postgrator.config.validateChecksums, false)
+})
+
+test('by default a changed already-applied migration fails with a checksum error', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('sqlite')
+  t.after(() => dropTestDB())
+  const coreConfig = { connectionString: connectionInfo.connectionString }
+
+  const migrationDir = await makeMigrationsDir(baseMigrations)
+
+  // Apply migration 001.
+  const first = new Migrator({ dir: migrationDir }, coreConfig, nullLogger)
+  await first.applyMigrations()
+  await first.close()
+
+  // Tamper the already-applied file and add a later migration so that
+  // Postgrator validates the applied history before running the new one.
+  await writeFile(join(migrationDir, '001.do.sql'), 'CREATE TABLE test1 (id INTEGER, name TEXT);')
+  await writeFile(join(migrationDir, '002.do.sql'), 'CREATE TABLE test2 (id INTEGER);')
+  await writeFile(join(migrationDir, '002.undo.sql'), 'DROP TABLE test2;')
+
+  const second = new Migrator({ dir: migrationDir }, coreConfig, nullLogger)
+  t.after(() => second.close())
+
+  await assert.rejects(second.applyMigrations(), /checksum/i)
+})
+
+test('with validateChecksums: false a changed already-applied migration is not flagged', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('sqlite')
+  t.after(() => dropTestDB())
+  const coreConfig = { connectionString: connectionInfo.connectionString }
+
+  const migrationDir = await makeMigrationsDir(baseMigrations)
+
+  const first = new Migrator({ dir: migrationDir, validateChecksums: false }, coreConfig, nullLogger)
+  await first.applyMigrations()
+  await first.close()
+
+  await writeFile(join(migrationDir, '001.do.sql'), 'CREATE TABLE test1 (id INTEGER, name TEXT);')
+  await writeFile(join(migrationDir, '002.do.sql'), 'CREATE TABLE test2 (id INTEGER);')
+  await writeFile(join(migrationDir, '002.undo.sql'), 'DROP TABLE test2;')
+
+  const second = new Migrator({ dir: migrationDir, validateChecksums: false }, coreConfig, nullLogger)
+  t.after(() => second.close())
+
+  await assert.doesNotReject(second.applyMigrations())
+})


### PR DESCRIPTION
## Problem

`@platformatic/db` reads `migrations.validateChecksums` from the config and passes it to Postgrator verbatim:

https://github.com/platformatic/platformatic/blob/d758e865909568a312a872a541160bd02ba4ef01/packages/db/lib/migrator.js#L67-L92

```js
this.postgrator = new Postgrator({
  ...
  validateChecksums: this.validateChecksums,   // undefined when not set in config
  ...
})
```

`this.validateChecksums` comes straight from the config with no default ([`migrator.js#L13`](https://github.com/platformatic/platformatic/blob/d758e865909568a312a872a541160bd02ba4ef01/packages/db/lib/migrator.js#L13)), and the config schema declares the option without one ([`schema.js#L402-L404`](https://github.com/platformatic/platformatic/blob/d758e865909568a312a872a541160bd02ba4ef01/packages/db/lib/schema.js#L402-L404)).

Postgrator itself defaults `validateChecksums` to **`true`** ([postgrator.js#L13-L16](https://github.com/rickbergfalk/postgrator/blob/v8.0.0/postgrator.js#L13-L16)), but its option merge is `Object.assign({}, DEFAULT_CONFIG, config)` ([#L21](https://github.com/rickbergfalk/postgrator/blob/v8.0.0/postgrator.js#L21)) — an explicitly present `undefined` key wins over the default. The validation gate ([#L271-L273](https://github.com/rickbergfalk/postgrator/blob/v8.0.0/postgrator.js#L271-L273)) then evaluates falsy:

```js
if (config.validateChecksums && data.targetVersion >= databaseVersion) {
  await this.validateMigrations(databaseVersion);
}
```

Net effect: unless a user explicitly sets `migrations.validateChecksums: true`, checksum validation is **off** when Postgrator is driven through `@platformatic/db` — the opposite of what the same Postgrator version does standalone. The `md5` column in the versions table is still written on every applied migration, it is just never compared. Nothing in the config schema or docs signals this inversion.

**Why it hurts** — checksum validation is the only guard tying the migration *files* to the migration *history* recorded in the database. With it silently off:

1. **A stale version row silently swallows a new migration.** We hit this concretely: a dev database had a leftover row for version `N` from an abandoned branch (same version number, different file content). A newly written migration `N` from the current branch was then skipped with no signal — `max(version)` looked right, but the column it should have created didn't exist, discovered only at runtime. With `validateChecksums` on, this exact case fails loudly at startup ("MD5 checksum failed for migration [N]", [postgrator.js#L177-L179](https://github.com/rickbergfalk/postgrator/blob/v8.0.0/postgrator.js#L177-L179)).
2. **Edits to already-applied migrations pass silently.** In a DB-per-tenant deployment the same migration history is applied to N databases at different times. If a migration file changes after some databases already ran it, the fleet silently diverges — some ran the old text, the rest the new one, and nothing ever reports the mismatch.

We only discovered validation was off during incident forensics — we had assumed the Postgrator default applied. Related prior art: #1326 (v0.33 era) asked for these Postgrator pass-through options to be documented; the option is in the schema today, but the effective default is still invisible.

## What this PR does

Treat unset as `true`, matching what the underlying library does standalone:

- `packages/db/lib/migrator.js` — `this.validateChecksums = migrationConfig.validateChecksums ?? true` (stops leaking `undefined` into Postgrator's merge).
- `packages/db/lib/schema.js` — add `default: true` + a `description` ("Validate checksums of applied migrations before running new ones. Matches Postgrator's default.").
- Regenerate `packages/db/schema.json` + `config.d.ts`.

**Behavior change / semver:** apps that (knowingly or not) edited an already-applied migration file will now fail at startup with "MD5 checksum failed". **That failure is the feature** — but it is a behavior change, so it warrants a minor/major note, and the escape hatch is `migrations.validateChecksums: false`.

## Test plan

New tests in `packages/db/test/migrate/validate-checksums.test.js` (SQLite-backed, no external database):

1. **Default state:** build a Migrator with a `migrations` config that omits `validateChecksums`; assert `postgrator.config.validateChecksums === true` — i.e. no `undefined` reaches Postgrator.
2. **Escape hatch (config):** `validateChecksums: false` → `postgrator.config.validateChecksums === false` (still honoured).
3. **Behavioral:** apply migration 001, rewrite the file's content, run `applyMigrations` again with a later migration present → rejects with a checksum error.
4. **Behavioral escape hatch:** the same tamper scenario with `validateChecksums: false` → does not reject.

## Environment

- `@platformatic/db` 3.62.2 — defect present on current `main` `d758e865` (`migrator.js` unchanged since 3.62.2; the `schema.js` block shifted +5 lines from an unrelated `schemalock.readOnly` addition — permalinks above are pinned to `d758e865`).
- `postgrator` 8.0.0, Node.js 20+.
