### PR TITLE
fix(sql-events): publish events when entities are updated via updateMany

### DIFF
--- a/docs/reference/sql-mapper/entities/hooks.md
+++ b/docs/reference/sql-mapper/entities/hooks.md
@@ -9,7 +9,7 @@ The Platformatic DB SQL Mapper provides an `addEntityHooks(entityName, spec)` fu
 `addEntityHooks` accepts two arguments:
 
 1. A string representing the entity name (singularized), for example `'page'`.
-1. A key/value object where the key is one of the API methods (`find`, `insert`, `save`, `delete`) and the value is a callback function. The callback will be called with the _original_ API method and the options that were passed to that method. See the example below.
+1. A key/value object where the key is one of the API methods (`find`, `count`, `insert`, `save`, `delete`, `updateMany`) and the value is a callback function. The callback will be called with the _original_ API method and the options that were passed to that method. See the example below.
 
 ### Usage
 

--- a/packages/sql-events/index.js
+++ b/packages/sql-events/index.js
@@ -72,7 +72,8 @@ export function setupEmitter ({ log, mq, mapper, connectionString }) {
       },
 
       delete: multiElement('delete'),
-      insert: multiElement('save')
+      insert: multiElement('save'),
+      updateMany: multiElement('save')
     })
 
     function multiElement (action) {

--- a/packages/sql-events/test/simple.test.js
+++ b/packages/sql-events/test/simple.test.js
@@ -229,6 +229,76 @@ test('insert', async t => {
   }
 })
 
+test('updateMany', async t => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    t.after(() => db.dispose())
+
+    if (isSQLite) {
+      await db.query(sql`CREATE TABLE pages (
+        id INTEGER PRIMARY KEY,
+        title VARCHAR(42)
+      );`)
+    } else {
+      await db.query(sql`CREATE TABLE pages (
+        id SERIAL PRIMARY KEY,
+        title VARCHAR(255) NOT NULL
+      );`)
+    }
+  }
+  const mapper = await connect({
+    log: fakeLogger,
+    ...connInfo,
+    onDatabaseLoad
+  })
+  const pageEntity = mapper.entities.page
+
+  const mq = MQEmitter()
+  equal(setupEmitter({ mapper, mq, log: fakeLogger }), undefined)
+
+  const page1 = await pageEntity.save({
+    input: { title: 'fourth page' }
+  })
+
+  const page2 = await pageEntity.save({
+    input: { title: 'fifth page' }
+  })
+
+  // subscribe after the seed saves so the queue only sees the bulk update
+  const queue = await mapper.subscribe('/entity/page/save/+')
+  equal(mapper.mq, mq)
+
+  const expected = []
+
+  // update all pages in one go
+  const pages = await pageEntity.updateMany({
+    where: {
+      id: {
+        in: [page1.id, page2.id]
+      }
+    },
+    input: {
+      title: 'updated title'
+    }
+  })
+
+  for (const page of pages) {
+    expected.push({
+      topic: '/entity/page/save/' + page.id,
+      payload: {
+        id: page.id
+      }
+    })
+  }
+
+  for await (const ev of queue) {
+    same(ev, expected.shift())
+    if (expected.length === 0) {
+      break
+    }
+  }
+})
+
 test('more than one element for delete', async t => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)
@@ -368,6 +438,21 @@ test('emit events when the primary key is not in the requested fields', async t 
     topic: '/entity/page/delete/' + found2.id,
     payload: {
       id: found2.id
+    }
+  })
+
+  // updateMany - without the primary key in the fields
+  const updated = await pageEntity.updateMany({
+    where: { id: { eq: found.id } },
+    input: { title: 'an updated page' },
+    fields: ['title']
+  })
+  same(updated, [{ title: 'an updated page' }], 'updateMany returns only the requested fields')
+
+  expected.push({
+    topic: '/entity/page/save/' + found.id,
+    payload: {
+      id: found.id
     }
   })
 


### PR DESCRIPTION
### Problem

`setupEmitter` in `@platformatic/sql-events` registers entity hooks only for `save`, `delete` and `insert`. `entity.updateMany` is not wrapped, so it never publishes events.

Since `@platformatic/sql-openapi` maps the bulk update route `PUT /<entity>/?where...` to `entity.updateMany`, any REST bulk update goes through with zero events: GraphQL subscriptions and message-queue consumers see single-row saves, inserts and deletes, but silently miss bulk updates. The data changes, no event fires, and consumers that mirror state (caches, live UIs, sync engines) silently diverge.

The `EntityHooks` type in `@platformatic/sql-mapper` already declares `updateMany` as hookable, so this looks like the event layer simply never caught up when `updateMany` was added in #288 (requested in #249).

### Fix

One line in `setupEmitter`: `updateMany: multiElement('save')`. `updateMany` returns the array of updated rows (with the primary key ensured by `ensurePrimaryKeyField`), which is exactly the shape `multiElement` already consumes for `insert`, so a bulk update now publishes one `save` event per updated row, consistent with `insert`.

Also aligned the sql-mapper hooks docs with the `EntityHooks` type: the hookable-methods list said `find`, `insert`, `save`, `delete`, while `count` and `updateMany` are hookable too.

### Tests

A new `updateMany` test in `packages/sql-events/test/simple.test.js`, mirroring the existing `insert` test: seed two rows, subscribe to `/entity/page/save/+`, run one `updateMany` over both rows, assert one event per updated row. Verified red/green: without the one-line fix the test times out waiting for events that never arrive. Also extended the issue #1805 regression test ("emit events when the primary key is not in the requested fields") with an `updateMany` step, locking in the `ensurePrimaryKeyField`/`stripPrimaryKey` behavior for the newly hooked method. Full sql-events suite is green locally on SQLite; the other databases run in CI.

### Notes

- An N-row bulk update publishes N events, the same behaviour `insert` already has for bulk inserts.
- There is no `deleteMany`: `entity.delete` takes arbitrary criteria and covers both single and bulk deletes, and it is already wrapped, so deletes were never affected.
- While tracing this we noticed the built-in adminSecret rule in `@platformatic/db-authorization` grants `find`/`save`/`delete` but not `updateMany`, so the REST bulk `PUT /<entity>/` answers 403 (`PLT_DB_AUTH_UNAUTHORIZED`, "operation not allowed") even for the admin (`fromRuleToWhere` throws on a missing rule key). If that is intentional, a short docs note may help; happy to file it separately either way.
