### PR TITLE
fix(foundation): report environment variables resolved by the onMissingEnv fallback

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -325,6 +325,12 @@ Controls what happens when a `{PLT_*}` environment variable placeholder referenc
 - `true`: loading the configuration fails at startup with an error listing all the missing variables.
 - `"warn"`: a warning listing the missing variables is logged, but the placeholders are still replaced with an empty string.
 
+Not every unset variable is reported as missing. When loading the configuration of an application, the
+runtime resolves any variable whose name ends in `_URL` to the internal URL of that application, so such
+a variable gets a value even when it is not set. When `strictEnv` is enabled, these variables are listed
+in a separate warning. They are never turned into an error, not even when `strictEnv` is `true`, because
+they do resolve to a value and failing on them would change which configurations are able to boot.
+
 The value is also applied when loading the configuration files of the applications in the runtime.
 
 ```json

--- a/packages/foundation/lib/configuration.js
+++ b/packages/foundation/lib/configuration.js
@@ -503,6 +503,7 @@ export async function loadConfiguration (source, schema, options = {}) {
 
   if (shouldReplaceEnv) {
     const missingEnv = new Set()
+    const fallbackEnv = new Set()
 
     config = replaceEnv(
       config,
@@ -512,6 +513,11 @@ export async function loadConfiguration (source, schema, options = {}) {
 
         if (typeof value === 'undefined' || value === null) {
           missingEnv.add(key)
+        } else {
+          // The variable is not set: it only has a value because onMissingEnv provided a fallback.
+          // Track it separately so that strictEnv can still report it, as a fallback can silently
+          // mask a misconfiguration.
+          fallbackEnv.add(key)
         }
 
         return value
@@ -523,17 +529,31 @@ export async function loadConfiguration (source, schema, options = {}) {
     // (runtime configurations) or in the runtime property (capabilities configurations).
     const strictEnv = normalizeStrictEnv(strictEnvOption ?? config.strictEnv ?? config.runtime?.strictEnv)
 
+    function warn (message) {
+      if (logger) {
+        logger.warn(message)
+      } else {
+        process.emitWarning(message)
+      }
+    }
+
+    // Variables resolved by a fallback are always reported as a warning, never as an error: they did
+    // resolve to a value, so failing on them would change which configurations are able to boot.
+    // This is emitted before handling the missing ones so that a throw does not swallow it.
+    if (strictEnv && fallbackEnv.size > 0) {
+      const keys = Array.from(fallbackEnv).sort().join(', ')
+
+      warn(
+        'The configuration references the following environment variables which are not set ' +
+          `and have been replaced by a fallback value: ${keys}`
+      )
+    }
+
     if (strictEnv && missingEnv.size > 0) {
       const keys = Array.from(missingEnv).sort().join(', ')
 
       if (strictEnv === 'warn') {
-        const message = `The configuration references the following environment variables which are not set: ${keys}`
-
-        if (logger) {
-          logger.warn(message)
-        } else {
-          process.emitWarning(message)
-        }
+        warn(`The configuration references the following environment variables which are not set: ${keys}`)
       } else {
         throw new MissingEnvVariablesError(keys)
       }

--- a/packages/foundation/test/configuration.test.js
+++ b/packages/foundation/test/configuration.test.js
@@ -1775,6 +1775,134 @@ test('loadConfiguration - strictEnv should not throw when onMissingEnv provides 
   equal(result.host, 'default_MISSING_VAR')
 })
 
+test('loadConfiguration - strictEnv should warn about variables resolved by onMissingEnv', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{MISSING_VAR}' }
+  const warnings = []
+  const logger = {
+    warn (message) {
+      warnings.push(message)
+    }
+  }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  const result = await loadConfiguration(configFile, null, {
+    ignoreProcessEnv: true,
+    strictEnv: true,
+    onMissingEnv: key => `default_${key}`,
+    logger
+  })
+
+  // The value is still resolved by the fallback: reporting it must not change what can boot.
+  equal(result.host, 'default_MISSING_VAR')
+  deepEqual(warnings, [
+    'The configuration references the following environment variables which are not set and have been replaced by a fallback value: MISSING_VAR'
+  ])
+})
+
+test('loadConfiguration - strictEnv should report resolved and missing variables separately', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{RESOLVED_URL}', other: '{MISSING_VAR}' }
+  const warnings = []
+  const logger = {
+    warn (message) {
+      warnings.push(message)
+    }
+  }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  const result = await loadConfiguration(configFile, null, {
+    ignoreProcessEnv: true,
+    strictEnv: 'warn',
+    onMissingEnv: key => (key.endsWith('_URL') ? 'http://fallback.local' : undefined),
+    logger
+  })
+
+  equal(result.host, 'http://fallback.local')
+  equal(result.other, '')
+  deepEqual(warnings, [
+    'The configuration references the following environment variables which are not set and have been replaced by a fallback value: RESOLVED_URL',
+    'The configuration references the following environment variables which are not set: MISSING_VAR'
+  ])
+})
+
+test('loadConfiguration - strictEnv should warn about resolved variables before throwing on the missing ones', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{RESOLVED_URL}', other: '{MISSING_VAR}' }
+  const warnings = []
+  const logger = {
+    warn (message) {
+      warnings.push(message)
+    }
+  }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  await rejects(
+    async () => {
+      await loadConfiguration(configFile, null, {
+        ignoreProcessEnv: true,
+        strictEnv: true,
+        onMissingEnv: key => (key.endsWith('_URL') ? 'http://fallback.local' : undefined),
+        logger
+      })
+    },
+    {
+      code: 'PLT_MISSING_ENV_VARIABLES',
+      message: 'The configuration references the following environment variables which are not set: MISSING_VAR'
+    }
+  )
+
+  // The warning must survive the throw, otherwise the silently resolved variable stays invisible.
+  deepEqual(warnings, [
+    'The configuration references the following environment variables which are not set and have been replaced by a fallback value: RESOLVED_URL'
+  ])
+})
+
+test('loadConfiguration - variables resolved by onMissingEnv are not reported when strictEnv is disabled', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const configFile = join(tmpDir, 'config.json')
+  const config = { host: '{MISSING_VAR}' }
+  const warnings = []
+  const logger = {
+    warn (message) {
+      warnings.push(message)
+    }
+  }
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(configFile, JSON.stringify(config))
+
+  const result = await loadConfiguration(configFile, null, {
+    ignoreProcessEnv: true,
+    onMissingEnv: key => `default_${key}`,
+    logger
+  })
+
+  equal(result.host, 'default_MISSING_VAR')
+  deepEqual(warnings, [])
+})
+
 test('loadConfiguration - strictEnv should not throw when all variables are set', async t => {
   const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
   const configFile = join(tmpDir, 'config.json')


### PR DESCRIPTION
## Problem

When `strictEnv` is enabled, a variable whose name ends in `_URL` is resolved by the `onMissingEnv`
fallback and is not reported by the load that resolved it.

In `loadConfiguration`, a placeholder that cannot be resolved from the environment is offered to the
`onMissingEnv` callback, and a key only enters the `missingEnv` set when that callback returns nothing
(`packages/foundation/lib/configuration.js:511`). The runtime wires `fetchApplicationUrl` as that callback
(`packages/runtime/lib/worker/controller.js:31`, bound at `:98`, passed at `:145`), and that function
resolves **any** key ending in `_URL` to `getApplicationUrl(application.id)`, which is the URL of the
application currently being configured, not of the application the key names.

So an unset `{PLT_DATABASE_URL}` becomes `http://<current-application>.plt.local` for that load, and the
report for that load says nothing about it. The operator opted into strict environment checking and still
gets a value that looks plausible, is not what they meant, and is not mentioned.

