### PR TITLE
fix(foundation): give process.env precedence over .env files in placeholder resolution

### DIFF
--- a/packages/foundation/lib/configuration.js
+++ b/packages/foundation/lib/configuration.js
@@ -383,10 +383,13 @@ export async function loadEnv (root, ignoreProcessEnv = false, additionalEnv = {
   const baseEnv = ignoreProcessEnv ? {} : process.env
   const envFromFile = envFile ? parseEnv(await readFile(envFile, 'utf-8')) : {}
 
+  // The env file provides fallback defaults: variables already set in the real
+  // environment (and explicit programmatic values) take precedence over it,
+  // matching the dotenv/docker-compose/Vite convention.
   return {
+    ...envFromFile,
     ...baseEnv,
-    ...additionalEnv,
-    ...envFromFile
+    ...additionalEnv
   }
 }
 

--- a/packages/foundation/test/configuration.test.js
+++ b/packages/foundation/test/configuration.test.js
@@ -637,6 +637,41 @@ test('loadEnv - should load environment variables from .env file', async t => {
   })
 })
 
+test('loadEnv - process.env should take precedence over .env file values', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const envFile = join(tmpDir, '.env')
+
+  process.env.PLT_PRECEDENCE_TEST = 'from-process'
+
+  t.after(async () => {
+    delete process.env.PLT_PRECEDENCE_TEST
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(envFile, 'PLT_PRECEDENCE_TEST=from-file\nPLT_FILE_ONLY_TEST=from-file')
+
+  const result = await loadEnv(tmpDir)
+  equal(result.PLT_PRECEDENCE_TEST, 'from-process')
+  equal(result.PLT_FILE_ONLY_TEST, 'from-file')
+})
+
+test('loadEnv - additionalEnv should take precedence over both process.env and the .env file', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const envFile = join(tmpDir, '.env')
+
+  process.env.PLT_PRECEDENCE_TEST = 'from-process'
+
+  t.after(async () => {
+    delete process.env.PLT_PRECEDENCE_TEST
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(envFile, 'PLT_PRECEDENCE_TEST=from-file')
+
+  const result = await loadEnv(tmpDir, false, { PLT_PRECEDENCE_TEST: 'from-additional' })
+  equal(result.PLT_PRECEDENCE_TEST, 'from-additional')
+})
+
 test('loadEnv - should return process.env when no .env file exists', async t => {
   const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
 


### PR DESCRIPTION
Fixes #4967.

## Problem

`loadEnv` in `@platformatic/foundation` resolves `{PLT_*}` placeholders from a merge where a discovered `.env` file **overrides** the real environment ([`configuration.js#L386-L390`](https://github.com/platformatic/platformatic/blob/c28219c9eee978917e18e204152ea295cef63afb/packages/foundation/lib/configuration.js#L386-L390)):

```js
return {
  ...baseEnv,        // process.env
  ...additionalEnv,
  ...envFromFile     // .env file wins over everything
}
```

Three things argue this is a bug rather than a preference:

1. **It contradicts Platformatic's own documentation.** The environment-variables tutorial says you "can override environment variables directly when starting your application" (`PORT=4042 LOG_LEVEL=debug npx wattpm dev`) and its troubleshooting section states outright: "Remember: command line variables override `.env` files" ([`docs/learn/beginner/environment-variables.md`](https://github.com/platformatic/platformatic/blob/c28219c9eee978917e18e204152ea295cef63afb/docs/learn/beginner/environment-variables.md)). For placeholder resolution, today, they don't.
2. **Platformatic itself already does the opposite in the other layer.** The runtime worker path loads env files via Node's `process.loadEnvFile`, which does *not* overwrite variables that are already set. So the same variable can resolve one way inside a `{PLT_*}` placeholder and the other way in the worker's real environment — two precedence rules in one product.
3. **It's the inverse of the whole ecosystem.** dotenv's `override` defaults to `false` ("never modify any environment variable that has already been set"); docker-compose puts `env_file` below the shell environment in its precedence chain; Vite documents that variables which already exist "have the highest priority and will not be overwritten by `.env` files"; Prisma behaves the same way. Everywhere else, the file is fallback defaults and the real environment is authoritative.

The practical failure mode: a `.env` left over in a working copy or baked into an image silently beats deploy-time configuration. An operator sets `PLT_SOMETHING=x` on the container and the app keeps reading the stale file value, with nothing in the logs to say why. We hit exactly this while running a multi-service Watt deployment; the workaround (moving `.env` aside before running tooling) is what prompted #4967.

## The fix

Reorder the spreads so the file becomes the fallback tier:

```js
return {
  ...envFromFile,    // .env = defaults (lowest)
  ...baseEnv,        // real environment overrides the file
  ...additionalEnv   // explicit programmatic env stays highest
}
```

Scope is deliberately narrow: this is the foundation placeholder-resolution path only, the single source feeding `loadConfiguration` → `replaceEnv`. The runtime worker path (`worker/main.js`, Node's `loadEnvFile` into the worker's real `process.env`) is a separate mechanism and is not touched; the env spreads in `management-api.js` and `itc.js` are reporting-only.

## Behavior change, stated plainly

Apps that rely on a `.env` file overriding an already-set environment variable will see the environment win after this change. We'd argue that reliance is almost always the bug this PR fixes, and the alignment with the docs and with dotenv/docker-compose/Vite/Prisma makes the new behavior the least-surprising one. If you'd rather keep an escape hatch, `envFilePrecedence: 'process' | 'file'` (default `'process'`) can be wired exactly like the existing `ignoreProcessEnv` plumbing — happy to add it to this PR if you prefer; we left it out to avoid adding config surface for behavior nobody should opt into.

`ignoreProcessEnv` is unaffected: it still drops the real environment entirely when set, and with it the file remains the only source, as today.

## Tests

- New regression tests in `packages/foundation/test/configuration.test.js`: a key set in both `process.env` and the `.env` file resolves to the process value; a file-only key still resolves from the file; `additionalEnv` still beats both.
- No existing test pins the old collision behavior (the `loadEnv` blocks in `configuration.test.js` use non-colliding keys, and the runtime/wattpm suites exercise the separate worker-path mechanism).
- Full `foundation` suite green locally (357 tests + type tests + lint); `service` and `runtime` were run as well — the single failure observed reproduces identically on a clean `main` checkout (pre-existing, unrelated to this change).
- No documentation changes needed: this makes the already-documented behavior true.

## Environment

- Verified against current `main` at [`c28219c9e`](https://github.com/platformatic/platformatic/commit/c28219c9eee978917e18e204152ea295cef63afb); `configuration.js` last touched by #4976 (strictEnv), which did not change the merge order.
- Node.js 20+.
