### PR TITLE
fix(gateway): name the offending application when a downstream OpenAPI schema is invalid

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -24,6 +24,10 @@
 
 **Message:** Fastify instance is already listening. Cannot call "addGatewayOnRouteHook"!
 
+### PLT_GATEWAY_INVALID_OPENAPI_SCHEMA
+
+**Message:** Failed to compose OpenAPI schemas: %s
+
 ### PLT_GATEWAY_PATH_ALREADY_EXISTS
 
 **Message:** Path "%s" already exists

--- a/packages/gateway/lib/errors.js
+++ b/packages/gateway/lib/errors.js
@@ -19,3 +19,7 @@ export const CouldNotReadOpenAPIConfigError = createError(
   `${ERROR_PREFIX}_COULD_NOT_READ_OPENAPI_CONFIG`,
   'Could not read openapi config for "%s" application'
 )
+export const InvalidOpenAPISchemaError = createError(
+  `${ERROR_PREFIX}_INVALID_OPENAPI_SCHEMA`,
+  'Failed to compose OpenAPI schemas: %s'
+)

--- a/packages/gateway/lib/openapi-generator.js
+++ b/packages/gateway/lib/openapi-generator.js
@@ -1,10 +1,11 @@
 import fastifyReplyFrom from '@fastify/reply-from'
 import fastifySwagger from '@fastify/swagger'
 import { getRuntimeBasePath } from '@platformatic/globals'
+import { Validator } from '@platformatic/openapi-schema-validator'
 import fp from 'fastify-plugin'
 import { readFile } from 'node:fs/promises'
 import { getGlobalDispatcher, request } from 'undici'
-import { CouldNotReadOpenAPIConfigError } from './errors.js'
+import { CouldNotReadOpenAPIConfigError, InvalidOpenAPISchemaError } from './errors.js'
 import { composeOpenApi } from './openapi-composer.js'
 import { loadOpenApiConfig } from './openapi-load-config.js'
 import { modifyOpenApiSchema, originPathSymbol } from './openapi-modifier.js'
@@ -51,6 +52,93 @@ function generateRenamedPath (renamedOpenApiPath, routeParams) {
   return renamedOpenApiPath.replace(/{(.*?)}/g, () => routeParams.shift())
 }
 
+const MAX_REPORTED_VALIDATION_ERRORS = 5
+
+function escapeJsonPointerToken (token) {
+  return token.replaceAll('~', '~0').replaceAll('/', '~1')
+}
+
+function findNullTypeConstructs (node, path = '#', found = []) {
+  if (node === null || typeof node !== 'object') {
+    return found
+  }
+
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      findNullTypeConstructs(node[i], `${path}/${i}`, found)
+    }
+    return found
+  }
+
+  if (node.type === 'null' || (Array.isArray(node.type) && node.type.includes('null'))) {
+    found.push(`${path}/type`)
+  }
+
+  for (const key of Object.keys(node)) {
+    findNullTypeConstructs(node[key], `${path}/${escapeJsonPointerToken(key)}`, found)
+  }
+
+  return found
+}
+
+function describeInvalidSchema (declaredVersion, errors, schema) {
+  // The most common reason a composed specification is rejected: the document
+  // declares OpenAPI 3.0.x but contains { "type": "null" }, which only exists
+  // in OpenAPI 3.1. Report the exact location instead of the raw Ajv errors,
+  // which only point at the enclosing anyOf/oneOf.
+  if (typeof declaredVersion === 'string' && declaredVersion.startsWith('3.0')) {
+    const nullTypes = findNullTypeConstructs(schema)
+
+    if (nullTypes.length > 0) {
+      return (
+        `the document declares OpenAPI ${declaredVersion} but uses "type": "null", which only exists in OpenAPI 3.1, ` +
+        `at ${nullTypes.join(', ')}. Replace it with "nullable": true or upgrade the document to OpenAPI 3.1.`
+      )
+    }
+  }
+
+  if (!Array.isArray(errors)) {
+    return String(errors)
+  }
+
+  const reported = errors.slice(0, MAX_REPORTED_VALIDATION_ERRORS).map(error => {
+    return `${error.instancePath || '#'} ${error.message}`
+  })
+
+  const remaining = errors.length - reported.length
+  if (remaining > 0) {
+    reported.push(`(${remaining} more errors)`)
+  }
+
+  return reported.join('; ')
+}
+
+async function findInvalidOpenApiSchemas (openApiSchemas, applications) {
+  const validator = new Validator()
+  const invalid = []
+
+  for (const { id, schema } of openApiSchemas) {
+    const result = await validator.validate(schema)
+
+    if (result.valid) {
+      continue
+    }
+
+    const application = applications.find(application => application.id === id)
+    const source = application?.openapi?.url
+      ? application.origin + prefixWithSlash(application.openapi.url)
+      : application?.openapi?.file
+    const declaredVersion = schema.openapi ?? schema.swagger
+
+    invalid.push(
+      `the schema of the "${id}" application (${source}) is not a valid OpenAPI document: ` +
+        describeInvalidSchema(declaredVersion, result.errors, schema)
+    )
+  }
+
+  return invalid
+}
+
 async function openApiGatewayPlugin (app, { opts, generated }) {
   const { apiByApiRoutes } = generated
 
@@ -61,7 +149,34 @@ async function openApiGatewayPlugin (app, { opts, generated }) {
     destroyAgent: false
   })
 