One caveat worth stating up front, because it is visible to anyone who boots a multi application runtime.
Each application currently loads its configuration twice, and only the load described above passes
`onMissingEnv`. The second load, the one the capability actually runs on, does not: `controller.js:149`
hands the config path to `pkg.create`, which loads it again through the capability's own
`loadConfiguration` (for example `packages/db/index.js:23`), spreading a context that carries `strictEnv`
but stores the callback under the name `fetchApplicationUrl` rather than `onMissingEnv`. The practical
consequences are that those `_URL` names do surface in a second warning line today, and that the value
reaching the capability is the empty string rather than the resolved application URL.

That second line is an artefact of the duplicate load, not the report working. The load that resolves the
variable is still the one that never mentions it, and if the duplicate load is ever removed or made
consistent, the warning this PR adds becomes the only signal that a variable was silently substituted.

The type confusion this can produce is not theoretical. The canonical example in your own beginner guide is
a database connection string behind exactly such a placeholder:

```json
"connectionString": "{DATABASE_URL}"
```

(`docs/learn/beginner/environment-variables.md:115`, with `DATABASE_URL=postgresql://localhost:5432/myapp`
at `:124`). If that variable is not set for one of the applications, the load that picks the configuration
module receives an HTTP URL where a Postgres DSN is expected, and `strictEnv` stays quiet about it.

