### PR TITLE
fix(runtime): apply pending worker scaling after startup

### DIFF
--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -776,6 +776,7 @@ export class Runtime extends EventEmitter {
     }
 
     this.emitAndNotify('application:started', id)
+    await this.#dynamicWorkersScaler?.applyPendingUpdate(id)
   }
 
   async stopApplication (id, silent = false, dependents = []) {

--- a/packages/runtime/lib/worker-scaler.js
+++ b/packages/runtime/lib/worker-scaler.js
@@ -121,16 +121,25 @@ export class DynamicWorkersScaler {
 
     if (config.minWorkers > 1) {
       const update = { application: application.id, workers: config.minWorkers }
-
-      if (!this.#status === 'started') {
-        await this.#runtime.updateApplicationsResources([update])
-      } else {
-        this.#initialUpdates.push(update)
-      }
+      this.#initialUpdates.push(update)
     }
 
     this.#appsConfigs[application.id] = config
     this.#algorithm.addApplication(application.id, config)
+  }
+
+  async applyPendingUpdate (applicationId) {
+    if (this.#status !== 'started') {
+      return
+    }
+
+    const update = this.#initialUpdates.find(update => update.application === applicationId)
+    if (!update) {
+      return
+    }
+
+    await this.#runtime.updateApplicationsResources([update])
+    this.#initialUpdates = this.#initialUpdates.filter(pending => pending !== update)
   }
 
   remove (application) {

--- a/packages/runtime/test/dynamic-applications.test.js
+++ b/packages/runtime/test/dynamic-applications.test.js
@@ -314,7 +314,9 @@ test('vertical autoscaler should work properly when adding and removing applicat
             id: 'application-2',
             path: './application-2',
             workers: {
-              dynamic: true
+              dynamic: true,
+              minimum: 2,
+              maximum: 3
             }
           },
           config.workers
@@ -325,6 +327,10 @@ test('vertical autoscaler should work properly when adding and removing applicat
 
     await addPromise
     await restartPromise
+
+    const workers = await runtime.getWorkers()
+    const applicationWorkers = Object.values(workers).filter(worker => worker.application === 'application-2')
+    deepStrictEqual(applicationWorkers.length, 2)
   }
 
   // Stress applications and wait for both of them to be upscaled

--- a/packages/runtime/test/worker-scaler-1.test.js
+++ b/packages/runtime/test/worker-scaler-1.test.js
@@ -390,6 +390,30 @@ test('should apply application scaleUpELU and scaleDownELU', async t => {
   assert.strictEqual(service2Workers.length, 2)
 })
 
+test('applies the minimum workers after a dynamically added application starts', async t => {
+  const updates = []
+  const runtime = {
+    async updateApplicationsResources (applications) {
+      updates.push(applications)
+    }
+  }
+  const scaler = new DynamicWorkersScaler(runtime, { maxMemory: 1 })
+
+  await scaler.start()
+  t.after(() => scaler.stop())
+
+  await scaler.add({
+    id: 'application',
+    workers: { dynamic: true, minimum: 3, maximum: 4 }
+  })
+
+  assert.deepStrictEqual(updates, [])
+
+  await scaler.applyPendingUpdate('application')
+
+  assert.deepStrictEqual(updates, [[{ application: 'application', workers: 3 }]])
+})
+
 test('logs worker health errors and refreshes the health check timeout', async t => {
   const error = new Error('health check failed')
   const errors = []


### PR DESCRIPTION
Defer minimum-worker updates until dynamically added applications finish starting.