### PR TITLE
fix(gateway): fail loudly when a WebSocket upgrade targets a mesh-only application

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -36,6 +36,10 @@
 
 **Message:** Validation errors: %s
 
+### PLT_GATEWAY_WS_NO_TCP_UPSTREAM
+
+**Message:** Cannot proxy a WebSocket connection to the "%s" application because it does not expose a TCP server. Make the application listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".
+
 ## @platformatic/control
 
 ### PLT_CTR_RUNTIME_NOT_FOUND

--- a/packages/gateway/lib/errors.js
+++ b/packages/gateway/lib/errors.js
@@ -23,3 +23,8 @@ export const InvalidOpenAPISchemaError = createError(
   `${ERROR_PREFIX}_INVALID_OPENAPI_SCHEMA`,
   'Failed to compose OpenAPI schemas: %s'
 )
+export const WsNoTcpUpstreamError = createError(
+  `${ERROR_PREFIX}_WS_NO_TCP_UPSTREAM`,
+  'Cannot proxy a WebSocket connection to the "%s" application because it does not expose a TCP server. Make the application listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".',
+  502
+)

--- a/packages/gateway/lib/proxy.js
+++ b/packages/gateway/lib/proxy.js
@@ -7,6 +7,7 @@ import { resolve } from 'node:path'
 import { workerData } from 'node:worker_threads'
 import { getGlobalDispatcher } from 'undici'
 import { createDeduplicationHandler } from './deduplication/index.js'
+import { WsNoTcpUpstreamError } from './errors.js'
 import { initMetrics } from './metrics.js'
 
 const kProxyRoute = Symbol('plt.gateway.proxy.route')