-  await app.register(await import('@platformatic/fastify-openapi-glue'), {
+  const openApiGlue = await import('@platformatic/fastify-openapi-glue')
+
+  try {
+    await registerOpenApiGlue(app, openApiGlue, opts, apiByApiRoutes)
+  } catch (error) {
+    // The glue rejects the whole composed specification with a generic error.
+    // Re-validate each downstream schema separately so the error names the
+    // application and the source of the invalid document.
+    const invalidSchemas = await findInvalidOpenApiSchemas(app.openApiSchemas, opts.applications)
+
+    if (invalidSchemas.length === 0) {
+      throw error
+    }
+
+    const invalidSchemaError = new InvalidOpenAPISchemaError(invalidSchemas.join('\n'))
+    invalidSchemaError.cause = error
+    throw invalidSchemaError
+  }
+
+  app.addHook('preValidation', async req => {
+    if (typeof req.query.fields === 'string') {
+      req.query.fields = req.query.fields.split(',')
+    }
+  })
+}
+
+async function registerOpenApiGlue (app, openApiGlue, opts, apiByApiRoutes) {
+  await app.register(openApiGlue, {
     specification: app.composedOpenApiSchema,
     addEmptySchema: opts.addEmptySchema,
     operationResolver: (operationId, method, openApiPath) => {
@@ -120,12 +235,6 @@ async function openApiGatewayPlugin (app, { opts, generated }) {
           reply.from(origin + newRoutePath, replyOptions)
         }
       }
-    }
-  })
-
-  app.addHook('preValidation', async req => {
-    if (typeof req.query.fields === 'string') {
-      req.query.fields = req.query.fields.split(',')
     }
   })
 }

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -57,6 +57,7 @@
     "@platformatic/foundation": "workspace:^",
     "@platformatic/globals": "workspace:*",
     "@platformatic/graphql-composer": "^0.11.0",
+    "@platformatic/openapi-schema-validator": "^3.0.0",
     "@platformatic/scalar-theme": "workspace:*",
     "@platformatic/service": "workspace:*",
     "@platformatic/telemetry": "workspace:*",

