### PR TITLE
feat(runtime): let extensions contribute health checks and probe routes

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -66,7 +66,7 @@ before any application is started. TypeScript files are supported out of the box
 [Node.js type stripping](https://nodejs.org/api/typescript.html#type-stripping).
 
 ```js
-export default async function setup ({ runtime, itc, sharedContext, logger, options, root, metrics }) {
+export default async function setup ({ runtime, itc, sharedContext, logger, options, root, metrics, health }) {
   // React to runtime events
   runtime.on('application:worker:started', payload => {
     logger.info({ payload }, 'worker started')
@@ -89,6 +89,17 @@ export default async function setup ({ runtime, itc, sharedContext, logger, opti
     registers: [registry]
   })
   jobs.set(0)
+
+  // Contribute readiness/liveness checks and diagnostic routes on the health probes server
+  health.registerReadinessCheck('dispatchable', async () => {
+    return { status: true }
+  })
+
+  health.registerLivenessCheck('control-plane', async () => true)
+
+  health.registerRoutes(async app => {
+    app.get('/inventory', async () => ({ ok: true }))
+  })
 
   return {
     async start () {
@@ -145,6 +156,21 @@ The setup function receives a context object with the following properties:
   restart metrics, or application worker metrics. Collisions fail with
   `PLT_RUNTIME_METRIC_FAMILY_COLLISION`, identifying the extension and metric family. The registry is
   cleared when the extension closes (including partial startup failures).
+- **`health`** - API for contributing readiness/liveness checks and diagnostic routes on Watt's health
+  probes server (the metrics server when probes are shared with it, or the dedicated health probes
+  server when configured separately):
+  - **`registerReadinessCheck(name, check)`** - Registers a named check that participates in `/ready`.
+    Check names must be unique across extensions. The check may return a boolean or
+    `{ status, statusCode?, body? }`. Rejected, timed-out, or malformed checks fail closed. Timeouts
+    use the configured health checks timeout. **Readiness-only failures do not fail `/status`**
+    (liveness), so a temporary control-plane condition can stop traffic without triggering a pod
+    restart loop. Returns an unregister function.
+  - **`registerLivenessCheck(name, check)`** - Same contract as readiness, but the check participates
+    in `/status`. Returns an unregister function.
+  - **`registerRoutes(plugin)`** - Registers a Fastify plugin on the health probes server before it
+    starts listening. Works for shared and separate probe servers. Route collisions fail startup with
+    a coded error identifying the extension and route. Returns an unregister function that disables
+    the routes. Closing the extension removes its checks and routes.
 
 The setup function can optionally return an object with awaited lifecycle hooks:
 
@@ -163,7 +189,8 @@ The setup function can optionally return an object with awaited lifecycle hooks:
 When multiple extensions are configured, they are set up and started in registration order. `stop` and
 `close` run in reverse registration order. Each of `stop` and `close` is invoked at most once per
 Runtime life, including repeated `stop`/`close` calls and failed-start cleanup paths. Existing
-extensions that only return `close()` keep their previous behavior.
+extensions that only return `close()` keep their previous behavior. Health checks and routes registered
+by an extension are cleaned up with it.
 
 Listening to Runtime `EventEmitter` events is not a substitute for these hooks: `emit()` does not await
 asynchronous listeners. Lifecycle ordering is enforced by Runtime itself so it covers signal handling,

--- a/packages/runtime/fixtures/extensions/extension-health-api.js
+++ b/packages/runtime/fixtures/extensions/extension-health-api.js
@@ -1,0 +1,69 @@
+export default function setup ({ health, options, logger }) {
+  const state = (globalThis.__pltExtensionHealthApi ??= {
+    readiness: true,
+    readinessResult: undefined,
+    readinessThrow: false,
+    readinessDelay: 0,
+    readinessMalformed: false,
+    liveness: true,
+    livenessResult: undefined,
+    livenessThrow: false,
+    events: []
+  })
+
+  state.events.push({ event: 'setup', options })
+
+  if (options.registerReadiness !== false) {
+    state.unregisterReadiness = health.registerReadinessCheck(options.readinessName ?? 'dispatchable', async () => {
+      if (state.readinessDelay > 0) {
+        await new Promise(resolve => setTimeout(resolve, state.readinessDelay))
+      }
+
+      if (state.readinessThrow) {
+        throw new Error('readiness boom')
+      }
+
+      if (state.readinessMalformed) {
+        return 'nope'
+      }
+
+      if (typeof state.readinessResult !== 'undefined') {
+        return state.readinessResult
+      }
+
+      return state.readiness
+    })
+  }
+
+  if (options.registerLiveness !== false) {
+    state.unregisterLiveness = health.registerLivenessCheck(options.livenessName ?? 'control-plane', async () => {
+      if (state.livenessThrow) {
+        throw new Error('liveness boom')
+      }
+
+      if (typeof state.livenessResult !== 'undefined') {
+        return state.livenessResult
+      }
+
+      return state.liveness
+    })
+  }
+
+  if (options.registerRoutes !== false) {
+    state.unregisterRoutes = health.registerRoutes(async app => {
+      app.get(options.routePath ?? '/inventory', async () => {
+        return { ok: true, from: options.id ?? 'extension' }
+      })
+    })
+  }
+
+  return {
+    async close () {
+      state.events.push({ event: 'close' })
+      // Runtime also cleans up health contributions; explicit unregisters exercise the API.
+      state.unregisterReadiness?.()
+      state.unregisterLiveness?.()
+      state.unregisterRoutes?.()
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-health-duplicate-check-a.js
+++ b/packages/runtime/fixtures/extensions/extension-health-duplicate-check-a.js
@@ -1,0 +1,3 @@
+export default function setup ({ health }) {
+  health.registerReadinessCheck('shared', () => true)
+}

--- a/packages/runtime/fixtures/extensions/extension-health-duplicate-check-b.js
+++ b/packages/runtime/fixtures/extensions/extension-health-duplicate-check-b.js
@@ -1,0 +1,3 @@
+export default function setup ({ health }) {
+  health.registerReadinessCheck('shared', () => false)
+}

--- a/packages/runtime/fixtures/extensions/extension-health-duplicate-check.js
+++ b/packages/runtime/fixtures/extensions/extension-health-duplicate-check.js
@@ -1,0 +1,4 @@
+export default function setup ({ health }) {
+  health.registerReadinessCheck('shared', () => true)
+  health.registerReadinessCheck('shared', () => true)
+}

--- a/packages/runtime/fixtures/extensions/extension-health-duplicate-route.js
+++ b/packages/runtime/fixtures/extensions/extension-health-duplicate-route.js
@@ -1,0 +1,9 @@
+export default function setup ({ health }) {
+  health.registerRoutes(async app => {
+    app.get('/inventory', async () => ({ ok: 1 }))
+  })
+
+  health.registerRoutes(async app => {
+    app.get('/inventory', async () => ({ ok: 2 }))
+  })
+}

--- a/packages/runtime/fixtures/extensions/extension-health-ready-only.js
+++ b/packages/runtime/fixtures/extensions/extension-health-ready-only.js
@@ -1,0 +1,7 @@
+export default function setup ({ health }) {
+  const state = (globalThis.__pltExtensionReadyOnly ??= {
+    readiness: true
+  })
+
+  health.registerReadinessCheck('ready-only', async () => state.readiness)
+}

--- a/packages/runtime/fixtures/extensions/extension-health-second.js
+++ b/packages/runtime/fixtures/extensions/extension-health-second.js
@@ -1,0 +1,17 @@
+export default function setup ({ health, options }) {
+  health.registerReadinessCheck(options.readinessName ?? 'second-ready', async () => {
+    const state = globalThis.__pltExtensionHealthSecond ?? { readiness: true }
+    return state.readiness
+  })
+
+  health.registerLivenessCheck(options.livenessName ?? 'second-live', async () => {
+    const state = globalThis.__pltExtensionHealthSecond ?? { liveness: true }
+    return state.liveness
+  })
+
+  if (options.registerRoutes !== false) {
+    health.registerRoutes(async app => {
+      app.get(options.routePath ?? '/second-inventory', async () => ({ ok: true, from: 'second' }))
+    })
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health-api-separate.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health-api-separate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": [
+    {
+      "path": "./extension-health-api.js",
+      "options": {
+        "id": "primary"
+      }
+    }
+  ],
+  "autoload": {
+    "path": "./services",
+    "exclude": ["crash-on-start"]
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": "{{METRICS_PORT}}"
+  },
+  "healthProbes": {
+    "hostname": "127.0.0.1",
+    "port": "{{HEALTH_PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health-api.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health-api.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": [
+    {
+      "path": "./extension-health-api.js",
+      "options": {
+        "id": "primary"
+      }
+    }
+  ],
+  "autoload": {
+    "path": "./services",
+    "exclude": ["crash-on-start"]
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": "{{METRICS_PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health-duplicate-check-multi.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health-duplicate-check-multi.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": [
+    "./extension-health-duplicate-check-a.js",
+    "./extension-health-duplicate-check-b.js"
+  ],
+  "autoload": {
+    "path": "./services",
+    "exclude": ["crash-on-start"]
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health-duplicate-check.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health-duplicate-check.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "./extension-health-duplicate-check.js",
+  "autoload": {
+    "path": "./services",
+    "exclude": ["crash-on-start"]
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health-duplicate-route.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health-duplicate-route.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "./extension-health-duplicate-route.js",
+  "autoload": {
+    "path": "./services",
+    "exclude": ["crash-on-start"]
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health-multi.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health-multi.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": [
+    {
+      "path": "./extension-health-api.js",
+      "options": {
+        "id": "primary",
+        "registerRoutes": false
+      }
+    },
+    {
+      "path": "./extension-health-second.js",
+      "options": {
+        "registerRoutes": false
+      }
+    }
+  ],
+  "autoload": {
+    "path": "./services",
+    "exclude": ["crash-on-start"]
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": "{{METRICS_PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-health-ready-only.json
+++ b/packages/runtime/fixtures/extensions/platformatic-health-ready-only.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "a",
+  "extensions": "./extension-health-ready-only.js",
+  "autoload": {
+    "path": "./services",
+    "exclude": ["crash-on-start"]
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "{{PORT}}"
+  },
+  "metrics": {
+    "hostname": "127.0.0.1",
+    "port": "{{METRICS_PORT}}"
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -63,6 +63,14 @@ export namespace errors {
     metricFamily: string,
     otherSource: string
   ) => FastifyError
+  export const DuplicateExtensionHealthCheckError: (kind: string, name: string, extension: string) => FastifyError
+  export const DuplicateExtensionHealthRouteError: (
+    extension: string,
+    method: string,
+    url: string,
+    error: string
+  ) => FastifyError
+  export const ExtensionHealthRoutesUnavailableError: () => FastifyError
   export const LastProfileTimeoutError: (id: string) => FastifyError
 }
 
@@ -209,6 +217,36 @@ export interface RuntimeExtensionMetrics {
   registry: PromClient.Registry
 }
 
+export type ExtensionHealthCheckResult =
+  | boolean
+  | {
+    status: boolean
+    statusCode?: number
+    body?: string | object
+  }
+
+export type ExtensionHealthCheck = () => ExtensionHealthCheckResult | Promise<ExtensionHealthCheckResult>
+
+export interface RuntimeExtensionHealth {
+  /**
+   * Registers a readiness check that participates in `/ready`.
+   * Readiness-only failures do not fail `/status` (liveness).
+   * Returns an unregister function.
+   */
+  registerReadinessCheck (name: string, check: ExtensionHealthCheck): () => void
+  /**
+   * Registers a liveness check that participates in `/status`.
+   * Returns an unregister function.
+   */
+  registerLivenessCheck (name: string, check: ExtensionHealthCheck): () => void
+  /**
+   * Registers a Fastify plugin on the health probes server (shared with metrics
+   * when they use the same address). Routes are registered before the server
+   * starts listening. Returns an unregister function that disables the routes.
+   */
+  registerRoutes (plugin: (instance: any, opts: any) => unknown | Promise<unknown>): () => void
+}
+
 export interface RuntimeExtensionContext {
   runtime: Runtime
   itc: RuntimeExtensionITC
@@ -224,6 +262,7 @@ export interface RuntimeExtensionContext {
    * `metrics.labels` (excluding the application label name) are applied.
    */
   metrics: RuntimeExtensionMetrics
+  health: RuntimeExtensionHealth
 }
 
 export interface RuntimeExtensionInstance {

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -185,6 +185,21 @@ export const MetricFamilyCollisionError = createError(
   'Extension "%s" registered metric family "%s" which collides with %s'
 )
 
+export const DuplicateExtensionHealthCheckError = createError(
+  `${ERROR_PREFIX}_DUPLICATE_EXTENSION_HEALTH_CHECK`,
+  'The extension health %s check "%s" has already been registered by "%s"'
+)
+
+export const DuplicateExtensionHealthRouteError = createError(
+  `${ERROR_PREFIX}_DUPLICATE_EXTENSION_HEALTH_ROUTE`,
+  'The extension "%s" failed to register health route %s %s: %s'
+)
+
+export const ExtensionHealthRoutesUnavailableError = createError(
+  `${ERROR_PREFIX}_EXTENSION_HEALTH_ROUTES_UNAVAILABLE`,
+  'Extensions registered health routes but no health probes server is available'
+)
+
 export const FailedToSendHealthSignalsError = createError(
   `${ERROR_PREFIX}_FAILED_TO_SEND_HEALTH_SIGNALS`,
   'Cannot send health signals from application "%s": %s'

--- a/packages/runtime/lib/prom-server.js
+++ b/packages/runtime/lib/prom-server.js
@@ -4,6 +4,7 @@ import { loadModule, sanitizeHTTPSOptions } from '@platformatic/foundation'
 import fastify from 'fastify'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
+import { DuplicateExtensionHealthRouteError } from './errors.js'
 
 const DEFAULT_HOSTNAME = '0.0.0.0'
 const DEFAULT_PORT = 9090
@@ -19,7 +20,7 @@ const DEFAULT_LIVENESS_SUCCESS_BODY = 'OK'
 const DEFAULT_LIVENESS_FAIL_STATUS_CODE = 500
 const DEFAULT_LIVENESS_FAIL_BODY = 'ERR'
 
-async function checkReadiness (runtime) {
+async function checkWorkerReadiness (runtime) {
   const workers = await runtime.getWorkers()
   const applications = await runtime.getApplicationsIds()
 
@@ -52,18 +53,39 @@ async function checkReadiness (runtime) {
   return { response, status }
 }
 
-async function checkLiveness (runtime) {
-  const { status: ready, response: readinessResponse } = await checkReadiness(runtime)
-  if (!ready) {
-    return { status: false, readiness: readinessResponse }
+async function checkReadiness (runtime) {
+  const workerResult = await checkWorkerReadiness(runtime)
+  if (!workerResult.status) {
+    return workerResult
   }
-  // TODO test, doc
-  // in case of readiness check failure, if custom readiness response is set, we return the readiness check response on health check endpoint
+
+  // Extension readiness checks participate in /ready only.
+  const extensionResult = await runtime.runExtensionReadinessChecks()
+  if (!extensionResult.status) {
+    return {
+      status: false,
+      response: extensionResult.response ?? workerResult.response
+    }
+  }
+
+  return {
+    status: true,
+    response: extensionResult.response ?? workerResult.response
+  }
+}
+
+async function checkLiveness (runtime) {
+  // Worker readiness still gates liveness (existing semantics), but extension
+  // readiness-only failures must not fail /status and cause restart loops.
+  const workerReadiness = await checkWorkerReadiness(runtime)
+  if (!workerReadiness.status) {
+    return { status: false, readiness: workerReadiness.response }
+  }
 
   const checks = await runtime.getCustomHealthChecks()
 
   let response
-  const status = Object.values(checks).every(check => {
+  const workerStatus = Object.values(checks).every(check => {
     if (typeof check === 'boolean') {
       return check
     } else if (typeof check === 'object') {
@@ -73,7 +95,22 @@ async function checkLiveness (runtime) {
     return false
   })
 
-  return { response, status }
+  if (!workerStatus) {
+    return { response, status: false }
+  }
+
+  const extensionResult = await runtime.runExtensionLivenessChecks()
+  if (!extensionResult.status) {
+    return {
+      status: false,
+      response: extensionResult.response ?? response
+    }
+  }
+
+  return {
+    status: true,
+    response: extensionResult.response ?? response
+  }
 }
 
 function isHealthProbesServerEnabled (healthProbes) {
@@ -119,6 +156,37 @@ function resolveHealthProbesOptions (metricsOpts, healthProbes) {
     port,
     readiness: healthProbes.readiness ?? metricsOpts.readiness,
     liveness: healthProbes.liveness ?? metricsOpts.liveness
+  }
+}
+
+async function registerExtensionHealthRoutes (promServer, runtime) {
+  const routes = runtime.getExtensionHealthRoutes?.() ?? []
+
+  for (const entry of routes) {
+    if (!entry.active) {
+      continue
+    }
+
+    try {
+      await promServer.register(async function extensionHealthRoutes (app) {
+        app.addHook('onRequest', async (_req, reply) => {
+          if (!entry.active) {
+            return reply.code(404).send({ message: 'Not Found' })
+          }
+        })
+
+        await app.register(entry.plugin)
+      })
+      entry.applied = true
+    } catch (err) {
+      const routeMatch = typeof err.message === 'string'
+        ? err.message.match(/Method '([^']+)' already declared for route '([^']+)'/i)
+        : null
+      const method = routeMatch?.[1] ?? 'UNKNOWN'
+      const url = routeMatch?.[2] ?? 'unknown'
+
+      throw new DuplicateExtensionHealthRouteError(entry.extensionPath, method, url, err.message, { cause: err })
+    }
   }
 }
 
@@ -279,6 +347,11 @@ async function startServer (runtime, opts, metricsEnabled, healthProbesEnabled) 
   for (const pluginPath of opts.plugins ?? []) {
     const plugin = await loadModule(require, pluginPath)
     await promServer.register(plugin)
+  }
+
+  // Extension routes must be registered before the server starts listening.
+  if (healthProbesEnabled) {
+    await registerExtensionHealthRoutes(promServer, runtime)
   }
 
   await promServer.listen({ port, host })

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -39,7 +39,9 @@ import {
   ApplicationNotStartedError,
   ApplicationStartTimeoutError,
   CannotRemoveEntrypointError,
+  DuplicateExtensionHealthCheckError,
   DuplicateITCHandlerNameError,
+  ExtensionHealthRoutesUnavailableError,
   FailedToLoadExtensionError,
   FailedToStartExtensionError,
   FailedToStopExtensionError,
@@ -192,6 +194,9 @@ export class Runtime extends EventEmitter {
   #reservedITCHandlerNames
   #extensions
   #extensionsWantHealthMetrics
+  #extensionReadinessChecks
+  #extensionLivenessChecks
+  #extensionHealthRoutes
   #lastOverloadProfiles
   #restartingApplications
   #restartingWorkers
@@ -269,6 +274,9 @@ export class Runtime extends EventEmitter {
     this.#reservedITCHandlerNames.add('profiling:started')
     this.#extensions = []
     this.#extensionsWantHealthMetrics = false
+    this.#extensionReadinessChecks = new Map()
+    this.#extensionLivenessChecks = new Map()
+    this.#extensionHealthRoutes = []
     this.#lastOverloadProfiles = new Map()
     this.#sharedContext = {}
 
@@ -300,12 +308,6 @@ export class Runtime extends EventEmitter {
       this.#metricsLabelName = 'applicationId'
     }
 
-    if (config.metrics || (typeof config.healthProbes === 'object' && config.healthProbes !== null)) {
-      this.#prometheusServer = await startPrometheusServer(this, config.metrics ?? false, config.healthProbes)
-    }
-
-    this.#healthProbesServer = await startHealthProbesServer(this, config.metrics, config.healthProbes)
-
     // Initialize process-level metrics registry in the main thread if metrics or management API is enabled
     // These metrics are the same across all workers and only need to be collected once
     // We need this for management API as it can request metrics even without explicit metrics config
@@ -314,7 +316,7 @@ export class Runtime extends EventEmitter {
       collectProcessMetrics(this.#processMetricsRegistry)
     }
 
-    // Create the logger
+    // Create the logger before extensions and health/metrics servers so that both can use it.
     const [logger, destination, context] = await createLogger(config)
     this.logger = logger
     this.#loggerDestination = destination
@@ -335,8 +337,17 @@ export class Runtime extends EventEmitter {
     }
 
     // Load extensions before creating any worker so that custom ITC handlers
-    // registered by the extensions are available to all workers.
+    // registered by the extensions are available to all workers. Also load them
+    // before starting the health/metrics servers so extensions can register
+    // readiness/liveness checks and probe routes before Fastify starts listening.
     await this.#loadExtensions()
+
+    if (config.metrics || (typeof config.healthProbes === 'object' && config.healthProbes !== null)) {
+      this.#prometheusServer = await startPrometheusServer(this, config.metrics ?? false, config.healthProbes)
+    }
+
+    this.#healthProbesServer = await startHealthProbesServer(this, config.metrics, config.healthProbes)
+    this.#assertExtensionHealthRoutesApplied()
 
     await this.addApplications(this.#config.applications)
     await this.#setDispatcher(config.undici)
@@ -1085,9 +1096,15 @@ export class Runtime extends EventEmitter {
     this.#config.metrics = metricsConfig
     this.#metricsLabelName = metricsConfig?.applicationLabel || 'applicationId'
 
+    // Allow extension health routes to be re-applied on the restarted servers.
+    for (const entry of this.#extensionHealthRoutes) {
+      entry.applied = false
+    }
+
     this.#prometheusServer = await startPrometheusServer(this, metricsConfig, this.#config.healthProbes)
 
     this.#healthProbesServer = await startHealthProbesServer(this, metricsConfig, this.#config.healthProbes)
+    this.#assertExtensionHealthRoutesApplied()
 
     await this.#startOpenTelemetryMetricsForwarder(metricsConfig?.opentelemetry)
 
@@ -1394,7 +1411,7 @@ export class Runtime extends EventEmitter {
       undefined,
       [],
       this.#concurrency,
-      this.#config.metrics.healthChecksTimeout,
+      this.#getHealthChecksTimeout(),
       {}
     )
   }
@@ -1415,9 +1432,21 @@ export class Runtime extends EventEmitter {
       undefined,
       [],
       this.#concurrency,
-      this.#config.metrics.healthChecksTimeout,
+      this.#getHealthChecksTimeout(),
       {}
     )
+  }
+
+  getExtensionHealthRoutes () {
+    return this.#extensionHealthRoutes
+  }
+
+  async runExtensionReadinessChecks () {
+    return this.#runExtensionHealthChecks(this.#extensionReadinessChecks, 'readiness')
+  }
+
+  async runExtensionLivenessChecks () {
+    return this.#runExtensionHealthChecks(this.#extensionLivenessChecks, 'liveness')
   }
 
   async getMetrics (format = 'json') {
@@ -4050,6 +4079,7 @@ export class Runtime extends EventEmitter {
       }
 
       const logger = this.logger.child({ name: `extension:${basename(path)}` })
+      const health = this.#createExtensionHealth(path, logger)
 
       // One registry per extension so metric conflicts and cleanup are isolated.
       // Extension metrics are main-thread only: Runtime never invents a worker ID.
@@ -4064,12 +4094,15 @@ export class Runtime extends EventEmitter {
           logger,
           options: options ?? {},
           root: this.#root,
-          metrics
+          metrics,
+          health
         })
 
-        this.#extensions.push({ path, instance, registry, started: false, stopped: false, closed: false })
+        this.#extensions.push({ path, instance, registry, health, started: false, stopped: false, closed: false })
       } catch (e) {
         registry.clear()
+        // Drop any health contributions from a failed extension setup.
+        health.cleanup()
         throw new FailedToLoadExtensionError(path, e.message, { cause: e })
       }
     }
@@ -4156,6 +4189,9 @@ export class Runtime extends EventEmitter {
           { err: ensureLoggableError(e) },
           `Failed to close the extension "${extension.path}".`
         )
+      } finally {
+        // Always drop health contributions with the extension, even if close fails.
+        extension.health?.cleanup?.()
       }
 
       // Drop the extension registry after close so its metrics stop appearing in
@@ -4182,6 +4218,197 @@ export class Runtime extends EventEmitter {
         await this.updateSharedContext({ ...options, context: update })
       }
     }
+  }
+
+  #getHealthChecksTimeout () {
+    const metrics = this.#config.metrics
+    if (typeof metrics !== 'object' || metrics === null) {
+      return 5000
+    }
+
+    // Prefer the schema property; keep the historical misspelled key as a fallback.
+    return metrics.healthChecksTimeouts ?? metrics.healthChecksTimeout ?? 5000
+  }
+
+  #assertExtensionHealthRoutesApplied () {
+    const pending = this.#extensionHealthRoutes.filter(entry => entry.active && !entry.applied)
+    if (pending.length > 0) {
+      throw new ExtensionHealthRoutesUnavailableError()
+    }
+  }
+
+  async #runExtensionHealthChecks (checks, kind) {
+    if (checks.size === 0) {
+      return { status: true }
+    }
+
+    const timeout = this.#getHealthChecksTimeout()
+    let response
+
+    for (const [name, entry] of checks) {
+      const result = await this.#runExtensionHealthCheck(name, entry, kind, timeout)
+
+      if (typeof result === 'object' && result !== null) {
+        response = result
+      }
+
+      if (!this.#isExtensionHealthCheckSuccessful(result)) {
+        this.logger.error(
+          { extension: entry.extensionPath, check: name, kind },
+          `Extension ${kind} check "${name}" failed.`
+        )
+        return { status: false, response }
+      }
+    }
+
+    return { status: true, response }
+  }
+
+  async #runExtensionHealthCheck (name, entry, kind, timeout) {
+    try {
+      const result = await executeWithTimeout(
+        Promise.resolve().then(() => entry.check()),
+        timeout,
+        kTimeout
+      )
+
+      if (result === kTimeout) {
+        this.logger.error(
+          { extension: entry.extensionPath, check: name, kind, timeout },
+          `Extension ${kind} check "${name}" timed out.`
+        )
+        return false
+      }
+
+      if (typeof result === 'boolean') {
+        return result
+      }
+
+      if (typeof result === 'object' && result !== null && typeof result.status === 'boolean') {
+        return result
+      }
+
+      this.logger.error(
+        { extension: entry.extensionPath, check: name, kind, result },
+        `Extension ${kind} check "${name}" returned a malformed result.`
+      )
+      return false
+    } catch (err) {
+      this.logger.error(
+        { err: ensureLoggableError(err), extension: entry.extensionPath, check: name, kind },
+        `Extension ${kind} check "${name}" rejected.`
+      )
+      return false
+    }
+  }
+
+  #isExtensionHealthCheckSuccessful (result) {
+    if (typeof result === 'boolean') {
+      return result
+    }
+
+    if (typeof result === 'object' && result !== null) {
+      return !!result.status
+    }
+
+    return false
+  }
+
+  #createExtensionHealth (extensionPath, logger) {
+    const readinessNames = new Set()
+    const livenessNames = new Set()
+    const routeEntries = []
+
+    const registerCheck = (map, names, kind, name, check) => {
+      if (typeof name !== 'string' || name.length === 0) {
+        throw new InvalidArgumentError(`${kind} check name must be a non-empty string`)
+      }
+
+      if (typeof check !== 'function') {
+        throw new InvalidArgumentError(`${kind} check "${name}" must be a function`)
+      }
+
+      const existing = map.get(name)
+      if (existing) {
+        throw new DuplicateExtensionHealthCheckError(kind, name, existing.extensionPath)
+      }
+
+      const entry = { extensionPath, check }
+      map.set(name, entry)
+      names.add(name)
+
+      logger.debug({ check: name, kind }, `Registered extension ${kind} check "${name}"`)
+
+      return () => {
+        const current = map.get(name)
+        if (current === entry) {
+          map.delete(name)
+        }
+        names.delete(name)
+      }
+    }
+
+    const api = {
+      registerReadinessCheck: (name, check) => {
+        return registerCheck(this.#extensionReadinessChecks, readinessNames, 'readiness', name, check)
+      },
+      registerLivenessCheck: (name, check) => {
+        return registerCheck(this.#extensionLivenessChecks, livenessNames, 'liveness', name, check)
+      },
+      registerRoutes: plugin => {
+        if (typeof plugin !== 'function') {
+          throw new InvalidArgumentError('health route plugin must be a function')
+        }
+
+        const entry = {
+          extensionPath,
+          plugin,
+          active: true,
+          applied: false
+        }
+
+        this.#extensionHealthRoutes.push(entry)
+        routeEntries.push(entry)
+
+        logger.debug('Registered extension health routes plugin')
+
+        return () => {
+          entry.active = false
+          const index = this.#extensionHealthRoutes.indexOf(entry)
+          if (index !== -1) {
+            this.#extensionHealthRoutes.splice(index, 1)
+          }
+        }
+      },
+      cleanup: () => {
+        for (const name of readinessNames) {
+          const current = this.#extensionReadinessChecks.get(name)
+          if (current?.extensionPath === extensionPath) {
+            this.#extensionReadinessChecks.delete(name)
+          }
+        }
+        readinessNames.clear()
+
+        for (const name of livenessNames) {
+          const current = this.#extensionLivenessChecks.get(name)
+          if (current?.extensionPath === extensionPath) {
+            this.#extensionLivenessChecks.delete(name)
+          }
+        }
+        livenessNames.clear()
+
+        for (const entry of routeEntries) {
+          entry.active = false
+          const index = this.#extensionHealthRoutes.indexOf(entry)
+          if (index !== -1) {
+            this.#extensionHealthRoutes.splice(index, 1)
+          }
+        }
+        routeEntries.length = 0
+      }
+    }
+
+    return api
   }
 
   #createExtensionITC () {

--- a/packages/runtime/test/extension-health.test.js
+++ b/packages/runtime/test/extension-health.test.js
@@ -1,0 +1,427 @@
+import getPort from 'get-port'
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { request } from 'undici'
+import { transform } from '../lib/config.js'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+function resetHealthApiState (overrides = {}) {
+  globalThis.__pltExtensionHealthApi = {
+    readiness: true,
+    readinessResult: undefined,
+    readinessThrow: false,
+    readinessDelay: 0,
+    readinessMalformed: false,
+    liveness: true,
+    livenessResult: undefined,
+    livenessThrow: false,
+    events: [],
+    ...overrides
+  }
+  globalThis.__pltExtensionReadyOnly = { readiness: true }
+  globalThis.__pltExtensionHealthSecond = { readiness: true, liveness: true }
+}
+
+async function startWithMetrics (t, configName, extraEnv = {}) {
+  process.env.PORT = '0'
+  const metricsPort = await getPort()
+  process.env.METRICS_PORT = String(metricsPort)
+
+  for (const [key, value] of Object.entries(extraEnv)) {
+    process.env[key] = String(value)
+  }
+
+  const configFile = join(fixturesDir, 'extensions', configName)
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  return { app, metricsPort }
+}
+
+async function probe (port, path) {
+  const { statusCode, body } = await request(`http://127.0.0.1:${port}${path}`)
+  const text = await body.text()
+  return { statusCode, text }
+}
+
+test('extension readiness and liveness success, plus custom routes on shared probe server', async t => {
+  resetHealthApiState()
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-api.json')
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/ready')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/status')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode, body } = await request(`http://127.0.0.1:${metricsPort}/inventory`)
+    strictEqual(statusCode, 200)
+    deepStrictEqual(await body.json(), { ok: true, from: 'primary' })
+  }
+})
+
+test('extension readiness failure fails /ready', async t => {
+  resetHealthApiState({ readiness: false })
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-api.json')
+
+  const { statusCode, text } = await probe(metricsPort, '/ready')
+  strictEqual(statusCode, 500)
+  strictEqual(text, 'ERR')
+})
+
+test('extension readiness rejection fails closed on /ready', async t => {
+  resetHealthApiState({ readinessThrow: true })
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-api.json')
+
+  const { statusCode, text } = await probe(metricsPort, '/ready')
+  strictEqual(statusCode, 500)
+  strictEqual(text, 'ERR')
+})
+
+test('extension readiness malformed result fails closed on /ready', async t => {
+  resetHealthApiState({ readinessMalformed: true })
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-api.json')
+
+  const { statusCode, text } = await probe(metricsPort, '/ready')
+  strictEqual(statusCode, 500)
+  strictEqual(text, 'ERR')
+})
+
+test('extension readiness timeout fails closed on /ready', async t => {
+  resetHealthApiState({ readinessDelay: 200 })
+  process.env.PORT = '0'
+  const metricsPort = await getPort()
+  process.env.METRICS_PORT = String(metricsPort)
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health-api.json')
+  const app = await createRuntime(configFile, null, {
+    async transform (config, ...args) {
+      config = await transform(config, ...args)
+      config.metrics = {
+        ...config.metrics,
+        healthChecksTimeouts: 50
+      }
+      return config
+    }
+  })
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const { statusCode, text } = await probe(metricsPort, '/ready')
+  strictEqual(statusCode, 500)
+  strictEqual(text, 'ERR')
+})
+
+test('extension readiness custom response body and status code', async t => {
+  resetHealthApiState({
+    readinessResult: { status: false, statusCode: 503, body: 'not-dispatchable' }
+  })
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-api.json')
+
+  const { statusCode, text } = await probe(metricsPort, '/ready')
+  strictEqual(statusCode, 503)
+  strictEqual(text, 'not-dispatchable')
+})
+
+test('extension liveness failure fails /status', async t => {
+  resetHealthApiState({ liveness: false })
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-api.json')
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/ready')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/status')
+    strictEqual(statusCode, 500)
+    strictEqual(text, 'ERR')
+  }
+})
+
+test('readiness-only extension failure does not fail liveness', async t => {
+  resetHealthApiState()
+  globalThis.__pltExtensionReadyOnly = { readiness: false }
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-ready-only.json')
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/ready')
+    strictEqual(statusCode, 500)
+    strictEqual(text, 'ERR')
+  }
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/status')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+})
+
+test('multiple extension checks aggregate deterministically', async t => {
+  resetHealthApiState({ readiness: true, liveness: true })
+  globalThis.__pltExtensionHealthSecond = { readiness: false, liveness: true }
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-multi.json')
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/ready')
+    strictEqual(statusCode, 500)
+    strictEqual(text, 'ERR')
+  }
+
+  globalThis.__pltExtensionHealthSecond.readiness = true
+  globalThis.__pltExtensionHealthApi.liveness = false
+  globalThis.__pltExtensionHealthSecond.liveness = true
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/ready')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/status')
+    strictEqual(statusCode, 500)
+    strictEqual(text, 'ERR')
+  }
+})
+
+test('extension routes work on a separate health probes server', async t => {
+  resetHealthApiState()
+  process.env.PORT = '0'
+  const metricsPort = await getPort()
+  const healthPort = await getPort()
+  process.env.METRICS_PORT = String(metricsPort)
+  process.env.HEALTH_PORT = String(healthPort)
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health-api-separate.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  {
+    const { statusCode } = await request(`http://127.0.0.1:${metricsPort}/inventory`)
+    strictEqual(statusCode, 404)
+  }
+
+  {
+    const { statusCode, body } = await request(`http://127.0.0.1:${healthPort}/inventory`)
+    strictEqual(statusCode, 200)
+    deepStrictEqual(await body.json(), { ok: true, from: 'primary' })
+  }
+
+  {
+    const { statusCode, text } = await probe(healthPort, '/ready')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode, text } = await probe(healthPort, '/status')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+})
+
+test('duplicate readiness check names fail startup with a coded error', async t => {
+  resetHealthApiState()
+  process.env.PORT = '0'
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health-duplicate-check.json')
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_FAILED_TO_LOAD_EXTENSION')
+      strictEqual(err.cause.code, 'PLT_RUNTIME_DUPLICATE_EXTENSION_HEALTH_CHECK')
+      ok(err.cause.message.includes('shared'))
+      return true
+    }
+  )
+})
+
+test('duplicate readiness check names across extensions fail startup', async t => {
+  resetHealthApiState()
+  process.env.PORT = '0'
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health-duplicate-check-multi.json')
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_FAILED_TO_LOAD_EXTENSION')
+      strictEqual(err.cause.code, 'PLT_RUNTIME_DUPLICATE_EXTENSION_HEALTH_CHECK')
+      return true
+    }
+  )
+})
+
+test('duplicate health routes fail startup with a coded error', async t => {
+  resetHealthApiState()
+  process.env.PORT = '0'
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health-duplicate-route.json')
+  const app = await createRuntime(configFile)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_DUPLICATE_EXTENSION_HEALTH_ROUTE')
+      ok(err.message.includes('/inventory'))
+      return true
+    }
+  )
+})
+
+test('closing an extension removes its checks and routes', async t => {
+  resetHealthApiState()
+  const { metricsPort } = await startWithMetrics(t, 'platformatic-health-api.json')
+
+  {
+    const { statusCode } = await request(`http://127.0.0.1:${metricsPort}/inventory`)
+    strictEqual(statusCode, 200)
+  }
+
+  // Simulate extension cleanup (as runtime close does) while the server is still up.
+  const state = globalThis.__pltExtensionHealthApi
+  state.unregisterReadiness()
+  state.unregisterLiveness()
+  state.unregisterRoutes()
+
+  // Without extension readiness checks, workers alone keep /ready healthy.
+  {
+    const { statusCode, text } = await probe(metricsPort, '/ready')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode } = await request(`http://127.0.0.1:${metricsPort}/inventory`)
+    strictEqual(statusCode, 404)
+  }
+})
+
+test('probe behavior is unchanged without extension health registrations', async t => {
+  process.env.PORT = '0'
+  const metricsPort = await getPort()
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile, null, {
+    async transform (config, ...args) {
+      config = await transform(config, ...args)
+      config.metrics = {
+        hostname: '127.0.0.1',
+        port: metricsPort
+      }
+      return config
+    }
+  })
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/ready')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode, text } = await probe(metricsPort, '/status')
+    strictEqual(statusCode, 200)
+    strictEqual(text, 'OK')
+  }
+
+  {
+    const { statusCode } = await request(`http://127.0.0.1:${metricsPort}/inventory`)
+    strictEqual(statusCode, 404)
+  }
+})
+
+test('registering health routes fails when health probes are disabled', async t => {
+  resetHealthApiState()
+  process.env.PORT = '0'
+  const metricsPort = await getPort()
+  process.env.METRICS_PORT = String(metricsPort)
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health-api.json')
+  const app = await createRuntime(configFile, null, {
+    async transform (config, ...args) {
+      config = await transform(config, ...args)
+      config.healthProbes = false
+      return config
+    }
+  })
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await rejects(
+    () => app.init(),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_EXTENSION_HEALTH_ROUTES_UNAVAILABLE')
+      return true
+    }
+  )
+})
+
+test('partial start failure cleans up extension health contributions', async t => {
+  resetHealthApiState()
+  process.env.PORT = '0'
+  const metricsPort = await getPort()
+  process.env.METRICS_PORT = String(metricsPort)
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-health-api.json')
+  const app = await createRuntime(configFile)
+  await app.init()
+
+  // Force a start failure after init (health routes already applied).
+  app.startApplications = async () => {
+    throw new Error('forced start failure')
+  }
+
+  await rejects(() => app.start(), /forced start failure/)
+
+  // closeAndThrow already closed the runtime; health contributions must be gone.
+  await sleep(10)
+  ok(globalThis.__pltExtensionHealthApi.events.some(e => e.event === 'close'))
+  strictEqual(app.getExtensionHealthRoutes().length, 0)
+})

