### PR TITLE
feat(runtime): issue a deployment version cookie for skew protection [WIP]

### DIFF
--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticAstroConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -28,6 +28,11 @@ export interface PlatformaticBasicConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -84,6 +84,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -196,6 +196,11 @@ export interface PlatformaticComposerConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -757,6 +757,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -526,6 +526,11 @@ export interface PlatformaticDatabaseConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1453,6 +1453,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -1048,6 +1048,28 @@ export const runtimeProperties = {
   basePath: {
     type: 'string'
   },
+  skewProtection: {
+    type: 'object',
+    default: {},
+    properties: {
+      // Pin a browser session to the deployment version that served it, by
+      // setting a cookie on the entrypoint's responses.
+      enabled: {
+        type: 'boolean',
+        default: false
+      },
+      cookieName: {
+        type: 'string',
+        default: '__plt_dpl'
+      },
+      maxAge: {
+        type: 'number',
+        minimum: 1,
+        default: 43200
+      }
+    },
+    additionalProperties: false
+  },
   autoload: {
     type: 'object',
     additionalProperties: false,

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -463,6 +463,11 @@ export interface PlatformaticGatewayConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1740,6 +1740,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticNestJSConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticNextJsConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticNodeJsConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticNuxtConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticReactRouterConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticRemixConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -29,6 +29,11 @@ export type PlatformaticRuntimeConfig = {
       )[];
   entrypoint?: string;
   basePath?: string;
+  skewProtection?: {
+    enabled?: boolean;
+    cookieName?: string;
+    maxAge?: number;
+  };
   autoload?: {
     path: string;
     exclude?: string[];

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -315,7 +315,7 @@ async function main () {
   const sharedContext = new SharedContext()
 
   if (applicationConfig.entrypoint) {
-    const skewConfig = resolveSkewConfig(process.env)
+    const skewConfig = resolveSkewConfig(runtimeConfig.skewProtection)
     if (skewConfig) {
       const getVersion = createVersionResolver(sharedContext, process.env)
       installSkewProtection({ ...skewConfig, getVersion, basePath: runtimeConfig.basePath })

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -25,6 +25,7 @@ import { Controller } from './controller.js'
 import { initHealthSignalsApi, startEventLoopDelayMonitor } from './health-signals.js'
 import { setDispatcher } from './interceptors.js'
 import { setupITC } from './itc.js'
+import { createVersionResolver, installSkewProtection, resolveSkewConfig } from './skew-protection.js'
 import { SharedContext } from './shared-context.js'
 import { kStderrMarker } from './symbols.js'
 
@@ -312,6 +313,15 @@ async function main () {
   }
 
   const sharedContext = new SharedContext()
+
+  if (applicationConfig.entrypoint) {
+    const skewConfig = resolveSkewConfig(process.env)
+    if (skewConfig) {
+      const getVersion = createVersionResolver(sharedContext, process.env)
+      installSkewProtection({ ...skewConfig, getVersion, basePath: runtimeConfig.basePath })
+      logger.info({ deploymentVersion: getVersion() }, 'Skew protection enabled: pinning sessions to this deployment version')
+    }
+  }
   // Limit the amount of methods a user can call
   updateGlobals({
     sharedContext: {

--- a/packages/runtime/lib/worker/shared-context.js
+++ b/packages/runtime/lib/worker/shared-context.js
@@ -18,6 +18,17 @@ export class SharedContext {
     return this.sharedContext
   }
 
+  // The context as it stands, without awaiting. get() caches a promise on its
+  // first call, so only an already-delivered context is readable here; callers
+  // that cannot await (a diagnostics channel subscriber, for one) get null until
+  // the first update arrives.
+  getSync () {
+    if (this.sharedContext === null || typeof this.sharedContext.then === 'function') {
+      return null
+    }
+    return this.sharedContext
+  }
+
   _set (context) {
     this.sharedContext = context
   }

--- a/packages/runtime/lib/worker/skew-protection.js
+++ b/packages/runtime/lib/worker/skew-protection.js
@@ -6,12 +6,12 @@ export const DEFAULT_COOKIE_NAME = '__plt_dpl'
 export const DEFAULT_COOKIE_MAX_AGE = 43200
 const PREVIEW_HEADER = 'x-deployment-id'
 
-export function resolveSkewConfig (env) {
-  if (env.PLT_SKEW_PROTECTION !== 'true') return null
+export function resolveSkewConfig (config) {
+  if (!config?.enabled) return null
 
-  const maxAge = Number(env.PLT_SKEW_COOKIE_MAX_AGE)
+  const maxAge = Number(config.maxAge)
   return {
-    cookieName: env.PLT_SKEW_COOKIE_NAME || DEFAULT_COOKIE_NAME,
+    cookieName: config.cookieName || DEFAULT_COOKIE_NAME,
     maxAge: maxAge > 0 ? maxAge : DEFAULT_COOKIE_MAX_AGE
   }
 }

--- a/packages/runtime/lib/worker/skew-protection.js
+++ b/packages/runtime/lib/worker/skew-protection.js
@@ -1,0 +1,105 @@
+import { subscribe } from 'node:diagnostics_channel'
+
+// Skew protection pins a browser session to one deployment version.
+
+export const DEFAULT_COOKIE_NAME = '__plt_dpl'
+export const DEFAULT_COOKIE_MAX_AGE = 43200
+const PREVIEW_HEADER = 'x-deployment-id'
+
+export function resolveSkewConfig (env) {
+  if (env.PLT_SKEW_PROTECTION !== 'true') return null
+
+  const maxAge = Number(env.PLT_SKEW_COOKIE_MAX_AGE)
+  return {
+    cookieName: env.PLT_SKEW_COOKIE_NAME || DEFAULT_COOKIE_NAME,
+    maxAge: maxAge > 0 ? maxAge : DEFAULT_COOKIE_MAX_AGE
+  }
+}
+
+export function createVersionResolver (sharedContext, env) {
+  return function currentVersion () {
+    return sharedContext?.getSync()?.deploymentVersion || env.PLT_DEPLOYMENT_VERSION || null
+  }
+}
+
+function hasCookie (cookieHeader, name) {
+  if (!cookieHeader) return false
+
+  for (const pair of String(cookieHeader).split(';')) {
+    const eq = pair.indexOf('=')
+    if (eq !== -1 && pair.slice(0, eq).trim() === name) return true
+  }
+  return false
+}
+
+// An instance knows its own version but not whether it is the active one, so
+// the decision is made from the request alone.
+export function shouldIssueCookie (headers, cookieName) {
+  // A preview request names its version explicitly and must not pin the browser
+  // to it; the Gateway's preview rule sets no cookie either.
+  if (headers[PREVIEW_HEADER]) return false
+
+  // An existing pin is never refreshed. A draining version only ever receives
+  // requests that are already pinned to it, so refreshing would extend its own
+  // pin on every request and it could never finish draining.
+  return !hasCookie(headers.cookie, cookieName)
+}
+
+export function buildCookie ({ cookieName, version, path, maxAge }) {
+  return `${cookieName}=${version}; Path=${path}; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`
+}
+
+function appendSetCookie (response, headers, cookie) {
+  // writeHead's own headers win over anything set earlier, so when the caller
+  // passes set-cookie there it has to be appended in place.
+  if (headers) {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === 'set-cookie') {
+        const existing = headers[key]
+        headers[key] = Array.isArray(existing) ? [...existing, cookie] : [existing, cookie]
+        return
+      }
+    }
+  }
+
+  const existing = response.getHeader('set-cookie')
+  if (existing === undefined) {
+    response.setHeader('set-cookie', cookie)
+  } else {
+    response.setHeader('set-cookie', Array.isArray(existing) ? [...existing, cookie] : [existing, cookie])
+  }
+}
+
+// Works on the raw response rather than through a Fastify hook, because an
+// entrypoint can be any capability (node, next, astro) with its own server.
+//
+// The cookie is appended at writeHead rather than set here, because a header set
+// this early is silently dropped: writeHead's own headers replace same-named ones
+// set beforehand, so any app that sets its own cookie would erase this one. Only
+// the response instance is patched -- the prototype is left alone, so nothing
+// leaks to other servers in this worker.
+export function installSkewProtection ({ getVersion, cookieName, maxAge, basePath }) {
+  const path = basePath || '/'
+
+  subscribe('http.server.request.start', ({ request, response }) => {
+    if (!shouldIssueCookie(request.headers, cookieName)) return
+
+    const version = getVersion()
+    if (!version) return
+
+    const cookie = buildCookie({ cookieName, version, path, maxAge })
+    const originWriteHead = response.writeHead
+
+    // Every response reaches writeHead: explicitly, or through _implicitHeader
+    // when the handler only calls end().
+    response.writeHead = function (statusCode, statusMessage, headers) {
+      if (headers === undefined && typeof statusMessage === 'object' && statusMessage !== null) {
+        headers = statusMessage
+        statusMessage = undefined
+      }
+
+      appendSetCookie(this, headers, cookie)
+      return originWriteHead.call(this, statusCode, statusMessage, headers)
+    }
+  })
+}

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -81,6 +81,26 @@
     "basePath": {
       "type": "string"
     },
+    "skewProtection": {
+      "type": "object",
+      "default": {},
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "cookieName": {
+          "type": "string",
+          "default": "__plt_dpl"
+        },
+        "maxAge": {
+          "type": "number",
+          "minimum": 1,
+          "default": 43200
+        }
+      },
+      "additionalProperties": false
+    },
     "autoload": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/runtime/test/skew-protection-http.test.js
+++ b/packages/runtime/test/skew-protection-http.test.js
@@ -1,0 +1,134 @@
+import assert from 'node:assert'
+import http from 'node:http'
+import { after, test } from 'node:test'
+import { installSkewProtection } from '../lib/worker/skew-protection.js'
+
+// installSkewProtection subscribes once per process, so every server in this
+// file shares one installation, which is also how it runs in a worker.
+let currentVersion = 'v3'
+installSkewProtection({
+  getVersion: () => currentVersion,
+  cookieName: '__plt_dpl',
+  maxAge: 43200,
+  basePath: null
+})
+
+const servers = []
+
+function startServer (handler) {
+  const server = http.createServer(handler)
+  servers.push(server)
+  return new Promise(resolve => {
+    server.listen(0, () => resolve(`http://127.0.0.1:${server.address().port}`))
+  })
+}
+
+after(() => {
+  for (const server of servers) server.close()
+})
+
+test('a first-time visitor is pinned to this deployment version', async () => {
+  const url = await startServer((req, res) => res.end('ok'))
+  const response = await fetch(url)
+
+  assert.deepStrictEqual(response.headers.getSetCookie(), [
+    '__plt_dpl=v3; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=43200'
+  ])
+})
+
+test('an application cookie set through writeHead is not replaced by ours', async () => {
+  // Setting the header at request start loses this race: writeHead's headers
+  // replace anything set earlier, so the pin would silently disappear.
+  const url = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain', 'set-cookie': 'session=abc' })
+    res.end('ok')
+  })
+
+  const cookies = (await fetch(url)).headers.getSetCookie()
+  assert.strictEqual(cookies.length, 2)
+  assert.ok(cookies.includes('session=abc'))
+  assert.ok(cookies.some(c => c.startsWith('__plt_dpl=v3')))
+})
+
+test('an application cookie set through setHeader is not replaced by ours', async () => {
+  const url = await startServer((req, res) => {
+    res.setHeader('set-cookie', 'session=abc')
+    res.end('ok')
+  })
+
+  const cookies = (await fetch(url)).headers.getSetCookie()
+  assert.strictEqual(cookies.length, 2)
+  assert.ok(cookies.includes('session=abc'))
+  assert.ok(cookies.some(c => c.startsWith('__plt_dpl=v3')))
+})
+
+test('several application cookies are all preserved alongside ours', async () => {
+  const url = await startServer((req, res) => {
+    res.setHeader('set-cookie', ['a=1', 'b=2'])
+    res.end('ok')
+  })
+
+  const cookies = (await fetch(url)).headers.getSetCookie()
+  assert.deepStrictEqual(cookies.slice(0, 2), ['a=1', 'b=2'])
+  assert.ok(cookies[2].startsWith('__plt_dpl=v3'))
+})
+
+test('an already pinned visitor is left alone so a draining version can drain', async () => {
+  const url = await startServer((req, res) => res.end('ok'))
+  const response = await fetch(url, { headers: { cookie: '__plt_dpl=v1' } })
+
+  assert.deepStrictEqual(response.headers.getSetCookie(), [])
+})
+
+test('a preview request is never pinned to the version it previews', async () => {
+  const url = await startServer((req, res) => res.end('ok'))
+  const response = await fetch(url, { headers: { 'x-deployment-id': 'v9' } })
+
+  assert.deepStrictEqual(response.headers.getSetCookie(), [])
+})
+
+test('a redirect still carries the pin', async () => {
+  const url = await startServer((req, res) => {
+    res.writeHead(302, { location: '/elsewhere' })
+    res.end()
+  })
+
+  const response = await fetch(url, { redirect: 'manual' })
+  assert.strictEqual(response.status, 302)
+  assert.ok(response.headers.getSetCookie().some(c => c.startsWith('__plt_dpl=v3')))
+})
+
+test('a streamed response still carries the pin', async () => {
+  const url = await startServer((req, res) => {
+    res.write('chunk one')
+    res.write('chunk two')
+    res.end()
+  })
+
+  const response = await fetch(url)
+  assert.ok(response.headers.getSetCookie().some(c => c.startsWith('__plt_dpl=v3')))
+  assert.strictEqual(await response.text(), 'chunk onechunk two')
+})
+
+test('nothing is pinned until a version is assigned a version', async () => {
+  const url = await startServer((req, res) => res.end('ok'))
+
+  currentVersion = null
+  try {
+    assert.deepStrictEqual((await fetch(url)).headers.getSetCookie(), [])
+  } finally {
+    currentVersion = 'v3'
+  }
+})
+
+test('a version arriving after boot is picked up without a restart', async () => {
+  const url = await startServer((req, res) => res.end('ok'))
+
+  currentVersion = 'v4'
+  try {
+    const cookies = (await fetch(url)).headers.getSetCookie()
+    assert.ok(cookies.some(c => c.startsWith('__plt_dpl=v4')))
+  } finally {
+    currentVersion = 'v3'
+  }
+})

--- a/packages/runtime/test/skew-protection.test.js
+++ b/packages/runtime/test/skew-protection.test.js
@@ -1,5 +1,7 @@
 import assert from 'node:assert'
+import { join } from 'node:path'
 import { test } from 'node:test'
+import { loadConfiguration } from '../index.js'
 import { SharedContext } from '../lib/worker/shared-context.js'
 import {
   DEFAULT_COOKIE_MAX_AGE,
@@ -10,15 +12,26 @@ import {
   shouldIssueCookie
 } from '../lib/worker/skew-protection.js'
 
-test('skew protection stays off unless the flag is set', () => {
+test('the schema supplies the defaults, so a config that says nothing leaves it off', async () => {
+  const config = await loadConfiguration(join(import.meta.dirname, '..', 'fixtures', 'configs', 'monorepo.json'))
+
+  assert.deepStrictEqual(config.skewProtection, {
+    enabled: false,
+    cookieName: DEFAULT_COOKIE_NAME,
+    maxAge: DEFAULT_COOKIE_MAX_AGE
+  })
+  assert.strictEqual(resolveSkewConfig(config.skewProtection), null)
+})
+
+test('skew protection stays off unless it is enabled', () => {
+  assert.strictEqual(resolveSkewConfig(undefined), null)
   assert.strictEqual(resolveSkewConfig({}), null)
-  assert.strictEqual(resolveSkewConfig({ PLT_DEPLOYMENT_VERSION: 'v1' }), null)
-  // Anything other than the exact string is off, so a stray value cannot enable it.
-  assert.strictEqual(resolveSkewConfig({ PLT_SKEW_PROTECTION: '1' }), null)
+  assert.strictEqual(resolveSkewConfig({ enabled: false }), null)
+  assert.strictEqual(resolveSkewConfig({ cookieName: '__custom' }), null)
 })
 
 test('skew protection defaults the cookie name and lifetime', () => {
-  assert.deepStrictEqual(resolveSkewConfig({ PLT_SKEW_PROTECTION: 'true' }), {
+  assert.deepStrictEqual(resolveSkewConfig({ enabled: true }), {
     cookieName: DEFAULT_COOKIE_NAME,
     maxAge: DEFAULT_COOKIE_MAX_AGE
   })
@@ -53,12 +66,12 @@ test('a pending shared context read is not mistaken for a version', () => {
 })
 
 test('the cookie name and max age can be overridden, and bad values fall back', () => {
-  const base = { PLT_SKEW_PROTECTION: 'true' }
+  const base = { enabled: true }
 
-  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_NAME: '__custom' }).cookieName, '__custom')
-  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_MAX_AGE: '60' }).maxAge, 60)
-  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_MAX_AGE: 'nope' }).maxAge, DEFAULT_COOKIE_MAX_AGE)
-  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_MAX_AGE: '0' }).maxAge, DEFAULT_COOKIE_MAX_AGE)
+  assert.strictEqual(resolveSkewConfig({ ...base, cookieName: '__custom' }).cookieName, '__custom')
+  assert.strictEqual(resolveSkewConfig({ ...base, maxAge: 60 }).maxAge, 60)
+  assert.strictEqual(resolveSkewConfig({ ...base, maxAge: 0 }).maxAge, DEFAULT_COOKIE_MAX_AGE)
+  assert.strictEqual(resolveSkewConfig({ ...base, maxAge: undefined }).maxAge, DEFAULT_COOKIE_MAX_AGE)
 })
 
 test('the cookie matches the attributes the Kubernetes gateway sets', () => {

--- a/packages/runtime/test/skew-protection.test.js
+++ b/packages/runtime/test/skew-protection.test.js
@@ -1,0 +1,103 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+import { SharedContext } from '../lib/worker/shared-context.js'
+import {
+  DEFAULT_COOKIE_MAX_AGE,
+  DEFAULT_COOKIE_NAME,
+  buildCookie,
+  createVersionResolver,
+  resolveSkewConfig,
+  shouldIssueCookie
+} from '../lib/worker/skew-protection.js'
+
+test('skew protection stays off unless the flag is set', () => {
+  assert.strictEqual(resolveSkewConfig({}), null)
+  assert.strictEqual(resolveSkewConfig({ PLT_DEPLOYMENT_VERSION: 'v1' }), null)
+  // Anything other than the exact string is off, so a stray value cannot enable it.
+  assert.strictEqual(resolveSkewConfig({ PLT_SKEW_PROTECTION: '1' }), null)
+})
+
+test('skew protection defaults the cookie name and lifetime', () => {
+  assert.deepStrictEqual(resolveSkewConfig({ PLT_SKEW_PROTECTION: 'true' }), {
+    cookieName: DEFAULT_COOKIE_NAME,
+    maxAge: DEFAULT_COOKIE_MAX_AGE
+  })
+})
+
+test('the version comes from the environment at boot', () => {
+  const resolve = createVersionResolver(new SharedContext(), { PLT_DEPLOYMENT_VERSION: 'v1' })
+  assert.strictEqual(resolve(), 'v1')
+})
+
+test('the shared context wins, so a version arriving after boot is used', () => {
+  const sharedContext = new SharedContext()
+  const resolve = createVersionResolver(sharedContext, { PLT_DEPLOYMENT_VERSION: 'stale' })
+
+  assert.strictEqual(resolve(), 'stale')
+  sharedContext._set({ deploymentVersion: 'v2', iccAuthHeaders: {} })
+  assert.strictEqual(resolve(), 'v2')
+})
+
+test('no version anywhere resolves to null, and nothing is pinned', () => {
+  const resolve = createVersionResolver(new SharedContext(), {})
+  assert.strictEqual(resolve(), null)
+})
+
+test('a pending shared context read is not mistaken for a version', () => {
+  const sharedContext = new SharedContext()
+  // get() caches a promise; reading it synchronously must not yield one.
+  sharedContext.sharedContext = Promise.resolve({ deploymentVersion: 'v2' })
+
+  assert.strictEqual(sharedContext.getSync(), null)
+  assert.strictEqual(createVersionResolver(sharedContext, { PLT_DEPLOYMENT_VERSION: 'v1' })(), 'v1')
+})
+
+test('the cookie name and max age can be overridden, and bad values fall back', () => {
+  const base = { PLT_SKEW_PROTECTION: 'true' }
+
+  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_NAME: '__custom' }).cookieName, '__custom')
+  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_MAX_AGE: '60' }).maxAge, 60)
+  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_MAX_AGE: 'nope' }).maxAge, DEFAULT_COOKIE_MAX_AGE)
+  assert.strictEqual(resolveSkewConfig({ ...base, PLT_SKEW_COOKIE_MAX_AGE: '0' }).maxAge, DEFAULT_COOKIE_MAX_AGE)
+})
+
+test('the cookie matches the attributes the Kubernetes gateway sets', () => {
+  const cookie = buildCookie({ cookieName: '__plt_dpl', version: 'v3', path: '/', maxAge: 43200 })
+  assert.strictEqual(cookie, '__plt_dpl=v3; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=43200')
+})
+
+test('the cookie path follows the base path so it is scoped like the gateway rule', () => {
+  const cookie = buildCookie({ cookieName: '__plt_dpl', version: 'v3', path: '/my-app', maxAge: 43200 })
+  assert.ok(cookie.includes('Path=/my-app'))
+})
+
+test('a request with no pin is issued one', () => {
+  assert.strictEqual(shouldIssueCookie({}, '__plt_dpl'), true)
+  assert.strictEqual(shouldIssueCookie({ cookie: 'other=1' }, '__plt_dpl'), true)
+})
+
+test('an existing pin is never refreshed, so a draining version can finish draining', () => {
+  // The gateway sets the cookie only on the default (active) rule; the draining
+  // and preview rules set nothing. A draining version that refreshed its own pin
+  // would hold an active browser on it forever.
+  assert.strictEqual(shouldIssueCookie({ cookie: '__plt_dpl=v1' }, '__plt_dpl'), false)
+  assert.strictEqual(shouldIssueCookie({ cookie: 'a=1; __plt_dpl=v1; b=2' }, '__plt_dpl'), false)
+  assert.strictEqual(shouldIssueCookie({ cookie: '__plt_dpl=v1;' }, '__plt_dpl'), false)
+})
+
+test('a cookie whose name merely contains ours does not count as a pin', () => {
+  assert.strictEqual(shouldIssueCookie({ cookie: 'x__plt_dpl=v1' }, '__plt_dpl'), true)
+  assert.strictEqual(shouldIssueCookie({ cookie: '__plt_dpl_other=v1' }, '__plt_dpl'), true)
+  // A value that looks like our cookie must not be mistaken for one.
+  assert.strictEqual(shouldIssueCookie({ cookie: 'other=__plt_dpl=v1' }, '__plt_dpl'), true)
+})
+
+test('a preview request is never pinned to the version it previews', () => {
+  assert.strictEqual(shouldIssueCookie({ 'x-deployment-id': 'v2' }, '__plt_dpl'), false)
+  assert.strictEqual(shouldIssueCookie({ 'x-deployment-id': 'v2', cookie: 'a=1' }, '__plt_dpl'), false)
+})
+
+test('a custom cookie name is what gets looked for', () => {
+  assert.strictEqual(shouldIssueCookie({ cookie: '__plt_dpl=v1' }, '__custom'), true)
+  assert.strictEqual(shouldIssueCookie({ cookie: '__custom=v1' }, '__custom'), false)
+})

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -351,6 +351,11 @@ export interface PlatformaticServiceConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1126,6 +1126,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticTanStackConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -148,6 +148,11 @@ export interface PlatformaticViteConfig {
             }
         )[];
     basePath?: string;
