### PR TITLE
fix(runtime): exit with PROCESS_UNHANDLED_ERROR on post-initialization unhandled errors

### DIFF
--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -24,7 +24,7 @@ import { resolve } from 'node:path'
 import { getActiveResourcesInfo } from 'node:process'
 import { workerData } from 'node:worker_threads'
 import { getGlobalDispatcher, setGlobalDispatcher } from 'undici'
-import { ApplicationAlreadyStartedError, RuntimeNotStartedError } from '../errors.js'
+import { ApplicationAlreadyStartedError, exitCodes, RuntimeNotStartedError } from '../errors.js'
 import { getApplicationUrl } from '../utils.js'
 import { markAsPlatformaticDispatcher, refreshGlobalDispatcher } from './interceptors.js'
 
@@ -43,7 +43,7 @@ function handleUnhandled (app, event, listeners, timeout, err, ...args) {
   logger.error({ err: ensureLoggableError(err) }, `The ${label} threw an ${event} event.`)
 
   // Give some time to the listeners, logger and ITC notifications to land before shutting down
-  setTimeout(() => process.exit(1), timeout)
+  setTimeout(() => process.exit(exitCodes.PROCESS_UNHANDLED_ERROR), timeout)
 
   for (const listener of listeners) {
     try {

--- a/packages/runtime/test/unhandled-mode.test.js
+++ b/packages/runtime/test/unhandled-mode.test.js
@@ -3,6 +3,7 @@ import { once } from 'node:events'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import { request } from 'undici'
+import { exitCodes } from '../lib/errors.js'
 import { createRuntime, readLogs } from './helpers.js'
 
 const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
@@ -121,4 +122,25 @@ test('should invoke tracked unhandledRejection listeners when exitOnUnhandledErr
       )
     )
   )
+})
+
+test('should exit with the PROCESS_UNHANDLED_ERROR code on uncaught exceptions raised after initialization', async t => {
+  const configFile = join(fixturesDir, 'unhandled-mode', 'platformatic.handled.json')
+  const server = await createRuntime(configFile)
+  const url = await server.start()
+
+  t.after(() => {
+    return server.close()
+  })
+
+  // Listen before triggering, the worker exits about 100ms after the error is raised
+  const errored = once(server, 'application:worker:error')
+
+  const res = await request(url + '/service/trigger')
+  strictEqual(res.statusCode, 200)
+
+  const [payload] = await errored
+
+  strictEqual(payload.application, 'service')
+  strictEqual(payload.code, exitCodes.PROCESS_UNHANDLED_ERROR)
 })


### PR DESCRIPTION
## Problem

A worker that hits an uncaught exception or an unhandled rejection **after** initialization exits with a
bare `1` (`packages/runtime/lib/worker/controller.js:46`), while the two other paths that handle the very
same condition use the dedicated `PROCESS_UNHANDLED_ERROR` code:

- pre-initialization, `packages/runtime/lib/worker/main.js:36`
- child process capabilities, `packages/basic/lib/worker/child-process.js:725`

So the exit code for "this worker died of an unhandled error" depends on when it happened, and only the
post-initialization case, which is the common one in production, uses the generic code.

## Why this is not cosmetic

`safeHandleInITC` branches on that exact code (`packages/runtime/lib/worker/itc.js:91`) to decide how a
worker that dies during an ITC call is reported:

```js
if (typeof worker[kWorkerId] !== 'undefined' && exitCode !== exitCodes.PROCESS_UNHANDLED_ERROR) {
  throw new WorkerExitedError(worker[kWorkerId], worker[kApplicationId], exitCode)
} else {
  throw new ApplicationExitedError(worker[kId], exitCode)
}
```

The same unhandled error therefore surfaces as `PLT_RUNTIME_APPLICATION_WORKER_EXIT` or as
`PLT_RUNTIME_APPLICATION_EXIT` purely as a function of whether initialization had completed, which is
almost certainly not the intent of that branch: `init-error.test.js` already pins the pre-initialization
case to `The application "main:0" exited prematurely with error code 20`.

## What this PR does

One line: `process.exit(1)` becomes `process.exit(exitCodes.PROCESS_UNHANDLED_ERROR)` in `handleUnhandled`.

This is an observable change and we would rather name it than have you find it:

- the `application:worker:error` event payload now carries `code: 20` instead of `code: 1` for this case,
  and the accompanying `The worker N of the application "x" unexpectedly exited with code 20.` log line
  changes with it;
- a worker that dies this way during an ITC call is now reported as `ApplicationExitedError` where it used
  to be `WorkerExitedError`.

Nothing else changes. The restart path does not look at the exit code at all, and the condition that gates
the error event (`!config.watch || code !== 0`) is satisfied by both the old value and the new one, so the
same events fire, only with a different number in them.

## Blast radius

Two existing tests assert the `exited prematurely` message. Neither pins this path:

- `packages/runtime/test/init-error.test.js:16` is the pre-initialization path, already at 20;
- `packages/runtime/test/multiple-workers/crash-handling.test.js:93` pins `WorkerExitedError` with code
  `1`, but its fixture calls `process.exit(1)` literally (`:63`), so the code comes from the application,
  not from `handleUnhandled`. Verified by running it: green on the patched branch.

## Test plan

One new test in `packages/runtime/test/unhandled-mode.test.js` that triggers an uncaught exception after
the runtime has started and asserts the exit code carried by the `application:worker:error` event is
`exitCodes.PROCESS_UNHANDLED_ERROR`. Proven by mutation: with the fix reverted it fails with
`actual: 1, expected: 20`.

No second test for the unhandled rejection half on purpose. The obvious candidate, the `node` application
in the `unhandled-mode` fixture, runs as a child process, so its exit code comes from
`child-process.js:725` and the test stays green with or without this fix. Both events are bound to the same
`handleUnhandled` function, so the single test covers the changed line.

Verified locally on the branch: `test/unhandled-mode.test.js` + `init-error` + `exit-event` +
`graceful-close` green at 8/8, the whole `test:multiple-workers` script green at 70 passing and 1 skipped,
`pnpm lint` clean.
