### PR TITLE
fix(runtime): await in-flight worker startup in ITC

### DIFF
--- a/packages/runtime/lib/worker/itc.js
+++ b/packages/runtime/lib/worker/itc.js
@@ -167,6 +167,10 @@ export async function setupITC (controller, application, dispatcher, sharedConte
     }
   })
 
+  // ITC handlers run concurrently, so later start/stop requests must wait for
+  // the actual in-flight start operation rather than a controller event.
+  let controllerStartPromise
+
   const itc = new ITC({
     name: controller.applicationConfig.id + '-worker',
     port: parentPort,
@@ -175,14 +179,15 @@ export async function setupITC (controller, application, dispatcher, sharedConte
         const status = controller.getStatus()
 
         if (status === 'starting') {
-          await once(controller, 'start')
+          await controllerStartPromise
         } else {
           // This gives a chance to a capability to perform custom logic
           const events = getEvents()
           events.emit('start')
 
           try {
-            await controller.start()
+            controllerStartPromise = controller.start()
+            await controllerStartPromise
           } catch (e) {
             await controller.stop(true)
 
@@ -222,7 +227,7 @@ export async function setupITC (controller, application, dispatcher, sharedConte
           const status = controller.getStatus()
 
           if (!force && status === 'starting') {
-            await once(controller, 'start')
+            await controllerStartPromise
           }
 
           if (force || status.startsWith('start')) {

--- a/packages/runtime/test/api/stop.6.test.js
+++ b/packages/runtime/test/api/stop.6.test.js
@@ -1,0 +1,104 @@
+import { rejects, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { transform } from '../../index.js'
+import { createRuntime } from '../helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', '..', 'fixtures')
+
+async function waitForStarting (app, applicationId) {
+  let status
+  for (let i = 0; i < 100; i++) {
+    status = (await app.getApplicationDetails(applicationId)).status
+    if (status === 'starting') {
+      break
+    }
+    await sleep(10)
+  }
+  strictEqual(status, 'starting')
+}
+
+test('should stop an application while it is starting', async t => {
+  const configFile = join(fixturesDir, 'parallel-management', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile, null, {
+    async transform (config, ...args) {
+      config = await transform(config, ...args)
+      config.gracefulShutdown.application = 5000
+      config.restartOnError = false
+      return config
+    }
+  })
+
+  await app.init()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  let stopTimeouts = 0
+  let exitTimeouts = 0
+  app.on('application:worker:stop:timeout', () => stopTimeouts++)
+  app.on('application:worker:exit:timeout', () => exitTimeouts++)
+
+  const startPromise = app.startApplication('service-1')
+
+  await waitForStarting(app, 'service-1')
+
+  await Promise.all([startPromise, app.stopApplication('service-1')])
+
+  strictEqual(stopTimeouts, 0)
+  strictEqual(exitTimeouts, 0)
+  strictEqual((await app.getApplicationDetails('service-1', true)).status, 'stopped')
+})
+
+test('should stop an application when starting fails', async t => {
+  const configFile = join(fixturesDir, 'parallel-management', 'platformatic.with-failure.runtime.json')
+  const app = await createRuntime(configFile, null, {
+    async transform (config, ...args) {
+      config = await transform(config, ...args)
+      config.gracefulShutdown.application = 5000
+      return config
+    }
+  })
+
+  await app.init()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  let stopTimeouts = 0
+  let exitTimeouts = 0
+  app.on('application:worker:stop:timeout', () => stopTimeouts++)
+  app.on('application:worker:exit:timeout', () => exitTimeouts++)
+
+  const startPromise = app.startApplication('service-3')
+  const startRejection = rejects(startPromise, /Service 3 failed to start/)
+
+  await waitForStarting(app, 'service-3')
+
+  await Promise.all([startRejection, app.stopApplication('service-3')])
+
+  strictEqual(stopTimeouts, 0)
+  strictEqual(exitTimeouts, 0)
+  strictEqual((await app.getApplicationDetails('service-3', true)).status, 'stopped')
+})
+
+test('should handle another start command while an application is starting', async t => {
+  const configFile = join(fixturesDir, 'parallel-management', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile)
+
+  await app.init()
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const startPromise = app.startApplication('service-1')
+
+  await waitForStarting(app, 'service-1')
+  await Promise.all([startPromise, app.sendCommandToApplication('service-1', 'start')])
+
+  strictEqual((await app.getApplicationDetails('service-1')).status, 'started')
+})


### PR DESCRIPTION
It waited for start event on the controller but it's never emitted.
This leaves concurrent requests to wait for timeout or exit. 
Track start promise and await it that covers both success and error cases.