--- a/packages/runtime/test/types/errors.tst.ts
+++ b/packages/runtime/test/types/errors.tst.ts
@@ -21,4 +21,7 @@ test('errors', () => {
   expect(errors.CannotMapSpecifierToAbsolutePathError('specifier')).type.toBe<FastifyError>()
   expect(errors.NodeInspectorFlagsNotSupportedError()).type.toBe<FastifyError>()
   expect(errors.MetricFamilyCollisionError('ext.js', 'metric', 'runtime process metrics')).type.toBe<FastifyError>()
+  expect(errors.DuplicateExtensionHealthCheckError('readiness', 'name', 'ext.js')).type.toBe<FastifyError>()
+  expect(errors.DuplicateExtensionHealthRouteError('ext.js', 'GET', '/inventory', 'dup')).type.toBe<FastifyError>()
+  expect(errors.ExtensionHealthRoutesUnavailableError()).type.toBe<FastifyError>()
 })


### PR DESCRIPTION
## Summary

Extensions can now contribute readiness/liveness checks and diagnostic routes on Watt's health probes server via a `health` API on `RuntimeExtensionContext`.

```js
export default function setup ({ health }) {
  health.registerReadinessCheck('dispatchable', async () => true)
  health.registerLivenessCheck('control-plane', async () => true)
  health.registerRoutes(async app => {
    app.get('/inventory', async () => ({ ok: true }))
  })
}
```