We hit this while adopting `strictEnv: "warn"` across a 22 application runtime after #4976 landed. The
warnings were genuinely useful, 21 applications reported 47 variables between them. Then we noticed the
`_URL` names were absent from the first of the two warning lines each application emits: 7 more variables
were unset and being resolved by the fallback rather than reported, including a `PLT_EVENTS_DATABASE_URL`
that names another application's database.

This is the same bug class as #4968, inside the feature #4976 built to answer it: a variable that is not
set gets a value that looks like a value, and the load that substituted it does not say so. The
`onMissingEnv` callback is even named in the title of #4968, it is just the one case the resulting report
does not cover.

## What this PR does

Keys resolved by the `onMissingEnv` fallback are collected in their own set and, when `strictEnv` is
enabled, reported with their own warning:

```
The configuration references the following environment variables which are not set and have been
replaced by a fallback value: PLT_EVENTS_DATABASE_URL
```

Deliberate choices:

- **Never an error, not even with `strictEnv: true`.** These variables do resolve to a value, so turning
  them into an error would change which configurations are able to boot. Every runtime that boots today
  still boots after this PR, it just says more.
- **The warning is emitted before the missing variables are handled**, so a `strictEnv: true` throw does
  not swallow it.
- **Gated on `strictEnv` being enabled**, so there is no new output for anyone who has not opted in.
- No false positives are possible: `replaceEnv` calls the callback through `env[key] ?? onMissingEnv?.(key)`
  (`packages/foundation/lib/configuration.js:436`), so it only ever fires on keys that are nullish in the
  environment. A variable that is set, including one deliberately set to the empty string, cannot end up in
  this set, which keeps the `#4968` semantics intact.

The docs are updated too: `docs/reference/runtime/_shared-configuration.md` enumerated exactly three
`strictEnv` behaviours and this adds a fourth.

## Blast radius

`onMissingEnv` has a single producer in the whole monorepo, `fetchApplicationUrl`, and no existing test
pins the old behaviour of dropping fallback resolved keys from the report.

## Test plan

Four new tests in `packages/foundation/test/configuration.test.js`, mirroring the four existing `strictEnv`
tests:

1. with `strictEnv: true` and a fallback that resolves the key, the variable is warned about and the load
   still succeeds with the fallback value;
2. with `strictEnv: "warn"`, one fallback resolved variable and one genuinely missing one produce two
   distinct warnings, the fallback one first;
3. with `strictEnv: true`, the same pair still throws `PLT_MISSING_ENV_VARIABLES` on the missing variable,
   and the warning about the resolved one survives the throw;
4. nothing is warned when `strictEnv` is disabled.

Three of the four fail if the fix is reverted. The fourth asserts an absence, so it is green either way by
design.

Verified locally: full `packages/foundation` suite (12 files) green at 361/361, `packages/runtime`
`test/config.test.js` green at 26/26, `pnpm lint` clean in both packages, `pnpm lint:markdown` clean.