+    skewProtection?: {
+      enabled?: boolean;
+      cookieName?: string;
+      maxAge?: number;
+    };
     services?: {
       [k: string]: unknown;
     }[];

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -483,6 +483,26 @@
         "basePath": {
           "type": "string"
         },
+        "skewProtection": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "cookieName": {
+              "type": "string",
+              "default": "__plt_dpl"
+            },
+            "maxAge": {
+              "type": "number",
+              "minimum": 1,
+              "default": 43200
+            }
+          },
+          "additionalProperties": false
+        },
         "services": {
           "type": "array",
           "items": {

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -29,6 +29,11 @@ export type PlatformaticRuntimeConfig = {
       )[];
   entrypoint?: string;
   basePath?: string;
+  skewProtection?: {
+    enabled?: boolean;
+    cookieName?: string;
+    maxAge?: number;
+  };
   autoload?: {
     path: string;
     exclude?: string[];

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -81,6 +81,26 @@
     "basePath": {
       "type": "string"
     },
+    "skewProtection": {
+      "type": "object",
+      "default": {},
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "cookieName": {
+          "type": "string",
+          "default": "__plt_dpl"
+        },
+        "maxAge": {
+          "type": "number",
+          "minimum": 1,
+          "default": 43200
+        }
+      },
+      "additionalProperties": false
+    },
     "autoload": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
The runtime can now issue the `__plt_dpl` cookie that pins a browser session to a single deployment version, so skew protection also works where the ingress in front of the application cannot add response headers of its own.

It is off by default and enabled with `PLT_SKEW_PROTECTION=true`. The version is read from `PLT_DEPLOYMENT_VERSION`, or from a `deploymentVersion` published into the shared context, which takes precedence so a version delivered after boot is picked up without a restart. When no version resolves, nothing is issued and an application behaves exactly as it does today. `PLT_SKEW_COOKIE_NAME` and `PLT_SKEW_COOKIE_MAX_AGE` override the defaults, and the cookie path follows the runtime base path.

The cookie is added by patching the response instance from an `http.server.request.start` subscriber rather than through a Fastify hook, because an entrypoint can be any capability with its own HTTP server. 

Two request shapes are deliberately left unpinned. A request that already carries the cookie is never refreshed, since a draining version only ever receives requests already pinned to it and would otherwise keep extending its own pin and never finish draining. A request carrying the `x-deployment-id` preview header is not pinned either, so previewing a version does not stick the browser to it.

# TODO:
- [ ] docs
