### PR TITLE
feat: add lint:fix script to all packages and root workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ pnpm run global-links  # Link CLI tools globally for development
 pnpm test              # Run all tests (uses Docker for databases)
 pnpm run build         # Build all packages
 pnpm run lint          # Lint all packages
+pnpm run lint:fix      # Auto-fix lint issues across all packages (runs eslint --fix)
 pnpm run gen-schema    # Generate JSON schemas
 pnpm run gen-types     # Generate TypeScript types
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gen-types": "pnpm -r --workspace-concurrency=1 run --if-present gen-types",
     "build": "pnpm -r --workspace-concurrency=1 run --if-present build",
     "lint": "pnpm -r --workspace-concurrency=1 --if-present lint",
+    "lint:fix": "pnpm -r --workspace-concurrency=1 --if-present lint:fix",
     "lint:markdown": "markdownlint-cli2",
     "lint:updated-only": "node ./scripts/lint-updated-packages.js",
     "gen-schemas-types": "node ./scripts/gen-schemas-types.js",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -12,7 +12,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "test": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "lint": "eslint",
-    "license": "license-checker-rseidelsohn --production --onlyAllow 'Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause;CC-BY-4.0;BlueOak-1.0.0'"
+    "license": "license-checker-rseidelsohn --production --onlyAllow 'Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause;CC-BY-4.0;BlueOak-1.0.0'",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -12,7 +12,8 @@
     "prepublishOnly": "npm run build",
     "lint": "eslint",
     "gen-schema": "node scripts/schema.js > schema.json",
-    "gen-types": "json2ts > config.d.ts < schema.json"
+    "gen-types": "json2ts > config.d.ts < schema.json",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "test:types": "tstyche",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/create-platformatic/package.json
+++ b/packages/create-platformatic/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "test": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "lint": "eslint",
-    "license": "license-checker --production --onlyAllow 'Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause;CC-BY-4.0;BlueOak-1.0.0'"
+    "license": "license-checker --production --onlyAllow 'Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause;CC-BY-4.0;BlueOak-1.0.0'",
+    "lint:fix": "eslint --fix"
   },
   "license": "Apache-2.0",
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",

--- a/packages/create-wattpm/package.json
+++ b/packages/create-wattpm/package.json
@@ -15,7 +15,8 @@
     "test": "npm run test:unit && npm run test:cli",
     "test:cli": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/cli/*.test.js",
     "test:unit": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/unit/*.test.js",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "license": "Apache-2.0",
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",

--- a/packages/db-authorization/package.json
+++ b/packages/db-authorization/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "test:types": "tstyche",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "types": "index.d.ts",
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",

--- a/packages/db-core/package.json
+++ b/packages/db-core/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "test:types": "tstyche",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -12,7 +12,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "lint": "eslint",
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
-    "test:types": "tstyche"
+    "test:types": "tstyche",
+    "lint:fix": "eslint --fix"
   },
   "keywords": [],
   "dependencies": {

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "test:types": "tstyche",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/itc/package.json
+++ b/packages/itc/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
     "test:types": "tstyche",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -15,7 +15,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -25,7 +25,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -24,7 +24,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,7 +16,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/sql-events/package.json
+++ b/packages/sql-events/package.json
@@ -12,7 +12,8 @@
     "test:mysql8": "DB=mysql8 node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
     "test:sqlite": "DB=sqlite node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
     "test:types": "tstyche",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/sql-graphql/package.json
+++ b/packages/sql-graphql/package.json
@@ -13,7 +13,8 @@
     "test:mysql": "DB=mysql node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
     "test:mysql8": "DB=mysql8 node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
     "test:sqlite": "DB=sqlite node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js",
-    "test:types": "tstyche"
+    "test:types": "tstyche",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/sql-json-schema-mapper/package.json
+++ b/packages/sql-json-schema-mapper/package.json
@@ -11,7 +11,8 @@
     "test:mariadb": "DB=mariadb node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000--timeout=1200000 test/*.test.js",
     "test:mysql": "DB=mysql node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000--timeout=1200000 test/*.test.js",
     "test:mysql8": "DB=mysql8 node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000--timeout=1200000 test/*.test.js",
-    "test:sqlite": "DB=sqlite node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000--timeout=1200000 test/*.test.js"
+    "test:sqlite": "DB=sqlite node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000--timeout=1200000 test/*.test.js",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -14,7 +14,8 @@
     "test:mysql": "DB=mysql npm run test:runner",
     "test:mysql8": "DB=mysql8 npm run test:runner",
     "test:sqlite": "DB=sqlite npm run test:runner",
-    "test:types": "tstyche"
+    "test:types": "tstyche",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/sql-openapi/package.json
+++ b/packages/sql-openapi/package.json
@@ -13,7 +13,8 @@
     "test:mysql": "DB=mysql node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "test:mysql8": "DB=mysql8 node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "test:sqlite": "DB=sqlite node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
-    "test:types": "tstyche"
+    "test:types": "tstyche",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/tanstack/package.json
+++ b/packages/tanstack/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
   "repository": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -11,7 +11,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/wattpm-pprof-capture/package.json
+++ b/packages/wattpm-pprof-capture/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/wattpm-utils/package.json
+++ b/packages/wattpm-utils/package.json
@@ -18,7 +18,8 @@
     "test": "node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "build": "node scripts/list-package.js > lib/packages.js",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "bin": {
     "watt-utils": "./bin/cli.js",

--- a/packages/wattpm/package.json
+++ b/packages/wattpm/package.json
@@ -20,7 +20,8 @@
     "gen-types": "json2ts > config.d.ts < schema.json",
     "build": "npm run gen-schema && npm run gen-types",
     "prepublishOnly": "npm run build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "bin": {
     "watt": "./bin/cli.js",


### PR DESCRIPTION
## Summary

Adds a `lint:fix` script (`eslint --fix`) to every package in the monorepo, plus a root workspace script to run it across all packages.

## Changes

- **Root `package.json`**: Added `"lint:fix": "pnpm -r --workspace-concurrency=1 --if-present lint:fix"`
- **All 35 packages**: Added `"lint:fix": "eslint --fix"` in each `package.json`
- **`CLAUDE.md`**: Documented the new `pnpm run lint:fix` command

## Usage

```bash
pnpm run lint:fix
```

This will auto-fix lint issues across all packages in parallel.