--- a/packages/gateway/test/openapi/invalid-schema.test.js
+++ b/packages/gateway/test/openapi/invalid-schema.test.js
@@ -1,0 +1,167 @@
+import fastify from 'fastify'
+import assert from 'node:assert/strict'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { createFromConfig, createOpenApiApplication } from '../helper.js'
+
+function buildSchemaWithNullType () {
+  // An OpenAPI 3.1-only construct ({ "type": "null" }) inside a document
+  // declared as 3.0.x. This is what TypeBox's Type.Union([X, Type.Null()])
+  // emits and it makes the whole composed specification invalid.
+  return {
+    openapi: '3.0.3',
+    info: { title: 'Bad API', version: '1.0.0' },
+    paths: {
+      '/capacity': {
+        get: {
+          operationId: 'getCapacity',
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      capacity: { anyOf: [{ type: 'number' }, { type: 'null' }] }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+async function writeSchemaFile (schema) {
+  const cwd = await mkdtemp(join(tmpdir(), 'gateway-'))
+  const schemaFile = join(cwd, 'bad-api.openapi.json')
+  await writeFile(schemaFile, JSON.stringify(schema))
+  return schemaFile
+}
+
+async function startGateway (t, applications) {
+  const capability = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: { applications }
+  })
+
+  await capability.start({ listen: true })
+}
+
+test('should name the offending application when a downstream schema file is invalid', async t => {
+  const schemaFile = await writeSchemaFile(buildSchemaWithNullType())
+
+  try {
+    await startGateway(t, [
+      {
+        id: 'bad-api',
+        origin: 'http://127.0.0.1:1',
+        openapi: {
+          file: schemaFile
+        }
+      }
+    ])
+    assert.fail('should throw error')
+  } catch (err) {
+    assert.equal(err.code, 'PLT_GATEWAY_INVALID_OPENAPI_SCHEMA')
+    assert.match(err.message, /the schema of the "bad-api" application/)
+    assert.ok(err.message.includes(schemaFile))
+    assert.match(err.message, /declares OpenAPI 3\.0\.3 but uses "type": "null"/)
+    assert.ok(err.message.includes('#/paths/~1capacity/get/responses/200/content/application~1json/schema/properties/capacity/anyOf/1/type'))
+    assert.match(err.message, /"nullable": true/)
+    assert.ok(err.cause)
+  }
+})
+
+test('should name the offending application when a downstream schema url is invalid', async t => {
+  const api = fastify({ keepAliveTimeout: 10, forceCloseConnections: true })
+  api.get('/documentation/json', async () => buildSchemaWithNullType())
+  await api.listen({ port: 0 })
+  t.after(() => api.close())
+
+  const origin = 'http://127.0.0.1:' + api.server.address().port
+
+  try {
+    await startGateway(t, [
+      {
+        id: 'bad-api',
+        origin,
+        openapi: {
+          url: '/documentation/json'
+        }
+      }
+    ])
+    assert.fail('should throw error')
+  } catch (err) {
+    assert.equal(err.code, 'PLT_GATEWAY_INVALID_OPENAPI_SCHEMA')
+    assert.match(err.message, /the schema of the "bad-api" application/)
+    assert.ok(err.message.includes(origin + '/documentation/json'))
+    assert.match(err.message, /declares OpenAPI 3\.0\.3 but uses "type": "null"/)
+  }
+})
+
+test('should only name the invalid applications when other schemas are valid', async t => {
+  const api = await createOpenApiApplication(t, ['users'])
+  await api.listen({ port: 0 })
+
+  const schemaFile = await writeSchemaFile(buildSchemaWithNullType())
+
+  try {
+    await startGateway(t, [
+      {
+        id: 'valid-api',
+        origin: 'http://127.0.0.1:' + api.server.address().port,
+        openapi: {
+          url: '/documentation/json'
+        }
+      },
+      {
+        id: 'bad-api',
+        origin: 'http://127.0.0.1:1',
+        openapi: {
+          file: schemaFile
+        }
+      }
+    ])
+    assert.fail('should throw error')
+  } catch (err) {
+    assert.equal(err.code, 'PLT_GATEWAY_INVALID_OPENAPI_SCHEMA')
+    assert.match(err.message, /the schema of the "bad-api" application/)
+    assert.ok(!err.message.includes('valid-api'))
+  }
+})
+
+test('should report the validation errors when the schema is invalid for other reasons', async t => {
+  const schema = buildSchemaWithNullType()
+  schema.paths['/capacity'].get.responses[200].content['application/json'].schema = {
+    type: 'not-a-type'
+  }
+  const schemaFile = await writeSchemaFile(schema)
+
+  try {
+    await startGateway(t, [
+      {
+        id: 'bad-api',
+        origin: 'http://127.0.0.1:1',
+        openapi: {
+          file: schemaFile
+        }
+      }
+    ])
+    assert.fail('should throw error')
+  } catch (err) {
+    assert.equal(err.code, 'PLT_GATEWAY_INVALID_OPENAPI_SCHEMA')
+    assert.match(err.message, /the schema of the "bad-api" application/)
+    assert.match(err.message, /\/paths\/~1capacity\/get\/responses\/200/)
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,6 +763,9 @@ importers:
       '@platformatic/graphql-composer':
         specifier: ^0.11.0
         version: 0.11.0
+      '@platformatic/openapi-schema-validator':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@platformatic/scalar-theme':
         specifier: workspace:*
         version: link:../scalar-theme


### PR DESCRIPTION
## Problem

When a gateway composes the OpenAPI schemas of its applications and one of them contains an invalid construct, the boot fails with a generic error that names neither the application nor the reason:

```
'specification' parameter must contain a valid version 2.0 or 3.0.x or 3.1.x specification
```

Under `@platformatic/runtime` this becomes a restart loop (the worker dies, gets restarted, dies again with the same one-liner) and the operator has no lead: nothing says which application's schema file or URL is the culprit, or what is wrong with it.

The most common way to hit this in practice: a downstream document declares `openapi: 3.0.x` but contains `{ "type": "null" }`, which only exists in OpenAPI 3.1. This is exactly what TypeBox emits for `Type.Union([Type.Number(), Type.Null()])`, so any TypeBox-based service can produce it — the document looks fine at a glance and the paradoxical message ("3.1.x is valid" — yet a 3.1 construct is rejected) sends the operator in the wrong direction.

Why the message is so poor: the gateway hands the **composed** document to `@platformatic/fastify-openapi-glue`, whose parser validates it, `console.log`s the detailed Ajv errors (bypassing the logger), and then throws the generic message above. Even if the operator finds the Ajv dump on stdout, the instance paths refer to the composed document, not to any application's source.

## What this PR does

Wraps the glue registration in `openApiGatewayPlugin` and, **only when it fails**, re-validates each downstream schema separately with `@platformatic/openapi-schema-validator` (the same validator the glue uses, promoted from transitive to direct dependency). The boot still fails, but now with an error that names the application, its schema source, and the reason:

```
Failed to compose OpenAPI schemas: the schema of the "bad-api" application (/opt/app/schemas/bad-api.openapi.json) is not a valid OpenAPI document: the document declares OpenAPI 3.0.3 but uses "type": "null", which only exists in OpenAPI 3.1, at #/paths/~1capacity/get/responses/200/content/application~1json/schema/properties/capacity/anyOf/1/type. Replace it with "nullable": true or upgrade the document to OpenAPI 3.1.
```

Specifics:

- New error code `PLT_GATEWAY_INVALID_OPENAPI_SCHEMA` (`Failed to compose OpenAPI schemas: %s`), with the original glue error attached as `cause`.
- The `type: "null"`-in-3.0.x case is detected explicitly and reported with the exact JSON Pointer(s) and remediation, because the raw Ajv errors for it only point at the enclosing `anyOf`/`oneOf` ("must match exactly one schema in oneOf") — technically true, practically useless.
- Any other invalid schema falls back to the Ajv errors (instance path + message, capped at 5).
- If every downstream schema is individually valid (i.e. the failure is not attributable to one application), the original error is rethrown unchanged.
- **The happy path is untouched**: no extra validation work on successful boots, and nothing that boots today stops booting — this only rewrites the error after the boot has already failed.

## Test plan

Four new tests in `packages/gateway/test/openapi/invalid-schema.test.js`:

1. file-sourced invalid schema → error names the application, the file path, the JSON Pointer of the `type: "null"` construct, and the remediation;
2. URL-sourced invalid schema → error names the application and the URL;
3. one valid + one invalid application → only the invalid one is named;
4. schema invalid for another reason (bogus `type` value) → Ajv errors with instance paths are reported.

Full `packages/gateway` suite (including `tstyche` type tests) is green locally.
