### PR TITLE
fix(runtime): expose extension shared context and control-plane types

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -66,11 +66,14 @@ before any application is started. TypeScript files are supported out of the box
 [Node.js type stripping](https://nodejs.org/api/typescript.html#type-stripping).
 
 ```js
-export default async function setup ({ runtime, itc, logger, options, root }) {
+export default async function setup ({ runtime, itc, sharedContext, logger, options, root }) {
   // React to runtime events
   runtime.on('application:worker:started', payload => {
     logger.info({ payload }, 'worker started')
   })
+
+  // Publish state to every application worker
+  await sharedContext.update({ reconciler: { ready: true } })
 
   // Register a custom command that applications can invoke via
   // getITC().send('acme:hello', payload)
@@ -89,7 +92,9 @@ export default async function setup ({ runtime, itc, logger, options, root }) {
 The setup function receives a context object with the following properties:
 
 - **`runtime`** - The [Runtime](./programmatic.md) instance. It is an `EventEmitter`, so extensions can
-  subscribe to all [runtime events](./programmatic.md#events) and invoke any public method.
+  subscribe to all [runtime events](./programmatic.md#events) and invoke any public method, including
+  application and worker introspection (`getApplications()`, `getWorkers()`), application configuration and
+  environment (`getApplicationConfig(id)`, `getApplicationEnv(id)`), and metrics (`getMetrics()`).
 - **`itc`** - A facade over the runtime ITC:
   - **`handle(name, handler)`** - Registers a custom command invocable from any application via
     the [ITC API](./globals.md#communicating-with-runtime-extensions) returned by `getITC()` from
@@ -100,6 +105,11 @@ The setup function receives a context object with the following properties:
   - **`notify(target, name, payload)`** - Sends a fire-and-forget notification. When `target` is an
     application ID, all its running workers are notified; use `application:worker-index` to target a
     specific worker. Workers receive notifications via `getITC().on(name, handler)`.
+- **`sharedContext`** - The shared context API used by application workers. `get()` synchronously returns a
+  snapshot of the current context in main-thread extensions. `update(update, options?)` merges `update` into
+  the context and broadcasts the result to every running worker; pass `{ overwrite: true }` to replace the
+  context instead. Newly started workers receive the latest context. Use `update()` rather than mutating the
+  object returned by `get()`.
 - **`logger`** - A child of the runtime logger.
 - **`options`** - The `options` object specified in the configuration, if any.
 - **`root`** - The runtime project root directory.

--- a/docs/reference/runtime/programmatic.md
+++ b/docs/reference/runtime/programmatic.md
@@ -177,7 +177,15 @@ test('handles ping messages', async t => {
 - **`runtime.getRuntimeConfig(includeMeta = false): object`** — The resolved configuration. When `includeMeta` is `true` the `[kMetadata]` symbol is preserved (needed by `prepareApplication()`).
 - **`runtime.getRuntimeEnv(): Record<string, string>`** — Environment variables visible to the runtime process.
 - **`runtime.getApplicationsIds(): string[]`** — IDs of all configured applications.
-- **`runtime.getApplicationDetails(id, allowUnloaded = false): Promise<ApplicationDetails>`** — Per-application info: `type`, `status`, `dependencies`, `version`, `localUrl`, `entrypoint`, `workers`, `url`.
+- **`runtime.getApplications(allowUnloaded = false): Promise<{ entrypoint, production, applications }>`** — Runtime topology and per-application details. With `allowUnloaded: true`, applications without a worker are returned as `{ id, status: 'stopped' }`.
+- **`runtime.getWorkers(includeRaw = false): Promise<Record<string, WorkerDetails>>`** — Status, worker index and thread ID for each worker. `includeRaw` is for internal diagnostics and exposes the underlying worker in the direct Runtime API only.
+- **`runtime.getApplicationDetails(id, allowUnloaded = false): Promise<ApplicationDetails>`** — Per-application info: `type`, `status`, `dependencies`, `version`, `localUrl`, `entrypoint`, `workers`, `url`. With `allowUnloaded: true`, returns `{ id, status: 'stopped' }` when no worker is loaded.
+- **`runtime.getApplicationConfig(id, ensureStarted = true): Promise<object>`** — The resolved application configuration.
+- **`runtime.getApplicationEnv(id, ensureStarted = true): Promise<Record<string, string>>`** — The effective worker environment, including capability-provided variables. It requires a loaded worker: it throws `PLT_RUNTIME_APPLICATION_NOT_STARTED` if the worker exists but is stopped, `PLT_RUNTIME_WORKER_NOT_FOUND` after an application has been unloaded/stopped, and `PLT_RUNTIME_APPLICATION_NOT_FOUND` for an unknown ID.
+- **`runtime.getApplicationOpenapiSchema(id): Promise<unknown>`** and **`runtime.getApplicationGraphqlSchema(id): Promise<unknown>`** — The application's generated API schemas.
+- **`runtime.getMetrics(format = 'json'): Promise<{ metrics }>`** — Runtime metrics in JSON or the requested text format.
+- **`runtime.getSharedContext(): object`** — The current main-thread shared context. Do not mutate it directly; use `updateSharedContext()` so workers are notified.
+- **`runtime.updateSharedContext({ context, overwrite = false }): Promise<object>`** — Merges `context` into the shared context and broadcasts the new state to all running workers. Set `overwrite` to replace it instead. Broadcast failures are logged without rejecting the update.
 
 ### Per-application control
 

--- a/packages/runtime/fixtures/extensions/extension-1.js
+++ b/packages/runtime/fixtures/extensions/extension-1.js
@@ -1,9 +1,10 @@
-export default async function setup ({ runtime, itc, logger, options, root }) {
+export default async function setup ({ runtime, itc, logger, options, root, sharedContext }) {
   const events = (globalThis.__pltExtensionEvents ??= [])
   events.push({ event: 'setup', extension: 'first' })
 
-  // Expose the facade so that tests can drive it from the outside
+  // Expose the facades so that tests can drive them from the outside
   globalThis.__pltExtensionItc = itc
+  globalThis.__pltExtensionSharedContext = sharedContext
 
   itc.handle('extension:context', () => {
     return {
@@ -11,6 +12,7 @@ export default async function setup ({ runtime, itc, logger, options, root }) {
       root,
       hasRuntime: typeof runtime.getApplicationsIds === 'function',
       hasLogger: typeof logger.info === 'function',
+      hasSharedContext: typeof sharedContext?.get === 'function' && typeof sharedContext?.update === 'function',
       applications: runtime.getApplicationsIds()
     }
   })

--- a/packages/runtime/fixtures/extensions/services/a/plugin.js
+++ b/packages/runtime/fixtures/extensions/services/a/plugin.js
@@ -1,4 +1,4 @@
-import { getITC } from '@platformatic/globals'
+import { getITC, getSharedContext } from '@platformatic/globals'
 
 export default async function (fastify) {
   const itc = getITC()
@@ -24,5 +24,9 @@ export default async function (fastify) {
 
   fastify.get('/pings', async () => {
     return pings
+  })
+
+  fastify.get('/shared-context', async () => {
+    return getSharedContext().get()
   })
 }

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -109,6 +109,28 @@ export interface ApplicationDetails {
   url?: string | null
 }
 
+export interface ApplicationsTopology {
+  entrypoint: string
+  production: boolean
+  applications: ApplicationDetails[]
+}
+
+export interface WorkerDetails {
+  application: string
+  worker: string
+  status: string
+  thread: number
+  raw?: unknown
+}
+
+export interface SharedContextUpdateOptions {
+  overwrite?: boolean
+}
+
+export interface RuntimeSharedContextUpdateOptions extends SharedContextUpdateOptions {
+  context?: object
+}
+
 export interface RuntimeMetadata {
   pid: number
   cwd: string
@@ -131,8 +153,8 @@ export declare class ManagementClient {
   getRuntimeConfig (): Promise<Record<string, unknown>>
   getRuntimeEnv (): Promise<Record<string, string>>
   getApplicationsIds (): Promise<string[]>
-  getApplications (): Promise<{ entrypoint: string; production: boolean; applications: ApplicationDetails[] }>
-  getWorkers (): Promise<Record<string, unknown>>
+  getApplications (): Promise<ApplicationsTopology>
+  getWorkers (): Promise<Record<string, WorkerDetails>>
   getApplicationDetails (id: string): Promise<ApplicationDetails>
   getApplicationConfig (id: string): Promise<Record<string, unknown>>
   getApplicationEnv (id: string): Promise<Record<string, string>>
@@ -160,12 +182,29 @@ export interface RuntimeExtensionITC {
   notify (target: string, name: string, payload?: unknown): Promise<void>
 }
 
+/**
+ * Shared context facade exposed to main-thread runtime extensions.
+ *
+ * Mirrors the worker-side `sharedContext` API from `@platformatic/globals`:
+ * - `get()` returns the current snapshot (a plain object). On the main thread
+ *   this is always synchronous; the `Promise` variant exists for parity with
+ *   workers where the first read may be asynchronous.
+ * - `update(update, options?)` merges `update` into the current context by
+ *   default. Pass `{ overwrite: true }` to replace it. Updates are broadcast
+ *   to all running workers exactly like worker-originated updates.
+ */
+export interface RuntimeExtensionSharedContext {
+  get (): object | Promise<object>
+  update (update: object, options?: SharedContextUpdateOptions): Promise<void>
+}
+
 export interface RuntimeExtensionContext {
   runtime: Runtime
   itc: RuntimeExtensionITC
   logger: Logger
   options: Record<string, unknown>
   root: string
+  sharedContext: RuntimeExtensionSharedContext
 }
 
 export interface RuntimeExtensionInstance {
@@ -189,7 +228,52 @@ export declare class Runtime extends EventEmitter {
   getRuntimeEnv (): Record<string, string>
   getRuntimeConfig (includeMeta?: boolean): Record<string, unknown>
   getApplicationsIds (): string[]
+  /**
+   * Returns topology for every configured application.
+   * When `allowUnloaded` is `true`, applications without running workers are
+   * reported as `{ id, status: 'stopped' }` instead of throwing.
+   */
+  getApplications (allowUnloaded?: boolean): Promise<ApplicationsTopology>
+  getWorkers (includeRaw?: boolean): Promise<Record<string, WorkerDetails>>
+  /**
+   * Returns details for a single application.
+   * When `allowUnloaded` is `true` and the application has no running workers,
+   * returns `{ id, status: 'stopped' }` instead of throwing.
+   */
   getApplicationDetails (id: string, allowUnloaded?: boolean): Promise<ApplicationDetails>
+  /**
+   * Returns the resolved configuration of an application worker.
+   * When `ensureStarted` is `true` (default), throws `PLT_RUNTIME_APPLICATION_NOT_STARTED`
+   * if the application is not running. When no worker exists for a known application,
+   * throws `PLT_RUNTIME_WORKER_NOT_FOUND`. Unknown applications throw
+   * `PLT_RUNTIME_APPLICATION_NOT_FOUND`.
+   */
+  getApplicationConfig (id: string, ensureStarted?: boolean): Promise<Record<string, unknown>>
+  /**
+   * Returns the effective environment of an application worker (`process.env`
+   * merged with the capability env).
+   * When `ensureStarted` is `true` (default), throws `PLT_RUNTIME_APPLICATION_NOT_STARTED`
+   * if the application is not running. When no worker exists for a known application
+   * (stopped/unloaded), throws `PLT_RUNTIME_WORKER_NOT_FOUND`. Unknown applications
+   * throw `PLT_RUNTIME_APPLICATION_NOT_FOUND`.
+   */
+  getApplicationEnv (id: string, ensureStarted?: boolean): Promise<Record<string, string>>
+  getApplicationOpenapiSchema (id: string): Promise<unknown>
+  getApplicationGraphqlSchema (id: string): Promise<unknown>
+  getMetrics (format?: string): Promise<{ metrics: unknown }>
+  /**
+   * Returns the current shared context. Synchronous on the main thread.
+   * Do not mutate it in place — use `updateSharedContext()` so changes are
+   * broadcast to workers.
+   */
+  getSharedContext (): object
+  /**
+   * Merges `options.context` into the shared context (or replaces it when
+   * `options.overwrite` is `true`) and broadcasts the result to every running
+   * worker. Returns the updated snapshot. Broadcast failures are logged and do
+   * not reject the promise.
+   */
+  updateSharedContext (options?: RuntimeSharedContextUpdateOptions): Promise<object>
   startApplication (id: string, silent?: boolean): Promise<void>
   stopApplication (id: string, silent?: boolean): Promise<void>
   restartApplication (id: string): Promise<void>

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -3938,6 +3938,7 @@ export class Runtime extends EventEmitter {
         const instance = await setup({
           runtime: this,
           itc: this.#createExtensionITC(),
+          sharedContext: this.#createExtensionSharedContext(),
           logger,
           options: options ?? {},
           root: this.#root
@@ -3966,6 +3967,19 @@ export class Runtime extends EventEmitter {
         await instance?.close?.()
       } catch (e) {
         this.logger.error({ err: ensureLoggableError(e) }, `Failed to close the extension "${path}".`)
+      }
+    }
+  }
+
+  #createExtensionSharedContext () {
+    return {
+      // Synchronous on the main thread. Return an isolated snapshot so an
+      // extension cannot mutate the store without going through update(),
+      // which broadcasts changes to workers.
+      get: () => structuredClone(this.getSharedContext()),
+      update: async (update, options = {}) => {
+        // Keep the positional update authoritative, matching the worker API.
+        await this.updateSharedContext({ ...options, context: update })
       }
     }
   }

--- a/packages/runtime/test/api/service-env.test.js
+++ b/packages/runtime/test/api/service-env.test.js
@@ -1,0 +1,78 @@
+import { ok, rejects, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { createRuntime } from '../helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', '..', 'fixtures')
+
+test('should get application env when started', async t => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const env = await app.getApplicationEnv('with-logger')
+  ok(env)
+  strictEqual(typeof env, 'object')
+  // Runtime injects PLT_ENVIRONMENT into every worker
+  ok(env.PLT_ENVIRONMENT)
+})
+
+test('getApplicationEnv throws ApplicationNotStarted when workers exist but are not started', async t => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const app = await createRuntime(configFile)
+  await app.init()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await rejects(
+    () => app.getApplicationEnv('with-logger'),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_APPLICATION_NOT_STARTED')
+      return true
+    }
+  )
+})
+
+test('getApplicationEnv throws WorkerNotFound after the application is stopped', async t => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const app = await createRuntime(configFile)
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.stopApplication('with-logger')
+
+  await rejects(
+    () => app.getApplicationEnv('with-logger'),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_WORKER_NOT_FOUND')
+      return true
+    }
+  )
+})
+
+test('getApplicationEnv throws ApplicationNotFound for unknown applications', async t => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const app = await createRuntime(configFile)
+  await app.init()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await rejects(
+    () => app.getApplicationEnv('does-not-exist'),
+    err => {
+      strictEqual(err.code, 'PLT_RUNTIME_APPLICATION_NOT_FOUND')
+      return true
+    }
+  )
+})

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -9,6 +9,7 @@ const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
 function cleanExtensionGlobals () {
   globalThis.__pltExtensionEvents = []
   globalThis.__pltExtensionItc = undefined
+  globalThis.__pltExtensionSharedContext = undefined
 }
 
 test('extensions receive the runtime, the ITC facade, the logger, the options and the root', async t => {
@@ -31,6 +32,7 @@ test('extensions receive the runtime, the ITC facade, the logger, the options an
   strictEqual(context.root, join(fixturesDir, 'extensions'))
   strictEqual(context.hasRuntime, true)
   strictEqual(context.hasLogger, true)
+  strictEqual(context.hasSharedContext, true)
   deepStrictEqual(context.applications, ['a'])
 })
 
@@ -219,6 +221,103 @@ test('extensions receive the profiles captured by the continuous profiler, also 
   strictEqual(eventAfterRestart.application, 'a')
 
   await app.stopApplicationProfiling(eventAfterRestart.id, { type: 'cpu' })
+})
+
+test('extensions can read and update the shared context, including newly started workers', async t => {
+  cleanExtensionGlobals()
+  process.env.PORT = 0
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile)
+  const entryUrl = await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  const sharedContext = globalThis.__pltExtensionSharedContext
+  ok(sharedContext)
+
+  // Initial snapshot is empty
+  deepStrictEqual(sharedContext.get(), {})
+  deepStrictEqual(app.getSharedContext(), {})
+
+  // Merge update is visible to the runtime and existing workers
+  await sharedContext.update({ foo: 'bar' })
+  deepStrictEqual(sharedContext.get(), { foo: 'bar' })
+  deepStrictEqual(app.getSharedContext(), { foo: 'bar' })
+
+  {
+    const res = await request(entryUrl + '/shared-context')
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { foo: 'bar' })
+  }
+
+  // Second merge keeps previous keys
+  await sharedContext.update({ bar: 'baz' })
+  deepStrictEqual(sharedContext.get(), { foo: 'bar', bar: 'baz' })
+
+  {
+    const res = await request(app.getUrl() + '/shared-context')
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { foo: 'bar', bar: 'baz' })
+  }
+
+  // Overwrite replaces the snapshot. The positional update wins over a
+  // same-named untyped options property, as it does in the worker API.
+  await sharedContext.update({ only: true }, { context: { ignored: true }, overwrite: true })
+  deepStrictEqual(sharedContext.get(), { only: true })
+  deepStrictEqual(app.getSharedContext(), { only: true })
+
+  {
+    const res = await request(app.getUrl() + '/shared-context')
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { only: true })
+  }
+
+  // get() returns an isolated deep snapshot, so nested mutations do not
+  // silently change the main-thread context without a worker broadcast.
+  await sharedContext.update({ nested: { value: 1 } }, { overwrite: true })
+  const snapshot = sharedContext.get()
+  snapshot.nested.value = 2
+  deepStrictEqual(sharedContext.get(), { nested: { value: 1 } })
+  deepStrictEqual(app.getSharedContext(), { nested: { value: 1 } })
+
+  {
+    const res = await request(app.getUrl() + '/shared-context')
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { nested: { value: 1 } })
+  }
+
+  // Concurrent updates are applied in invocation order and reach workers.
+  await sharedContext.update({ order: 0 }, { overwrite: true })
+  await Promise.all([
+    sharedContext.update({ order: 1, first: true }),
+    sharedContext.update({ order: 2, second: true })
+  ])
+  deepStrictEqual(sharedContext.get(), { order: 2, first: true, second: true })
+
+  // Newly started (restarted) workers observe the latest snapshot
+  await app.restartApplication('a')
+
+  {
+    const res = await request(app.getUrl() + '/shared-context')
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { order: 2, first: true, second: true })
+  }
+
+  // After stop, get/update still work on the main-thread snapshot
+  await app.stop()
+  deepStrictEqual(sharedContext.get(), { order: 2, first: true, second: true })
+  await sharedContext.update({ afterStop: true })
+  deepStrictEqual(sharedContext.get(), { order: 2, first: true, second: true, afterStop: true })
+  deepStrictEqual(app.getSharedContext(), { order: 2, first: true, second: true, afterStop: true })
+
+  // The facade retains the main-thread snapshot after close; with no workers,
+  // updates remain local and do not attempt an ITC broadcast.
+  await app.close()
+  await sharedContext.update({ afterClose: true })
+  deepStrictEqual(sharedContext.get(), { order: 2, first: true, second: true, afterStop: true, afterClose: true })
 })
 
 test('extensions cannot register reserved ITC commands', async t => {

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -1,6 +1,21 @@
 import { expect, test } from 'tstyche'
 import type { Configuration } from '@platformatic/foundation'
-import { create, loadConfiguration, type Runtime, type RuntimeConfiguration, type ApplicationDetails, type InjectParams, type InjectResponse, type RuntimeExtension, type RuntimeExtensionContext, type RuntimeExtensionInstance, type RuntimeMetadata } from '../../index.js'
+import {
+  create,
+  loadConfiguration,
+  type ApplicationsTopology,
+  type Runtime,
+  type RuntimeConfiguration,
+  type ApplicationDetails,
+  type InjectParams,
+  type InjectResponse,
+  type RuntimeExtension,
+  type RuntimeExtensionContext,
+  type RuntimeExtensionInstance,
+  type RuntimeExtensionSharedContext,
+  type RuntimeMetadata,
+  type WorkerDetails
+} from '../../index.js'
 
 const context = {} as Configuration
 
@@ -81,9 +96,52 @@ test('Runtime.getApplicationsIds', () => {
   expect(runtime.getApplicationsIds()).type.toBe<string[]>()
 })
 
+test('Runtime.getApplications', () => {
+  expect(runtime.getApplications()).type.toBe<Promise<ApplicationsTopology>>()
+  expect(runtime.getApplications(true)).type.toBe<Promise<ApplicationsTopology>>()
+})
+
+test('Runtime.getWorkers', () => {
+  expect(runtime.getWorkers()).type.toBe<Promise<Record<string, WorkerDetails>>>()
+  expect(runtime.getWorkers(true)).type.toBe<Promise<Record<string, WorkerDetails>>>()
+})
+
 test('Runtime.getApplicationDetails', () => {
   expect(runtime.getApplicationDetails('api')).type.toBe<Promise<ApplicationDetails>>()
   expect(runtime.getApplicationDetails('api', true)).type.toBe<Promise<ApplicationDetails>>()
+})
+
+test('Runtime.getApplicationConfig', () => {
+  expect(runtime.getApplicationConfig('api')).type.toBe<Promise<Record<string, unknown>>>()
+  expect(runtime.getApplicationConfig('api', false)).type.toBe<Promise<Record<string, unknown>>>()
+})
+
+test('Runtime.getApplicationEnv', () => {
+  expect(runtime.getApplicationEnv('api')).type.toBe<Promise<Record<string, string>>>()
+  expect(runtime.getApplicationEnv('api', false)).type.toBe<Promise<Record<string, string>>>()
+})
+
+test('Runtime.getApplicationOpenapiSchema', () => {
+  expect(runtime.getApplicationOpenapiSchema('api')).type.toBe<Promise<unknown>>()
+})
+
+test('Runtime.getApplicationGraphqlSchema', () => {
+  expect(runtime.getApplicationGraphqlSchema('api')).type.toBe<Promise<unknown>>()
+})
+
+test('Runtime.getMetrics', () => {
+  expect(runtime.getMetrics()).type.toBe<Promise<{ metrics: unknown }>>()
+  expect(runtime.getMetrics('text')).type.toBe<Promise<{ metrics: unknown }>>()
+})
+
+test('Runtime.getSharedContext', () => {
+  expect(runtime.getSharedContext()).type.toBe<object>()
+})
+
+test('Runtime.updateSharedContext', () => {
+  expect(runtime.updateSharedContext()).type.toBe<Promise<object>>()
+  expect(runtime.updateSharedContext({ context: { foo: 'bar' } })).type.toBe<Promise<object>>()
+  expect(runtime.updateSharedContext({ context: { foo: 'bar' }, overwrite: true })).type.toBe<Promise<object>>()
 })
 
 test('Runtime.startApplication', () => {
@@ -130,16 +188,37 @@ test('Runtime.getApplicationLastProfile', () => {
 })
 
 test('RuntimeExtension', () => {
-  const extension: RuntimeExtension = async ({ runtime, itc, logger, options, root }: RuntimeExtensionContext) => {
+  const extension: RuntimeExtension = async ({
+    runtime,
+    itc,
+    logger,
+    options,
+    root,
+    sharedContext
+  }: RuntimeExtensionContext) => {
     expect(runtime).type.toBe<Runtime>()
     expect(options).type.toBe<Record<string, unknown>>()
     expect(root).type.toBe<string>()
+    expect(sharedContext).type.toBe<RuntimeExtensionSharedContext>()
 
     logger.info('loaded')
 
     itc.handle('custom:command', payload => payload)
     expect(itc.send<number>('api', 'custom:command', { value: 42 })).type.toBe<Promise<number>>()
     expect(itc.notify('api', 'custom:event', { value: 42 })).type.toBe<Promise<void>>()
+
+    expect(sharedContext.get()).type.toBe<object | Promise<object>>()
+    expect(sharedContext.update({ feature: true })).type.toBe<Promise<void>>()
+    expect(sharedContext.update({ feature: false }, { overwrite: true })).type.toBe<Promise<void>>()
+
+    // Newly public control-plane methods are callable from extensions
+    expect(runtime.getApplications()).type.toBe<Promise<ApplicationsTopology>>()
+    expect(runtime.getWorkers()).type.toBe<Promise<Record<string, WorkerDetails>>>()
+    expect(runtime.getApplicationConfig('api')).type.toBe<Promise<Record<string, unknown>>>()
+    expect(runtime.getApplicationEnv('api')).type.toBe<Promise<Record<string, string>>>()
+    expect(runtime.getMetrics()).type.toBe<Promise<{ metrics: unknown }>>()
+    expect(runtime.getSharedContext()).type.toBe<object>()
+    expect(runtime.updateSharedContext({ context: { fromExtension: true } })).type.toBe<Promise<object>>()
 
     return {
       async close () {}


### PR DESCRIPTION
## Summary

- expose Runtime control-plane operations in the public TypeScript declarations
- add a snapshot-based `sharedContext` facade to main-thread runtime extensions
- document application environment lifecycle errors and shared-context semantics
- cover extension updates, worker broadcasts, overwrite/concurrency, lifecycle states, and types

Fixes #4999

## Validation

- `cd packages/runtime && npm test`
