### PR TITLE
feat(runtime): add awaited start/stop lifecycle hooks for extensions

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -91,8 +91,16 @@ export default async function setup ({ runtime, itc, sharedContext, logger, opti
   jobs.set(0)
 
   return {
+    async start () {
+      // Invoked after applications are prepared, before they accept traffic.
+      // Can add/start dynamic applications; Runtime will not start them again.
+    },
+    async stop () {
+      // Invoked during shutdown after the entrypoint stops and before remaining
+      // applications stop. Useful for control-plane handoff.
+    },
     async close () {
-      // Invoked when the runtime is closed
+      // Invoked when the runtime is closed, after all applications have stopped.
     }
   }
 }
@@ -138,9 +146,28 @@ The setup function receives a context object with the following properties:
   `PLT_RUNTIME_METRIC_FAMILY_COLLISION`, identifying the extension and metric family. The registry is
   cleared when the extension closes (including partial startup failures).
 
-The setup function can optionally return an object with a `close` method, which is invoked when the
-runtime is being closed. When multiple extensions are configured, they are loaded in order and closed
-in reverse order. The extension metrics registry is cleared after `close`.
+The setup function can optionally return an object with awaited lifecycle hooks:
+
+- **`start()`** - Called once applications have been prepared and registered, and **before** the
+  originally configured applications start accepting traffic. Runtime awaits every extension `start`
+  hook. An extension may add and start dynamic applications here; those applications are excluded from
+  the normal startup pass so they are not started twice. Runtime does not report `started` until
+  extension and application startup complete. If a later extension or application fails, Runtime stops
+  and closes already-started extensions during cleanup.
+- **`stop()`** - Called during shutdown **after** the entrypoint has been stopped and **before** the
+  remaining applications stop. Runtime awaits every extension `stop` hook so control-plane extensions
+  can settle work and hand off state.
+- **`close()`** - Called when the runtime is being closed, after applications have stopped. The
+  extension metrics registry is cleared after `close`.
+
+When multiple extensions are configured, they are set up and started in registration order. `stop` and
+`close` run in reverse registration order. Each of `stop` and `close` is invoked at most once per
+Runtime life, including repeated `stop`/`close` calls and failed-start cleanup paths. Existing
+extensions that only return `close()` keep their previous behavior.
+
+Listening to Runtime `EventEmitter` events is not a substitute for these hooks: `emit()` does not await
+asynchronous listeners. Lifecycle ordering is enforced by Runtime itself so it covers signal handling,
+internal failure cleanup, and future lifecycle entry points.
 
 Extensions are not loaded when building the applications (for example via `wattpm build`).
 

--- a/packages/runtime/fixtures/extensions/extension-1.js
+++ b/packages/runtime/fixtures/extensions/extension-1.js
@@ -21,6 +21,12 @@ export default async function setup ({ runtime, itc, logger, options, root, shar
   itc.handle('extension:sum', ({ x, y }) => x + y)
 
   return {
+    start () {
+      events.push({ event: 'start', extension: 'first' })
+    },
+    stop () {
+      events.push({ event: 'stop', extension: 'first' })
+    },
     close () {
       events.push({ event: 'close', extension: 'first' })
     }

--- a/packages/runtime/fixtures/extensions/extension-2.js
+++ b/packages/runtime/fixtures/extensions/extension-2.js
@@ -3,6 +3,12 @@ export default function setup () {
   events.push({ event: 'setup', extension: 'second' })
 
   return {
+    start () {
+      events.push({ event: 'start', extension: 'second' })
+    },
+    stop () {
+      events.push({ event: 'stop', extension: 'second' })
+    },
     close () {
       events.push({ event: 'close', extension: 'second' })
     }

--- a/packages/runtime/fixtures/extensions/extension-close-only.js
+++ b/packages/runtime/fixtures/extensions/extension-close-only.js
@@ -1,0 +1,10 @@
+export default function setup () {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  events.push({ event: 'setup', extension: 'close-only' })
+
+  return {
+    close () {
+      events.push({ event: 'close', extension: 'close-only' })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-dynamic.js
+++ b/packages/runtime/fixtures/extensions/extension-dynamic.js
@@ -1,0 +1,37 @@
+import { prepareApplication } from '../../index.js'
+
+export default function setup ({ runtime }) {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  const name = 'dynamic'
+
+  events.push({ event: 'setup', extension: name })
+
+  runtime.on('application:started', id => {
+    events.push({ event: 'application:started', application: id })
+  })
+
+  return {
+    async start () {
+      events.push({ event: 'start', extension: name })
+
+      const config = runtime.getRuntimeConfig(true)
+      await runtime.addApplications(
+        [
+          await prepareApplication(config, {
+            id: 'b',
+            path: './services/b'
+          })
+        ],
+        true
+      )
+
+      events.push({ event: 'dynamic-started', application: 'b' })
+    },
+    async stop () {
+      events.push({ event: 'stop', extension: name })
+    },
+    async close () {
+      events.push({ event: 'close', extension: name })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-lifecycle-tracker.js
+++ b/packages/runtime/fixtures/extensions/extension-lifecycle-tracker.js
@@ -1,0 +1,26 @@
+export default function setup ({ runtime }) {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  const name = 'tracker'
+
+  events.push({ event: 'setup', extension: name })
+
+  runtime.on('application:started', id => {
+    events.push({ event: 'application:started', application: id })
+  })
+
+  runtime.on('application:stopped', id => {
+    events.push({ event: 'application:stopped', application: id })
+  })
+
+  return {
+    async start () {
+      events.push({ event: 'start', extension: name })
+    },
+    async stop () {
+      events.push({ event: 'stop', extension: name })
+    },
+    async close () {
+      events.push({ event: 'close', extension: name })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-start-configured.js
+++ b/packages/runtime/fixtures/extensions/extension-start-configured.js
@@ -1,0 +1,26 @@
+export default function setup ({ runtime }) {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  const name = 'start-configured'
+
+  events.push({ event: 'setup', extension: name })
+
+  runtime.on('application:started', id => {
+    events.push({ event: 'application:started', application: id })
+  })
+
+  return {
+    async start () {
+      events.push({ event: 'start', extension: name })
+      // Start the originally configured application from the extension start hook.
+      // The normal startup pass must not start it a second time.
+      await runtime.startApplication('a')
+      events.push({ event: 'started-configured', application: 'a' })
+    },
+    async stop () {
+      events.push({ event: 'stop', extension: name })
+    },
+    async close () {
+      events.push({ event: 'close', extension: name })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-start-fail.js
+++ b/packages/runtime/fixtures/extensions/extension-start-fail.js
@@ -1,0 +1,17 @@
+export default function setup () {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  events.push({ event: 'setup', extension: 'start-fail' })
+
+  return {
+    start () {
+      events.push({ event: 'start', extension: 'start-fail' })
+      throw new Error('start intentionally failed')
+    },
+    stop () {
+      events.push({ event: 'stop', extension: 'start-fail' })
+    },
+    close () {
+      events.push({ event: 'close', extension: 'start-fail' })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-app-fail.json
+++ b/packages/runtime/fixtures/extensions/platformatic-app-fail.json
@@ -1,19 +1,21 @@
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
   "entrypoint": "a",
-  "extensions": "missing.js",
-  "autoload": {
-    "path": "./services",
-    "exclude": [
-      "b",
-      "crash-on-start"
-    ]
-  },
+  "extensions": [
+    "extension-1.js"
+  ],
+  "applications": [
+    {
+      "id": "a",
+      "path": "./services/crash-on-start"
+    }
+  ],
   "server": {
     "hostname": "127.0.0.1",
     "port": "{{PORT}}"
   },
   "logger": {
     "level": "error"
-  }
+  },
+  "restartOnError": false
 }

--- a/packages/runtime/fixtures/extensions/platformatic-close-only.json
+++ b/packages/runtime/fixtures/extensions/platformatic-close-only.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
   "entrypoint": "a",
-  "extensions": "missing.js",
+  "extensions": [
+    "extension-close-only.js"
+  ],
   "autoload": {
     "path": "./services",
     "exclude": [

--- a/packages/runtime/fixtures/extensions/platformatic-duplicate.json
+++ b/packages/runtime/fixtures/extensions/platformatic-duplicate.json
@@ -3,7 +3,11 @@
   "entrypoint": "a",
   "extensions": "extension-duplicate.js",
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": [
+      "b",
+      "crash-on-start"
+    ]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-dynamic.json
+++ b/packages/runtime/fixtures/extensions/platformatic-dynamic.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
   "entrypoint": "a",
-  "extensions": "missing.js",
+  "extensions": [
+    "extension-dynamic.js"
+  ],
   "autoload": {
     "path": "./services",
     "exclude": [

--- a/packages/runtime/fixtures/extensions/platformatic-health.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health.json
@@ -3,7 +3,11 @@
   "entrypoint": "a",
   "extensions": "extension-health.js",
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": [
+      "b",
+      "crash-on-start"
+    ]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-invalid.json
+++ b/packages/runtime/fixtures/extensions/platformatic-invalid.json
@@ -3,7 +3,11 @@
   "entrypoint": "a",
   "extensions": "extension-invalid.js",
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": [
+      "b",
+      "crash-on-start"
+    ]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-lifecycle.json
+++ b/packages/runtime/fixtures/extensions/platformatic-lifecycle.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
   "entrypoint": "a",
-  "extensions": "missing.js",
+  "extensions": [
+    "extension-lifecycle-tracker.js"
+  ],
   "autoload": {
     "path": "./services",
-    "exclude": [
-      "b",
-      "crash-on-start"
-    ]
+    "exclude": ["crash-on-start"]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-metrics-collision.json
+++ b/packages/runtime/fixtures/extensions/platformatic-metrics-collision.json
@@ -6,7 +6,8 @@
     "extension-metrics-collision.js"
   ],
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": ["crash-on-start"]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-metrics-disabled.json
+++ b/packages/runtime/fixtures/extensions/platformatic-metrics-disabled.json
@@ -5,7 +5,8 @@
     "extension-metrics-1.js"
   ],
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": ["crash-on-start"]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-metrics-multi.json
+++ b/packages/runtime/fixtures/extensions/platformatic-metrics-multi.json
@@ -6,7 +6,8 @@
     "extension-metrics-2.js"
   ],
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": ["crash-on-start"]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-metrics-process-collision.json
+++ b/packages/runtime/fixtures/extensions/platformatic-metrics-process-collision.json
@@ -5,7 +5,8 @@
     "extension-metrics-process-collision.js"
   ],
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": ["crash-on-start"]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-metrics.json
+++ b/packages/runtime/fixtures/extensions/platformatic-metrics.json
@@ -5,7 +5,8 @@
     "extension-metrics-1.js"
   ],
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": ["crash-on-start"]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-profiles.json
+++ b/packages/runtime/fixtures/extensions/platformatic-profiles.json
@@ -3,7 +3,11 @@
   "entrypoint": "a",
   "extensions": "extension-profiles.js",
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": [
+      "b",
+      "crash-on-start"
+    ]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-reserved.json
+++ b/packages/runtime/fixtures/extensions/platformatic-reserved.json
@@ -3,7 +3,11 @@
   "entrypoint": "a",
   "extensions": "extension-reserved.js",
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": [
+      "b",
+      "crash-on-start"
+    ]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic-start-configured.json
+++ b/packages/runtime/fixtures/extensions/platformatic-start-configured.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
   "entrypoint": "a",
-  "extensions": "missing.js",
+  "extensions": [
+    "extension-start-configured.js"
+  ],
   "autoload": {
     "path": "./services",
     "exclude": [

--- a/packages/runtime/fixtures/extensions/platformatic-start-fail.json
+++ b/packages/runtime/fixtures/extensions/platformatic-start-fail.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
   "entrypoint": "a",
-  "extensions": "missing.js",
+  "extensions": [
+    "extension-1.js",
+    "extension-start-fail.js"
+  ],
   "autoload": {
     "path": "./services",
     "exclude": [

--- a/packages/runtime/fixtures/extensions/platformatic-ts.json
+++ b/packages/runtime/fixtures/extensions/platformatic-ts.json
@@ -3,7 +3,11 @@
   "entrypoint": "a",
   "extensions": "extension-ts.ts",
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": [
+      "b",
+      "crash-on-start"
+    ]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/platformatic.runtime.json
+++ b/packages/runtime/fixtures/extensions/platformatic.runtime.json
@@ -11,7 +11,8 @@
     "extension-2.js"
   ],
   "autoload": {
-    "path": "./services"
+    "path": "./services",
+    "exclude": ["b", "crash-on-start"]
   },
   "server": {
     "hostname": "127.0.0.1",

--- a/packages/runtime/fixtures/extensions/services/b/platformatic.service.json
+++ b/packages/runtime/fixtures/extensions/services/b/platformatic.service.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "server": {
+    "logger": {
+      "level": "warn"
+    }
+  },
+  "plugins": {
+    "paths": [{
+      "path": "plugin.js",
+      "encapsulate": false
+    }]
+  }
+}

--- a/packages/runtime/fixtures/extensions/services/b/plugin.js
+++ b/packages/runtime/fixtures/extensions/services/b/plugin.js
@@ -1,0 +1,5 @@
+export default async function (fastify) {
+  fastify.get('/hello', async () => {
+    return { from: 'b' }
+  })
+}

--- a/packages/runtime/fixtures/extensions/services/crash-on-start/index.mjs
+++ b/packages/runtime/fixtures/extensions/services/crash-on-start/index.mjs
@@ -1,0 +1,3 @@
+export function create () {
+  throw new Error('application intentionally failed to start')
+}

--- a/packages/runtime/fixtures/extensions/services/crash-on-start/package.json
+++ b/packages/runtime/fixtures/extensions/services/crash-on-start/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index.mjs",
+  "type": "module"
+}

--- a/packages/runtime/fixtures/extensions/services/crash-on-start/platformatic.json
+++ b/packages/runtime/fixtures/extensions/services/crash-on-start/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.6.0.json",
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -227,6 +227,8 @@ export interface RuntimeExtensionContext {
 }
 
 export interface RuntimeExtensionInstance {
+  start?: () => void | Promise<void>
+  stop?: () => void | Promise<void>
   close?: () => void | Promise<void>
 }
 

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -155,6 +155,16 @@ export const FailedToLoadExtensionError = createError(
   'Failed to load the extension "%s": %s'
 )
 
+export const FailedToStartExtensionError = createError(
+  `${ERROR_PREFIX}_FAILED_TO_START_EXTENSION`,
+  'Failed to start the extension "%s": %s'
+)
+
+export const FailedToStopExtensionError = createError(
+  `${ERROR_PREFIX}_FAILED_TO_STOP_EXTENSION`,
+  'Failed to stop the extension "%s": %s'
+)
+
 export const InvalidExtensionError = createError(
   `${ERROR_PREFIX}_INVALID_EXTENSION`,
   'The extension "%s" must export a setup function as its default export'

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -41,6 +41,8 @@ import {
   CannotRemoveEntrypointError,
   DuplicateITCHandlerNameError,
   FailedToLoadExtensionError,
+  FailedToStartExtensionError,
+  FailedToStopExtensionError,
   InvalidArgumentError,
   InvalidExtensionError,
   LastProfileTimeoutError,
@@ -355,10 +357,16 @@ export class Runtime extends EventEmitter {
     this.#createWorkersBroadcastChannel()
 
     try {
-      const applications = this.getApplicationsIds()
-      await this.startApplications(applications, silent)
+      // Snapshot originally configured application IDs before extension start hooks.
+      // Dynamic applications started by an extension are excluded from the normal startup pass.
+      const configuredApplications = this.getApplicationsIds()
 
-      if (applications.length === 0) {
+      await this.#startExtensions()
+
+      const applicationsToStart = configuredApplications.filter(id => !this.#isApplicationStarted(id))
+      await this.startApplications(applicationsToStart, silent)
+
+      if (this.getApplicationsIds().length === 0) {
         this.#updateStatus('started')
         await this.close(silent)
         return
@@ -419,6 +427,15 @@ export class Runtime extends EventEmitter {
       await once(this, 'started')
     }
 
+    if (this.#status === 'stopping') {
+      await once(this, 'stopped')
+      return
+    }
+
+    if (this.#status === 'stopped' || this.#status === 'closing' || this.#status === 'closed') {
+      return
+    }
+
     this.#updateStatus('stopping')
 
     if (this.#scheduler) {
@@ -435,6 +452,10 @@ export class Runtime extends EventEmitter {
     if (this.#entrypointId) {
       await this.stopApplication(this.#entrypointId, silent)
     }
+
+    // Await extension stop hooks before stopping remaining applications so that
+    // control-plane extensions can settle work and hand off state first.
+    await this.#stopExtensions()
 
     await this.stopApplications(this.getApplicationsIds(), silent)
 
@@ -461,6 +482,15 @@ export class Runtime extends EventEmitter {
   }
 
   async close (silent = false) {
+    if (this.#status === 'closing') {
+      await once(this, 'closed')
+      return
+    }
+
+    if (this.#status === 'closed') {
+      return
+    }
+
     clearTimeout(this.#healthMetricsTimer)
     this.#healthMetricsCollectionActive = false
     this.#lastOverloadProfiles.clear()
@@ -4036,7 +4066,7 @@ export class Runtime extends EventEmitter {
           metrics
         })
 
-        this.#extensions.push({ path, instance, registry })
+        this.#extensions.push({ path, instance, registry, started: false, stopped: false, closed: false })
       } catch (e) {
         registry.clear()
         throw new FailedToLoadExtensionError(path, e.message, { cause: e })
@@ -4050,26 +4080,91 @@ export class Runtime extends EventEmitter {
     this.#extensionsWantHealthMetrics = this.listenerCount('application:worker:health:metrics') > 0
   }
 
+  #isApplicationStarted (id) {
+    const applicationConfig = this.#applications.get(id)
+    if (!applicationConfig) {
+      return false
+    }
+
+    const workers = applicationConfig.workers.static
+    for (let i = 0; i < workers; i++) {
+      const worker = this.#workers.get(`${id}:${i}`)
+      const status = worker?.[kWorkerStatus]
+
+      // Match startApplication(): anything past boot/init means already started.
+      if (status && status !== 'boot' && status !== 'init') {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  async #startExtensions () {
+    for (const extension of this.#extensions) {
+      if (extension.started) {
+        continue
+      }
+
+      try {
+        await extension.instance?.start?.()
+        extension.started = true
+      } catch (e) {
+        throw new FailedToStartExtensionError(extension.path, e.message, { cause: e })
+      }
+    }
+  }
+
+  async #stopExtensions () {
+    // Stop in reverse order, so that extensions loaded later, which might depend
+    // on earlier ones, are stopped first. Only extensions that completed start
+    // (including those without a start hook) are stopped, and at most once.
+    for (const extension of [...this.#extensions].reverse()) {
+      if (!extension.started || extension.stopped) {
+        continue
+      }
+
+      // Mark before invoking so repeated stop is idempotent even if stop throws.
+      extension.stopped = true
+
+      try {
+        await extension.instance?.stop?.()
+      } catch (e) {
+        const err = new FailedToStopExtensionError(extension.path, e.message, { cause: e })
+        this.logger.error({ err: ensureLoggableError(err) }, `Failed to stop the extension "${extension.path}".`)
+      }
+    }
+  }
+
   async #closeExtensions () {
     // Close in reverse order, so that extensions loaded later, which might depend
-    // on earlier ones, are closed first.
+    // on earlier ones, are closed first. Close is invoked at most once per extension.
     const extensions = this.#extensions.splice(0).reverse()
 
-    for (const { path, instance, registry } of extensions) {
+    for (const extension of extensions) {
+      if (extension.closed) {
+        continue
+      }
+
+      extension.closed = true
+
       try {
-        await instance?.close?.()
+        await extension.instance?.close?.()
       } catch (e) {
-        this.logger.error({ err: ensureLoggableError(e) }, `Failed to close the extension "${path}".`)
+        this.logger.error(
+          { err: ensureLoggableError(e) },
+          `Failed to close the extension "${extension.path}".`
+        )
       }
 
       // Drop the extension registry after close so its metrics stop appearing in
       // getMetrics()/exporters and collectors cannot keep running in the background.
       try {
-        registry?.clear()
+        extension.registry?.clear()
       } catch (e) {
         this.logger.error(
           { err: ensureLoggableError(e) },
-          `Failed to clear metrics registry for extension "${path}".`
+          `Failed to clear metrics registry for extension "${extension.path}".`
         )
       }
     }

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -97,7 +97,7 @@ test('extensions can notify workers', async t => {
   throw new Error('The worker never received the notification')
 })
 
-test('extensions are closed in reverse order when the runtime is closed', async t => {
+test('extensions start, stop and close in registration and reverse order', async t => {
   cleanExtensionGlobals()
   process.env.PORT = 0
 
@@ -107,7 +107,9 @@ test('extensions are closed in reverse order when the runtime is closed', async 
 
   deepStrictEqual(globalThis.__pltExtensionEvents, [
     { event: 'setup', extension: 'first' },
-    { event: 'setup', extension: 'second' }
+    { event: 'setup', extension: 'second' },
+    { event: 'start', extension: 'first' },
+    { event: 'start', extension: 'second' }
   ])
 
   await app.close()
@@ -115,6 +117,165 @@ test('extensions are closed in reverse order when the runtime is closed', async 
   deepStrictEqual(globalThis.__pltExtensionEvents, [
     { event: 'setup', extension: 'first' },
     { event: 'setup', extension: 'second' },
+    { event: 'start', extension: 'first' },
+    { event: 'start', extension: 'second' },
+    { event: 'stop', extension: 'second' },
+    { event: 'stop', extension: 'first' },
+    { event: 'close', extension: 'second' },
+    { event: 'close', extension: 'first' }
+  ])
+})
+
+test('close-only extensions keep their current behavior', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-close-only.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  deepStrictEqual(globalThis.__pltExtensionEvents, [
+    { event: 'setup', extension: 'close-only' }
+  ])
+
+  await app.close()
+
+  deepStrictEqual(globalThis.__pltExtensionEvents, [
+    { event: 'setup', extension: 'close-only' },
+    { event: 'close', extension: 'close-only' }
+  ])
+})
+
+test('entrypoint stops before extension stop, remaining applications stop after', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-lifecycle.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  await app.close()
+
+  const events = globalThis.__pltExtensionEvents
+  const entrypointStopped = events.findIndex(e => e.event === 'application:stopped' && e.application === 'a')
+  const extensionStop = events.findIndex(e => e.event === 'stop' && e.extension === 'tracker')
+  const remainingStopped = events.findIndex(e => e.event === 'application:stopped' && e.application === 'b')
+
+  ok(entrypointStopped !== -1)
+  ok(extensionStop !== -1)
+  ok(remainingStopped !== -1)
+  ok(entrypointStopped < extensionStop)
+  ok(extensionStop < remainingStopped)
+})
+
+test('dynamic application started by an extension is not started twice', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-dynamic.json')
+  const app = await createRuntime(configFile)
+  const entryUrl = await app.start()
+
+  t.after(() => app.close())
+
+  const startedB = globalThis.__pltExtensionEvents.filter(
+    e => e.event === 'application:started' && e.application === 'b'
+  )
+  strictEqual(startedB.length, 1)
+
+  deepStrictEqual(app.getApplicationsIds().toSorted(), ['a', 'b'])
+
+  const details = await app.getApplicationDetails('b')
+  strictEqual(details.status, 'started')
+  ok(entryUrl)
+})
+
+test('configured application started by an extension is not started twice', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-start-configured.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  t.after(() => app.close())
+
+  const startedA = globalThis.__pltExtensionEvents.filter(
+    e => e.event === 'application:started' && e.application === 'a'
+  )
+  strictEqual(startedA.length, 1)
+  ok(globalThis.__pltExtensionEvents.some(e => e.event === 'started-configured' && e.application === 'a'))
+})
+
+test('start-hook rejection performs partial cleanup', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-start-fail.json')
+  const app = await createRuntime(configFile)
+
+  await rejects(
+    () => app.start(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_FAILED_TO_START_EXTENSION')
+      ok(err.message.includes('start intentionally failed'))
+      strictEqual(err.cause.message, 'start intentionally failed')
+      return true
+    }
+  )
+
+  deepStrictEqual(globalThis.__pltExtensionEvents, [
+    { event: 'setup', extension: 'first' },
+    { event: 'setup', extension: 'start-fail' },
+    { event: 'start', extension: 'first' },
+    { event: 'start', extension: 'start-fail' },
+    { event: 'stop', extension: 'first' },
+    { event: 'close', extension: 'start-fail' },
+    { event: 'close', extension: 'first' }
+  ])
+})
+
+test('application startup rejection performs extension cleanup', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-app-fail.json')
+  const app = await createRuntime(configFile)
+
+  await rejects(() => app.start())
+
+  ok(globalThis.__pltExtensionEvents.some(e => e.event === 'start' && e.extension === 'first'))
+  ok(globalThis.__pltExtensionEvents.some(e => e.event === 'stop' && e.extension === 'first'))
+  ok(globalThis.__pltExtensionEvents.some(e => e.event === 'close' && e.extension === 'first'))
+
+  const startIdx = globalThis.__pltExtensionEvents.findIndex(e => e.event === 'start' && e.extension === 'first')
+  const stopIdx = globalThis.__pltExtensionEvents.findIndex(e => e.event === 'stop' && e.extension === 'first')
+  const closeIdx = globalThis.__pltExtensionEvents.findIndex(e => e.event === 'close' && e.extension === 'first')
+  ok(startIdx < stopIdx)
+  ok(stopIdx < closeIdx)
+})
+
+test('repeated stop and close are idempotent for extension hooks', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  await app.stop()
+  await app.stop()
+  await app.close()
+  await app.close()
+
+  const stops = globalThis.__pltExtensionEvents.filter(e => e.event === 'stop')
+  const closes = globalThis.__pltExtensionEvents.filter(e => e.event === 'close')
+
+  deepStrictEqual(stops, [
+    { event: 'stop', extension: 'second' },
+    { event: 'stop', extension: 'first' }
+  ])
+  deepStrictEqual(closes, [
     { event: 'close', extension: 'second' },
     { event: 'close', extension: 'first' }
   ])

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -225,6 +225,8 @@ test('RuntimeExtension', () => {
     expect(runtime.updateSharedContext({ context: { fromExtension: true } })).type.toBe<Promise<object>>()
 
     return {
+      async start () {},
+      async stop () {},
       async close () {}
     }
   }
@@ -232,5 +234,7 @@ test('RuntimeExtension', () => {
   expect(extension).type.toBe<RuntimeExtension>()
 
   const instance: RuntimeExtensionInstance = {}
+  expect(instance.start).type.toBe<(() => void | Promise<void>) | undefined>()
+  expect(instance.stop).type.toBe<(() => void | Promise<void>) | undefined>()
   expect(instance.close).type.toBe<(() => void | Promise<void>) | undefined>()
 })


### PR DESCRIPTION
## Summary

Implements awaited lifecycle hooks for runtime extensions (#4996).

Extensions can now return:

```ts
interface RuntimeExtensionInstance {
  start?: () => void | Promise<void>
  stop?: () => void | Promise<void>
  close?: () => void | Promise<void>
}
```

### Semantics

- **Setup** still runs once during `Runtime.init()` (unchanged)
- **start** runs after applications are prepared/registered, before they accept traffic; Runtime awaits all extension starts
- Dynamic applications started by an extension are excluded from the normal startup pass (not started twice)
- Runtime does not report `started` until extension + application startup complete
- **stop** runs after the entrypoint is stopped and before remaining applications stop
- **stop** / **close** run in reverse registration order, at most once per Runtime life (including failed-start cleanup and repeated `stop`/`close`)
- Start failures use `PLT_RUNTIME_FAILED_TO_START_EXTENSION` with cause preserved; partial cleanup stops already-started extensions
- Close-only extensions keep their previous behavior

### Docs

Updated `docs/reference/runtime/_shared-configuration.md` with the new hooks and ordering guarantees.

## Test plan

- [x] `packages/runtime` extensions tests (18) — lifecycle order, reverse stop/close, dynamic app not double-started, entrypoint-before-stop, remaining-apps-after-stop, start-hook partial cleanup, app-start rejection cleanup, idempotent stop/close, close-only compatibility
- [x] `packages/runtime` type tests
- [x] ESLint on changed package

Fixes #4996
