### PR TITLE
docs: complete Phase 5 — applications terminology and capability coverage

### DIFF
--- a/DOCS_RESTRUCTURE_PLAN.md
+++ b/DOCS_RESTRUCTURE_PLAN.md
@@ -273,12 +273,31 @@ application (version `0.1.0`) rather than Next.js `16.2.12`. The dev server then
 running `npx next dev` directly in `web/next` fails identically — so it is a naming collision, not a
 runtime bug. A `:::caution` block in the tutorial now explains it and the remedy.
 
-**Still open:** after renaming the workspace package, module resolution is correct
-(`node_modules/next` resolves to Next.js 16.2.12) but the `next` worker still exits with code 1 and no
-diagnostic output, so the Next.js half of the quick start was **not** verified working end to end.
-`@platformatic/next` declares support for `^16.0.0`, so this is not a declared-version mismatch. This
-needs a product decision rather than a docs change, and the tutorial has not been rewritten to claim
-the Next.js flow works.
+**Found — a second, independent bug, now documented:** with the name collision avoided, the `next`
+worker still exited with code 1 and no diagnostic output. Running Next's dev binary directly with
+stderr captured produced the real error, which the runtime was swallowing:
+
+```
+Next.js inferred your workspace root, but it may not be correct.
+We couldn't find the Next.js package (next/package.json) from the project directory
+```
+
+Next.js 16 builds with Turbopack by default. Turbopack infers a workspace root, and because npm
+workspaces hoists `next` to the Watt project root it cannot resolve `next/package.json` from the
+application directory. Setting `turbopack.root` to the Watt project root fixes it. Verified: before,
+five consecutive `exited prematurely with error code 1` retries; after, `Started the worker 0` plus
+`✓ Ready`, and `GET /` through Watt returns **200** with ~16KB of rendered Next.js markup. This also
+reproduces with plain `next dev` outside Watt, so like the name collision it is an npm workspace
+resolution problem rather than a Watt runtime bug.
+
+**The Next.js half of the quick start is now verified working end to end** with both adjustments
+documented in a `:::caution` block.
+
+**Worth a product follow-up (not a docs fix):** the runtime reported only
+`exited prematurely with error code 1` with no stderr from the child, even at
+`PLT_SERVER_LOGGER_LEVEL=trace`. The underlying Next.js error was recoverable only by bypassing Watt
+and running the binary directly. Surfacing child stderr on a startup failure would have made this
+diagnosable in seconds rather than requiring a bisect.
 
 **Not attempted:** `learn/beginner/crud-application.md`, which needs a database.
 

--- a/DOCS_RESTRUCTURE_PLAN.md
+++ b/DOCS_RESTRUCTURE_PLAN.md
@@ -223,13 +223,64 @@ moving or renaming a page, otherwise CLI warnings and generated READMEs start po
     checked-in example did not run. Directory renamed to `applications/`, and `composer/` within it
     to `gateway/`.
   - `guides/cache-with-platformatic-watt.md` had two sections both numbered "Step 4"; renumbered.
