### PR TITLE
fix(runtime): let the env file of an application override the one of the runtime

### DIFF
--- a/packages/foundation/index.d.ts
+++ b/packages/foundation/index.d.ts
@@ -6,6 +6,7 @@ import { LevelWithSilentOrString, Logger } from 'pino'
 
 // Symbols
 export declare const kCanceled: unique symbol
+export declare const kEnvFileFallbackKeys: unique symbol
 export declare const kFailedImport: unique symbol
 export declare const kHandledError: unique symbol
 export declare const kMetadata: unique symbol

--- a/packages/foundation/lib/configuration.js
+++ b/packages/foundation/lib/configuration.js
@@ -18,7 +18,7 @@ import {
 } from './errors.js'
 import { isFileAccessible } from './file-system.js'
 import { loadModule, splitModuleFromVersion } from './module.js'
-import { kMetadata } from './symbols.js'
+import { kEnvFileFallbackKeys, kMetadata } from './symbols.js'
 
 const { parse: parseJSON5, stringify: rawStringifyJSON5 } = JSON5
 const { parse: parseTOML, stringify: stringifyTOML } = toml
@@ -386,11 +386,21 @@ export async function loadEnv (root, ignoreProcessEnv = false, additionalEnv = {
   // The env file provides fallback defaults: variables already set in the real
   // environment (and explicit programmatic values) take precedence over it,
   // matching the dotenv/docker-compose/Vite convention.
-  return {
+  const env = {
     ...envFromFile,
     ...baseEnv,
     ...additionalEnv
   }
+
+  // Keys whose only source is the env file are not real environment variables, they are defaults:
+  // a more specific env file, like the one of a single application inside a runtime, must still be
+  // able to override them. The list is attached non enumerably, so spreading, Object.keys,
+  // JSON.stringify and structuredClone of the returned environment are all unchanged.
+  const fallbackKeys = Object.keys(envFromFile).filter(key => !(key in baseEnv) && !(key in additionalEnv))
+
+  Object.defineProperty(env, kEnvFileFallbackKeys, { value: fallbackKeys, enumerable: false })
+
+  return env
 }
 
 export function replaceEnv (config, env, onMissingEnv, ignore) {

--- a/packages/foundation/lib/symbols.js
+++ b/packages/foundation/lib/symbols.js
@@ -1,4 +1,5 @@
 export const kCanceled = Symbol('plt.foundation.canceled')
+export const kEnvFileFallbackKeys = Symbol('plt.foundation.envFileFallbackKeys')
 export const kFailedImport = Symbol('plt.foundation.failedImport')
 export const kHandledError = Symbol('plt.foundation.handledError')
 export const kMetadata = Symbol('plt.foundation.metadata')

--- a/packages/foundation/test/configuration.test.js
+++ b/packages/foundation/test/configuration.test.js
@@ -12,6 +12,7 @@ import {
   findConfigurationFileRecursive,
   getParser,
   getStringifier,
+  kEnvFileFallbackKeys,
   kMetadata,
   knownConfigurationFilesExtensions,
   knownConfigurationFilesSchemas,
@@ -670,6 +671,44 @@ test('loadEnv - additionalEnv should take precedence over both process.env and t
 
   const result = await loadEnv(tmpDir, false, { PLT_PRECEDENCE_TEST: 'from-additional' })
   equal(result.PLT_PRECEDENCE_TEST, 'from-additional')
+})
+
+test('loadEnv - should mark as fallback the keys only provided by the .env file', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const envFile = join(tmpDir, '.env')
+
+  process.env.PLT_PRECEDENCE_TEST = 'from-process'
+
+  t.after(async () => {
+    delete process.env.PLT_PRECEDENCE_TEST
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(envFile, 'PLT_PRECEDENCE_TEST=from-file\nPLT_FILE_ONLY_TEST=from-file')
+
+  const result = await loadEnv(tmpDir, false, { PLT_ADDITIONAL_TEST: 'from-additional' })
+
+  // Only the key whose sole source is the discovered file is a fallback
+  deepEqual(result[kEnvFileFallbackKeys], ['PLT_FILE_ONLY_TEST'])
+
+  // The marker is not enumerable, so the shape of the returned environment is unchanged
+  equal(Object.getOwnPropertyDescriptor(result, kEnvFileFallbackKeys).enumerable, false)
+  deepEqual(Object.getOwnPropertySymbols({ ...result }), [])
+})
+
+test('loadEnv - should mark as fallback the keys provided by a custom env file', async t => {
+  const tmpDir = await mkdtemp(join(os.tmpdir(), 'plt-utils-test-'))
+  const customEnvFile = join(tmpDir, 'custom.env')
+
+  t.after(async () => {
+    await safeRemove(tmpDir)
+  })
+
+  await writeFile(customEnvFile, 'PLT_FILE_ONLY_TEST=from-file')
+
+  const result = await loadEnv(tmpDir, true, {}, customEnvFile)
+  equal(result.PLT_FILE_ONLY_TEST, 'from-file')
+  deepEqual(result[kEnvFileFallbackKeys], ['PLT_FILE_ONLY_TEST'])
 })
 
 test('loadEnv - should return process.env when no .env file exists', async t => {

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -69,6 +69,8 @@ export async function loadConfiguration (configOrRoot, sourceOrConfig, context) 
   })
 
   if (config.envfile) {
+    // The context is optional, so it might not have been provided at all
+    context ??= {}
     context.envFile = config.envfile
   }
 

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -5,6 +5,7 @@ import {
   executeInParallel,
   executeWithTimeout,
   features,
+  kEnvFileFallbackKeys,
   kMetadata,
   kTimeout,
   parseMemorySize
@@ -2433,7 +2434,10 @@ export class Runtime extends EventEmitter {
           codeRangeSizeMb
         },
         inspectorOptions,
-        dirname: this.#root
+        dirname: this.#root,
+        // Keys of the worker environment which only come from an env file of the runtime:
+        // the env file of the application is allowed to override those.
+        envFileFallbackKeys: this.#env[kEnvFileFallbackKeys] ?? []
       },
       argv: applicationConfig.arguments,
       execArgv,

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -11,12 +11,14 @@ import { addPinoInstrumentation } from '@platformatic/telemetry'
 import { Buffer } from 'node:buffer'
 import { subscribe } from 'node:diagnostics_channel'
 import { EventEmitter } from 'node:events'
+import { readFile } from 'node:fs/promises'
 import { ServerResponse } from 'node:http'
 import inspector from 'node:inspector'
 import { hostname } from 'node:os'
 import { join, resolve } from 'node:path'
 import { setDefaultHighWaterMark } from 'node:stream'
 import { pathToFileURL } from 'node:url'
+import { parseEnv } from 'node:util'
 import { threadId, workerData } from 'node:worker_threads'
 import pino from 'pino'
 import { install as installUndiciGlobals } from 'undici'
@@ -240,8 +242,21 @@ async function main () {
   const logger = getLogger()
   logger.debug({ envfile }, 'Loading envfile...')
 
+  // Note that process.loadEnvFile is not used here as it never overrides an already defined
+  // variable. The worker environment is seeded from the environment the runtime resolved, which
+  // might contain values coming from an env file of the runtime. Those are only defaults, so the
+  // env file of this application, which is more specific, is allowed to override them. Real
+  // environment variables are never overridden.
+  const envFileFallbackKeys = new Set(workerData.envFileFallbackKeys ?? [])
+
   try {
-    process.loadEnvFile(envfile)
+    const applicationEnv = parseEnv(await readFile(envfile, 'utf-8'))
+
+    for (const [key, value] of Object.entries(applicationEnv)) {
+      if (!(key in process.env) || envFileFallbackKeys.has(key)) {
+        process.env[key] = value
+      }
+    }
   } catch {
     // Ignore if the file doesn't exist, similar to dotenv behavior
   }

--- a/packages/runtime/test/start/custom-environment.test.js
+++ b/packages/runtime/test/start/custom-environment.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import { request } from 'undici'
+import { create } from '../../index.js'
 import { createRuntime, createTemporaryDirectory, updateConfigFile } from '../helpers.js'
 
 const fixturesDir = join(import.meta.dirname, '..', '..', 'fixtures')
@@ -132,6 +133,159 @@ test('should prefer the config envfile over the envFile option', async t => {
   await writeFile(overrideEnvFile, 'FROM_ENV_FILE=override', 'utf8')
 
   const app = await createRuntime(root, null, { envFile: overrideEnvFile, ignoreProcessEnv: true })
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const { payload } = await app.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  strictEqual(data.FROM_ENV_FILE, 'custom')
+})
+
+test('should prefer the envfile of an application over a discovered .env file', async t => {
+  const root = await createTemporaryDirectory(t, 'custom-env')
+  await cp(join(fixturesDir, 'env'), root, { recursive: true })
+  await createDirectory(join(root, 'node_modules/@platformatic'))
+  await symlink(join(import.meta.dirname, '../../../node'), join(root, 'node_modules/@platformatic/node'), 'dir')
+
+  // The .env file of the runtime already defines FROM_ENV_FILE
+  await writeFile(join(root, 'services/hello/custom.env'), 'FROM_ENV_FILE=application-envfile', 'utf8')
+  await updateConfigFile(join(root, 'platformatic.json'), config => {
+    config.server.port = 0
+    config.services[0].envfile = 'services/hello/custom.env'
+  })
+
+  const app = await createRuntime(root)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const { payload } = await app.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  strictEqual(data.FROM_ENV_FILE, 'application-envfile')
+})
+
+test('should prefer the .env file of an application over a discovered .env file', async t => {
+  const root = await createTemporaryDirectory(t, 'custom-env')
+  await cp(join(fixturesDir, 'env'), root, { recursive: true })
+  await createDirectory(join(root, 'node_modules/@platformatic'))
+  await symlink(join(import.meta.dirname, '../../../node'), join(root, 'node_modules/@platformatic/node'), 'dir')
+
+  // The .env file of the runtime already defines FROM_ENV_FILE
+  await writeFile(join(root, 'services/hello/.env'), 'FROM_ENV_FILE=application-env-file', 'utf8')
+  await updateConfigFile(join(root, 'platformatic.json'), config => {
+    config.server.port = 0
+  })
+
+  const app = await createRuntime(root)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const { payload } = await app.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  strictEqual(data.FROM_ENV_FILE, 'application-env-file')
+})
+
+test('should prefer the .env file of an application over the envfile of the runtime', async t => {
+  const root = await createTemporaryDirectory(t, 'custom-env')
+  await cp(join(fixturesDir, 'env'), root, { recursive: true })
+  await createDirectory(join(root, 'node_modules/@platformatic'))
+  await symlink(join(import.meta.dirname, '../../../node'), join(root, 'node_modules/@platformatic/node'), 'dir')
+
+  await writeFile(join(root, 'custom.env'), 'FROM_ENV_FILE=runtime-envfile', 'utf8')
+  await writeFile(join(root, 'services/hello/.env'), 'FROM_ENV_FILE=application-env-file', 'utf8')
+  await updateConfigFile(join(root, 'platformatic.json'), config => {
+    config.server.port = 0
+    config.envfile = 'custom.env'
+  })
+
+  const app = await createRuntime(root)
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.start()
+
+  const { payload } = await app.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  strictEqual(data.FROM_ENV_FILE, 'application-env-file')
+})
+
+test('should prefer real environment variables over the .env file of an application', async t => {
+  const root = await createTemporaryDirectory(t, 'custom-env')
+  await cp(join(fixturesDir, 'env'), root, { recursive: true })
+  await createDirectory(join(root, 'node_modules/@platformatic'))
+  await symlink(join(import.meta.dirname, '../../../node'), join(root, 'node_modules/@platformatic/node'), 'dir')
+
+  await writeFile(join(root, 'services/hello/.env'), 'FROM_ENV_FILE=application-env-file', 'utf8')
+  await updateConfigFile(join(root, 'platformatic.json'), config => {
+    config.server.port = 0
+  })
+
+  process.env.FROM_ENV_FILE = 'process-env'
+
+  const app = await createRuntime(root)
+
+  t.after(async () => {
+    delete process.env.FROM_ENV_FILE
+    await app.close()
+  })
+
+  await app.start()
+
+  const { payload } = await app.inject('hello', {
+    method: 'GET',
+    url: '/'
+  })
+  const data = JSON.parse(payload)
+
+  strictEqual(data.FROM_ENV_FILE, 'process-env')
+})
+
+test('should not require a context when the configuration file defines envfile', async t => {
+  const root = await createTemporaryDirectory(t, 'custom-env')
+  await cp(join(fixturesDir, 'env'), root, { recursive: true })
+  await createDirectory(join(root, 'node_modules/@platformatic'))
+  await symlink(join(import.meta.dirname, '../../../node'), join(root, 'node_modules/@platformatic/node'), 'dir')
+
+  const envFile = join(root, 'custom.env')
+  await updateConfigFile(join(root, 'platformatic.json'), config => {
+    config.server.port = 0
+    config.envfile = envFile
+    config.logger = { level: 'fatal' }
+  })
+
+  await writeFile(envFile, 'FROM_ENV_FILE=custom', 'utf8')
+
+  // create is invoked without any context at all
+  const app = await create(root)
 
   t.after(async () => {
     await app.close()


### PR DESCRIPTION
Fixes #5034

The env file of an application never took effect when the same key was already present in the env
file of the runtime, including a `.env` merely discovered by walking up from the runtime root. This
makes the rule **the more specific env file wins, while real environment variables and the `env`
objects of the configuration keep winning over any env file**.

Two defects are fixed:

1. `applications[].envfile` and the default `<application path>/.env` were silently ignored. The
   environment resolved for the runtime configuration seeds the `process.env` of every worker
   (`runtime.js`: `this.#env` → `workerEnv` → `new Worker(…, { env: workerEnv })`), and
   `process.loadEnvFile` never overrides an already defined variable, so loading the env file of the
   application was a no-op. This is a regression from #4992: giving `process.env` precedence over
   env files was right, but it also promoted the runtime env file values to `process.env` rank
   inside workers.
2. A top level `envfile` made `create(root)` throw `TypeError: Cannot set properties of undefined
   (setting 'envFile')` — `index.js:72` assigned onto the optional `context`.

## Implementation

- `loadEnv` keeps its merge order and additionally records the keys whose only source was the env
  file, attached with `Object.defineProperty(…, { enumerable: false })`. Spreading, `Object.keys`,
  `JSON.stringify`, `structuredClone` and `assert.deepEqual` against `process.env` are therefore
  unchanged for existing consumers. Exposed as `kEnvFileFallbackKeys`, the only new export.
- `Runtime` forwards that list to each worker through `workerData`.
- The worker replaces `process.loadEnvFile(envfile)` with `parseEnv` on the file contents plus an
  assignment that writes a key when it is absent **or** on that list. `runtimeConfig.env` and
  `applicationConfig.env` are still applied afterwards. Both are Node built-ins over the same
  parser, so `.env` parsing is unchanged — only the override rule differs.
- `context ??= {}` in `packages/runtime/index.js`.

No schema or API change. Considered and rejected: demoting only *implicitly discovered* env files,
which would make precedence depend on how the runtime env file was found rather than on how
specific it is, so the same two files would behave differently depending on whether the path was
written down.

## Tests

`packages/runtime/test/start/custom-environment.test.js` pins the whole ordering — the envfile of an
application over a discovered `.env`, its own `.env` over a discovered `.env`, its own `.env` over
the runtime `envfile`, real environment variables over its own `.env`, and `create(root)` with no
context. `packages/foundation/test/configuration.test.js` pins which keys are marked as fallback.

With the tests in place but the sources reverted to `main`, the first three fail because the env
file of the runtime wins, and the last fails on the `TypeError`:

```
✖ should prefer the envfile of an application over a discovered .env file
  AssertionError: actual: 'true', expected: 'application-envfile'
✖ should prefer the .env file of an application over a discovered .env file
  AssertionError: actual: 'true', expected: 'application-env-file'
✖ should prefer the .env file of an application over the envfile of the runtime
  AssertionError: actual: 'runtime-envfile', expected: 'application-env-file'
✖ should not require a context when the configuration file defines envfile
  TypeError: Cannot set properties of undefined (setting 'envFile')
      at loadConfiguration (packages/runtime/index.js:72:21)
ℹ pass 6
ℹ fail 4
```

`should prefer real environment variables over the .env file of an application` passes either way
by design — it is a regression guard for #4992.

With the change:

| command | result |
|---|---|
| `packages/foundation`: `node --test test/*.test.js test/**/*.test.js` | 359 pass, 0 fail |
| `packages/foundation`: `test:types` / `lint` | 33 pass / clean |
| `packages/runtime`: `node --test test/start/*.test.js` | 24 pass, 0 fail |
| `packages/runtime`: `test:main` | 396 pass, 4 fail |
| `packages/runtime`: `test:types` / `lint` | 38 pass / clean |

CI is green across the full matrix. The four `test:main` failures in the local run above are unrelated to this change — `permissions.test.js` and `utils.test.js` (`getMemoryInfo - should get the host memory info`) fail identically with the sources reverted to `03a6491`. `test:api`, `test:cli` and `test:multiple-workers` were not run locally; CI covers them.


