### PR TITLE
fix(types): runtime and foundation declaration gaps

### DIFF
--- a/packages/foundation/index.d.ts
+++ b/packages/foundation/index.d.ts
@@ -78,7 +78,17 @@ export interface ValidationError {
 export type ConfigurationOptions<T = {}> = Partial<{
   validate: boolean
   validationOptions: object
-  transform: (config: Configuration<T>) => Promise<Configuration<T>> | Configuration<T>
+  // Read directly off the context by every capability package (astro, basic,
+  // next, node, service, ...) to pick a development/production code path.
+  isProduction: boolean
+  // loadConfiguration() always invokes the caller-supplied transform hook
+  // with all three arguments (config, schema, options), mirroring the
+  // exported transform() function's own parameter list.
+  transform: (
+    config: Configuration<T>,
+    schema: object,
+    options: ConfigurationOptions<T>
+  ) => Promise<Configuration<T>> | Configuration<T>
   upgrade: (logger: Logger, config: RawConfiguration, version: string) => Promise<RawConfiguration> | RawConfiguration
   env: Record<string, string>
   ignoreProcessEnv: boolean
@@ -155,9 +165,13 @@ export declare function replaceEnv (
   onMissingEnv?: (key: string) => string | undefined,
   ignore?: string[]
 ): RawConfiguration
+// `config` also accepts an array: the exported `applications` schema is a
+// JSONSchemaType<object[]> (an ARRAY schema), and validate() is called with
+// a matching array of application configs before they are handed to
+// prepareApplication()/addApplications().
 export declare function validate (
   schema: JSONSchemaType<any>,
-  config: RawConfiguration,
+  config: RawConfiguration | RawConfiguration[],
   validationOptions?: object,
   fixPaths?: boolean,
   root?: string
@@ -167,7 +181,22 @@ export declare function loadConfiguration (
   schema?: any,
   options?: ConfigurationOptions
 ): Promise<Configuration>
-export declare function loadConfigurationModule (root: string, config: RawConfiguration | ModuleWithVersion): any
+
+// The capability module object returned by loadConfigurationModule(): the
+// object a capability exports (its shape is otherwise capability-defined,
+// hence the index signature).
+export interface ConfigurationModule {
+  loadConfiguration?: (configPath: string) => Promise<unknown>
+  skipTelemetryHooks?: boolean
+  createCommands?: (applicationId: string) => unknown
+  modulesToLoad?: string[]
+  [key: string]: unknown
+}
+export declare function loadConfigurationModule (
+  root: string,
+  config: RawConfiguration | ModuleWithVersion,
+  pkg?: string
+): Promise<ConfigurationModule>
 
 // Error types
 export declare const ERROR_PREFIX: string

--- a/packages/foundation/test/types/index.tst.ts
+++ b/packages/foundation/test/types/index.tst.ts
@@ -1,16 +1,22 @@
+import type { JSONSchemaType } from 'ajv'
 import type { ParseArgsOptionsConfig } from 'node:util'
 import type { Logger } from 'pino'
 import { describe, expect, test } from 'tstyche'
 import {
   applicationToEnvVariable,
+  applications,
   createCLIContext,
   createCliLogger,
   fallbackToTemporaryConfigFile,
   findRuntimeConfigurationFile,
   getRoot,
+  loadConfigurationModule,
   logFatalError,
   logo,
-  parseArgs
+  parseArgs,
+  validate,
+  type ConfigurationModule,
+  type ConfigurationOptions
 } from '../../index.js'
 
 describe('createCLIContext', () => {
@@ -254,5 +260,59 @@ describe('fallbackToTemporaryConfigFile', () => {
     const logger: Logger = {} as Logger
     const result = await fallbackToTemporaryConfigFile(logger, '/root', false)
     expect(result).type.toBe<string | false | undefined>()
+  })
+})
+
+describe('validate', () => {
+  test('with a single object config', () => {
+    const schema = {} as JSONSchemaType<any>
+    expect(validate(schema, { foo: 'bar' })).type.toBe<void>()
+    expect(validate(schema, { foo: 'bar' }, {}, true, '/root')).type.toBe<void>()
+  })
+
+  test('with an array config (the exported `applications` schema)', () => {
+    // Cast needed purely due to an unrelated ajv `exactOptionalPropertyTypes`
+    // strictness gap between `JSONSchemaType<object[]>` and `JSONSchemaType<any>`
+    // - orthogonal to the array-vs-object `config` fix under test here.
+    const schema = applications as JSONSchemaType<any>
+    expect(validate(schema, [{ id: 'api' }])).type.toBe<void>()
+    expect(validate(schema, [{ id: 'api' }], {}, true, '/root')).type.toBe<void>()
+  })
+})
+
+describe('loadConfigurationModule', () => {
+  test('with required arguments', async () => {
+    const result = await loadConfigurationModule('/root', { module: '@platformatic/service' })
+    expect(result).type.toBe<ConfigurationModule>()
+    expect(result.loadConfiguration).type.toBe<((configPath: string) => Promise<unknown>) | undefined>()
+  })
+
+  test('with an explicit pkg override', async () => {
+    const result = await loadConfigurationModule('/root', {}, '@platformatic/basic')
+    expect(result).type.toBe<ConfigurationModule>()
+  })
+})
+
+describe('ConfigurationOptions', () => {
+  test('transform is invoked with three arguments', () => {
+    const options: ConfigurationOptions = {
+      isProduction: true,
+      transform: async (config, schema, transformOptions) => {
+        expect(config).type.toBe<typeof config>()
+        expect(schema).type.toBe<object>()
+        expect(transformOptions).type.toBe<ConfigurationOptions>()
+        return config
+      }
+    }
+
+    expect(options.isProduction).type.toBe<boolean | undefined>()
+  })
+
+  test('a one-argument transform hook remains assignable', () => {
+    const options: ConfigurationOptions = {
+      transform: async config => config
+    }
+
+    expect(options.transform).type.not.toBe<undefined>()
   })
 })

--- a/packages/globals/lib/index.d.ts
+++ b/packages/globals/lib/index.d.ts
@@ -147,6 +147,15 @@ export interface PlatformaticGlobal {
 /** @deprecated Use `PlatformaticGlobal` instead. */
 export type PlatformaticGlobalInterface = PlatformaticGlobal
 
+// updateGlobals() (see lib/index.js) assigns a real, shared
+// `globalThis.platformatic` object at worker/main-thread startup. Consumers
+// that read the global directly (rather than via the getters below) need an
+// ambient declaration to type it.
+declare global {
+  // eslint-disable-next-line no-var
+  var platformatic: PlatformaticGlobal | undefined
+}
+
 export declare function getGlobal<T extends {}> (): (PlatformaticGlobal & T) | undefined
 export declare function updateGlobals (updates: Partial<PlatformaticGlobal>): PlatformaticGlobal
 export declare function removeGlobals (fields: string[]): PlatformaticGlobal | undefined

--- a/packages/globals/test/types/index.tst.ts
+++ b/packages/globals/test/types/index.tst.ts
@@ -46,6 +46,15 @@ test("PlatformaticGlobal", () => {
   expect(platformatic.valkeyClients).type.toBe<Map<string, any>>()
 });
 
+test("ambient globalThis.platformatic", () => {
+  // updateGlobals() assigns a real, shared `globalThis.platformatic` object
+  // at worker/main-thread startup; consumers that read it directly (rather
+  // than via the getters below) need this ambient declaration.
+  expect(globalThis.platformatic).type.toBe<PlatformaticGlobal | undefined>()
+  expect(globalThis.platformatic?.sharedContext).type.toBe<PlatformaticGlobal['sharedContext'] | undefined>()
+  expect(globalThis.platformatic?.itc).type.toBe<PlatformaticGlobal['itc'] | undefined>()
+})
+
 test("updateGlobals", () => {
   expect(globals.updateGlobals({ config: {} })).type.toBe<PlatformaticGlobal>()
   expect(globals.updateGlobals).type.toBeCallableWith({ logger: {} as Pino.Logger })

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -9,7 +9,7 @@ import { EventEmitter } from 'node:events'
 import { Logger } from 'pino'
 import { PlatformaticRuntimeConfig } from './config.js'
 
-export type RuntimeConfiguration = Promise<Configuration<PlatformaticRuntimeConfig>>
+export type RuntimeConfiguration = Configuration<PlatformaticRuntimeConfig>
 
 export type ApplicationCommandContext = {
   colorette: typeof colorette
@@ -286,6 +286,11 @@ export declare class Runtime extends EventEmitter {
   getRuntimeStatus (): string
   getRuntimeMetadata (): Promise<RuntimeMetadata>
   getRuntimeEnv (): Record<string, string>
+  // `includeMeta: true` returns the full merged Configuration object (which
+  // carries the kMetadata symbol key: `{ root, path, env, module }`), not a
+  // plain Record; the argument-invariant overload below covers every other
+  // call.
+  getRuntimeConfig (includeMeta: true): RuntimeConfiguration
   getRuntimeConfig (includeMeta?: boolean): Record<string, unknown>
   getApplicationsIds (): string[]
   /**
@@ -345,6 +350,12 @@ export declare class Runtime extends EventEmitter {
   stopApplicationProfiling (id: string, options: Record<string, unknown> & { includeSampleCount: true }, ensureStarted?: boolean): Promise<{ profile: Buffer, sampleCount: number }>
   stopApplicationProfiling (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<Buffer>
   getApplicationLastProfile (id: string, options?: Record<string, unknown>, ensureStarted?: boolean): Promise<{ profile: Buffer, timestamp: number | null, sampleCount: number | null, preserved: boolean }>
+
+  // Patches one application's resolved configuration through the same
+  // per-application JSON-Patch mechanism the runtime already applies during
+  // create()/start().
+  setApplicationConfigPatch (applicationId: string, patch: Array<Record<string, unknown>>): void
+  removeApplicationConfigPatch (applicationId: string): void
 }
 
 export function wrapInRuntimeConfig (
@@ -360,13 +371,27 @@ export declare function loadConfiguration (
   context?: ConfigurationOptions
 ): Promise<RuntimeConfiguration>
 
+// create() additionally accepts `setupSignals`, a Runtime-only option (it is
+// never read outside this package) that controls whether SIGUSR2/close-with-grace
+// handlers are installed.
+export interface RuntimeCreateContext extends ConfigurationOptions<PlatformaticRuntimeConfig> {
+  setupSignals?: boolean
+}
+
 export function create (
   root: string,
   source?: string | PlatformaticRuntimeConfig,
-  context?: ConfigurationOptions
+  context?: RuntimeCreateContext
 ): Promise<Runtime>
 
-export declare function prepareApplication (config: RuntimeConfiguration, application: object): object
+// The runtime's actual per-application preparation (worker defaults, paths,
+// telemetry hooks, capability resolution) also takes the resolved worker
+// count as a third argument, and is itself async.
+export declare function prepareApplication (
+  config: RuntimeConfiguration,
+  application: object,
+  workers?: PlatformaticRuntimeConfig['workers']
+): Promise<object>
 
 export declare function transform (
   config: RuntimeConfiguration,

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -1,11 +1,14 @@
 import { expect, test } from 'tstyche'
-import type { Configuration } from '@platformatic/foundation'
+import type { Configuration, ConfigurationOptions } from '@platformatic/foundation'
 import {
   create,
   loadConfiguration,
+  prepareApplication,
+  transform,
   type ApplicationsTopology,
   type Runtime,
   type RuntimeConfiguration,
+  type RuntimeCreateContext,
   type ApplicationDetails,
   type InjectParams,
   type InjectResponse,
@@ -17,6 +20,7 @@ import {
   type RuntimeMetadata,
   type WorkerDetails
 } from '../../index.js'
+import type { PlatformaticRuntimeConfig } from '../../config.js'
 
 const context = {} as Configuration
 
@@ -27,6 +31,34 @@ test('create', () => {
   expect(create('.', { baseUrl: 'http://localhost:3000' })).type.toBe<Promise<Runtime>>()
 
   expect(create('.', './config.json', context)).type.toBe<Promise<Runtime>>()
+
+  // isProduction/setupSignals are real, documented Runtime-only create()
+  // options; setupSignals is Runtime-only, isProduction lives on the shared
+  // ConfigurationOptions.
+  const runtimeContext: RuntimeCreateContext = { isProduction: true, setupSignals: false }
+  expect(create('.', './config.json', runtimeContext)).type.toBe<Promise<Runtime>>()
+
+  // The runtime invokes a caller-supplied transform hook with three
+  // arguments (config, schema, options), not just the config.
+  expect(create('.', './config.json', {
+    transform: async (config, schema, options) => {
+      expect(schema).type.toBe<object>()
+      expect(options).type.toBe<ConfigurationOptions<PlatformaticRuntimeConfig>>()
+      return config
+    }
+  })).type.toBe<Promise<Runtime>>()
+})
+
+test('prepareApplication', () => {
+  const config = {} as RuntimeConfiguration
+  expect(prepareApplication(config, {})).type.toBe<Promise<object>>()
+  expect(prepareApplication(config, {}, config.workers)).type.toBe<Promise<object>>()
+})
+
+test('transform', () => {
+  const config = {} as RuntimeConfiguration
+  expect(transform(config)).type.toBe<Promise<RuntimeConfiguration>>()
+  expect(transform(config, {}, context)).type.toBe<Promise<RuntimeConfiguration>>()
 })
 
 test('loadConfiguration', () => {
@@ -90,7 +122,17 @@ test('Runtime.getRuntimeEnv', () => {
 
 test('Runtime.getRuntimeConfig', () => {
   expect(runtime.getRuntimeConfig()).type.toBe<Record<string, unknown>>()
-  expect(runtime.getRuntimeConfig(true)).type.toBe<Record<string, unknown>>()
+  // Passing `true` returns the full merged Configuration (carrying the
+  // kMetadata symbol), not a plain Record.
+  expect(runtime.getRuntimeConfig(true)).type.toBe<RuntimeConfiguration>()
+})
+
+test('Runtime.setApplicationConfigPatch', () => {
+  expect(runtime.setApplicationConfigPatch('api', [{ op: 'replace', path: '/foo', value: 'bar' }])).type.toBe<void>()
+})
+
+test('Runtime.removeApplicationConfigPatch', () => {
+  expect(runtime.removeApplicationConfigPatch('api')).type.toBe<void>()
 })
 
 test('Runtime.getApplicationsIds', () => {

--- a/packages/scalar-theme/package.json
+++ b/packages/scalar-theme/package.json
@@ -3,6 +3,7 @@
   "version": "3.63.0",
   "description": "Platformatic's Scalar theme for @scalar/fastify-api-reference",
   "main": "theme.js",
+  "types": "theme.d.ts",
   "type": "module",
   "homepage": "https://docs.platformatic.dev/",
   "scripts": {

--- a/packages/scalar-theme/theme.d.ts
+++ b/packages/scalar-theme/theme.d.ts
@@ -1,0 +1,8 @@
+export interface ScalarTheme {
+  /** The Platformatic Scalar theme CSS, passed to @scalar/fastify-api-reference's configuration.customCss. */
+  theme: string
+}
+
+declare const scalarTheme: ScalarTheme
+
+export default scalarTheme


### PR DESCRIPTION
## Summary

Fixes several `@platformatic/runtime`, `@platformatic/foundation`, `@platformatic/globals`, and `@platformatic/scalar-theme` type declarations that don't match their implementations (or, for scalar-theme, don't exist). Each was discovered while strictly typing a Watt runtime extension, and verified against the real JS implementation in this repository before being changed here.

## Gaps and evidence

### `@platformatic/runtime`

- **`Runtime#setApplicationConfigPatch`** — missing from the shipped class declaration even though it's a real public method (`lib/runtime.js:1165`). Added, plus its counterpart `removeApplicationConfigPatch` (`lib/runtime.js:1169`). These are the only way for an extension to inject per-application config patches programmatically, so their absence forces consumers to cast the `Runtime` instance.
- **`create()`'s context / `transform` arity** — `loadConfiguration()` in `packages/foundation/lib/configuration.js:526` always invokes the caller's `transform` hook as `transform(config, schema, options)` (three arguments), for every capability, not just runtime. The shared `ConfigurationOptions.transform` type was declared with one argument, causing "Target signature provides too few arguments" for any three-argument transform hook. Fixed at the source in foundation. Also added `isProduction` to `ConfigurationOptions`, since it's read directly off context by nearly every capability package (astro, basic, next, node, service, nest, nuxt, remix, react-router, tanstack, vite — verified via grep). `setupSignals` (`index.js:146`, runtime-only) is added via a new `RuntimeCreateContext` on `create()`.
- **`RuntimeConfiguration` double-`Promise` bug** — declared as `Promise<Configuration<PlatformaticRuntimeConfig>>`, but every other place in `index.d.ts` (including `transform`'s own parameter) uses it as an already-resolved config object. Any caller that does `const resolved = await transform(...)` and then reads `resolved.entrypoint` or `resolved.server` gets a corrupted type. Fixed to the plain `Configuration<PlatformaticRuntimeConfig>`.
- **`prepareApplication`** — shipped as a *synchronous*, two-parameter `(config, application): object`. The real function (`lib/config.js:229`) is `async function prepareApplication (config, application, defaultWorkers)` — three parameters, and itself async (real call sites, including the runtime's own `transform()` at `lib/config.js:429` and this repo's own test suite at `test/dynamic-applications.test.js:50`, always `await` it). Fixed to `Promise<object>` with the third `workers` argument.
- **`getRuntimeConfig(true)`** — shipped as argument-invariant (`Record<string, unknown>` regardless of the boolean). `lib/runtime.js:1316-1323` shows `includeMeta: true` returns the full merged `Configuration` object (carrying the `kMetadata` symbol). Added the `getRuntimeConfig(includeMeta: true): RuntimeConfiguration` overload.

### `@platformatic/foundation`

- **`loadConfigurationModule`** — returned `any`. `lib/configuration.js:535` (`loadModule()` in `lib/module.js:166-197`) either resolves to the loaded module object or throws — it never resolves to `null` — so the fix types it as `Promise<ConfigurationModule>`. Also added the optional third `pkg` parameter the real function accepts (used internally at `lib/worker/controller.js:150`).
- **`validate`** — `config` was typed as a single `RawConfiguration`, but the exported `applications` schema is `JSONSchemaType<object[]>` (an array schema), and `validate()` is called with a matching config array before handing it to `prepareApplication()`/`addApplications()`. Widened to `RawConfiguration | RawConfiguration[]`; the underlying `ajv` validator call in `lib/configuration.js:319-321` is generic over whatever `config` shape is passed, so this is a pure widening, not a behavior change.

### `@platformatic/scalar-theme`

- **No type declarations at all** — the package ships `main: theme.js` with no `types` field, so TypeScript consumers of the default `{ theme: string }` export (the pattern `packages/service/lib/plugins/openapi.js` itself uses for Scalar's `customCss`) have to write their own ambient module declaration. Added `theme.d.ts` and the `types` field.

### `@platformatic/globals`

- **`globalThis.platformatic`** — `updateGlobals()` (`lib/index.js:17-27`) assigns a real, shared `globalThis.platformatic` object at worker/main-thread startup, but the package shipped no ambient declaration for it, only per-field accessor functions. Added `declare global { var platformatic: PlatformaticGlobal | undefined }`, reusing the already-exported `PlatformaticGlobal` interface, so direct reads of the global no longer need casts.

## Notes

- `loadConfigurationModule`'s return type deliberately has no `| null`: the implementation throws on failure rather than resolving to `null`.
- The `transform` arity fix lives in foundation's shared `ConfigurationOptions` (root cause, affects every capability package) rather than being overridden locally in `packages/runtime/index.d.ts`.
- `getRuntimeConfig(true)` and `prepareApplication`'s `workers` parameter are typed against the `Configuration<PlatformaticRuntimeConfig>` / `PlatformaticRuntimeConfig['workers']` types already available in this package.

## Test plan

- [x] Extended `packages/{runtime,foundation,globals}/test/types/index.tst.ts` with cases for every new/changed declaration
- [x] `npx tstyche` green in `packages/runtime`, `packages/foundation`, `packages/globals`
- [x] `npx tstyche` green in every other package that consumes `ConfigurationOptions` (astro, next, node, gateway, nest, nuxt, react-router, remix, tanstack, vite) — `db`'s pre-existing type-test failure reproduces identically on `main`, unrelated to this change
- [x] `npx eslint .` clean in `packages/runtime`, `packages/foundation`, `packages/globals`, `packages/scalar-theme`
- [x] `packages/scalar-theme/theme.d.ts` type-checks standalone under `strict` (the package has no test infrastructure; the declaration mirrors the two-line `theme.js` exactly)
- [x] Full `npm test` green in `packages/foundation` and `packages/globals`; `packages/runtime`'s behavioral suite (`test:main`, real Watt runtimes, 300s+ timeouts) was not run to completion given its length — this PR only touches `.d.ts`/type-test files, no runtime `.js` behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pub6cArhL48j36Hta5EiA2