-- [ ] **Services → Applications.** Align `docs/Overview.md`, `docs/overview/*.md`, and the sidebar
-      with the runtime docs' "applications" terminology.
-- [ ] **Complete the capability coverage.** Overview and architecture pages should reflect all ten
-      shipped capabilities, not the original three.
-- [ ] **Verify tutorials still run end-to-end.** `learn/beginner/crud-application.md` and
-      `getting-started/quick-start.md` have both drifted through many releases since their last
-      verification.
+- [x] **Services → Applications** ✅ 2026-07-28. The CLI is fully migrated (`wattpm applications`,
+      "Builds all applications of the project"), so the docs were the laggard. Changed:
+  - Every legacy runtime config key in examples — `"services": []` and `"web": []` → `"applications": []`.
+    All three keys are still concatenated by `runtime/lib/config.js`, so the old ones are not broken,
+    but `applications` is the current name. Each migrated example was validated against
+    `packages/runtime/schema.json`.
+  - Sidebar labels: `Services & APIs` → `Applications & APIs`, `HTTP Service` → `HTTP Application`,
+    `Database Service` → `Database Application`. Also caught `API Gateway (Composer)`, a leftover the
+    previous pass missed.
+  - Reference headings: `# HTTP Service` → `# HTTP Application`, `# Database Service` →
+    `# Database Application`, `# API Gateway (Gateway Service)` → `# API Gateway`, and the "Gateway
+    Service" prose throughout `reference/gateway/overview.md`.
+  - **Deliberately left alone:** "microservices", "service discovery", "service mesh",
+    "service-to-service", and references to external/non-Node services. These are industry terms in
+    passages comparing Watt to other architectures, not names for the units running inside Watt.
+    A blanket rename would have mangled them.
+  - Fixed a regression from the previous PR: `guides/logging.md` still showed
+    `"autoload": { "path": "services" }` after the logger example directory was renamed to
+    `applications/`, so the snippet contradicted the checked-in example.
+- [x] **Complete the capability coverage** ✅ 2026-07-28. `guides/frameworks.md` already listed all
+      ten; `guides/capabilities.md` was missing React Router and TanStack, now added. The framework
+      lists in `Overview.md`, `overview/what-is-watt.md`, `overview/comparison-with-alternatives.md`
+      and `README.md` named four or five and are now complete. Note `Overview.md` previously claimed
+      integration with "React, Vue" — neither is a capability — which is now corrected.
+- [~] **Verify tutorials run end-to-end** — partially done, and it found real bugs. See below.
+
+#### Tutorial verification results (2026-07-28)
+
+`getting-started/quick-start.md` was executed against Watt 3.64.0 on Node 24.14.1, driving the
+interactive generator through `PLT_USER_INPUT_HANDLER` so the real prompts could be captured.
+
+**Verified working:** project creation, the generated `web/node/index.js` (matches the documented
+snippet exactly), `npm start`, and `curl localhost:3042` → `{"hello":"world"}`. Then the Gateway step:
+creation, and `curl localhost:3042/node` → `{"hello":"world"}` routed through the gateway. The
+documented gateway config shape (`gateway.applications[].proxy.prefix`) is correct.
+
+**Fixed:** three transcript inaccuracies. The first run's transcript was missing the
+`Do you want to init the git repository?` prompt; the second run's was missing
+`Which package manager do you want to use?`; and both hard-coded version `3.0.0`, now genericised so
+the transcript does not go stale on every release.
+
+**Found — a real bug, now documented:** `npx create-next-app web/next` names the generated workspace
+package `next`. Because a Watt project sets `"workspaces": ["web/*"]`, npm links `node_modules/next`
+to `web/next`, and that symlink shadows the Next.js framework. Confirmed directly:
+`node_modules/next -> ../web/next`, and resolving `next` from the project root returned the
+application (version `0.1.0`) rather than Next.js `16.2.12`. The dev server then fails with dozens of
+`Module not found: Can't resolve 'react'` / `@swc/helpers` errors. This reproduces **outside Watt** —
+running `npx next dev` directly in `web/next` fails identically — so it is a naming collision, not a
+runtime bug. A `:::caution` block in the tutorial now explains it and the remedy.
+
+**Still open:** after renaming the workspace package, module resolution is correct
+(`node_modules/next` resolves to Next.js 16.2.12) but the `next` worker still exits with code 1 and no
+diagnostic output, so the Next.js half of the quick start was **not** verified working end to end.
+`@platformatic/next` declares support for `^16.0.0`, so this is not a declared-version mismatch. This
+needs a product decision rather than a docs change, and the tutorial has not been rewritten to claim
+the Next.js flow works.
+
+**Not attempted:** `learn/beginner/crud-application.md`, which needs a database.
 
 ### Phase 6: Fill the Diátaxis Gaps 🟢 MEDIUM
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Using Watt to run your app(s) brings the following advantages:
 
 🧱 Composable Architecture \- HTTP services, API gateways, frontend frameworks, and data services
 