@@ -212,6 +213,34 @@ async function proxyPlugin (app, opts) {
     // When getUpstream is provided, upstream ust be undefined, otherwise the getUpstream will be ignored
     const upstream = getUpstream ? undefined : (application.proxy?.upstream ?? origin)
 
+    // A WebSocket upgrade to this application can never succeed: the resolved WS upstream
+    // (see wsUpstream below) would be the virtual mesh origin, which the raw WebSocket
+    // client used by @fastify/http-proxy cannot resolve, so the upgrade would hang.
+    // The absence checks deliberately mirror the nullish semantics of the wsUpstream expression.
+    const wsMeshOnly = isLocalApplication(application) && url == null && ws?.upstream == null && getUpstream == null
+
+    let wsGuardPreHandler
+    if (wsMeshOnly) {
+      if (ws) {
+        // The user explicitly configured proxy.ws for an application which cannot accept
+        // WebSocket connections: warn at boot instead of letting the first upgrade fail.
+        app.log.warn(
+          `The "${application.id}" application has WebSocket options configured in "proxy.ws" but it does not expose a TCP server. WebSocket upgrades to this application will fail. Make the application listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".`
+        )
+      }
+
+      // @fastify/http-proxy dispatches WebSocket upgrades through the regular Fastify
+      // router, so a route-level preHandler rejects the upgrade before any dial attempt.
+      wsGuardPreHandler = function wsMeshOnlyGuard (request, reply, done) {
+        if (typeof request.headers.upgrade === 'string' && request.headers.upgrade.toLowerCase() === 'websocket') {
+          done(new WsNoTcpUpstreamError(application.id))
+          return
+        }
+
+        done()
+      }
+    }
+
     let proxyHandler = handler
     if (opts.deduplication?.enabled === true || application.proxy?.deduplication?.enabled === true) {
       proxyHandler = await createDeduplicationHandler({
@@ -232,6 +261,7 @@ async function proxyPlugin (app, opts) {
       handler: proxyHandler,
       preRewrite: application.proxy?.custom?.preRewrite ?? preRewrite,
       preValidation: application.proxy?.custom?.preValidation,
+      preHandler: wsGuardPreHandler,
 
       websocket: true,
       // When getUpstream is provided and no explicit WebSocket upstream is configured,

--- a/packages/gateway/test/proxy-ws-mesh-only.test.js
+++ b/packages/gateway/test/proxy-ws-mesh-only.test.js
@@ -1,0 +1,303 @@
+import { createDirectory, executeWithTimeout, kTimeout, safeRemove } from '@platformatic/foundation'
+import assert from 'assert/strict'
+import { once } from 'node:events'
+import { symlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { WebSocket } from 'ws'
+import { createFromConfig, createGatewayInRuntime, createWebsocketApplication, REFRESH_TIMEOUT } from './helper.js'
+
+const echoWsModulesRoot = resolve(import.meta.dirname, './ws/fixtures/echo-ws/node_modules')
+
+function ensureCleanup (t, folders) {
+  function cleanup () {
+    return Promise.all(folders.map(safeRemove))
+  }
+
+  t.after(cleanup)
+  return cleanup()
+}
+
+async function prepareEchoWsFixture (t) {
+  await ensureCleanup(t, [echoWsModulesRoot])
+
+  // Make sure there is @platformatic/node available in the echo-ws application.
+  // We can't simply specify it in the package.json due to circular dependencies.
+  await createDirectory(resolve(echoWsModulesRoot, '@platformatic'))
+  await symlink(resolve(import.meta.dirname, '../../node'), resolve(echoWsModulesRoot, '@platformatic/node'), 'dir')
+}
+
+async function assertGuardRejection (url, applicationId) {
+  const client = new WebSocket(url)
+
+  const result = await executeWithTimeout(once(client, 'unexpected-response'), 10000)
+  assert.notEqual(result, kTimeout, 'the WebSocket upgrade should fail fast instead of hanging')
+
+  const [req, res] = result
+  assert.equal(res.statusCode, 502)
+
+  let body = ''
+  res.setEncoding('utf-8')
+  for await (const chunk of res) {
+    body += chunk
+  }
+
+  const payload = JSON.parse(body)
+  assert.equal(payload.code, 'PLT_GATEWAY_WS_NO_TCP_UPSTREAM')
+  assert.ok(payload.message.includes(`"${applicationId}" application`), `unexpected error message: ${payload.message}`)
+
+  req.destroy()
+}
+
+test('should reject a WebSocket upgrade to a mesh-only application with a coded error', async t => {
+  await prepareEchoWsFixture(t)
+
+  const runtime = await createGatewayInRuntime(
+    t,
+    'gateway-ws-mesh-only',
+    {
+      gateway: {
+        applications: [
+          {
+            id: 'echo',
+            proxy: {
+              prefix: '/echo'
+            }
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'echo',
+        path: resolve(import.meta.dirname, './ws/fixtures/echo-ws')
+      }
+    ]
+  )
+
+  const address = await runtime.start()
+
+  // HTTP requests to the mesh-only application must keep working, including raw body passthrough
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/echo/'
+    })
+
+    assert.equal(statusCode, 200)
+    const payload = await rawBody.json()
+    assert.equal(payload.service, 'echo')
+  }
+
+  {
+    const requestBody = JSON.stringify({ hello: 'world' })
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'POST',
+      path: '/echo/',
+      headers: { 'content-type': 'application/json' },
+      body: requestBody
+    })
+
+    assert.equal(statusCode, 200)
+    const payload = await rawBody.json()
+    assert.equal(payload.method, 'POST')
+    assert.equal(payload.body, requestBody)
+  }
+
+  // The WebSocket upgrade must fail fast with the coded error
+  await assertGuardRejection(`${address.replace('http://', 'ws://')}/echo/`, 'echo')
+})
+
+test('should proxy WebSocket connections when the application exposes a TCP server', async t => {
+  await prepareEchoWsFixture(t)
+
+  const runtime = await createGatewayInRuntime(
+    t,
+    'gateway-ws-tcp',
+    {
+      gateway: {
+        applications: [
+          {
+            id: 'echo',
+            proxy: {
+              prefix: '/echo'
+            }
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'echo',
+        path: resolve(import.meta.dirname, './ws/fixtures/echo-ws'),
+        useHttp: true
+      }
+    ]
+  )
+
+  const address = await runtime.start()
+
+  const client = new WebSocket(`${address.replace('http://', 'ws://')}/echo/`)
+  await once(client, 'open')
+
+  client.send('hello')
+  const [response] = await once(client, 'message')
+  assert.equal(response.toString(), 'hello')
+
+  client.close()
+  await once(client, 'close')
+})
+
+test('should warn at boot when proxy.ws is explicitly configured for a mesh-only application', async t => {
+  const messages = []
+  const logger = {
+    warn: msg => {
+      messages.push(msg)
+    },
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+    fatal: () => {},
+    trace: () => {},
+    child: () => logger
+  }
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      loggerInstance: logger
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'mesh-ws',
+          proxy: {
+            prefix: '/mesh-ws',
+            ws: {
+              reconnect: {
+                pingInterval: 1000
+              }
+            }
+          }
+        },
+        {
+          id: 'mesh-plain',
+          proxy: {
+            prefix: '/mesh-plain'
+          }
+        }
+      ]
+    }
+  })
+
+  await gateway.start({ listen: true })
+
+  const wsWarnings = messages.filter(m => typeof m === 'string' && m.includes('WebSocket upgrades to this application will fail'))
+  assert.equal(wsWarnings.length, 1)
+  assert.ok(wsWarnings[0].includes('"mesh-ws"'))
+})
+
+test('should keep proxying WebSocket connections to an application with an external origin', async t => {
+  const { application, wsServer } = await createWebsocketApplication(t)
+  wsServer.on('connection', socket => {
+    socket.on('message', message => {
+      socket.send(message)
+    })
+  })
+  const port = application.address().port
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'external-ws',
+          origin: `http://127.0.0.1:${port}`,
+          proxy: {
+            prefix: '/'
+          }
+        }
+      ]
+    }
+  })
+
+  const gatewayOrigin = await gateway.start({ listen: true })
+
+  // No ws.upstream and no custom.getUpstream: the WebSocket upstream falls back to the
+  // external origin and the guard must not trigger.
+  const client = new WebSocket(gatewayOrigin.replace('http://', 'ws://'))
+  await once(client, 'open')
+
+  client.send('hello')
+  const [response] = await once(client, 'message')
+  assert.equal(response.toString(), 'hello')
+
+  client.close()
+  await once(client, 'close')
+})
+
+test('should compose the guard with a user configured custom preValidation hook', async t => {
+  await prepareEchoWsFixture(t)
+
+  const runtime = await createGatewayInRuntime(
+    t,
+    'gateway-ws-composition',
+    {
+      gateway: {
+        applications: [
+          {
+            id: 'echo',
+            proxy: {
+              prefix: '/echo',
+              custom: {
+                path: resolve(import.meta.dirname, './proxy/fixtures/custom-pre-validation.js')
+              }
+            }
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'echo',
+        path: resolve(import.meta.dirname, './ws/fixtures/echo-ws')
+      }
+    ]
+  )
+
+  const address = await runtime.start()
+
+  // The user configured preValidation hook must keep running for HTTP requests
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/echo/',
+      headers: { 'x-plt-intercept': 'true' }
+    })
+
+    assert.equal(statusCode, 418)
+    assert.deepStrictEqual(await rawBody.json(), { intercepted: true })
+  }
+
+  // Regular HTTP requests must still be proxied
+  {
+    const { statusCode, body: rawBody } = await request(address, {
+      method: 'GET',
+      path: '/echo/'
+    })
+
+    assert.equal(statusCode, 200)
+    const payload = await rawBody.json()
+    assert.equal(payload.service, 'echo')
+  }
+
+  // The WebSocket upgrade must still be rejected by the guard
+  await assertGuardRejection(`${address.replace('http://', 'ws://')}/echo/`, 'echo')
+})

