### PR TITLE
feat(runtime): add a websocket flag and make the gateway WebSocket upstream resilient to restarts

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -38,7 +38,7 @@
 
 ### PLT_GATEWAY_WS_NO_TCP_UPSTREAM
 
-**Message:** Cannot proxy a WebSocket connection to the "%s" application because it does not expose a TCP server. Make the application listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".
+**Message:** Cannot proxy a WebSocket connection to the "%s" application because it does not expose a TCP server. Set "websocket": true on the application, make it listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".
 
 ## @platformatic/control
 

--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -49,7 +49,7 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
     - **`hostname`** (`string`) - An additional domain name this application is reachable at. It will be matched against requests' `Host` header. When a hostname is specified, the service is accessible without the prefix when the Host header matches.
     - **`upstream`** (`string`) - The origin URL to proxy requests to. Required for external services. Not needed for Platformatic Runtime applications where the application `id` is used; will be ignored when using `custom.getUpstream`.
     - **`ws`** (`object`) - WebSocket proxy configuration. Supports the following options:
-      - **`upstream`** (`string`, **required**) - The WebSocket upstream URL (e.g., `ws://localhost:3000`).
+      - **`upstream`** (`string`) - The WebSocket upstream URL (e.g., `ws://localhost:3000`). Required for external services. Not needed for Platformatic Runtime applications exposing a TCP server (started with the `useHttp` or `websocket` flags): the gateway resolves their WebSocket upstream automatically, re-resolving it on every new connection so that new connections keep working across application restarts. Note that a connection arriving in the short window between a worker going away and the gateway observing its replacement can still be dialed against the previous port; the next connection succeeds.
       - **`reconnect`** (`object`) - WebSocket reconnection settings:
         - **`pingInterval`** (`number`) - Interval in milliseconds between ping messages to keep the connection alive.
         - **`maxReconnectionRetries`** (`number`) - Maximum number of reconnection attempts.

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -195,6 +195,7 @@ runtime. Each application object supports the following settings:
   the application.
 - **`useHttp`** (`boolean`) - The application will be started on a random HTTP port
   on `127.0.0.1`, and exposed to the other applications via that port, on default it is set to `false`. Set it to `true` if you are using [@fastify/express](https://github.com/fastify/fastify-express).
+- **`websocket`** (`boolean`) - The application will be started on a random HTTP port on `127.0.0.1` so that the gateway can proxy WebSocket connections to it, but, unlike `useHttp`, HTTP traffic between applications keeps using the in-memory mesh network when the capability supports in-thread dispatching (for example the service family); for the other capabilities it flows through the bound TCP port, as under `useHttp`. Set it to `true` when a non-entrypoint application behind the gateway needs to accept WebSocket connections. Default: `false`.
 - **`reuseTcpPorts`**: Enable the use of the [`reusePort`](https://nodejs.org/dist/latest/docs/api/net.html#serverlistenoptions-callback) option whenever any TCP server starts listening on a port. The default is `true`. The values specified here overrides the values specified in the runtime.
 - **`workers`** - The number of workers to start for this application. If the application is the entrypoint or if the runtime is running in development mode this value is ignored and hardcoded to `1`. This can be specified as:
   - **`number`** - A fixed number of workers

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -382,6 +382,22 @@ export class BaseCapability extends EventEmitter {
   }
 
   async getDispatchTarget () {
+    // When an application binds a TCP server only for WebSocket handoff purposes
+    // ("websocket" flag without "useHttp"), mesh HTTP traffic keeps being served
+    // in-thread: the TCP port is only advertised to the gateway via getMeta().
+    // This only applies to capabilities providing a real in-thread dispatch target
+    // (getDispatchFunc returning something other than the capability itself, whose
+    // inject is not implemented): the others dispatch via the bound TCP address,
+    // as under "useHttp".
+    const applicationConfig = this.context.applicationConfig
+    if (applicationConfig?.websocket && !applicationConfig.useHttp && !this.isEntrypoint) {
+      const dispatchFunc = await this.getDispatchFunc()
+
+      if (dispatchFunc !== this) {
+        return dispatchFunc
+      }
+    }
+
     return this.getUrl() ?? (await this.getDispatchFunc())
   }
 

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -141,6 +141,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/basic/test/capability.test.js
+++ b/packages/basic/test/capability.test.js
@@ -136,6 +136,38 @@ test('BaseCapability - other getters', async t => {
   deepStrictEqual(await capability.getDispatchFunc(), capability)
 })
 
+test('BaseCapability - getDispatchTarget - "websocket" flag falls back to the TCP address without an in-thread dispatch target', async t => {
+  const capability = await create(t, { applicationConfig: { websocket: true } })
+
+  capability.url = 'http://127.0.0.1:1234'
+
+  deepStrictEqual(await capability.getDispatchTarget(), 'http://127.0.0.1:1234')
+})
+
+test('BaseCapability - getDispatchTarget - "websocket" flag keeps in-thread dispatching when the capability provides it', async t => {
+  const capability = await create(t, { applicationConfig: { websocket: true } })
+
+  const dispatchTarget = { inject () {} }
+  capability.getDispatchFunc = async () => dispatchTarget
+  capability.url = 'http://127.0.0.1:1234'
+
+  deepStrictEqual(await capability.getDispatchTarget(), dispatchTarget)
+})
+
+test('BaseCapability - getDispatchTarget - "websocket" flag is ignored with "useHttp" or for the entrypoint', async t => {
+  const useHttpCapability = await create(t, { applicationConfig: { websocket: true, useHttp: true } })
+  useHttpCapability.getDispatchFunc = async () => ({ inject () {} })
+  useHttpCapability.url = 'http://127.0.0.1:1234'
+
+  deepStrictEqual(await useHttpCapability.getDispatchTarget(), 'http://127.0.0.1:1234')
+
+  const entrypointCapability = await create(t, { applicationConfig: { websocket: true }, isEntrypoint: true })
+  entrypointCapability.getDispatchFunc = async () => ({ inject () {} })
+  entrypointCapability.url = 'http://127.0.0.1:1234'
+
+  deepStrictEqual(await entrypointCapability.getDispatchTarget(), 'http://127.0.0.1:1234')
+})
+
 test('BaseCapability - waitForDependentsStop - should not wait for stopped dependents', async t => {
   const itc = new EventEmitter()
   itc.send = async () => ({

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -814,6 +814,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1512,6 +1512,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -881,6 +881,9 @@ export const application = {
     useHttp: {
       type: 'boolean'
     },
+    websocket: {
+      type: 'boolean'
+    },
     reuseTcpPorts: {
       type: 'boolean',
       default: true
@@ -1619,6 +1622,7 @@ export const applicationsUnwrappablePropertiesList = [
   'gitBranch',
   'dependencies',
   'useHttp',
+  'websocket',
   'management'
 ]
 

--- a/packages/gateway/lib/errors.js
+++ b/packages/gateway/lib/errors.js
@@ -25,6 +25,6 @@ export const InvalidOpenAPISchemaError = createError(
 )
 export const WsNoTcpUpstreamError = createError(
   `${ERROR_PREFIX}_WS_NO_TCP_UPSTREAM`,
-  'Cannot proxy a WebSocket connection to the "%s" application because it does not expose a TCP server. Make the application listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".',
+  'Cannot proxy a WebSocket connection to the "%s" application because it does not expose a TCP server. Set "websocket": true on the application, make it listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".',
   502
 )

--- a/packages/gateway/lib/proxy.js
+++ b/packages/gateway/lib/proxy.js
@@ -9,6 +9,7 @@ import { getGlobalDispatcher } from 'undici'
 import { createDeduplicationHandler } from './deduplication/index.js'
 import { WsNoTcpUpstreamError } from './errors.js'
 import { initMetrics } from './metrics.js'
+import { WsUpstreams } from './ws-upstreams.js'
 
 const kProxyRoute = Symbol('plt.gateway.proxy.route')
 
@@ -20,6 +21,10 @@ function isLocalApplication (application) {
   }
 
   return application.origin.endsWith('.plt.local')
+}
+
+function isWebSocketUpgrade (request) {
+  return typeof request.headers.upgrade === 'string' && request.headers.upgrade.toLowerCase() === 'websocket'
 }
 
 async function resolveApplicationProxyParameters (application, root) {
@@ -98,6 +103,7 @@ async function proxyPlugin (app, opts) {
   const meta = { proxies: {} }
   const hostnameLessProxies = []
   const root = opts.capability?.root ?? import.meta.dirname
+  let wsUpstreams = null
 
   let handler
   if (opts.handler) {
@@ -207,17 +213,15 @@ async function proxyPlugin (app, opts) {
       metrics = initMetrics(prometheus)
     }
 
-    const getUpstream = application.proxy?.custom?.getUpstream
+    const customGetUpstream = application.proxy?.custom?.getUpstream
     const customRewriteHeaders = application.proxy?.custom?.rewriteHeaders
     const customOnError = application.proxy?.custom?.onError
-    // When getUpstream is provided, upstream ust be undefined, otherwise the getUpstream will be ignored
-    const upstream = getUpstream ? undefined : (application.proxy?.upstream ?? origin)
 
     // A WebSocket upgrade to this application can never succeed: the resolved WS upstream
     // (see wsUpstream below) would be the virtual mesh origin, which the raw WebSocket
     // client used by @fastify/http-proxy cannot resolve, so the upgrade would hang.
     // The absence checks deliberately mirror the nullish semantics of the wsUpstream expression.
-    const wsMeshOnly = isLocalApplication(application) && url == null && ws?.upstream == null && getUpstream == null
+    const wsMeshOnly = isLocalApplication(application) && url == null && ws?.upstream == null && customGetUpstream == null
 
     let wsGuardPreHandler
     if (wsMeshOnly) {
@@ -225,14 +229,14 @@ async function proxyPlugin (app, opts) {
         // The user explicitly configured proxy.ws for an application which cannot accept
         // WebSocket connections: warn at boot instead of letting the first upgrade fail.
         app.log.warn(
-          `The "${application.id}" application has WebSocket options configured in "proxy.ws" but it does not expose a TCP server. WebSocket upgrades to this application will fail. Make the application listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".`
+          `The "${application.id}" application has WebSocket options configured in "proxy.ws" but it does not expose a TCP server. WebSocket upgrades to this application will fail. Set "websocket": true on the application, make it listen on a TCP port (e.g. "useHttp": true), set "proxy.ws.upstream", or provide a custom "proxy.custom.getUpstream".`
         )
       }
 
       // @fastify/http-proxy dispatches WebSocket upgrades through the regular Fastify
       // router, so a route-level preHandler rejects the upgrade before any dial attempt.
       wsGuardPreHandler = function wsMeshOnlyGuard (request, reply, done) {
-        if (typeof request.headers.upgrade === 'string' && request.headers.upgrade.toLowerCase() === 'websocket') {
+        if (isWebSocketUpgrade(request)) {
           done(new WsNoTcpUpstreamError(application.id))
           return
         }
@@ -240,6 +244,39 @@ async function proxyPlugin (app, opts) {
         done()
       }
     }
+
+    // For local applications exposing a TCP server ("useHttp" or "websocket" flags), resolve
+    // the WebSocket upstream per connection instead of freezing the registration-time URL:
+    // workers bind a new ephemeral port on every (re)start, so a static wsUpstream would
+    // leave the gateway dialing a dead port after a crash or a restart. HTTP requests keep
+    // being dispatched to the same upstream as before.
+    let getUpstream = customGetUpstream
+    let proxyRewritePrefix = rewritePrefix
+    const wsTcpHandoff = isLocalApplication(application) && url != null && ws?.upstream == null && customGetUpstream == null
+    if (wsTcpHandoff) {
+      wsUpstreams ??= new WsUpstreams(app.log)
+      wsUpstreams.track(application.id, url)
+
+      const httpUpstream = application.proxy?.upstream ?? origin
+
+      // Leaving the upstream undefined (see below) also disables the rewrite prefix
+      // derivation @fastify/http-proxy performs on the upstream URL pathname:
+      // replicate it so that HTTP requests keep being rewritten as before.
+      if (!proxyRewritePrefix) {
+        proxyRewritePrefix = new URL(httpUpstream).pathname
+      }
+
+      getUpstream = function tcpHandoffGetUpstream (request) {
+        if (isWebSocketUpgrade(request)) {
+          return wsUpstreams.get(application.id)
+        }
+
+        return httpUpstream
+      }
+    }
+
+    // When getUpstream is provided, upstream must be undefined, otherwise the getUpstream will be ignored
+    const upstream = getUpstream ? undefined : (application.proxy?.upstream ?? origin)
 
     let proxyHandler = handler
     if (opts.deduplication?.enabled === true || application.proxy?.deduplication?.enabled === true) {
@@ -256,7 +293,7 @@ async function proxyPlugin (app, opts) {
 
     const proxyOptions = {
       prefix,
-      rewritePrefix,
+      rewritePrefix: proxyRewritePrefix,
       upstream,
       handler: proxyHandler,
       preRewrite: application.proxy?.custom?.preRewrite ?? preRewrite,
@@ -378,6 +415,13 @@ async function proxyPlugin (app, opts) {
     }
 
     await app.register(httpProxy, options)
+  }
+
+  if (wsUpstreams) {
+    const upstreams = wsUpstreams
+    app.addHook('onClose', () => {
+      upstreams.close()
+    })
   }
 
   opts.capability?.registerMeta(meta)

--- a/packages/gateway/lib/ws-upstreams.js
+++ b/packages/gateway/lib/ws-upstreams.js
@@ -1,0 +1,124 @@
+import { getITC } from '@platformatic/globals'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+export const REFRESH_ATTEMPTS = 5
+export const REFRESH_RETRY_DELAY = 200
+
+// Tracks the TCP upstream of local applications so that WebSocket upgrades are
+// always dialed against a live worker: workers bind a new ephemeral port on
+// every (re)start, so the URL captured at plugin registration time would leave
+// the gateway dialing a dead port after a crash or a restart.
+export class WsUpstreams {
+  #logger
+  #urls
+  #itc
+  #handler
+  #inflight
+
+  constructor (logger) {
+    this.#logger = logger
+    this.#urls = new Map()
+    this.#inflight = new Set()
+  }
+
+  track (applicationId, url) {
+    this.#urls.set(applicationId, url)
+    this.#subscribe()
+  }
+
+  get (applicationId) {
+    return this.#urls.get(applicationId)
+  }
+
+  close () {
+    if (this.#handler) {
+      this.#itc.removeListener('runtime:event', this.#handler)
+      this.#handler = null
+    }
+  }
+
+  #subscribe () {
+    if (this.#handler) {
+      return
+    }
+
+    // When there is no ITC the gateway is running outside a runtime, so there
+    // are no workers which could restart and the tracked URLs cannot go stale.
+    const itc = getITC({ throwOnMissing: false })
+    if (!itc) {
+      return
+    }
+
+    this.#itc = itc
+    this.#handler = ({ event, payload }) => {
+      // emitAndNotify forwards the event arguments as an array
+      const eventPayload = payload?.[0]
+      const applicationId = eventPayload?.application
+
+      if (!this.#urls.has(applicationId)) {
+        return
+      }
+
+      if (event === 'application:worker:started') {
+        // Target the worker which just started: querying the application in
+        // round-robin mode could hit a worker which is about to be replaced
+        // and thus capture a stale URL.
+        this.#refresh(applicationId, eventPayload.worker)
+      } else if (event === 'application:worker:stopped' || event === 'application:worker:exited') {
+        // Re-resolve over the surviving workers to correct any URL captured
+        // from the worker which just went away. A single graceful stop emits
+        // both events: the in-flight guard in #refresh coalesces them.
+        this.#refresh(applicationId)
+      }
+    }
+
+    itc.on('runtime:event', this.#handler)
+  }
+
+  async #refresh (applicationId, workerId) {
+    const target = workerId == null ? applicationId : `${applicationId}:${workerId}`
+
+    if (this.#inflight.has(target)) {
+      return
+    }
+
+    this.#inflight.add(target)
+
+    try {
+      // The event may be delivered while the target worker is not addressable
+      // yet, so retry a few times before giving up.
+      for (let attempt = 0; attempt < REFRESH_ATTEMPTS; attempt++) {
+        try {
+          const allMeta = await this.#itc.send('getApplicationMeta', target)
+          const url = (allMeta.gateway ?? allMeta.composer)?.url
+
+          if (url) {
+            this.#logger.debug({ applicationId, url }, 'ws upstream refreshed')
+            this.#urls.set(applicationId, url)
+            return
+          }
+        } catch (err) {
+          // The worker is not addressable yet, retry below.
+          this.#logger.debug({ applicationId, target, err: err.message }, 'ws upstream refresh attempt failed')
+        }
+
+        await sleep(REFRESH_RETRY_DELAY)
+      }
+    } finally {
+      this.#inflight.delete(target)
+    }
+
+    if (workerId == null) {
+      // After a worker went away, finding no addressable worker is expected when
+      // the application was stopped for good: the next worker start triggers a
+      // new refresh, so this is only noteworthy at debug level.
+      this.#logger.debug(
+        `Could not refresh the WebSocket upstream of the "${applicationId}" application: no addressable worker. The upstream will be refreshed on the next worker start.`
+      )
+    } else {
+      this.#logger.warn(
+        `Could not refresh the WebSocket upstream of the "${applicationId}" application. New WebSocket connections may be dialed against a stale TCP port.`
+      )
+    }
+  }
+}

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1797,6 +1797,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/gateway/test/proxy-ws-tcp-handoff.test.js
+++ b/packages/gateway/test/proxy-ws-tcp-handoff.test.js
@@ -1,0 +1,203 @@
+import { createDirectory, executeWithTimeout, kTimeout, safeRemove } from '@platformatic/foundation'
+import assert from 'assert/strict'
+import { once } from 'node:events'
+import { symlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { request } from 'undici'
+import { WebSocket } from 'ws'
+import { createGatewayInRuntime, REFRESH_TIMEOUT } from './helper.js'
+
+const echoWsModulesRoot = resolve(import.meta.dirname, './ws/fixtures/echo-ws/node_modules')
+
+function ensureCleanup (t, folders) {
+  function cleanup () {
+    return Promise.all(folders.map(safeRemove))
+  }
+
+  t.after(cleanup)
+  return cleanup()
+}
+
+async function prepareEchoWsFixture (t) {
+  await ensureCleanup(t, [echoWsModulesRoot])
+
+  // Make sure there is @platformatic/node available in the echo-ws application.
+  // We can't simply specify it in the package.json due to circular dependencies.
+  await createDirectory(resolve(echoWsModulesRoot, '@platformatic'))
+  await symlink(resolve(import.meta.dirname, '../../node'), resolve(echoWsModulesRoot, '@platformatic/node'), 'dir')
+}
+
+async function connectAndEcho (address, path = '/echo/') {
+  // The timeouts make sure a single attempt cannot hang the test: when the
+  // gateway dials a dead port, @fastify/http-proxy completes the client
+  // handshake anyway and the echo message simply never arrives.
+  const client = new WebSocket(`${address.replace('http://', 'ws://')}${path}`, { handshakeTimeout: 3000 })
+
+  try {
+    await once(client, 'open')
+
+    client.send('hello')
+    const result = await executeWithTimeout(once(client, 'message'), 3000)
+    if (result === kTimeout) {
+      throw new Error('the WebSocket echo timed out')
+    }
+
+    assert.equal(result[0].toString(), 'hello')
+  } catch (err) {
+    client.terminate()
+    throw err
+  }
+
+  client.close()
+  await once(client, 'close')
+}
+
+test('should proxy WebSocket connections to a node application using the websocket flag', async t => {
+  await prepareEchoWsFixture(t)
+
+  const runtime = await createGatewayInRuntime(
+    t,
+    'gateway-ws-handoff-node',
+    {
+      gateway: {
+        applications: [
+          {
+            id: 'echo',
+            proxy: {
+              prefix: '/echo'
+            }
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'echo',
+        path: resolve(import.meta.dirname, './ws/fixtures/echo-ws'),
+        websocket: true
+      }
+    ]
+  )
+
+  const address = await runtime.start()
+
+  // The WebSocket upgrade must succeed with no manual proxy.ws wiring
+  await connectAndEcho(address)
+
+  // HTTP requests must keep being proxied
+  const { statusCode, body: rawBody } = await request(address, {
+    method: 'GET',
+    path: '/echo/'
+  })
+
+  assert.equal(statusCode, 200)
+  const payload = await rawBody.json()
+  assert.equal(payload.service, 'echo')
+})
+
+test('should proxy WebSocket connections to a service application using the websocket flag', async t => {
+  const runtime = await createGatewayInRuntime(
+    t,
+    'gateway-ws-handoff-service',
+    {
+      gateway: {
+        applications: [
+          {
+            id: 'echo',
+            proxy: {
+              prefix: '/echo'
+            }
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'echo',
+        path: resolve(import.meta.dirname, './ws/fixtures/echo-ws-service'),
+        websocket: true
+      }
+    ]
+  )
+
+  const address = await runtime.start()
+
+  // The WebSocket upgrade must succeed with no manual proxy.ws wiring
+  await connectAndEcho(address)
+
+  // HTTP requests must keep being proxied through the mesh
+  const { statusCode, body: rawBody } = await request(address, {
+    method: 'GET',
+    path: '/echo/'
+  })
+
+  assert.equal(statusCode, 200)
+  const payload = await rawBody.json()
+  assert.equal(payload.service, 'echo-service')
+})
+
+test('should dial a fresh TCP port after the application is restarted', async t => {
+  await prepareEchoWsFixture(t)
+
+  const runtime = await createGatewayInRuntime(
+    t,
+    'gateway-ws-handoff-restart',
+    {
+      gateway: {
+        applications: [
+          {
+            id: 'echo',
+            proxy: {
+              prefix: '/echo'
+            }
+          }
+        ],
+        refreshTimeout: REFRESH_TIMEOUT
+      }
+    },
+    [
+      {
+        id: 'echo',
+        path: resolve(import.meta.dirname, './ws/fixtures/echo-ws'),
+        websocket: true
+      }
+    ]
+  )
+
+  const address = await runtime.start()
+
+  const portBefore = new URL((await runtime.getApplicationMeta('echo')).gateway.url).port
+  await connectAndEcho(address)
+
+  await runtime.restartApplication('echo')
+
+  // The restarted worker binds a new ephemeral port
+  const portAfter = new URL((await runtime.getApplicationMeta('echo')).gateway.url).port
+  assert.notEqual(portAfter, portBefore)
+
+  // New WebSocket connections must reach the new port. The gateway refreshes its
+  // upstream asynchronously when the worker start event is delivered, so retry
+  // for a short while: without the refresh this loop can never succeed, since the
+  // gateway would keep dialing the dead port.
+  const deadline = Date.now() + 10000
+  let lastError
+
+  while (Date.now() < deadline) {
+    try {
+      await connectAndEcho(address)
+      lastError = null
+      break
+    } catch (err) {
+      lastError = err
+      await sleep(200)
+    }
+  }
+
+  if (lastError) {
+    throw lastError
+  }
+})

--- a/packages/gateway/test/ws/fixtures/echo-ws-service/platformatic.json
+++ b/packages/gateway/test/ws/fixtures/echo-ws-service/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "watch": false,
+  "plugins": {
+    "paths": [
+      {
+        "path": "./plugin.js"
+      }
+    ]
+  }
+}

--- a/packages/gateway/test/ws/fixtures/echo-ws-service/plugin.js
+++ b/packages/gateway/test/ws/fixtures/echo-ws-service/plugin.js
@@ -1,0 +1,19 @@
+import { WebSocketServer } from 'ws'
+
+export default async function (app) {
+  const wsServer = new WebSocketServer({ server: app.server })
+
+  wsServer.on('connection', socket => {
+    socket.on('message', message => {
+      socket.send(message)
+    })
+  })
+
+  app.addHook('onClose', () => {
+    wsServer.close()
+  })
+
+  app.get('/', async () => {
+    return { service: 'echo-service' }
+  })
+}

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -534,6 +534,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -43,6 +43,7 @@ export type PlatformaticRuntimeConfig = {
             };
         config?: string;
         useHttp?: boolean;
+        websocket?: boolean;
         reuseTcpPorts?: boolean;
         workers?:
           | number

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -215,7 +215,7 @@ export class Controller extends EventEmitter {
       }
     }
 
-    const listen = !!this.applicationConfig.useHttp
+    const listen = !!(this.applicationConfig.useHttp || this.applicationConfig.websocket)
 
     try {
       await this.capability.start({ listen })
@@ -264,7 +264,12 @@ export class Controller extends EventEmitter {
 
   async listen () {
     // This server is not an entrypoint or already listened in start. Behave as no-op.
-    if (!this.applicationConfig.entrypoint || this.applicationConfig.useHttp || this.#listening) {
+    if (
+      !this.applicationConfig.entrypoint ||
+      this.applicationConfig.useHttp ||
+      this.applicationConfig.websocket ||
+      this.#listening
+    ) {
       return
     }
 

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -259,7 +259,7 @@ async function main () {
   let serverConfig = null
   if (runtimeConfig.server && applicationConfig.entrypoint) {
     serverConfig = runtimeConfig.server
-  } else if (applicationConfig.useHttp) {
+  } else if (applicationConfig.useHttp || applicationConfig.websocket) {
     serverConfig = {
       port: 0,
       hostname: '127.0.0.1',

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -134,6 +134,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true
@@ -566,6 +569,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "websocket": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -996,6 +1002,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "websocket": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -1424,6 +1433,9 @@
             "default": "main"
           },
           "useHttp": {
+            "type": "boolean"
+          },
+          "websocket": {
             "type": "boolean"
           },
           "reuseTcpPorts": {

--- a/packages/runtime/test/multiple-workers/networking.test.js
+++ b/packages/runtime/test/multiple-workers/networking.test.js
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from 'node:assert'
+import { deepStrictEqual, ok } from 'node:assert'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { Client } from 'undici'
@@ -104,6 +104,45 @@ test('the mesh network works with the HTTP applications when using HTTP', async 
       }
     },
     { name: 'node', workerCount: 5, expectedSocket: 'Socket' }
+  ])
+})
+
+test('the mesh network stays in-memory for applications using the websocket flag', async t => {
+  const root = await prepareRuntime(t, 'multiple-workers', { node: ['node'] })
+  const configFile = resolve(root, './platformatic.json')
+
+  await updateConfigFile(configFile, contents => {
+    contents.services[0].websocket = true
+    contents.services.push({
+      id: 'service',
+      path: './service',
+      config: 'platformatic.json',
+      websocket: true,
+      workers: 3
+    })
+  })
+
+  const app = await createRuntime(configFile, null, { isProduction: true })
+  const entryUrl = await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Each worker binds its own TCP port and advertises it via meta ...
+  const ports = await Promise.all(
+    [0, 1, 2].map(async worker => {
+      const meta = await app.getApplicationMeta(`service:${worker}`)
+      return new URL(meta.gateway.url).port
+    })
+  )
+  ok(ports.every(port => Number.parseInt(port) > 0))
+  deepStrictEqual(new Set(ports).size, 3)
+
+  // ... but mesh HTTP traffic keeps using the in-memory transport
+  await testRoundRobin(entryUrl, [
+    { name: 'service', workerCount: 3, expectedSocket: 'MockSocket' },
+    { name: 'node', workerCount: 5, expectedSocket: 'MockSocket' }
   ])
 })
 

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1183,6 +1183,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -540,6 +540,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -43,6 +43,7 @@ export type PlatformaticRuntimeConfig = {
             };
         config?: string;
         useHttp?: boolean;
+        websocket?: boolean;
         reuseTcpPorts?: boolean;
         workers?:
           | number

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -134,6 +134,9 @@
               "useHttp": {
                 "type": "boolean"
               },
+              "websocket": {
+                "type": "boolean"
+              },
               "reuseTcpPorts": {
                 "type": "boolean",
                 "default": true
@@ -566,6 +569,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "websocket": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -996,6 +1002,9 @@
           "useHttp": {
             "type": "boolean"
           },
+          "websocket": {
+            "type": "boolean"
+          },
           "reuseTcpPorts": {
             "type": "boolean",
             "default": true
@@ -1424,6 +1433,9 @@
             "default": "main"
           },
           "useHttp": {
+            "type": "boolean"
+          },
+          "websocket": {
             "type": "boolean"
           },
           "reuseTcpPorts": {


### PR DESCRIPTION
## Problem

Follow-up to #2820 and the guard in #5003. Today the only way to make gateway WebSocket proxying work for a mesh-only application is `useHttp: true`, which has two problems:

1. For service-family capabilities, `useHttp` also reroutes all inter-application mesh HTTP traffic from the in-memory transport to real TCP sockets (`BaseCapability.getDispatchTarget` prefers the URL once bound). Users who only need WebSocket support pay a transport switch they did not ask for.
2. The gateway captures the application TCP address once, at proxy plugin registration time, from a single round-robin selected worker (`resolveApplicationProxyParameters`). Ephemeral ports change on every worker start, and worker crash-restart is a first-class runtime path: after any restart the gateway keeps dialing a dead port and new WebSocket connections hang or fail. The guard from #5003 cannot catch this case, because the application legitimately had a TCP server at registration time.

## What this PR does

### 1. A `websocket` application flag

`websocket: true` makes a non-entrypoint application bind a local ephemeral TCP port (the same listen path as `useHttp`) and advertise it via meta, so the gateway can proxy WebSocket upgrades to it with zero manual `proxy.ws.upstream` wiring. Unlike `useHttp`, mesh HTTP traffic keeps using the in-memory transport for capabilities which provide an in-thread dispatch target (the service family); capabilities which do not (for example `@platformatic/next`) fall back to dispatching over the bound TCP port, exactly as under `useHttp`, instead of being routed to an `inject` they cannot serve.

This follows the shape discussed in #2820 ("websocket: true-style flag"). The `@platformatic/node` capability already behaves this way under `useHttp` (URL dispatch is opt-in via `node.dispatchViaHttp`); this PR extends the same decoupling to service-family capabilities through the flag.

### 2. Per-connection WebSocket upstream resolution in the gateway

For local applications which expose a TCP server (either `useHttp` or `websocket`), the gateway now resolves the WebSocket upstream per connection instead of freezing the registration-time URL:

- upgrades are dialed against a tracked URL kept fresh by listening to the runtime worker lifecycle events (`application:worker:started`, `application:worker:stopped`, `application:worker:exited`) the runtime already broadcasts to every worker;
- on `application:worker:started` the refresh targets the worker which just started (querying in round-robin mode could capture the URL of a worker which is about to be replaced);
- HTTP requests keep being dispatched to the same upstream as before (the virtual mesh origin, or `proxy.upstream` when configured).

This mirrors, for the raw WebSocket dial, the address updates on worker replacement the mesh interceptor already provides for HTTP. Explicit `proxy.ws.upstream` and `proxy.custom.getUpstream` configurations are untouched and keep taking precedence.

## What this PR deliberately does not do

- No changes to undici-thread-interceptor. The WebSocket dial bypasses the dispatcher entirely (raw `ws` client in @fastify/http-proxy), so only `meta.url` plumbing is involved.
- Established WebSocket connections are not migrated on restart: `wsReconnect` re-dials the URL captured at connection time (`targetParams` in @fastify/http-proxy), so a reconnect-enabled connection whose worker died keeps trying the dead port. Fixing that requires re-running `findUpstream` inside http-proxy's `reconnect()`; happy to send that upstream to @fastify/http-proxy as a follow-up.
- Multi-worker WebSocket load balancing. The tracked URL points at one live worker (the last started); per-connection round-robin over all workers is a natural follow-up since `getApplicationMeta` already supports per-worker addressing (`id:index`).
- There is still a short window between a worker dying and the refresh landing where an upgrade can dial the dead port. With the current http-proxy behavior the client handshake still completes and the connection simply never receives data (which is why the tests pair a handshake timeout with an echo timeout); the next connection succeeds. This window is inherent to the event-driven refresh and is called out in the docs.

## Implementation notes

- The flag lives in the foundation application schema next to `useHttp` and is runtime-config-only (same unwrappable list as `useHttp`). Schema and types regenerated across the packages embedding the shared runtime schema.
- `BaseCapability.getDispatchTarget` returns the in-thread dispatch target when `websocket` is set without `useHttp` (and the application is not the entrypoint), so mesh HTTP is unaffected by the TCP bind. This only applies when the capability actually provides an in-thread target (its `getDispatchFunc` is overridden): the others keep dispatching via the bound TCP address, as under `useHttp`.
- The gateway tracker subscribes to `runtime:event` over ITC (the same mechanism the gateway already uses for `application:added`/`application:removed`) and re-fetches `getApplicationMeta` with a small retry loop, because the started event can be delivered while the new worker is not addressable yet. A single graceful stop emits both `application:worker:stopped` and `application:worker:exited`, so in-flight refreshes are coalesced per target. If the retries are exhausted the tracker keeps the previous URL until the next worker lifecycle event; this is logged at warn level when a just-started worker could not be queried, and at debug level after a worker went away (where finding no addressable worker usually just means the application was stopped).
- Moving upstream selection into `getUpstream` leaves the proxy `upstream` option undefined, which would also disable the rewrite prefix derivation @fastify/http-proxy performs on the upstream URL pathname: the gateway now replicates that derivation, so HTTP rewriting for pathful `proxy.upstream` configurations is unchanged.
- The `PLT_GATEWAY_WS_NO_TCP_UPSTREAM` message and the `proxy.ws` boot warning introduced in #5003 now suggest `"websocket": true` as the first remediation.
- When the gateway runs standalone (no runtime), nothing changes: there is no ITC, no meta and no tracked URLs.

## Tests

- runtime: a `websocket: true` application binds one TCP port per worker, advertises it via meta, and mesh HTTP traffic stays on the in-memory transport (extends the existing multiple-workers networking test).
- gateway: WebSocket echo through the gateway to a `websocket: true` node application (plain `http.Server` + `ws`) and to a service application (`ws` attached to the Fastify server), HTTP proxying unaffected in both cases.
- gateway: after `restartApplication`, a new WebSocket connection reaches the new ephemeral port. Without the refresh this test fails: the gateway keeps dialing the port of the replaced worker.
- basic: unit coverage for `getDispatchTarget` under the flag (in-thread target kept when available, TCP fallback otherwise, `useHttp` and entrypoint precedence).
- Full gateway, basic and foundation suites plus the runtime networking suite green locally; the remaining runtime suites are covered by CI.

---

Note: this PR is stacked on #5003 (the first commit here is that PR's guard, which this PR's error message edits build on). I will rebase once #5003 lands.
