### PR TITLE
fix(runtime): race during parallel application restarts

### DIFF
--- a/packages/runtime/fixtures/meta-worker-exit/platformatic.json
+++ b/packages/runtime/fixtures/meta-worker-exit/platformatic.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.63.0.json",
+  "watch": false,
+  "workers": 2,
+  "restartOnError": false,
+  "preload": "preload.js",
+  "applications": [
+    {
+      "id": "service",
+      "path": "./service"
+    },
+    {
+      "id": "dummy",
+      "path": "./service"
+    }
+  ]
+}

--- a/packages/runtime/fixtures/meta-worker-exit/preload.js
+++ b/packages/runtime/fixtures/meta-worker-exit/preload.js
@@ -1,0 +1,12 @@
+import { NodeCapability } from '@platformatic/node'
+import { workerData } from 'node:worker_threads'
+
+const getMeta = NodeCapability.prototype.getMeta
+
+NodeCapability.prototype.getMeta = function () {
+  if (workerData.applicationConfig.id === 'service' && workerData.worker.index === 0) {
+    process.exit(0)
+  }
+
+  return getMeta.call(this)
+}

--- a/packages/runtime/fixtures/meta-worker-exit/service/platformatic.json
+++ b/packages/runtime/fixtures/meta-worker-exit/service/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.63.0.json",
+  "node": {
+    "main": "plugin.js"
+  }
+}

--- a/packages/runtime/fixtures/meta-worker-exit/service/plugin.js
+++ b/packages/runtime/fixtures/meta-worker-exit/service/plugin.js
@@ -1,0 +1,5 @@
+import { createServer } from 'node:http'
+
+export function build () {
+  return createServer()
+}

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -1888,17 +1888,27 @@ export class Runtime extends EventEmitter {
   }
 
   async getApplicationMeta (id) {
-    const application = await this.#getApplicationById(id)
+    const hasWorkerId = /^.+:\d+$/.test(id)
+    const attempts = hasWorkerId ? 1 : Math.max(1, this.#workers.getKeys(id).length)
 
-    try {
-      return await sendViaITC(application, 'getApplicationMeta')
-    } catch (e) {
-      // The application exports no meta, return an empty object
-      if (e.code === 'PLT_ITC_HANDLER_NOT_FOUND') {
-        return {}
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const application = await this.#getApplicationById(id)
+
+      try {
+        return await sendViaITC(application, 'getApplicationMeta')
+      } catch (e) {
+        // The application exports no meta, return an empty object
+        if (e.code === 'PLT_ITC_HANDLER_NOT_FOUND') {
+          return {}
+        }
+
+        // A parallel restart can stop the selected worker while metadata is
+        // being retrieved. Retry another worker unless one was requested
+        // explicitly or every worker available at the start has been tried.
+        if (e.code !== 'PLT_RUNTIME_APPLICATION_WORKER_EXIT' || attempt === attempts - 1) {
+          throw e
+        }
       }
-
-      throw e
     }
   }
 

--- a/packages/runtime/test/api/meta.test.js
+++ b/packages/runtime/test/api/meta.test.js
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from 'node:assert'
+import { deepStrictEqual, ok } from 'node:assert'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import { createRuntime } from '../helpers.js'
@@ -27,4 +27,22 @@ test('should get meta for db applications in runtime schema', async t => {
     },
     connectionStrings: [`sqlite://${database}`]
   })
+})
+
+test('should retry meta retrieval when the selected worker exits', async t => {
+  const configFile = join(fixturesDir, 'meta-worker-exit', 'platformatic.json')
+  const app = await createRuntime(configFile)
+
+  await app.start()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  // Two calls guarantee that round-robin selects worker 0, whose fixture
+  // exits while handling getApplicationMeta. The retry should use worker 1.
+  for (let i = 0; i < 2; i++) {
+    const meta = await app.getApplicationMeta('service')
+    ok(meta.gateway)
+  }
 })


### PR DESCRIPTION
When metadata is requested from an application worker, it might concurrently be replaced and meta call will fail. Let it retry for another worker on exit error with application level ids, worker level ids stays same.

Related to [CI failure](https://github.com/platformatic/platformatic/actions/runs/30085858916/job/89458009179?pr=5013) on #5013 