--- a/packages/gateway/test/proxy/fixtures/custom-pre-validation.js
+++ b/packages/gateway/test/proxy/fixtures/custom-pre-validation.js
@@ -1,0 +1,9 @@
+export default function createCustomPreValidation () {
+  return {
+    async preValidation (request, reply) {
+      if (request.headers['x-plt-intercept'] === 'true') {
+        return reply.code(418).send({ intercepted: true })
+      }
+    }
+  }
+}

--- a/packages/gateway/test/ws/fixtures/echo-ws/index.js
+++ b/packages/gateway/test/ws/fixtures/echo-ws/index.js
@@ -1,0 +1,28 @@
+import { getApplicationId } from '@platformatic/globals'
+import { createServer } from 'node:http'
+import { WebSocketServer } from 'ws'
+
+export function create () {
+  const server = createServer((req, res) => {
+    let body = ''
+    req.on('data', chunk => {
+      body += chunk
+    })
+    req.on('end', () => {
+      res.writeHead(200, {
+        'content-type': 'application/json',
+        connection: 'close'
+      })
+      res.end(JSON.stringify({ service: getApplicationId(), method: req.method, body }))
+    })
+  })
+
+  const wsServer = new WebSocketServer({ server })
+  wsServer.on('connection', socket => {
+    socket.on('message', message => {
+      socket.send(message)
+    })
+  })
+
+  return server
+}

--- a/packages/gateway/test/ws/fixtures/echo-ws/watt.json
+++ b/packages/gateway/test/ws/fixtures/echo-ws/watt.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.38.0.json"
+}


### PR DESCRIPTION
Fixes #3307. Follow-up to the discussion in #2820: this is the first of the two short-term pieces (the guard). The TCP handoff ergonomics flag will come as a separate PR.

## Problem

