### PR TITLE
fix(sql-mapper): resolve foreign keys targeting a bare unique index

### DIFF
--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -604,6 +604,16 @@ export function buildEntity (
       schemaList?.length > 0 ? schemaList.includes(constraint.foreign_table_schema) : true
     /* istanbul ignore if */
     if (constraint.constraint_type === 'FOREIGN KEY' && isForeignKeySchemaInConfig) {
+      /* istanbul ignore next */
+      if (!constraint.foreign_table_name) {
+        // The referenced side of the foreign key could not be resolved by the introspection
+        // query. Ignore the relation rather than failing the whole boot.
+        log.warn(
+          { constraint },
+          `Could not resolve the table referenced by the foreign key "${constraint.constraint_name}" on "${constraint.table_name}.${constraint.column_name}". The relation will be ignored.`
+        )
+        continue
+      }
       field.foreignKey = true
       const foreignEntityName = singularize(
         camelcase(

--- a/packages/sql-mapper/lib/queries/pg.js
+++ b/packages/sql-mapper/lib/queries/pg.js
@@ -80,8 +80,8 @@ export async function listColumns (db, sql, table, schema) {
 
 export async function listConstraints (db, sql, table, schema) {
   const query = sql`
-    SELECT constraints.*, usage.*, foreign_usage.table_name AS foreign_table_name,
-      foreign_usage.column_name AS foreign_column_name, foreign_usage.table_schema AS foreign_table_schema
+    SELECT constraints.*, usage.*, foreign_table.relname AS foreign_table_name,
+      foreign_column.attname AS foreign_column_name, foreign_namespace.nspname AS foreign_table_schema
     FROM information_schema.table_constraints constraints
       JOIN information_schema.key_column_usage usage
         ON constraints.constraint_catalog = usage.constraint_catalog
@@ -89,15 +89,22 @@ export async function listConstraints (db, sql, table, schema) {
         AND constraints.constraint_name = usage.constraint_name
         AND constraints.table_schema = usage.table_schema
         AND constraints.table_name = usage.table_name
-      LEFT JOIN information_schema.referential_constraints referential
-        ON constraints.constraint_catalog = referential.constraint_catalog
-        AND constraints.constraint_schema = referential.constraint_schema
-        AND constraints.constraint_name = referential.constraint_name
-      LEFT JOIN information_schema.key_column_usage foreign_usage
-        ON referential.unique_constraint_catalog = foreign_usage.constraint_catalog
-        AND referential.unique_constraint_schema = foreign_usage.constraint_schema
-        AND referential.unique_constraint_name = foreign_usage.constraint_name
-        AND usage.position_in_unique_constraint = foreign_usage.ordinal_position
+      LEFT JOIN pg_catalog.pg_namespace local_namespace
+        ON local_namespace.nspname = constraints.table_schema
+      LEFT JOIN pg_catalog.pg_class local_table
+        ON local_table.relname = constraints.table_name
+        AND local_table.relnamespace = local_namespace.oid
+      LEFT JOIN pg_catalog.pg_constraint foreign_constraint
+        ON foreign_constraint.conrelid = local_table.oid
+        AND foreign_constraint.conname = constraints.constraint_name
+        AND foreign_constraint.contype = 'f'
+      LEFT JOIN pg_catalog.pg_class foreign_table
+        ON foreign_table.oid = foreign_constraint.confrelid
+      LEFT JOIN pg_catalog.pg_namespace foreign_namespace
+        ON foreign_namespace.oid = foreign_table.relnamespace
+      LEFT JOIN pg_catalog.pg_attribute foreign_column
+        ON foreign_column.attrelid = foreign_constraint.confrelid
+        AND foreign_column.attnum = foreign_constraint.confkey[usage.ordinal_position]
     WHERE constraints.table_name = ${table}
       AND constraints.table_schema = ${schema}
     ORDER BY usage.constraint_name, usage.ordinal_position

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -752,6 +752,67 @@ test('composite foreign keys inherit each referenced column output type', { skip
   strictEqual(typeof registration.code, 'number')
 })
 
+test('foreign keys referencing a bare unique index are resolved', { skip: !isPg }, async t => {
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      t.after(async () => {
+        await clear(db, sql)
+        db.dispose()
+      })
+
+      // The uniqueness of categories.code is backed by an index and not by a constraint,
+      // which is what Prisma emits for a `@unique` field. PostgreSQL accepts it as a
+      // foreign key target, but information_schema has no constraint to name for it.
+      await db.query(sql`
+        CREATE TABLE categories (
+          id SERIAL PRIMARY KEY,
+          code TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX categories_code_uidx ON categories (code);
+        CREATE TABLE pages (
+          id SERIAL PRIMARY KEY,
+          category_id INTEGER REFERENCES categories (id),
+          category_code TEXT REFERENCES categories (code)
+        );
+      `)
+    },
+    ignore: {},
+    hooks: {}
+  })
+
+  const pageEntity = mapper.entities.page
+
+  const relations = pageEntity.relations
+    .map(relation => ({
+      column: relation.column_name,
+      foreignTable: relation.foreign_table_name,
+      foreignColumn: relation.foreign_column_name,
+      foreignSchema: relation.foreign_table_schema
+    }))
+    .sort((a, b) => a.column.localeCompare(b.column))
+
+  deepEqual(relations, [
+    { column: 'category_code', foreignTable: 'categories', foreignColumn: 'code', foreignSchema: 'public' },
+    { column: 'category_id', foreignTable: 'categories', foreignColumn: 'id', foreignSchema: 'public' }
+  ])
+
+  strictEqual(pageEntity.fields.category_id.foreignKey, true)
+  strictEqual(pageEntity.fields.category_code.foreignKey, true)
+  // Only the foreign key referencing a primary key is stringified on output
+  strictEqual(pageEntity.fields.category_id.stringifyOutput, true)
+  strictEqual(pageEntity.fields.category_code.stringifyOutput, undefined)
+
+  const category = await mapper.entities.category.save({ input: { code: 'fiction' } })
+  const page = await pageEntity.save({ input: { categoryId: category.id, categoryCode: category.code } })
+
+  strictEqual(page.categoryId, category.id)
+  strictEqual(typeof page.categoryId, 'string')
+  strictEqual(page.categoryCode, 'fiction')
+})
+
 test('only include wanted fields - with foreign', async () => {
   async function onDatabaseLoad (db, sql) {
     await clear(db, sql)


### PR DESCRIPTION
Fixes #5028.

## Problem

Since 3.62.3 (#4982), booting a `@platformatic/db` application against a PostgreSQL schema that has a foreign key referencing a column whose uniqueness is backed by a **unique index** rather than a **unique constraint** crashes with:

```
TypeError: Expected the input to be `string | string[]`
    at camelCase (camelcase/index.js:58:9)
    at buildEntity (@platformatic/sql-mapper/lib/entity.js:609:9)
```

`listConstraints` resolved the referenced side through `information_schema.referential_constraints`. PostgreSQL accepts a bare unique index as a foreign key target, but `information_schema` only models constraints, so `unique_constraint_name` is `NULL` and the join to `key_column_usage` matches nothing — `foreign_table_name` comes back `NULL` and `camelcase(null)` throws.

`CREATE UNIQUE INDEX` is what Prisma emits for a `@unique` field, so any Prisma-managed schema with a foreign key onto such a column is affected. With the default configuration (`db.schemalock` off) this fires on every boot.

## Fix

Resolve the referenced side from `pg_catalog` (`pg_constraint.confrelid` / `confkey`), which is populated whether the target is a constraint or a bare index. Each foreign key column is paired to its referenced column through `confkey[usage.ordinal_position]`, so the composite-foreign-key pairing that #4982 introduced is preserved — `confkey[i]` corresponds to `conkey[i]`, and `key_column_usage.ordinal_position` is the position within `conkey`.

As a safety net, `buildEntity` now warns naming the constraint, the table and the column, and skips the relation when a `FOREIGN KEY` row carries no referenced table, instead of letting `camelcase` throw and taking down the boot.

## Verification

Reproduced the crash against PostgreSQL with the schema from the issue, and confirmed both foreign keys now resolve, with `stringifyOutput` still set only on the foreign key that references a primary key.

New regression test: `foreign keys referencing a bare unique index are resolved` in `packages/sql-mapper/test/entity.test.js`.

Suites run green: `sql-mapper` (postgresql, sqlite, mariadb), `sql-openapi` (postgresql), `sql-graphql` (postgresql), `db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAjFr1D1Nnwxa5DH4V3LbZ