-🧩 Framework Integration \- Works with Next.js, Astro, Remix, Vite, NestJS, and plain Node.js.
+🧩 Framework Integration \- Works with Astro, Next.js, Nitro, Nuxt, React Router, Remix, TanStack Start, Vite, NestJS, and plain Node.js.
 
 📦 Production Ready \- Docker deployment, environment configuration, and scaling built-in.
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -17,7 +17,7 @@ Watt is a complete Node.js application server that handles the complex infrastru
 - ⚡ **Built-in Observability** - Automatic logging, metrics, and distributed tracing
 - 🔧 **Zero Configuration** - Sensible defaults that work out of the box
 - 📊 **Auto-Generated APIs** - REST and GraphQL endpoints from your database schema
-- 🎨 **Framework Agnostic** - Works with Next.js, React, Vue, Express, Fastify, and more
+- 🎨 **Framework Agnostic** - Ten framework integrations, plus any existing Express, Fastify or plain Node.js application
 
 ## Why Choose Watt?
 
@@ -42,9 +42,9 @@ Modern Node.js development is fragmented. You need separate tools for databases,
 Watt provides a comprehensive set of capabilities:
 
 - **Database APIs** - Auto-generated REST and GraphQL endpoints from SQL databases (Platformatic DB)
-- **HTTP Services** - Custom application logic and APIs built on Fastify
+- **HTTP Applications** - Custom application logic and APIs built on Fastify
 - **API Gateways** - Aggregate multiple applications into unified endpoints
-- **Framework Integration** - [Next.js, Astro, Remix, Vite, NestJS applications](/docs/guides/frameworks)
+- **Framework Integration** - [Astro, Next.js, Nitro, Nuxt, React Router, Remix, TanStack Start, Vite and NestJS](/docs/guides/frameworks)
 - **Microservice Orchestration** - Multi-application deployments as single units
 - **Built-in Authorization** - Role-based access control and JWT authentication
 - **Real-time Features** - WebSocket and GraphQL subscriptions

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -33,15 +33,16 @@ npx wattpm create
 Which will output:
 
 ```
-Hello YOURNAME, welcome to Watt 3.0.0!
+Hello YOURNAME, welcome to Watt!
 ? Where would you like to create your project? .
 ? Which package manager do you want to use? npm
 ? Which kind of application do you want to create? @platformatic/node
-✔ Installing @platformatic/node@^3.0.0 using npm ...
+✔ Installing @platformatic/node using npm ...
 ? What is the name of the application? node
 ? Do you want to use TypeScript? no
 ? Do you want to create another application? no
 ? What port do you want to use? 3042
+? Do you want to init the git repository? no
 ```
 
 Dependencies are going to be installed. Your application is located in `web/node`.
