### PR TITLE
fix: runtime messaging request leak

### DIFF
--- a/packages/itc/lib/index.d.ts
+++ b/packages/itc/lib/index.d.ts
@@ -11,6 +11,10 @@ export interface ITCConstructorOptions {
   throwOnMissingHandler?: boolean
 }
 
+export interface ITCSendOptions extends Record<string, any> {
+  signal?: AbortSignal
+}
+
 export interface OutgoingMessagingSpanOptions {
   telemetryContext?: Context
   telemetryMetadata?: Record<string, string>
@@ -30,7 +34,7 @@ export interface OutgoingMessagingSpan {
 export class ITC extends EventEmitter {
   constructor (options: ITCConstructorOptions)
 
-  send (name: string, message: any, options?: Record<string, any>): Promise<any>
+  send (name: string, message: any, options?: ITCSendOptions): Promise<any>
   notify (name: string, message: any, options?: Record<string, any>): void
   process (name: string, message: any, context?: Record<string, any>): Promise<any>
   handle (message: string, handler: Handler): void

--- a/packages/itc/lib/index.js
+++ b/packages/itc/lib/index.js
@@ -307,24 +307,53 @@ export class ITC extends EventEmitter {
     }
 
     let reqId
+    let abortHandler
+    const signal = options?.signal
+
     try {
       this._enableKeepAlive()
+      signal?.throwIfAborted()
 
       const request = generateRequest(name, message, options?.meta)
-      this._send(request, options)
-
       const promiseWithResolvers = Promise.withResolvers()
       reqId = request.reqId
       this.#waitingRequests.set(request.reqId, promiseWithResolvers)
 
-      const { error, data } = await Unpromise.race([promiseWithResolvers.promise, this.#closePromise])
+      const responses = [promiseWithResolvers.promise, this.#closePromise]
+      if (signal) {
+        const aborted = Promise.withResolvers()
+        abortHandler = () => {
+          const error = signal.reason ?? new DOMException('This operation was aborted', 'AbortError')
+          aborted.resolve({ error, data: null })
+        }
+
+        if (signal.aborted) {
+          abortHandler()
+        } else {
+          signal.addEventListener('abort', abortHandler, { once: true })
+        }
+
+        responses.push(aborted.promise)
+      }
+
+      this._send(request, options)
+
+      const { error, data } = await Unpromise.race(responses)
 
       if (error !== null) throw error
       return data
     } finally {
+      if (abortHandler) {
+        signal.removeEventListener('abort', abortHandler)
+      }
+
       // Clean up the waiting requests map even if an error occurred
       this.#waitingRequests.delete(reqId)
       this._manageKeepAlive()
+
+      if (reqId) {
+        this._onRequestSettled?.(reqId, options)
+      }
     }
   }
 

--- a/packages/itc/test/itc.test.js
+++ b/packages/itc/test/itc.test.js
@@ -1,4 +1,4 @@
-import { deepStrictEqual, fail, ifError, throws } from 'node:assert'
+import { deepStrictEqual, fail, ifError, rejects, throws } from 'node:assert'
 import { once } from 'node:events'
 import { test } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -31,6 +31,40 @@ test('should send a request between threads', async t => {
   const response = await itc1.send(requestName, testRequest)
   deepStrictEqual(response, testResponse)
   deepStrictEqual(requests, [testRequest])
+})
+
+test('should abort a pending request', async t => {
+  const { port1, port2 } = new MessageChannel()
+
+  const itc1 = new ITC({ port: port1, name: 'itc1' })
+  const itc2 = new ITC({ port: port2, name: 'itc2' })
+  const handlerStarted = Promise.withResolvers()
+  const handlerRelease = Promise.withResolvers()
+
+  itc2.handle('test-command', async () => {
+    handlerStarted.resolve()
+    return handlerRelease.promise
+  })
+
+  itc1.listen()
+  itc2.listen()
+
+  t.after(() => itc1.close())
+  t.after(() => itc2.close())
+
+  const abortController = new AbortController()
+  const abortReason = new Error('Request aborted')
+  const response = itc1.send('test-command', 'test-request', { signal: abortController.signal })
+
+  await handlerStarted.promise
+  abortController.abort(abortReason)
+
+  await rejects(response, error => {
+    deepStrictEqual(error, abortReason)
+    return true
+  })
+
+  handlerRelease.resolve('late-response')
 })
 
 test('should support close while replying to a message', async t => {

--- a/packages/itc/test/types/index.tst.ts
+++ b/packages/itc/test/types/index.tst.ts
@@ -39,6 +39,7 @@ test('ITC', () => {
 
   expect(itc.send('message', { key: 'value' })).type.toBe<Promise<any>>()
   expect(itc.send('message', { key: 'value' }, { timeout: 1000 })).type.toBe<Promise<any>>()
+  expect(itc.send('message', { key: 'value' }, { signal: new AbortController().signal })).type.toBe<Promise<any>>()
   expect(itc.send).type.not.toBeCallableWith(123, { key: 'value' })
 
   expect(itc.notify('message', { key: 'value' })).type.toBe<void>()

--- a/packages/runtime/lib/worker/messaging.js
+++ b/packages/runtime/lib/worker/messaging.js
@@ -114,14 +114,21 @@ export class MessagingITC extends ITC {
         context.meta = { ...options?.meta, ...telemetry?.meta }
       }
 
-      const send = () => executeWithTimeout(super.send(name, message, context), this.#timeout)
-      const response = telemetry ? await telemetry.run(send) : await send()
+      const abortController = new AbortController()
+      const timeout = setTimeout(() => abortController.abort(), this.#timeout).unref()
+      context.signal = abortController.signal
 
-      if (response === kTimeout) {
-        throw new MessagingError(application, 'Timeout while waiting for a response.')
+      try {
+        const send = () => super.send(name, message, context)
+        return telemetry ? await telemetry.run(send) : await send()
+      } catch (err) {
+        if (abortController.signal.aborted) {
+          throw new MessagingError(application, 'Timeout while waiting for a response.')
+        }
+        throw err
+      } finally {
+        clearTimeout(timeout)
       }
-
-      return response
     } catch (err) {
       error = err
       throw err
@@ -179,6 +186,12 @@ export class MessagingITC extends ITC {
     }
 
     channel.postMessage(sanitize(request, transferList), transferList)
+  }
+
+  _onRequestSettled (reqId, context) {
+    if (context.trackResponse) {
+      context.channel[kPendingResponses].delete(reqId)
+    }
   }
 
   _createClosePromise () {

--- a/packages/runtime/test/messaging.test.js
+++ b/packages/runtime/test/messaging.test.js
@@ -1,0 +1,86 @@
+import { abstractLogger } from '@platformatic/foundation'
+import { strictEqual, rejects } from 'node:assert'
+import { randomUUID } from 'node:crypto'
+import { setImmediate as nextImmediate } from 'node:timers/promises'
+import { MessageChannel } from 'node:worker_threads'
+import { test } from 'node:test'
+import { MessagingITC } from '../lib/worker/messaging.js'
+
+const kPendingResponsesDescription = 'plt.messaging.pendingResponses'
+
+class TestMessagingITC extends MessagingITC {
+  #worker
+
+  constructor (id, application, runtimeConfig, channel) {
+    super(id, runtimeConfig, abstractLogger)
+
+    this.#worker = { application, channel }
+    this.addSource(channel)
+  }
+
+  _getNextWorker () {
+    return this.#worker
+  }
+}
+
+function setupMessagingPair (t, messagingTimeout = 1000) {
+  const id = randomUUID()
+  const senderId = `sender-${id}`
+  const targetId = `target-${id}`
+  const channel = new MessageChannel()
+  const runtimeConfig = { messagingTimeout }
+
+  const sender = new TestMessagingITC(senderId, targetId, runtimeConfig, channel.port1)
+  const target = new TestMessagingITC(targetId, senderId, runtimeConfig, channel.port2)
+
+  t.after(() => {
+    sender.close()
+    target.close()
+    channel.port1.close()
+    channel.port2.close()
+  })
+
+  return { channel: channel.port1, sender, target, targetId }
+}
+
+function getPendingResponses (channel) {
+  const symbol = Object.getOwnPropertySymbols(channel).find(symbol => {
+    return symbol.description === kPendingResponsesDescription
+  })
+
+  return channel[symbol]
+}
+
+test('should release tracked requests after receiving responses', async t => {
+  const { channel, sender, target, targetId } = setupMessagingPair(t)
+
+  target.handle('echo', message => message)
+
+  const requests = Array.from({ length: 100 }, (_, id) => {
+    return sender.send(targetId, 'echo', { id, payload: 'x'.repeat(4096) })
+  })
+
+  await Promise.all(requests)
+
+  strictEqual(getPendingResponses(channel).size, 0)
+})
+
+test('should release tracked requests after a timeout', async t => {
+  const { channel, sender, target, targetId } = setupMessagingPair(t, 50)
+  const handlerStarted = Promise.withResolvers()
+  const handlerRelease = Promise.withResolvers()
+
+  target.handle('slow', async () => {
+    handlerStarted.resolve()
+    return handlerRelease.promise
+  })
+
+  const response = sender.send(targetId, 'slow')
+  await handlerStarted.promise
+
+  await rejects(response, /Timeout while waiting for a response/)
+  strictEqual(getPendingResponses(channel).size, 0)
+
+  handlerRelease.resolve('late-response')
+  await nextImmediate()
+})


### PR DESCRIPTION
## Summary

- Release tracked Runtime Messaging requests as soon as each send settles.
- Add `AbortSignal` support to ITC sends so pending requests can be cancelled.
- Abort the underlying ITC request when the configured messaging timeout is reached.
- Add regression coverage for completed and timed-out requests.

## Problem

Runtime Messaging stored each tracked request, including its payload, in a per-channel pending-responses map. Entries were only cleared when the communication channel closed, so successful and failed requests accumulated for the lifetime of a worker channel.

Timeouts caused a second retention path. Runtime Messaging raced `ITC.send()` against a timer, but timing out did not cancel the underlying send. If the target never responded, the request remained in the private ITC waiting map as well as the Runtime channel map.

## Solution

`ITC.send()` now accepts an optional abort signal and always releases its waiting entry when aborted. It also notifies subclasses when a request settles.

Runtime Messaging uses an `AbortController` for its configured timeout. Completion, handler failure, channel closure, and timeout now all remove the corresponding channel tracking entry, while the timeout also releases the lower-level ITC request.