### Behavior

- **Readiness checks** participate in `/ready` only
- **Liveness checks** participate in `/status`
- Extension readiness-only failures do **not** fail liveness (avoids restart loops for temporary control-plane conditions)
- Worker readiness still gates liveness (existing semantics unchanged)
- Rejected, timed-out, or malformed checks fail closed
- Timeouts use the configured health checks timeout policy
- Check names are unique across extensions; duplicates fail startup with a coded error
- Routes are registered before Fastify listens, on shared or separate probe servers
- Route collisions fail startup identifying the extension and route
- Closing an extension removes its checks and routes
- Probe behavior is unchanged when no extension health contributions exist

### Implementation notes

- Extension setup now runs **before** the health/metrics servers start, so routes can be collected and registered prior to `listen`
- Logger creation is moved earlier in `init()` so extensions and servers share it

Fixes #4997

## Test plan

- [x] `packages/runtime/test/extension-health.test.js` — readiness success/failure/rejection/malformed/timeout/custom response; liveness success/failure; readiness-only does not fail liveness; multi-extension aggregation; shared and separate probe servers; duplicate name/route errors; cleanup; no-registration baseline; health probes disabled; partial-start cleanup
- [x] Existing `test/extensions.test.js` and `test/prom-metrics.test.js` still pass
- [x] Lint clean