@@ -122,10 +123,11 @@ npx wattpm create
 This will output:
 
 ```
-Hello YOURNAME, welcome to Watt 3.0.0!
+Hello YOURNAME, welcome to Watt!
 Using existing configuration ...
+? Which package manager do you want to use? npm
 ? Which kind of application do you want to create? @platformatic/gateway
-✔ Installing @platformatic/gateway@^3.0.0 using npm ...
+✔ Installing @platformatic/gateway using npm ...
 ? What is the name of the application? gateway
 ? Do you want to use TypeScript? no
 ? Do you want to create another application? no
@@ -198,6 +200,29 @@ Which will output:
 ✔ Would you like to use App Router? (recommended) … Yes
 ✔ Would you like to customize the import alias (`@/*` by default)? … No
 ```
+
+:::caution[Name your Next.js workspace package something other than `next`]
+
+`create-next-app web/next` names the generated package after its directory, so `web/next/package.json`
+gets `"name": "next"`. A Watt project declares `"workspaces": ["web/*"]`, so npm then links
+`node_modules/next` to `web/next` — and that symlink **shadows the Next.js framework itself**.
+Resolving `next` from the project root returns your application instead of Next.js, and the dev server
+fails with a cascade of `Module not found: Can't resolve 'react'` and
+`Can't resolve '@swc/helpers/...'` errors.
+
+Before importing, open `web/next/package.json` and change the `name` field to something that is not an
+npm package name you depend on, for example:
+
+```json
+{
+  "name": "frontend"
+}
+```
+
+The directory can stay `web/next` — Watt derives the application id from the directory, so the `/next`
+prefix used below is unaffected. Only the package `name` needs to change.
+
+:::
 
 Then, let's import it to our Watt server:
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -201,17 +201,19 @@ Which will output:
 ✔ Would you like to customize the import alias (`@/*` by default)? … No
 ```
 
-:::caution[Name your Next.js workspace package something other than `next`]
+:::caution[Two adjustments are needed for npm workspaces]
 
-`create-next-app web/next` names the generated package after its directory, so `web/next/package.json`
-gets `"name": "next"`. A Watt project declares `"workspaces": ["web/*"]`, so npm then links
-`node_modules/next` to `web/next` — and that symlink **shadows the Next.js framework itself**.
-Resolving `next` from the project root returns your application instead of Next.js, and the dev server
-fails with a cascade of `Module not found: Can't resolve 'react'` and
-`Can't resolve '@swc/helpers/...'` errors.
+A Watt project declares `"workspaces": ["web/*"]`, and that hoists dependencies to the project root.
+Two things need adjusting before the Next.js application will start.
 
-Before importing, open `web/next/package.json` and change the `name` field to something that is not an
-npm package name you depend on, for example:
+**1. Rename the workspace package.** `create-next-app web/next` names the generated package after its
+directory, so `web/next/package.json` gets `"name": "next"`. npm then links `node_modules/next` to
+`web/next`, and that symlink **shadows the Next.js framework itself** — resolving `next` from the
+project root returns your application instead of Next.js. The dev server fails with a cascade of
+`Module not found: Can't resolve 'react'` and `Can't resolve '@swc/helpers/...'` errors.
+
+Open `web/next/package.json` and change the `name` field to something that is not a package you depend
+on:
 
 ```json
 {
@@ -221,6 +223,42 @@ npm package name you depend on, for example:
 
 The directory can stay `web/next` — Watt derives the application id from the directory, so the `/next`
 prefix used below is unaffected. Only the package `name` needs to change.
+
+**2. Set `turbopack.root`.** Next.js 16 builds with Turbopack by default. Turbopack infers a workspace
+root, and because npm hoisted `next` to the Watt project root it cannot resolve `next/package.json`
+from the application directory. It fails with:
+
+```
+Next.js inferred your workspace root, but it may not be correct.
+We couldn't find the Next.js package (next/package.json) from the project directory
+```
+
+Inside Watt this surfaces as the worker exiting during startup:
+
+```
+Failed to start worker 0 of the application "next": The worker 0 of the
+application "next" exited prematurely with error code 1
+```
+
+Point Turbopack at the Watt project root in `web/next/next.config.mjs`:
+
+```js
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  turbopack: {
+    // The Watt project root, where npm workspaces hoists the `next` package.
+    root: resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+  }
+}
+
+export default nextConfig
+```
+
+Both issues are npm workspace resolution problems rather than Watt runtime bugs — the Turbopack one
+reproduces with plain `next dev`, outside Watt entirely.
 
 :::
 

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -114,6 +114,18 @@ See the capability configuration documentation (e.g., [Next.js](../reference/nex
 - **Use Case**: Full-stack web applications with focus on web standards
 - **Features**: Nested routing, data loading, form handling, progressive enhancement
 
+##### [`@platformatic/react-router`](../reference/react-router/overview.md)
+
+- **Description**: React Router application integration
+- **Use Case**: React applications built on React Router, run unmodified as a Watt application
+- **Features**: Nested routing, data loading, server-side rendering, Vite-powered development
+
+##### [`@platformatic/tanstack`](../reference/tanstack/overview.md)
+
+- **Description**: TanStack Start application integration
+- **Use Case**: Full-stack React applications built with TanStack Start, run unmodified as a Watt application
+- **Features**: Type-safe routing, server functions, streaming SSR, Vite-powered development
+
 ##### [`@platformatic/nest`](../reference/nest/overview.md)
 
 - **Description**: NestJS framework integration

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -631,7 +631,7 @@ The main `watt` application has a shared logger configuration that is used by al
     "timestamp": "isoTime"
   },
   "autoload": {
-    "path": "services"
+    "path": "applications"
   }
 }
 ```

--- a/docs/guides/opentelemetry-logging.md
+++ b/docs/guides/opentelemetry-logging.md
@@ -494,7 +494,7 @@ When using multiple applications in a Watt runtime, each inherits the logger con
   "$schema": "https://schemas.platformatic.dev/wattpm/3.0.0.json",
   "entrypoint": "gateway",
   "autoload": {
-    "path": "services"
+    "path": "applications"
   },
   "logger": {
     "level": "info",

--- a/docs/guides/use-watt-multiple-repository.md
+++ b/docs/guides/use-watt-multiple-repository.md
@@ -89,7 +89,7 @@ Configure your `watt.json` to include applications from multiple repositories:
 ```json
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.0.0.json",
-  "web": [
+  "applications": [
     {
       "id": "gateway",
       "path": "web/gateway"
@@ -375,7 +375,7 @@ Pin specific application versions by using Git tags in URLs:
 
 ```json
 {
-  "web": [
+  "applications": [
     {
       "id": "user-application",
       "path": "web/user-application",

--- a/docs/overview/comparison-with-alternatives.md
+++ b/docs/overview/comparison-with-alternatives.md
@@ -103,7 +103,7 @@ npx wattpm create my-app
 ```json
 // Add database service alongside Express app
 {
-  "services": [
+  "applications": [
     { "path": "./existing-express-api", "id": "api" },
     { "path": "./database", "id": "db" }
   ]
@@ -146,7 +146,7 @@ Since Watt uses Fastify under the hood, the question is: **"What does Watt add t
 - **Service Orchestration**: Run multiple Fastify instances as unified application
 - **Auto-generated APIs**: Database schemas → REST/GraphQL endpoints
 - **Built-in Observability**: Structured logging, metrics, tracing without setup
-- **Framework Integration**: Native Next.js, Astro, Remix support
+- **Framework Integration**: Native support for ten frameworks, including Next.js, Astro, Nuxt, Remix and TanStack Start
 - **Unified Configuration**: Single configuration for entire application stack
 
 #### When to Choose Fastify
@@ -240,7 +240,7 @@ export default function ProductList ({ products }) {
 ```json
 // Full-stack application with auto-generated APIs
 {
-  "services": [
+  "applications": [
     { "path": "./database", "id": "db" }, // Auto-generated APIs
     { "path": "./business-logic", "id": "api" }, // Custom logic
     { "path": "./nextjs-frontend", "id": "web" } // Next.js UI
@@ -410,7 +410,7 @@ services:
 
 ```json
 {
-  "services": [
+  "applications": [
     { "path": "./user-service", "id": "users" },
     { "path": "./product-service", "id": "products" },
     { "path": "./api-gateway", "id": "gateway" }

--- a/docs/overview/use-cases-and-examples.md
+++ b/docs/overview/use-cases-and-examples.md
@@ -310,7 +310,7 @@ export default async function  (app) {
 
 ```json
 {
-  "services": [
+  "applications": [
     { "path": "./storefront", "id": "storefront" },
     { "path": "./admin", "id": "admin" },
     { "path": "./products", "id": "products" },

--- a/docs/overview/what-is-watt.md
+++ b/docs/overview/what-is-watt.md
@@ -47,7 +47,7 @@ npm start                  # Everything runs together
 
 **🎨 Framework Integration**
 
-- Native support for Next.js, Astro, Remix, Vite, NestJS applications
+- Native support for Astro, Next.js, Nitro, Nuxt, React Router, Remix, TanStack Start, Vite and NestJS applications
 - Integrates any existing Express, Fastify, or Node.js application
 - Unified routing and middleware across all applications
 
@@ -87,7 +87,7 @@ Watt fundamentally reimagines Node.js application architecture by providing a **
 
 **Worker Thread Applications** (Fast startup, low overhead):
 
-- **Next.js/Astro/Remix applications** - Frontend frameworks with SSR
+- **Frontend framework applications** - Next.js, Astro, Nuxt, Remix, React Router, TanStack Start and more, with SSR
 - **HTTP Applications** - Custom APIs built on Fastify
 - **Database Applications** - Auto-generated APIs from SQL schemas via Platformatic DB
 

--- a/docs/reference/db/overview.md
+++ b/docs/reference/db/overview.md
@@ -1,9 +1,9 @@
 ---
 title: Overview
-label: Database Service
+label: Database Application
 ---
 
-# Database Service
+# Database Application
 
 The Database Service is a core application type that runs within Watt (the Node.js Application Server). It automatically generates GraphQL and REST APIs from your database schema, eliminating the need to write boilerplate CRUD operations.
 
@@ -74,7 +74,7 @@ The easiest way to create a Database Service is within a Watt application:
 # Create a new Watt application
 wattpm create my-app
 
-# This will prompt you to add a Database Service
+# This will prompt you to add a Database Application
 cd my-app
 
 # Start in development mode

--- a/docs/reference/gateway/overview.md
+++ b/docs/reference/gateway/overview.md
@@ -1,10 +1,10 @@
 import Issues from '../../getting-started/issues.md';
 
-# API Gateway (Gateway Service)
+# API Gateway
 
-The Gateway Service is an API Gateway that runs within Watt (the Node.js Application Server). It automatically integrates multiple microservices into a unified API ecosystem, providing a single public endpoint for clients while managing routing, composition, and conflict resolution behind the scenes.
+The Gateway is an API Gateway application that runs within Watt (the Node.js Application Server). It automatically integrates multiple microservices into a unified API ecosystem, providing a single public endpoint for clients while managing routing, composition, and conflict resolution behind the scenes.
 
-The Gateway Service aggregates APIs from multiple sources - whether they're other applications in your Watt application, external APIs, or legacy systems - presenting them as a cohesive, well-documented API to your clients.
+The Gateway aggregates APIs from multiple sources - whether they're other applications in your Watt application, external APIs, or legacy systems - presenting them as a cohesive, well-documented API to your clients.
 
 For a high level overview of how Watt and its applications work, please reference the [Overview](../../Overview.md) guide.
 
@@ -36,9 +36,9 @@ The properties nested under that key are unchanged, so no other edits are needed
 - **Dynamic Updates**: Real-time schema updates when underlying applications change (in development mode)
 - **Custom Logic**: Extend with Fastify plugins for authentication, rate limiting, or request transformation
 
-## When to Use Gateway Service
+## When to Use the Gateway
 
-Gateway Service is ideal for:
+The Gateway is ideal for:
 
 - **Microservices Architecture**: Present a unified API from multiple independent services
 - **API Aggregation**: Combine internal and external APIs into a single public interface
@@ -49,7 +49,7 @@ Gateway Service is ideal for:
 
 ## Quick Start
 
-Create a Gateway Service within a Watt application:
+Create a Gateway within a Watt application:
 
 ```bash
 # Create a new Watt application
@@ -63,7 +63,7 @@ cd my-gateway
 wattpm dev
 ```
 
-Your Gateway Service will automatically discover other applications in your Watt application and create a unified API. Visit `http://localhost:3042/documentation` to see the composed API documentation.
+Your Gateway will automatically discover other applications in your Watt application and create a unified API. Visit `http://localhost:3042/documentation` to see the composed API documentation.
 
 For application-specific configuration and advanced usage, see the [Configuration](./configuration.md) guide.
 

--- a/docs/reference/service/overview.md
+++ b/docs/reference/service/overview.md
@@ -5,7 +5,7 @@ label: Platformatic Service
 
 import Issues from '../../getting-started/issues.md';
 
-# HTTP Service
+# HTTP Application
 
 The HTTP Service is a core application type that runs within Watt (the Node.js Application Server). It provides a fast, flexible foundation for building custom APIs and web applications using Fastify.
 
@@ -47,7 +47,7 @@ The easiest way to create an HTTP Service is within a Watt application:
 # Create a new Watt application
 wattpm create my-app
 
-# This will create a workspace with HTTP Service included
+# This will create a workspace with HTTP Application included
 cd my-app
 
 # Start in development mode
@@ -61,7 +61,7 @@ For application-specific configuration and advanced usage, see the [Configuratio
 HTTP Services work seamlessly with other service types in your Watt application:
 
 - **Database Services**: Access auto-generated database APIs
-- **Gateway Services**: Expose your HTTP service through an API gateway
+- **Gateway**: Expose your HTTP application through an API gateway
 - **Frontend Capabilities**: Serve frontend applications alongside your APIs
 
 <Issues />

--- a/docs/reference/wattpm/cli-commands.md
+++ b/docs/reference/wattpm/cli-commands.md
@@ -384,7 +384,7 @@ When manually editing your configuration file to add applications with git URLs,
 
 ```json
 {
-  "web": [
+  "applications": [
     {
       "id": "my-app",
       "url": "https://github.com/user/repo.git#develop"
@@ -405,7 +405,7 @@ You can specify npm packages, including version, by using the `npm:` protocol in
 
 ```json
 {
-  "web": [
+  "applications": [
     {
       "id": "my-app",
       "url": "npm:myapp"
@@ -418,7 +418,7 @@ The example above will install the latest version. But you can provide a version
 
 ```json
 {
-  "web": [
+  "applications": [
     {
       "id": "my-app",
       "url": "npm:myapp@0.2.0"

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -128,12 +128,12 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Services & APIs',
+          label: 'Applications & APIs',
           collapsed: true,
           items: [
             {
               type: 'category',
-              label: 'HTTP Service',
+              label: 'HTTP Application',
               collapsed: true,
               items: [
                 'reference/service/overview',
@@ -144,7 +144,7 @@ const sidebars = {
             },
             {
               type: 'category',
-              label: 'API Gateway (Composer)',
+              label: 'API Gateway',
               collapsed: true,
               items: [
                 'reference/gateway/overview',
@@ -157,7 +157,7 @@ const sidebars = {
             },
             {
               type: 'category',
-              label: 'Database Service',
+              label: 'Database Application',
               collapsed: true,
               items: [
                 'reference/db/overview',


### PR DESCRIPTION
## Summary

Completes Phase 5 of the documentation plan: terminology alignment and capability coverage. Verifying the quick start as part of this turned up a real bug, documented below.

## 1. Services → Applications

The CLI is already fully migrated — `wattpm applications`, "Builds all applications of the project", "The application ID to profile" — so the docs were the laggard.

- **Config keys in examples:** `"services": []` and `"web": []` → `"applications": []`. All three keys are still concatenated by `runtime/lib/config.js:319`, so the old ones are not broken, but `applications` is the current name. Every migrated example was validated against `packages/runtime/schema.json`.
- **Sidebar labels:** `Services & APIs` → `Applications & APIs`, `HTTP Service` → `HTTP Application`, `Database Service` → `Database Application`.
- **Reference headings:** `# HTTP Service` → `# HTTP Application`, `# Database Service` → `# Database Application`, `# API Gateway (Gateway Service)` → `# API Gateway`, plus the "Gateway Service" prose in `reference/gateway/overview.md`.

**Deliberately not renamed:** "microservices", "service discovery", "service mesh", "service-to-service", and references to external/non-Node services. These are industry terms in passages comparing Watt to other architectures, not names for the units running inside Watt — a blanket rename would have mangled them.

**Two bugs fixed along the way:**
- A regression from #5031: `guides/logging.md` still showed `"autoload": { "path": "services" }` after the logger example directory was renamed to `applications/`, so the snippet contradicted the checked-in example.
- An `API Gateway (Composer)` sidebar label that the Gateway rename missed.

## 2. Capability coverage

`guides/frameworks.md` already listed all ten capabilities, but `guides/capabilities.md` was missing React Router and TanStack, and the framework lists in `Overview.md`, `overview/what-is-watt.md`, `overview/comparison-with-alternatives.md` and `README.md` named only four or five. `Overview.md` also claimed integration with "React, Vue" — neither is a capability.

## 3. Quick start verification

Executed against Watt 3.64.0 on Node 24.14.1, driving the interactive generator through `PLT_USER_INPUT_HANDLER` so the real prompts could be captured rather than trusted.

**Verified working:** project creation; the generated `web/node/index.js` matches the documented snippet exactly; `npm start`; `curl localhost:3042` → `{"hello":"world"}`. Then the Gateway step: creation, and `curl localhost:3042/node` → `{"hello":"world"}` routed through the gateway. The documented gateway config shape (`gateway.applications[].proxy.prefix`) is correct.

**Transcript inaccuracies fixed:** the first run was missing the `Do you want to init the git repository?` prompt, the second run was missing `Which package manager do you want to use?`, and both hard-coded version `3.0.0` — now genericised so the transcript does not go stale every release.

### A real bug, now documented

`npx create-next-app web/next` names the generated workspace package `next`. Because a Watt project sets `"workspaces": ["web/*"]`, npm links `node_modules/next` to `web/next`, and **that symlink shadows the Next.js framework**.

Confirmed directly:

```
node_modules/next -> ../web/next
require.resolve('next/package.json')  ->  the application, version 0.1.0
                                          (not Next.js 16.2.12)
```

The dev server then fails with dozens of `Module not found: Can't resolve 'react'` and `Can't resolve '@swc/helpers/...'` errors. This reproduces **outside Watt** — running `npx next dev` directly in `web/next` fails identically — so it is a naming collision, not a runtime bug. A `:::caution` block in the tutorial now explains it and the remedy (change the package `name`; the directory can stay `web/next`, since Watt derives the application id from the directory).

## What is NOT verified

After renaming the workspace package, module resolution is correct (`node_modules/next` resolves to Next.js 16.2.12) but the `next` worker still exits with code 1 and no diagnostic output. `@platformatic/next` declares support for `^16.0.0`, so this is not a declared-version mismatch.

**The Next.js half of the quick start is therefore not verified working end to end, and I deliberately did not rewrite the tutorial to imply that it does.** This looks like it needs a product decision rather than a docs change. Flagging it here so it is not mistaken for something this PR fixed.

`learn/beginner/crud-application.md` was not attempted — it needs a database.

## Verification

- Every migrated config example validates against `packages/runtime/schema.json`
- No broken absolute or relative links repo-wide
- Sidebar coverage intact — only the 2 MDX partials unlisted, no broken refs
- Code fences balanced across all docs
- Pre-commit hooks clean

## Remaining after this

Phase 5 is complete except the Next.js verification above. Phase 6 — the missing `docs/concepts/` Explanation quadrant — is untouched and remains the largest structural gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8cs7qKZBvXp4GAGxiFwHG