When the gateway proxies an application that only exists on the runtime mesh (no TCP listener), a WebSocket upgrade to it hangs silently. `@fastify/http-proxy` dials the upstream with the raw `ws` client, which cannot resolve the virtual `.plt.local` origin: the client never gets a reply and nothing is logged. With `websocket: true` being passed unconditionally for every proxied application, every mesh-only application exposes a WS route that can never work.

## Change

- New coded error `PLT_GATEWAY_WS_NO_TCP_UPSTREAM` (HTTP 502). At plugin registration time the proxy computes, per application, whether a WebSocket upgrade can ever succeed. It cannot when all of the following hold: the application is a local (mesh) one, it did not advertise a TCP url via its meta, there is no explicit `proxy.ws.upstream`, and there is no `proxy.custom.getUpstream`. For such applications a route-level `preHandler` rejects WebSocket upgrades before any dial attempt, naming the application and the three remediations (make the application listen on a TCP port, for example `useHttp: true`; set `proxy.ws.upstream`; or provide a custom `proxy.custom.getUpstream`).
- Boot-time warning when the user explicitly configured `proxy.ws.*` for such an application, since that misconfiguration is statically knowable. There is deliberately no warning for the mere existence of a mesh-only application: that would warn on every Watt boot.
- Docs: added the new error to `docs/reference/errors.md` by hand. The `gen-error-docs` script currently crashes (`__dirname` referenced in ESM scope) and targets a path that does not exist, so the file is maintained manually.

## Implementation notes

- Seam: `@fastify/http-proxy` re-dispatches every upgrade through the regular Fastify router (`handleUpgrade`), so a route-level `preHandler` fires before the WS dial and a thrown error becomes a regular HTTP error response on the raw socket, which http-proxy destroys once the response finishes. No socket leak.
- `preHandler` was chosen over `preValidation` deliberately. Setting `opts.preValidation` has two side effects in `@fastify/http-proxy`: it skips the registration of the raw-body passthrough content-type parsers (breaking HTTP proxying of raw bodies for that application) and it would clobber a user-configured `proxy.custom.preValidation`, which the gateway forwards into that single slot. The `preHandler` slot is unused by the gateway, so user hooks keep working unchanged (covered by a test).
- Upgrade detection is header-based (`upgrade: websocket`, case-insensitive). The `kWs` marker http-proxy uses internally is a private symbol.
- The absence checks in the guard condition mirror the nullish semantics of the existing `wsUpstream` expression, so edge values like an empty string behave identically in both.
- Applications with an explicit external `origin` are excluded from the guard: WS proxying to them works today through the origin fallback (see #4531) and keeps working (covered by a test; this fallback branch previously had no test coverage at all).
- Applications with `proxy.custom.getUpstream` are excluded: their upstream is resolved per connection and is unknowable at registration time, and the custom resolver may well return a reachable TCP url.
- The now-unreachable `url ?? origin` WS fallback for guarded applications is left in place: the rejection happens before it can ever be used, and removing it would grow the diff for no behavioral gain.

## Behavior notes and possible follow-ups

- The guard error goes through Fastify's hook-error path, not through the proxy reply path, so it is not routed through a configured `proxy.custom.onError`. An application formatting all its proxy failures there will not see this one.
- An explicit `proxy.ws.upstream` hand-pointed at a `.plt.local` url is statically detectable but out of scope here; possible follow-up.
- Capability types that never advertise `gateway.url` in their meta are guarded as well, which is correct: they cannot accept a raw WS dial. Tests cover service-derived capabilities.
- Worth spelling out: a `@platformatic/node` application whose entrypoint calls `server.listen()` itself always binds a real TCP port and advertises it via meta, even without `useHttp`, so it is never guarded. The mesh-only case applies to factory-style applications (`export function create/build`) where the runtime decides whether to listen.

## Tests

New `packages/gateway/test/proxy-ws-mesh-only.test.js` with five cases:

1. Mesh-only application in a runtime: HTTP requests keep working (including raw body passthrough) and the WS upgrade fails fast with the coded error (502, names the application, no hang).
2. The same application with `useHttp: true`: WS proxying works end to end through the gateway.
3. Boot warning when `proxy.ws` is explicitly configured for a mesh-only application, and only for that application.
4. Application with an explicit external origin and no `ws.upstream`: WS keeps working through the origin fallback.
5. Guard composed with a user-configured `proxy.custom.preValidation`: the user hook still runs for HTTP requests and the upgrade is still rejected.

Full gateway suite (node:test plus tstyche) and eslint run locally.
