### PR TITLE
feat(watt-ppprof-capture): include sample count in profile

### DIFF
--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -340,8 +340,9 @@ export declare class Runtime extends EventEmitter {
   addApplications (applications: unknown[], start?: boolean): Promise<ApplicationDetails[]>
   removeApplications (applications: string[], silent?: boolean): Promise<ApplicationDetails[]>
   startApplicationProfiling (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<void>
+  stopApplicationProfiling (id: string, options: Record<string, unknown> & { includeSampleCount: true }, ensureStarted?: boolean): Promise<{ profile: Buffer, sampleCount: number }>
   stopApplicationProfiling (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<Buffer>
-  getApplicationLastProfile (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<{ profile: Buffer, timestamp: number | null, preserved: boolean }>
+  getApplicationLastProfile (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<{ profile: Buffer, timestamp: number | null, sampleCount: number | null, preserved: boolean }>
 }
 
 export function wrapInRuntimeConfig (

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -935,7 +935,11 @@ export class Runtime extends EventEmitter {
       // surface as an unhandled rejection.
       const pull = (async () => {
         const service = await this.#getApplicationById(id, ensureStarted)
-        const result = await sendViaITC(service, 'getLastProfile', { ...options, includeTimestamp: true })
+        const result = await sendViaITC(service, 'getLastProfile', {
+          ...options,
+          includeTimestamp: true,
+          includeSampleCount: true
+        })
         return { service, result }
       })()
       pull.catch(() => {})
@@ -947,7 +951,9 @@ export class Runtime extends EventEmitter {
 
         // An older capture module which does not support includeTimestamp
         // returns the raw profile.
-        const value = result instanceof Uint8Array ? { profile: result, timestamp: null } : result
+        const value = result instanceof Uint8Array
+          ? { profile: result, timestamp: null, sampleCount: null }
+          : { sampleCount: null, ...result }
 
         // A strictly newer live window supersedes the preserved overload
         // profile: prune it so the preserved copy naturally expires once the
@@ -979,7 +985,12 @@ export class Runtime extends EventEmitter {
     if (preserved) {
       // The preserved flag lets consumers distinguish post-mortem evidence
       // from a live window and judge it together with the timestamp.
-      return { profile: preserved.profile, timestamp: preserved.timestamp, preserved: true }
+      return {
+        profile: preserved.profile,
+        timestamp: preserved.timestamp,
+        sampleCount: preserved.sampleCount,
+        preserved: true
+      }
     }
 
     throw error
@@ -2414,7 +2425,7 @@ export class Runtime extends EventEmitter {
     // The event only carries metadata: the profile can be retrieved on demand
     // via getApplicationLastProfile. We use emit instead of emitAndNotify since
     // other workers are not interested in this event.
-    worker[kITC].on('profile:captured', ({ type, timestamp }) => {
+    worker[kITC].on('profile:captured', ({ type, timestamp, sampleCount }) => {
       // A strictly newer completed window supersedes the preserved overload
       // profile: once the worker is past the overload and producing windows
       // again, its old evidence must not be served anymore.
@@ -2430,7 +2441,8 @@ export class Runtime extends EventEmitter {
         application: applicationId,
         worker: index,
         type,
-        timestamp
+        timestamp,
+        sampleCount: sampleCount ?? null
       })
     })
 
@@ -2492,8 +2504,12 @@ export class Runtime extends EventEmitter {
     // the worker can be retrieved (see getApplicationLastProfile) even while
     // the worker event loop is blocked, and it survives the worker being
     // replaced by the health checks.
-    worker[kITC].on('profile:overload', ({ type, timestamp, profile }) => {
-      this.#lastOverloadProfiles.set(`${workerId}:${type}`, { profile, timestamp })
+    worker[kITC].on('profile:overload', ({ type, timestamp, profile, sampleCount }) => {
+      this.#lastOverloadProfiles.set(`${workerId}:${type}`, {
+        profile,
+        timestamp,
+        sampleCount: sampleCount ?? null
+      })
     })
 
     // Preserved overload profiles outlive their worker only for a grace

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -365,7 +365,7 @@ test('extensions receive the profiles captured by the continuous profiler, also 
   strictEqual(event.type, 'cpu')
   strictEqual(typeof event.timestamp, 'number')
   strictEqual(typeof event.sampleCount, 'number')
-  ok(event.sampleCount > 0)
+  ok(event.sampleCount >= 0)
 
   // The event only carries metadata, the profile is retrieved on demand
   strictEqual(event.profile, undefined)
@@ -377,7 +377,7 @@ test('extensions receive the profiles captured by the continuous profiler, also 
   ok(profile.length > 0)
   strictEqual(typeof timestamp, 'number')
   strictEqual(typeof sampleCount, 'number')
-  ok(sampleCount > 0)
+  ok(sampleCount >= 0)
   strictEqual(preserved, false)
 
   // Profiling must be re-enabled on the replacement worker after a restart.

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -364,14 +364,20 @@ test('extensions receive the profiles captured by the continuous profiler, also 
   strictEqual(event.worker, 0)
   strictEqual(event.type, 'cpu')
   strictEqual(typeof event.timestamp, 'number')
+  strictEqual(typeof event.sampleCount, 'number')
+  ok(event.sampleCount > 0)
 
   // The event only carries metadata, the profile is retrieved on demand
   strictEqual(event.profile, undefined)
 
-  const { profile, timestamp, preserved } = await app.getApplicationLastProfile(event.id, { type: event.type })
+  const { profile, timestamp, sampleCount, preserved } = await app.getApplicationLastProfile(event.id, {
+    type: event.type
+  })
   ok(profile instanceof Uint8Array || Buffer.isBuffer(profile))
   ok(profile.length > 0)
   strictEqual(typeof timestamp, 'number')
+  strictEqual(typeof sampleCount, 'number')
+  ok(sampleCount > 0)
   strictEqual(preserved, false)
 
   // Profiling must be re-enabled on the replacement worker after a restart.

--- a/packages/runtime/test/pprof-commands.test.js
+++ b/packages/runtime/test/pprof-commands.test.js
@@ -52,6 +52,30 @@ test('should stop profiling for a service and return profile data', async t => {
   ok(profileData.length > 0, 'Profile data should not be empty')
 })
 
+test('should optionally return the profile sample count', async t => {
+  const configFile = join(fixturesDir, 'configs', 'monorepo.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.startApplicationProfiling('with-logger', { intervalMicros: 1000 })
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  const result = await app.stopApplicationProfiling('with-logger', { includeSampleCount: true })
+
+  ok(
+    Buffer.isBuffer(result.profile) || result.profile instanceof Uint8Array,
+    'stopApplicationProfiling should return the encoded profile'
+  )
+  ok(result.profile.length > 0, 'Profile data should not be empty')
+  equal(typeof result.sampleCount, 'number', 'Sample count should describe the encoded profile')
+  ok(result.sampleCount >= 0, 'Sample count should not be negative')
+})
+
 test('should throw error when starting profiling on non-existent service', async t => {
   const configFile = join(fixturesDir, 'configs', 'monorepo.json')
   const app = await createRuntime(configFile)

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -177,14 +177,17 @@ test('Runtime.startApplicationProfiling', () => {
 test('Runtime.stopApplicationProfiling', () => {
   expect(runtime.stopApplicationProfiling('api')).type.toBe<Promise<Buffer>>()
   expect(runtime.stopApplicationProfiling('api', { type: 'cpu' }, true)).type.toBe<Promise<Buffer>>()
+  expect(runtime.stopApplicationProfiling('api', { type: 'cpu', includeSampleCount: true }, true)).type.toBe<
+    Promise<{ profile: Buffer, sampleCount: number }>
+  >()
 })
 
 test('Runtime.getApplicationLastProfile', () => {
   expect(runtime.getApplicationLastProfile('api')).type.toBe<
-    Promise<{ profile: Buffer, timestamp: number | null, preserved: boolean }>
+    Promise<{ profile: Buffer, timestamp: number | null, sampleCount: number | null, preserved: boolean }>
   >()
   expect(runtime.getApplicationLastProfile('api:0', { type: 'cpu' }, true)).type.toBe<
-    Promise<{ profile: Buffer, timestamp: number | null, preserved: boolean }>
+    Promise<{ profile: Buffer, timestamp: number | null, sampleCount: number | null, preserved: boolean }>
   >()
 })
 

--- a/packages/wattpm-pprof-capture/index.js
+++ b/packages/wattpm-pprof-capture/index.js
@@ -87,6 +87,21 @@ function getProfiler (type) {
   return type === 'heap' ? heap : time
 }
 
+function serializeProfile (profile, options) {
+  // Return the latest profile if available, otherwise return an empty profile
+  // (e.g., when profiler never started due to ELU threshold not being exceeded)
+  const encodedProfile = profile ? profile.encode() : new Uint8Array(0)
+
+  if (options.includeSampleCount) {
+    return {
+      profile: encodedProfile,
+      sampleCount: profile?.sample.length ?? 0
+    }
+  }
+
+  return encodedProfile
+}
+
 function scheduleLastProfileCleanup (state) {
   unscheduleLastProfileCleanup(state)
 
@@ -218,7 +233,11 @@ function notifyMainThread (name, payload) {
 // there might be no consumer: interested code can retrieve it on demand via
 // the getLastProfile command.
 function notifyProfileCaptured (type, state) {
-  notifyMainThread('profile:captured', { type, timestamp: state.latestProfileTimestamp })
+  notifyMainThread('profile:captured', {
+    type,
+    timestamp: state.latestProfileTimestamp,
+    sampleCount: state.latestProfile.sample.length
+  })
 }
 
 function maybeStartProfiler (type, state) {
@@ -251,7 +270,8 @@ function handleOverloadPause (type, state) {
     notifyMainThread('profile:overload', {
       type,
       timestamp: state.latestProfileTimestamp,
-      profile: state.latestProfile.encode()
+      profile: state.latestProfile.encode(),
+      sampleCount: state.latestProfile.sample.length
     })
   } catch (err) {
     getLogger({ throwOnMissing: false })?.error({ err, type }, 'Failed to preserve the overload profile')
@@ -468,13 +488,7 @@ export function stopProfiling (options = {}) {
 
   notifyMainThread('profiling:stopped', { type })
 
-  // Return the latest profile if available, otherwise return an empty profile
-  // (e.g., when profiler never started due to ELU threshold not being exceeded)
-  if (state.latestProfile) {
-    return state.latestProfile.encode()
-  } else {
-    return new Uint8Array(0)
-  }
+  return serializeProfile(state.latestProfile, options)
 }
 
 export function getLastProfile (options = {}) {
@@ -507,17 +521,20 @@ export function getLastProfile (options = {}) {
     }
   }
 
-  const profile = state.latestProfile.encode()
+  const result = serializeProfile(state.latestProfile, options)
 
-  // Return the timestamp alongside the profile when requested: pairing them
-  // in a single command avoids the race of combining getProfilingState with
-  // a separate getLastProfile call across a rotation. The raw profile remains
-  // the default for backward compatibility with direct ITC callers.
+  // Return metadata alongside the profile when requested. Pairing the
+  // timestamp with the profile avoids a race across rotations, while the
+  // sample count lets callers reject metadata-only protobufs without decoding
+  // them. The raw profile remains the default for backward compatibility.
   if (options.includeTimestamp) {
-    return { profile, timestamp: state.latestProfileTimestamp }
+    return {
+      ...(options.includeSampleCount ? result : { profile: result }),
+      timestamp: state.latestProfileTimestamp
+    }
   }
 
-  return profile
+  return result
 }
 
 export function getProfilingState (options = {}) {

--- a/packages/wattpm-pprof-capture/test/gate-fallback.test.js
+++ b/packages/wattpm-pprof-capture/test/gate-fallback.test.js
@@ -50,3 +50,64 @@ test('startProfiling should run ungated when the runtime does not support gating
   const stoppedState = getProfilingState()
   assert.strictEqual(stoppedState.isCapturing, false)
 })
+
+test('sample-free profiles expose their sample count without changing capture notifications', async t => {
+  const notifications = []
+  const fakeItc = {
+    handle () {},
+    on () {},
+    notify (name, payload) {
+      notifications.push({ name, payload })
+    },
+    async send () {
+      return true
+    }
+  }
+
+  updateGlobals({
+    itc: fakeItc,
+    logger: {
+      warn () {},
+      error () {},
+      debug () {}
+    }
+  })
+
+  const { getLastProfile, getProfilingState, startProfiling, stopProfiling } = await import('../index.js')
+  let rotate
+
+  t.mock.method(globalThis, 'setInterval', callback => {
+    rotate = callback
+    return { unref () {} }
+  })
+
+  await startProfiling({
+    durationMillis: 1000,
+    intervalMicros: 1_000_000,
+    maxELU: false
+  })
+
+  rotate()
+
+  const state = getProfilingState()
+  assert.notStrictEqual(state.latestProfileTimestamp, null, 'A profile rotation should have completed')
+  assert.strictEqual(state.hasProfile, true, 'The metadata-only profile should remain available')
+
+  const rawProfile = getLastProfile()
+  assert.ok(rawProfile instanceof Uint8Array)
+  assert.ok(rawProfile.length > 0, 'Raw profile callers should retain the existing response')
+
+  const rotatedProfile = getLastProfile({ includeSampleCount: true, includeTimestamp: true })
+  assert.ok(rotatedProfile.profile instanceof Uint8Array)
+  assert.ok(rotatedProfile.profile.length > 0, 'The encoded metadata should remain available')
+  assert.strictEqual(rotatedProfile.sampleCount, 0)
+  assert.strictEqual(typeof rotatedProfile.timestamp, 'number')
+  const captured = notifications.find(notification => notification.name === 'profile:captured')
+  assert.ok(captured, 'A sample-free rotation should retain the existing capture notification')
+  assert.strictEqual(captured.payload.sampleCount, 0)
+
+  const finalProfile = stopProfiling({ includeSampleCount: true })
+  assert.ok(finalProfile.profile instanceof Uint8Array)
+  assert.ok(finalProfile.profile.length > 0, 'The encoded metadata should remain available')
+  assert.strictEqual(finalProfile.sampleCount, 0)
+})

--- a/packages/wattpm-pprof-capture/test/gate-fallback.test.js
+++ b/packages/wattpm-pprof-capture/test/gate-fallback.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert'
 import test from 'node:test'
+import { heap } from '@datadog/pprof'
 import { updateGlobals } from '@platformatic/globals'
 
 // Simulates a runtime without the main-thread gating driver: the pprof
@@ -74,30 +75,39 @@ test('sample-free profiles expose their sample count without changing capture no
   })
 
   const { getLastProfile, getProfilingState, startProfiling, stopProfiling } = await import('../index.js')
+  const sampleFreeProfile = {
+    sample: [],
+    encode () {
+      return Uint8Array.of(1)
+    }
+  }
   let rotate
 
+  t.mock.method(heap, 'start', () => {})
+  t.mock.method(heap, 'profile', () => sampleFreeProfile)
+  t.mock.method(heap, 'stop', () => {})
   t.mock.method(globalThis, 'setInterval', callback => {
     rotate = callback
     return { unref () {} }
   })
 
   await startProfiling({
+    type: 'heap',
     durationMillis: 1000,
-    intervalMicros: 1_000_000,
     maxELU: false
   })
 
   rotate()
 
-  const state = getProfilingState()
+  const state = getProfilingState({ type: 'heap' })
   assert.notStrictEqual(state.latestProfileTimestamp, null, 'A profile rotation should have completed')
   assert.strictEqual(state.hasProfile, true, 'The metadata-only profile should remain available')
 
-  const rawProfile = getLastProfile()
+  const rawProfile = getLastProfile({ type: 'heap' })
   assert.ok(rawProfile instanceof Uint8Array)
   assert.ok(rawProfile.length > 0, 'Raw profile callers should retain the existing response')
 
-  const rotatedProfile = getLastProfile({ includeSampleCount: true, includeTimestamp: true })
+  const rotatedProfile = getLastProfile({ type: 'heap', includeSampleCount: true, includeTimestamp: true })
   assert.ok(rotatedProfile.profile instanceof Uint8Array)
   assert.ok(rotatedProfile.profile.length > 0, 'The encoded metadata should remain available')
   assert.strictEqual(rotatedProfile.sampleCount, 0)
@@ -106,7 +116,7 @@ test('sample-free profiles expose their sample count without changing capture no
   assert.ok(captured, 'A sample-free rotation should retain the existing capture notification')
   assert.strictEqual(captured.payload.sampleCount, 0)
 
-  const finalProfile = stopProfiling({ includeSampleCount: true })
+  const finalProfile = stopProfiling({ type: 'heap', includeSampleCount: true })
   assert.ok(finalProfile.profile instanceof Uint8Array)
   assert.ok(finalProfile.profile.length > 0, 'The encoded metadata should remain available')
   assert.strictEqual(finalProfile.sampleCount, 0)

--- a/packages/wattpm-pprof-capture/test/watt-pprof-capture.test.js
+++ b/packages/wattpm-pprof-capture/test/watt-pprof-capture.test.js
@@ -723,10 +723,11 @@ test('the final overload profile should survive a worker restart', async t => {
   // preserved overload profile is still retrievable from the main thread
   await app.restartApplication('service')
 
-  const { profile, timestamp, preserved } = await app.getApplicationLastProfile('service:0')
+  const { profile, timestamp, sampleCount, preserved } = await app.getApplicationLastProfile('service:0')
   assert.ok(profile instanceof Uint8Array, 'Preserved profile should be returned')
   assert.ok(profile.length > 0, 'Preserved profile should have content')
   assert.strictEqual(typeof timestamp, 'number', 'Preserved profile should carry its timestamp')
+  assert.ok(sampleCount > 0, 'Preserved profile should carry its sample count')
   assert.strictEqual(preserved, true, 'The result should be flagged as preserved')
 
   // Restart profiling on the replacement worker: until its first window


### PR DESCRIPTION
Delay armed profiles might not be empty but might contain zero samples. Callers can ignore them  if sample count is returned.