### PR TITLE
docs: complete Phase 6 — Explanation quadrant and verified migration guides

### DIFF
--- a/DOCS_RESTRUCTURE_PLAN.md
+++ b/DOCS_RESTRUCTURE_PLAN.md
@@ -101,19 +101,20 @@ reachable by clicking through, but they never appear in the sidebar tree.
    lines, a path-chooser with decision tree and success criteria). These serve different Diátaxis
    purposes and both are useful — but they need explicit cross-linking and distinct titles, or users
    will land on the wrong one.
-2. **The Explanation quadrant does not exist.** There is no `docs/concepts/`. Explanation-type content
-   is scattered across `guides/watt-architecture-patterns.md`,
-   `reference/runtime/multithread-architecture.md`, and `overview/architecture-overview.md` —
-   i.e. filed under How-to and Reference, violating Diátaxis separation.
-3. **`docs/learn/` never grew.** It still contains exactly two beginner tutorials
-   (`crud-application`, `environment-variables`). The planned `quick-start/`, `tutorials/`,
-   `examples/`, and `migrations/` subtrees do not exist. Every migration guide the plan called for
-   (Express, Fastify, monolith) is still missing — while `getting-started/port-your-app.md` covers
-   some of that ground and should be the seed for it.
+2. ~~**The Explanation quadrant does not exist.**~~ **Resolved in Phase 6.** `docs/concepts/` now
+   exists with four pages and its own sidebar category. The pre-existing explanation-flavoured pages
+   (`guides/watt-architecture-patterns.md`, `reference/runtime/multithread-architecture.md`,
+   `overview/architecture-overview.md`) were left in place and cross-linked rather than moved —
+   they are genuinely how-to and reference content; what was missing was the understanding-oriented
+   layer above them.
+3. ~~**`docs/learn/` never grew.**~~ **Partially resolved in Phase 6.** `learn/migrations/` now exists
+   with `from-express.md` and `from-fastify.md`. `learn/examples/` remains deliberately unbuilt (no
+   CI-tested example set to point at). The two beginner tutorials are unchanged.
 4. **`docs/Overview.md` vs `docs/overview/what-is-watt.md`** are near-duplicates in intent. Pick one
    as the canonical landing page.
-5. **TypeScript compilation guide split** — never done; `docs/guides/deployment/compiling-typescript.md`
-   remains a single file. Re-evaluate whether the split is still worth it (see Phase 6).
+5. ~~**TypeScript compilation guide split**~~ — **closed in Phase 6: will not do.** The commands the
+   split was designed around (`plt service compile`, `plt runtime compile`) no longer exist, so the
+   single file is now the correct shape.
 
 ---
 
@@ -301,65 +302,157 @@ diagnosable in seconds rather than requiring a bisect.
 
 **Not attempted:** `learn/beginner/crud-application.md`, which needs a database.
 
-### Phase 6: Fill the Diátaxis Gaps 🟢 MEDIUM
+### Phase 6: Fill the Diátaxis Gaps ✅ COMPLETED (2026-07-28)
 
-**Effort: high. Value: medium — do not start before Phases 4 and 5.**
+**Effort: high. Value: medium.**
 
-- [ ] **Create `docs/concepts/`** (the missing Explanation quadrant) and relocate/derive:
-  - [ ] `concepts/watt-architecture.md` — seed from `overview/architecture-overview.md` and
-        `guides/watt-architecture-patterns.md`
-  - [ ] `concepts/multithread-model.md` — seed from `reference/runtime/multithread-architecture.md`
-  - [ ] `concepts/application-lifecycle.md`
-  - [ ] `concepts/modular-monolith.md` — the positioning the README already leads with
-- [ ] **Grow `docs/learn/`**
-  - [ ] `learn/migrations/from-express.md`, `from-fastify.md` — seed from
-        `getting-started/port-your-app.md`
-  - [ ] Example gallery, if and only if the examples are CI-tested; an untested example gallery is a
-        net negative
-- [ ] **Re-evaluate the TypeScript guide split.** The original rationale (separating plain Node.js
-      compilation from `plt service compile` / `plt runtime compile`) may no longer hold given
-      current tooling. Confirm the commands still exist before splitting.
+- [x] **Created `docs/concepts/`** — the Explanation quadrant now exists and is in the sidebar as its
+      own top-level category between How-to Guides and Reference:
+  - [x] `concepts/watt-architecture.md` — why the platform is shaped this way: the problem being
+        solved, the thread-per-application decision, why `.plt.local` is not a network call, what the
+        runtime owns, and an explicit "what this architecture is not good at" section
+  - [x] `concepts/multithread-model.md` — threads vs processes vs single event loop, an isolated/not-isolated
+        table, shared-nothing consequences, multiple workers, and the process-boundary failure mode
+  - [x] `concepts/application-lifecycle.md` — the two nested lifecycles, dependency-level startup,
+        why shutdown stops the entrypoint first, crash restart vs unhealthy replacement
+  - [x] `concepts/modular-monolith.md` — what the term means, why the boundaries are enforced rather
+        than conventional, the full trade table, and explicit "when to stop" criteria
+- [x] **Grew `docs/learn/`**
+  - [x] `learn/migrations/from-express.md` and `from-fastify.md`, staged (wrap → export `build` →
+        runtime logger → split into applications), both **verified end to end** rather than written
+        from the seed doc
+  - [x] Example gallery — **not done, deliberately.** The condition was "if and only if the examples
+        are CI-tested". There is no `examples/` directory in this repo and no CI job referencing one,
+        so the precondition is unmet. The CI-tested fixtures under `packages/node/test/fixtures/`
+        served as the source of truth for the migration guides instead.
+- [x] **Re-evaluated the TypeScript guide split — decision: do not split.** The original rationale was
+      separating plain Node.js compilation from `plt service compile` / `plt runtime compile`. Those
+      commands **no longer exist**: `grep` across `packages/cli`, `packages/wattpm/lib/commands/`, and
+      `packages/wattpm-utils/lib/commands/` returns no `compile` command. The current story is a
+      single, simpler one — Node.js type stripping for server-side capabilities, the framework's own
+      pipeline for frontend capabilities, and `wattpm build` for production — which
+      `guides/deployment/compiling-typescript.md` already covers in 108 lines. Splitting it would
+      manufacture two thin pages out of one coherent one.
+
+**Verified, not asserted.** Every claim in the concepts pages was read out of source rather than
+paraphrased from the existing docs, and the migration guides were executed:
+
+| Claim | How it was checked |
+| --- | --- |
+| Dependency-level startup, parallel within a level | `runtime.js` `startApplications` → `topologicalSort` + `topologicalLevels` in `lib/utils.js`; observed live as `orders` starting before `gateway` |
+| A gateway declares its composed applications as dependencies | `packages/gateway/lib/capability.js` `getDependencies()` |
+| Shutdown stops the entrypoint first | `runtime.js` `stop()`, with the "so that no new requests are accepted" comment |
+| 5 bootstrap attempts, 5000 ms in dev / immediate in production | `MAX_BOOTSTRAP_ATTEMPTS`, `IMMEDIATE_RESTART_MAX_THRESHOLD`, `config.js` production branch |
+| Health defaults (30 s interval, 30 s grace, 10 checks, 0.99 ELU, 4 GB) | `packages/foundation/lib/schema.js` `health` |
+| Round-robin has a randomised start offset | `worker/round-robin-map.js` `next()` |
+| `.plt.local` is a `MessagePort` hop, not DNS | `worker/interceptors.js` `wire({ domain: '.plt.local' })` |
+| Express wraps with zero code changes | ran `create-wattpm` on a real Express 5 app; `GET /health` → 200 |
+| Mesh call between two applications | built a two-application project; `GET /users/42` returned data fetched over `notifier.plt.local` |
+| Gateway strips the prefix by default | `GET /orders/health` reached the app as `/health` → 200; prefixed routes → 404 |
+| `node.absoluteUrl: true` delivers the full path | `packages/node/lib/schema.js` (default `false`) plus the CI fixtures that set it |
+
+**The prefix behaviour is the finding most worth having written down.** By default the gateway strips
+its prefix before the request reaches the application, so a migrated application keeps its original
+routes unchanged — and adding the prefix to route definitions produces a 404 that reads like a
+routing bug. The opposite mode (`node.absoluteUrl: true`) requires prefixed routes. Mixing them fails
+in both directions. This was not documented anywhere outside the test fixtures.
+
+**Link hygiene, beyond scope.** Phase 4 claimed zero broken links; a stricter sweep (one that also
+rejects links resolving to a bare directory with no page behind it) found seven survivors, now fixed:
+
+| Link | File | Fix |
+| --- | --- | --- |
+| `reference/runtime/configuration.md#application` | `guides/capabilities.md` | missing `../` |
+| `monitoring.md` | `guides/profiling-with-watt.md` | → `metrics.md` (no monitoring guide exists) |
+| `../reference/db/authorization/introduction#user-metadata` | `reference/db/jwt-auth0.md` | → `./authorization/user-roles-metadata.md#user-metadata` |
+| `lib/utils.js#L3` | `reference/gateway/configuration.md` | → the graphql-composer GitHub URL |
+| `../api` | `reference/sql-mapper/entities/hooks.md` | → `./api.md` |
+| `../learn/` | `guides/frameworks.md` | bare directory → `../learn/beginner/crud-application.md` |
+| `../guides/deployment/` | `overview/architecture-overview.md` | bare directory → `dockerize-a-watt-app.md` |
+
+The remaining `docs.platformatic.dev/docs/...` self-links were also converted to routes (dropping
+`utm_*` tracking params), except one inside a quoted log transcript — which was itself **stale**: it
+showed the pre-Phase-4 `guides/debug-platformatic-db` URL, while `packages/db/lib/application.js` now
+emits `reference/troubleshooting#database-connection-issues`. Transcripts of program output are
+documentation too, and they drift silently.
+
+**Cross-links added** so the new pages are reachable from where readers already are:
+`overview/architecture-overview.md`, `guides/watt-architecture-patterns.md`,
+`reference/runtime/multithread-architecture.md`, `guides/build-modular-monolith.md`, and
+`getting-started/port-your-app.md`.
 
 ### Explicitly Not Doing
 
 - Splitting the monitoring/observability guide — the file no longer exists.
+- Splitting the TypeScript compilation guide — the commands that motivated the split are gone
+  (closed in Phase 6).
+- An example gallery under `learn/examples/` — the plan's own condition was "if and only if the
+  examples are CI-tested", and there is no `examples/` directory or CI job to satisfy it.
 - The success-metrics dashboard (bounce rates, completion rates, analytics tracking) from the
   original plan. This repo has no analytics pipeline; these were aspirational and unmeasurable.
 - Assigning named documentation roles.
 
 ---
 
-## Target Structure (Revised)
+## Remaining Work After Phase 6
 
-Reflects current package names and shipped capabilities.
+The restructure is complete. Two items are open, both carried forward rather than forgotten:
+
+1. **`learn/beginner/crud-application.md` is unverified.** It needs a database, so it was never run.
+   Given that the quick start had two blocking bugs when finally executed, this tutorial should be
+   treated as unverified rather than assumed working.
+2. **Product follow-up, not a docs fix:** the runtime reports `exited prematurely with error code 1`
+   without the child's stderr, even at `PLT_SERVER_LOGGER_LEVEL=trace`. Recovering the real error
+   during Phase 5 required bypassing Watt entirely. Surfacing child stderr on startup failure would
+   turn a bisect into a glance. Not filed as an issue yet.
+
+---
+
+## Target Structure — Reached (2026-07-28)
+
+Reflects current package names and shipped capabilities. All four Diátaxis quadrants now exist and
+every page below is reachable from `docs/sidebars.js`.
 
 ```
 docs/
 ├── Overview.md                        # Canonical landing page
-├── overview/                          # Discovery & orientation  [EXISTS, ORPHANED]
+├── overview/                          # Discovery & orientation  [DELIVERED — Phase 4]
 │   ├── what-is-watt.md
 │   ├── getting-started.md             # Path chooser
 │   ├── architecture-overview.md
 │   ├── use-cases-and-examples.md
 │   └── comparison-with-alternatives.md
 ├── getting-started/                   # Hands-on entry
-│   ├── quick-start.md
+│   ├── quick-start.md                 # verified end to end — Phase 5
 │   └── port-your-app.md
-├── learn/                             # Tutorials  [THIN — 2 files]
+├── learn/                             # Tutorials
 │   ├── beginner/
-│   └── migrations/                    # [MISSING]
+│   │   ├── crud-application.md        # NOT verified — needs a database
+│   │   └── environment-variables.md
+│   └── migrations/                    # [ADDED — Phase 6, both verified]
+│       ├── from-express.md
+│       └── from-fastify.md
+├── concepts/                          # Explanation  [ADDED — Phase 6]
+│   ├── watt-architecture.md
+│   ├── multithread-model.md
+│   ├── application-lifecycle.md
+│   └── modular-monolith.md
 ├── guides/                            # How-to  [HEALTHY]
 │   ├── deployment/
 │   └── ...
-├── reference/                         # Information-oriented  [HEALTHY]
-│   ├── wattpm/                        # Watt — primary product
-│   ├── runtime/
-│   ├── service/  gateway/  db/        # Applications
-│   ├── astro/ nest/ next/ nitro/ node/ nuxt/
-│   │   react-router/ remix/ tanstack/ vite/   # Capabilities
-│   └── sql-mapper/ sql-graphql/ sql-openapi/ sql-events/
-└── concepts/                          # Explanation  [MISSING ENTIRELY]
+└── reference/                         # Information-oriented  [HEALTHY]
+    ├── wattpm/                        # Watt — primary product
+    ├── runtime/
+    ├── service/  gateway/  db/        # Applications
+    ├── astro/ nest/ next/ nitro/ node/ nuxt/
+    │   react-router/ remix/ tanstack/ vite/   # Capabilities
+    └── sql-mapper/ sql-graphql/ sql-openapi/ sql-events/
 ```
+
+**Current state:** 137 `.md` files on disk, 132 sidebar entries. The difference is exactly the four
+MDX partials plus `getting-started/issues.md`, all deliberately excluded. Zero broken links, zero
+links resolving to a bare directory, zero `docs.platformatic.dev` self-links outside quoted program
+output.
 
 ---
 

--- a/docs/concepts/application-lifecycle.md
+++ b/docs/concepts/application-lifecycle.md
@@ -1,0 +1,190 @@
+---
+title: Application Lifecycle
+label: Application Lifecycle
+---
+
+# Application Lifecycle
+
+This page explains what happens between `wattpm start` and your application serving a request, what
+happens on the way back down, and what the runtime does when something goes wrong in between.
+
+Understanding this is what turns a startup log from noise into a diagnosis. The five-line failure you
+get when an application will not boot is much easier to read once you know which phase it came from.
+
+## Two lifecycles, not one
+
+Watt has a runtime lifecycle and, nested inside it, a lifecycle per application worker. They use
+similar names, which is a common source of confusion.
+
+The **runtime** moves through `init` → `starting` → `started` → `stopping` → `stopped`, with
+`closing`/`closed` for teardown and `errored` for a failure it could not recover from.
+
+Each **worker** moves through `init` → `starting` → `started` → `stopped`, with `start:error` when its
+capability throws during startup.
+
+A worker reaching `started` does not mean the runtime has; the runtime reaches `started` only once
+every application it was asked to start has. Conversely, the runtime can be `started` while an
+individual worker is cycling through restarts.
+
+## Phase 1 — Runtime initialisation
+
+Before any application code runs, the runtime sets up everything that exists once for the whole
+process:
+
+1. The management API starts, if configured.
+2. The logger is created. This happens early and deliberately, so that everything after it —
+   extensions, health servers, application startup — logs through the same destination.
+3. Extensions are loaded. This is before any worker is created, so that custom ITC handlers an
+   extension registers are available to every worker, and so that readiness and liveness checks are
+   registered before the probe server starts listening.
+4. Prometheus and health-probe servers start.
+5. Applications are registered and their worker threads are created — created, not started.
+6. The undici dispatcher is installed and the [scheduler](../guides/scheduler.md) starts.
+
+The runtime is now `init`. Nothing is serving yet.
+
+## Phase 2 — Dependency resolution and ordered startup
+
+Watt does not start applications in configuration order, and it does not start them all at once. It
+computes an order.
+
+**Dependencies are collected.** The runtime asks each application, over ITC, for its dependencies.
+Most applications report none. A gateway is the interesting case: it reports every local application
+it is configured to compose, which it derives from its own `gateway.applications` list. That means a
+gateway's dependencies are correct without you declaring anything.
+
+You can also declare dependencies explicitly with the `dependencies` property on an application, for
+the case where application A calls application B over the mesh during its own startup.
+
+**The graph is sorted.** The runtime topologically sorts the applications. A cycle is a hard error —
+`ApplicationsDependenciesCycleError` — not a warning, because there is no order that satisfies it.
+
+**The sort is grouped into levels.** This is the part worth knowing. Rather than starting
+applications one at a time in sorted order, the runtime groups them so that every application in a
+level has all of its dependencies in earlier levels. Levels start sequentially; applications within a
+level start in parallel.
+
+So a system with a gateway over three independent APIs starts the three APIs concurrently, waits for
+that whole level, then starts the gateway. Startup time is the depth of your dependency graph, not
+the number of applications in it.
+
+**Each capability then waits for its own dependencies.** Belt and braces: during its `init`, a
+capability calls `waitForDependenciesStart`, so it does not merely start after its dependencies were
+*launched* — it waits until they report `started`.
+
+Once the last level is up, the runtime is `started` and the entrypoint is listening.
+
+## Phase 3 — Serving
+
+At this point the interesting behaviour is per request rather than per lifecycle, and it is covered
+in [The Multithread Model](./multithread-model.md): mesh routing over `MessagePort`, round-robin
+across an application's workers, and shared-nothing state.
+
+One lifecycle-adjacent thing does keep running: health checks, described below.
+
+## Phase 4 — Shutdown
+
+Shutdown is not startup in reverse, and the difference matters.
+
+The **entrypoint is stopped first**, deliberately and on its own. It is the only application with a
+public socket, so stopping it first means no new external requests enter the system while everything
+else is still up and able to finish in-flight work.
+
+Then extension stop hooks run, so control-plane extensions can settle work and hand off state before
+the applications they were managing go away.
+
+Then the remaining applications stop. Each capability calls `waitForDependentsStop` before shutting
+down, so an application does not disappear while something that depends on it is still finishing.
+
+Finally the mesh interceptor and the broadcast channel close, and the runtime is `stopped`.
+
+## When a worker crashes
+
+A worker that exits unexpectedly is restarted. Two configuration values govern this, and their
+defaults differ between development and production in a way that is easy to misread.
+
+`restartOnError` defaults to `true`. What `true` resolves to depends on the mode:
+
+- **Development**: `true` becomes a **5000 ms** delay between attempts.
+- **Production**: the delay is forced to be effectively immediate.
+
+Setting it to `false` or `0` disables restarts entirely.
+
+Restarts are bounded: **5 bootstrap attempts**. After that the runtime gives up on the worker. This
+is the mechanism behind a log sequence that anyone who has broken a startup path will recognise:
+
+```
+Failed to start worker 0 of the application "next": The worker 0 of the application "next"
+  exited prematurely with error code 1
+Attempt 1 of 5 to start the worker 0 of the application "next" again will be performed in 5000ms ...
+```
+
+Five of those, five seconds apart, is a worker whose capability throws during startup — not a
+transient fault. When you see it, the useful question is what the capability's own startup is doing,
+because the runtime has already told you everything it knows.
+
+:::note
+The runtime reports the worker's **exit code**, which is often less informative than what the
+application printed on its way out. If the underlying error is not visible in the Watt logs, run the
+framework's own dev command directly in the application directory — the error usually appears
+immediately there.
+:::
+
+Each restarted worker gets a **new worker index** rather than reusing the old one, which is why the
+log above shows worker 0, then worker 1, then worker 2 for what is conceptually the same worker
+restarting. This is intentional — it keeps identifiers unique — but it does mean "worker 4" in a
+crash loop is not the fifth worker of a five-worker application.
+
+## When a worker is unhealthy but alive
+
+Crashing is the easy failure. The harder one is a worker that is still running but no longer useful:
+event loop pinned, heap exhausted, health checks not returning. Watt polls each worker and replaces
+it when it stays bad.
+
+The defaults:
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `true` | Health checking is on |
+| `interval` | `30000` ms | How often a worker is checked |
+| `gracePeriod` | `30000` ms | Delay before the first check, so slow startups are not punished |
+| `maxUnhealthyChecks` | `10` | Consecutive bad checks before replacement |
+| `maxELU` | `0.99` | Event loop utilisation ceiling |
+| `maxHeapUsed` | `0.99` | Fraction of the heap limit in use |
+| `maxHeapTotal` | 4 GB | Absolute heap ceiling |
+| `maxYoungGeneration` | 128 MB | Young generation ceiling |
+
+Two properties of this design are worth drawing out.
+
+**The counter is consecutive, not cumulative.** A single healthy check resets it to zero. A worker
+that spikes over `maxELU` for one interval and recovers is left alone; only sustained badness
+triggers replacement. With the defaults, that means roughly five minutes of continuous unhealthiness
+before a worker is replaced.
+
+**A failed health collection counts as unhealthy.** If the runtime cannot get an answer from a
+worker, that is not skipped — it is a bad check. This is what catches a genuinely stuck worker, which
+by definition cannot report that it is stuck.
+
+Replacement is not restart: the runtime starts a fresh worker and retires the old one, so capacity is
+not lost while the replacement boots.
+
+## Reading the lifecycle in practice
+
+Three questions locate almost any startup problem in this model:
+
+1. **Did the runtime reach `init`?** If not, the problem is configuration, logging, or an extension —
+   no application code has run yet.
+2. **Which level did startup stop at?** An application stuck waiting is usually waiting on a
+   dependency that never reached `started`. Look at the dependency, not the application reporting the
+   problem.
+3. **Is it crashing or unhealthy?** A crash gives you `exited prematurely` and a bounded restart
+   sequence. Unhealthiness gives you `is unhealthy ... Replacing it`. They have different causes and
+   different fixes.
+
+## Related reading
+
+- [Watt Architecture](./watt-architecture.md) — why the runtime supervises rather than just spawns
+- [The Multithread Model](./multithread-model.md) — what a worker is and what it shares
+- [Runtime configuration](../reference/runtime/configuration.md) — `health`, `restartOnError`, `workers`
+- [Troubleshooting](../reference/troubleshooting.md) — symptom-first debugging
+- [Dynamic Workers](../guides/dynamic-workers.md) — scaling workers on event loop utilisation

--- a/docs/concepts/modular-monolith.md
+++ b/docs/concepts/modular-monolith.md
@@ -1,0 +1,134 @@
+---
+title: The Modular Monolith
+label: The Modular Monolith
+---
+
+# The Modular Monolith
+
+"Modular monolith" is the phrase Watt's documentation leads with, and it is doing real work rather
+than acting as a slogan. This page explains what the term means, why it describes Watt accurately,
+and — more usefully — when you should stop using one.
+
+If you want to build one rather than reason about one, go to
+[Build a modular monolith](../guides/build-modular-monolith.md), which walks through a complete
+multi-application example.
+
+## The term
+
+A **monolith** is one deployment unit. A **modular** system has enforced internal boundaries. Most
+architectures give you one or the other:
+
+- A conventional monolith is one deployment unit with advisory boundaries. Modules are separated by
+  directory layout and code review. Nothing stops one part importing another's internals, and over a
+  few years, something always does.
+- Microservices give you enforced boundaries — you physically cannot import across a network — at the
+  cost of one deployment unit per boundary, and all the machinery that implies.
+
+A modular monolith is the combination that is usually assumed to be unavailable: one deployment unit,
+enforced boundaries. The boundaries are real, not conventional, but you still ship one thing.
+
+## Why Watt is one, mechanically
+
+The claim rests on the worker thread model. Each application runs in its own V8 isolate, so the
+boundary between applications is enforced by the runtime rather than by discipline:
+
+- There is no import path from one application to another's code. Separate module registries.
+- There is no shared object graph. Separate heaps.
+- The only way to reach another application is its HTTP interface over the mesh, at
+  `http://<id>.plt.local`.
+
+That last point is the important one. The boundary is not merely enforced — it is enforced *in the
+shape of a network interface*. An application interacts with its neighbour exactly as it would if
+that neighbour were a service in another datacentre: a URL, a request, a response, a status code.
+
+Meanwhile the deployment story stays monolithic. One `npm install`, one build, one process, one
+container, one thing to deploy and roll back.
+
+## The property that makes it worth doing
+
+Most architectural decisions are hard to reverse. This one is not, and that is the actual argument
+for it.
+
+Because applications already talk over HTTP, extracting one to its own deployment does not require
+rewriting how it is called. The call site is a URL either way. Moving an application out means giving
+it its own runtime and pointing callers at a real hostname instead of a `.plt.local` one. The
+application's own code — routes, handlers, business logic — does not change at all.
+
+This inverts the usual sequencing problem. The conventional advice is "start with a monolith, extract
+services when you need to", which is good advice with a bad failure mode: by the time you need to
+extract, the boundaries have eroded and the extraction is a rewrite. Watt's boundaries cannot erode,
+because the runtime enforces them from day one. The extraction stays cheap indefinitely.
+
+You are deferring a decision rather than making one. You get to find out where your real service
+boundaries are by operating the system, instead of guessing during design.
+
+## What you are actually trading
+
+Being concrete about the cost is more useful than repeating the benefit.
+
+**You get, compared to a conventional monolith:**
+
+- Enforced boundaries and per-application dependency trees — two applications can use incompatible
+  versions of the same library
+- Per-application scaling — give the expensive one four workers and the rest one
+- Event loop isolation — one application's CPU-bound work does not stall the others
+- A migration path that stays open
+
+**You get, compared to microservices:**
+
+- One deployment unit, one build, one rollback
+- No service discovery, no port allocation, no internal TLS, no network hop
+- Merged logs and connected traces without assembling a pipeline first
+- Far cheaper internal calls — a `MessagePort` message rather than a TCP round trip
+
+**You give up, compared to microservices:**
+
+- **Independent deployment.** Everything ships together. This is the big one.
+- **Process-level fault isolation.** Threads share a process. A native segfault or a process-wide OOM
+  takes down every application, as discussed in [The Multithread Model](./multithread-model.md).
+- **Per-application resource limits.** No per-application CPU quota or memory cgroup.
+- **Language diversity.** Worker threads are a Node.js mechanism.
+- **Independent technology upgrades.** One Node.js version for everyone.
+
+## When to stop
+
+A modular monolith is a good default, not a permanent answer. Extract an application to its own
+deployment when one of these becomes true — and note that none of them are about code size:
+
+- **Release cadence diverges.** Two parts of the system need to ship on genuinely independent
+  schedules, because different teams own them or because their risk profiles differ.
+- **Resource profiles diverge sharply.** One application wants 16 GB and a GPU; the rest want 512 MB.
+  A shared process cannot express that.
+- **A fault domain must be isolated.** An unstable native dependency, or untrusted third-party code,
+  that you cannot allow to take the process down.
+- **Compliance draws a boundary.** Payment or health data that must live in a separately audited
+  deployment.
+- **Scaling limits are reached.** You need more capacity than one process on one machine can provide,
+  and running several identical Watt instances behind a load balancer is no longer the right shape.
+
+Notice what is not on this list: number of applications, number of engineers, lines of code, or the
+system feeling "big". Those are the usual triggers for reaching for microservices, and none of them
+are reasons on their own — they are reasons to want enforced boundaries, which you already have.
+
+## Extracting, when the time comes
+
+The move is mechanical, which is the whole point:
+
+1. Give the application its own Watt runtime and deploy it.
+2. Change callers from `http://products.plt.local` to the real hostname. If you routed through
+   configuration or an environment variable rather than hardcoding the internal URL, this is a
+   config change.
+3. Replace what the mesh was giving you for free: TLS, retries, timeouts, authentication between the
+   two sides, and a way for traces to keep connecting across the new network boundary.
+
+Step 3 is where the cost you deferred finally arrives. That is the correct time to pay it — when a
+specific application has a specific reason to be separate, rather than for every boundary up front on
+the assumption that some of them will one day need it.
+
+## Related reading
+
+- [Build a modular monolith](../guides/build-modular-monolith.md) — a complete worked example
+- [Watt Architecture](./watt-architecture.md) — the design reasoning underneath
+- [The Multithread Model](./multithread-model.md) — what the boundary is made of
+- [Watt Architecture Patterns](../guides/watt-architecture-patterns.md) — pyramid and funnel topologies
+- [Comparison with Alternatives](../overview/comparison-with-alternatives.md) — Watt versus other approaches

--- a/docs/concepts/multithread-model.md
+++ b/docs/concepts/multithread-model.md
@@ -1,0 +1,149 @@
+---
+title: The Multithread Model
+label: The Multithread Model
+---
+
+# The Multithread Model
+
+Watt runs applications in worker threads. This page explains what that actually buys you, what it
+does not, and the mental model you need to reason about behaviour that surprises people coming from
+either a single-process Node.js background or a container-per-service background.
+
+For the component-level detail — mesh topology, ITC message formats, file layout — see
+[Multithread Architecture](../reference/runtime/multithread-architecture.md). For configuration, see
+[`workers` in the runtime configuration](../reference/runtime/configuration.md).
+
+## Why threads and not processes
+
+Node.js gives you three ways to run code concurrently, and Watt's choice of the third is deliberate.
+
+**A single event loop** is the cheapest and the most fragile. Everything shares one heap, one module
+registry, and one event loop. A CPU-bound handler in one part of the codebase stalls every other
+part. Two libraries that both want to patch `globalThis.fetch` fight. You cannot depend on two major
+versions of the same package.
+
+**Child processes** (or `cluster`) give real isolation: separate heaps, separate event loops,
+separate module registries, and a crash that takes down one process leaves the others running. The
+cost is that every interaction becomes IPC or a network call, memory usage multiplies by the number
+of processes, and startup means paying full Node.js bootstrap per process.
+
+**Worker threads** sit in between, and the position is more useful than it first appears. Each worker
+gets its own V8 isolate: its own heap, its own module registry, its own globals, its own event loop.
+That is the same *logical* isolation a child process gives you. What it does not give you is *fault*
+isolation — threads share a process, so a process-level failure is shared too.
+
+Watt takes this trade because the isolation that matters day-to-day is the logical kind, and the
+thing you get in exchange is a fast, in-process communication channel that a child process cannot
+offer.
+
+## What isolation you actually get
+
+It is worth being precise, because "isolated" is doing a lot of work in most descriptions.
+
+| Property | Isolated per worker? |
+| --- | --- |
+| Heap / object graph | Yes — separate V8 isolate |
+| Module registry (`require`/`import` cache) | Yes |
+| Globals, prototype patches, `AsyncLocalStorage` | Yes |
+| Event loop | Yes |
+| Dependency versions | Yes — each application resolves from its own directory |
+| Environment variables | Effectively yes — each worker gets its own `process.env` snapshot |
+| Uncaught exception handling | Per worker, with a runtime-level policy on top |
+| OS process, PID, cwd | **No** — shared |
+| Process-wide memory limit | **No** — shared |
+| Native addon state | **No** — a native crash kills the process |
+| File descriptors, signals | **No** — shared |
+
+The first block is why two applications can use incompatible versions of the same library, why one
+application's Next.js instrumentation does not leak into another, and why a blocked event loop in one
+application does not stall the others. The second block is why a segfault in a native module, or an
+OOM against the process heap limit, takes down the whole runtime.
+
+## Shared nothing, message everything
+
+Because heaps are separate, nothing is shared by reference. There is no shared cache object, no
+singleton visible across applications, no way to pass a closure. Everything crossing a worker
+boundary is copied or transferred.
+
+Watt gives you two channels for this, and they serve different purposes.
+
+**HTTP over the mesh** is the primary one. An application calls
+`fetch('http://other-app.plt.local/path')` and Watt routes it over a `MessagePort` instead of a
+socket. Use this for anything that is conceptually a request to another application — it keeps the
+call site identical to a real network call, which is what makes an application extractable later.
+
+**Messaging** (`@platformatic/globals`) is the lower-level channel, for the cases HTTP does not fit:
+broadcast notifications, cache invalidation, coordination between workers of the same application.
+
+The rule of thumb: if you would have written it as an HTTP endpoint between two services, use the
+mesh. If you would have written it as an event bus, use messaging.
+
+The practical consequence of shared-nothing is that in-memory caches are per worker. Three workers
+means three copies of that `Map` you are memoising into, each independently warmed. Watt's own HTTP
+cache is designed around this — the store is shared and coordinated through the runtime precisely
+because a naive per-worker cache would be three caches with three miss rates. This is explained in
+[Cache with Watt](../guides/cache-with-platformatic-watt.md).
+
+## Multiple workers per application
+
+An application can run more than one worker:
+
+```json
+{
+  "applications": [
+    { "id": "api", "path": "./web/api", "workers": 4 }
+  ]
+}
+```
+
+Each worker is a full independent instance of the application. Requests to `api.plt.local` are
+distributed across them round-robin — with a randomised starting offset per application, so that
+several callers starting at once do not all pile onto worker 0.
+
+This is horizontal scaling *inside* the process, and it is the answer to CPU-bound work in Node.js.
+An application doing image resizing or PDF generation can be given four workers while the rest of the
+system stays at one, and the expensive work occupies four event loops that are not the event loops
+serving your API.
+
+Three consequences follow directly from shared-nothing, and each surprises someone eventually:
+
+- **State does not survive across workers.** Anything a request handler stores in module scope is
+  visible only to the worker that handled it. Sessions, rate-limit counters, and caches need a shared
+  backing store, exactly as they would across containers.
+- **Startup cost multiplies.** Four workers means four module graphs loaded and four heaps. Memory
+  scales close to linearly with worker count.
+- **Only the entrypoint listens.** Non-entrypoint applications open no socket regardless of worker
+  count, unless they explicitly opt in with `useHttp`; the mesh addresses them by id.
+
+Workers can also be scaled automatically based on event loop utilisation, via `workers.dynamic`. See
+[Dynamic Workers](../guides/dynamic-workers.md).
+
+## Failure and the process boundary
+
+Watt supervises workers, and the supervision is the reason a shared process is tolerable.
+
+A worker that exits unexpectedly is restarted — with a delay, a bounded number of bootstrap attempts,
+and a fresh worker index. A worker that stays alive but stops behaving (event loop utilisation pinned
+at 100%, heap over the configured ceiling, health checks not returning) is replaced after a
+configurable number of consecutive unhealthy checks. The mechanics, thresholds, and defaults are in
+[Application Lifecycle](./application-lifecycle.md).
+
+What supervision cannot rescue is a failure at the process level. If a native addon segfaults, if the
+process hits its V8 heap limit, or if something calls `process.exit()`, every worker dies with it,
+because they are all threads in that process. This is the single most important operational
+difference between Watt and a container-per-service deployment, and it is the reason
+[Watt Architecture](./watt-architecture.md) is explicit that Watt trades operational isolation for
+code isolation rather than claiming to give you both.
+
+If a particular application genuinely needs process-level fault isolation — an unstable native
+dependency, an untrusted plugin — the answer is to run it as its own Watt runtime and let the two
+talk over real HTTP. Because the mesh and the network look the same to application code, that change
+is a configuration and URL change rather than a rewrite.
+
+## Related reading
+
+- [Watt Architecture](./watt-architecture.md) — why the runtime is designed this way
+- [Application Lifecycle](./application-lifecycle.md) — startup ordering, health checks, restarts
+- [Multithread Architecture](../reference/runtime/multithread-architecture.md) — component-level reference
+- [Dynamic Workers](../guides/dynamic-workers.md) — automatic scaling on event loop utilisation
+- [Watt Architecture Patterns](../guides/watt-architecture-patterns.md) — where to spend your workers

--- a/docs/concepts/watt-architecture.md
+++ b/docs/concepts/watt-architecture.md
@@ -1,0 +1,152 @@
+---
+title: Watt Architecture
+label: Watt Architecture
+---
+
+# Watt Architecture
+
+This page explains *why* Watt is shaped the way it is. It is not a setup guide and it is not an API
+listing — it is the reasoning behind the design, so that the configuration options and CLI commands
+you meet elsewhere feel like consequences rather than arbitrary choices.
+
+If you want to configure something, go to [Runtime configuration](../reference/runtime/configuration.md).
+If you want a component-by-component map, go to [Architecture Overview](../overview/architecture-overview.md).
+If you want to pick a topology for your own system, go to
+[Watt Architecture Patterns](../guides/watt-architecture-patterns.md).
+
+## The problem Watt is solving
+
+Splitting a Node.js backend into separate services buys you real things: independent deployment,
+independent scaling, clear ownership boundaries, and failure isolation. It also charges for them.
+Every service becomes a process to supervise, a container to build, a port to allocate, a network hop
+to trace, a TLS handshake to configure, and an entry in whatever service-discovery mechanism you
+adopted. The boundary you drew for code-organisation reasons has to be paid for in operational
+machinery.
+
+Keeping everything in one process avoids that bill, but re-introduces the coupling: one dependency
+tree, one build, one event loop, and a codebase where module boundaries are advisory because nothing
+enforces them.
+
+Watt's premise is that these two options are not the only ones available, because the two things
+being traded — *code isolation* and *deployment separation* — are separable. You can enforce hard
+boundaries between applications without giving each one its own deployment unit.
+
+## The core decision: a thread per application
+
+Watt runs each application in its own [worker thread](./multithread-model.md), inside a single Node.js
+process, supervised by a runtime.
+
+A worker thread gets its own V8 isolate. That means its own heap, its own module registry, its own
+globals, and its own event loop. Two applications in the same Watt process cannot see each other's
+memory, cannot monkey-patch each other's modules, and cannot block each other's event loop. They can
+depend on different, incompatible versions of the same library. One can be a Next.js frontend and
+another a Fastify API, each with the build tooling it expects.
+
+That is most of the isolation people actually want from microservices, obtained without a second
+process, a second container, or a network.
+
+What you give up is deployment independence. Every application in a Watt runtime starts, stops, and
+ships together. Watt does not pretend otherwise — that trade is the whole point, and
+[Modular Monolith](./modular-monolith.md) discusses when it is the right one and when it is not.
+
+## The mesh: why `.plt.local` is not a network call
+
+Applications inside Watt address each other by an internal hostname derived from the application id:
+
+```js
+const res = await fetch('http://products.plt.local/items')
+```
+
+This looks like HTTP, and from the application's point of view it *is* HTTP — same `fetch`, same
+request and response semantics, same status codes. But no TCP socket is opened and no DNS lookup is
+performed. Watt installs an undici dispatcher in every worker that claims the `.plt.local` domain and
+routes matching requests over a `MessagePort` directly to the destination thread.
+
+The mechanism is [`undici-thread-interceptor`](https://github.com/platformatic/undici-thread-interceptor),
+wired in [`packages/runtime/lib/worker/interceptors.js`](https://github.com/platformatic/platformatic/blob/main/packages/runtime/lib/worker/interceptors.js).
+The comment in that file explains why the domain is declared explicitly: without it, every internal
+call would flood the DNS resolver with lookups for names that will never resolve.
+
+This choice is what makes the rest of the architecture pay off:
+
+- **Nothing to configure.** There are no ports to assign, no service registry to keep in sync, no
+  addresses to inject as environment variables. The application id *is* the address.
+- **The code is portable in both directions.** An application that calls `fetch` against a URL does
+  not know or care whether the target is a thread in the same process or a service on another
+  continent. Extracting an application to its own deployment later is a URL change, not a rewrite.
+- **The transport cost drops out.** No serialization to the wire format, no TCP, no TLS, no
+  connection pool. Just a message between threads.
+
+The last point is worth stating carefully: internal calls are cheaper than network calls, but they
+are not free. Request and response bodies still cross a thread boundary. A chatty design is still a
+chatty design; Watt makes the hop cheap, not free.
+
+## The runtime: supervision, not just process management
+
+The runtime is the main thread. It owns everything that should exist exactly once for the whole
+application, and it is the reason Watt is a platform rather than a thread-pool helper.
+
+**Ordering.** Applications are started in dependency order. The runtime asks each application for its
+dependencies, topologically sorts them, then groups them into levels so that everything within a
+level can start in parallel while still guaranteeing its dependencies came up first. See
+[Application Lifecycle](./application-lifecycle.md) for how this is derived and what happens when
+there is a cycle.
+
+**Supervision.** The runtime health-checks every worker, restarts crashed ones with backoff, and
+replaces workers that stay unhealthy. This is the layer that would otherwise be your orchestrator's
+job.
+
+**Shared concerns.** Logging, metrics, OpenTelemetry tracing, and the HTTP cache are configured once
+on the runtime and apply to every application. Logs from all applications are merged into one
+stream, already tagged with the application id and worker index. Traces propagate across the internal
+mesh, so a request that touches four applications produces one connected trace rather than four
+disconnected ones.
+
+**One public surface.** Exactly one application is the entrypoint. Everything else is reachable only
+from inside the mesh. This is a genuine security property, not just a routing convention: a
+non-entrypoint application does not open a listening socket, so it cannot be reached from outside the
+process even by mistake. (An application can opt back in with `useHttp` when it genuinely needs a
+real port — but that is a decision you make, not a default you inherit.)
+
+## Capabilities: the framework adapter layer
+
+Watt does not require your application to be written against a Watt API. Instead, a *capability*
+adapts an existing framework to the runtime — `@platformatic/next` for Next.js,
+`@platformatic/vite` for Vite, `@platformatic/node` for a plain `node:http` server, and so on.
+
+A capability's job is to implement a small lifecycle contract (`init`, `start`, `stop`, `build`) and
+translate between the runtime's expectations and the framework's own conventions. Where a framework
+insists on owning its own dev server or its own build pipeline, the capability lets it, and bridges
+the result back.
+
+This is what allows an unmodified Next.js application to become a Watt application by adding a
+config file. The full list is in the [capabilities guide](../guides/capabilities.md).
+
+## What this architecture is not good at
+
+Being explicit about the limits is more useful than another list of benefits.
+
+- **Independent deployment.** One runtime deploys as one unit. If two parts of your system must ship
+  on genuinely independent schedules — different teams, different release cadences, different
+  compliance boundaries — they want to be different deployments, and Watt will not change that.
+- **Language diversity.** Worker threads are a Node.js mechanism. A capability can supervise a child
+  process in another language, but that is a different and less integrated arrangement than a thread.
+- **Fault isolation at the process level.** Threads share a process. A segfault in a native addon, an
+  OOM against the process-wide heap limit, or an `uncaughtException` policy that exits will take down
+  every application in the runtime, not just one. Watt mitigates this — see the health and restart
+  behaviour in [Application Lifecycle](./application-lifecycle.md) — but it cannot make a shared
+  process behave like separate ones.
+- **Independent resource limits.** You can give an application more workers, but you cannot give it
+  its own CPU quota or memory cgroup the way a container gives you.
+
+The honest summary: Watt gives you microservice-grade *code* isolation with monolith-grade
+operations. When you need microservice-grade *operational* isolation, run several Watt runtimes — the
+mesh-vs-network transparency described above means the applications themselves barely change.
+
+## Related reading
+
+- [The Multithread Model](./multithread-model.md) — why threads, and what isolation they actually give
+- [Application Lifecycle](./application-lifecycle.md) — startup ordering, health, and restarts
+- [Modular Monolith](./modular-monolith.md) — the positioning, and when to stop using it
+- [Watt Architecture Patterns](../guides/watt-architecture-patterns.md) — pyramid and funnel topologies
+- [Runtime reference](../reference/runtime/overview.md) — the configuration surface

--- a/docs/getting-started/port-your-app.md
+++ b/docs/getting-started/port-your-app.md
@@ -139,5 +139,7 @@ By default, Watt will run on random port. If you want to choose a specific port,
 
 ## Learn More
 
+- [Migrate from Express](../learn/migrations/from-express.md) - a staged migration, from zero-change wrapping to splitting into multiple applications
+- [Migrate from Fastify](../learn/migrations/from-fastify.md) - the same, with Fastify specifics
 - [Watt Quick Start](/docs/getting-started/quick-start/)
 - [Framework Integration Guides](/docs/guides/frameworks) - Setup guides for Next.js, Astro, Remix, Vite, and more

--- a/docs/guides/build-modular-monolith.md
+++ b/docs/guides/build-modular-monolith.md
@@ -2,11 +2,17 @@
 
 ## Introduction
 
+:::note
+This guide builds a modular monolith. For what the term means, why Watt's boundaries are enforced
+rather than conventional, and when you should extract an application into its own deployment, see
+[The Modular Monolith](../concepts/modular-monolith.md).
+:::
+
 In this guide we'll create a "modular monolith" Library application. It will be a Watt project which contains multiple Platformatic DB and Gateway applications. We'll learn how to:
 
 - Create and configure a [Platformatic Runtime](/docs/reference/runtime/overview) app with multiple applications
   - Three [Platformatic DB](/docs/reference/db/overview) applications, each with their own databases
-  - A [Platformatic Gateway](https://docs.platformatic.dev/docs/reference/gateway/overview) application which aggregates multiple application's REST APIs into a composed API
+  - A [Platformatic Gateway](/docs/reference/gateway/overview) application which aggregates multiple application's REST APIs into a composed API
 - Customise the composed API that's automatically generated in a Gateway application
 - Generate a client for an application's REST API and use it in a Watt application to make API requests
 - Add custom functionality to a Gateway application's composed API by modifying its routes and responses
@@ -85,7 +91,7 @@ npm start
 We'll see a warning message displayed like this in our terminal:
 
 ```
-[17:56:00.807] WARN (people-service/8615): No tables found in the database. Are you connected to the right database? Did you forget to run your migrations? This guide can help with debugging Platformatic DB: https://docs.platformatic.dev/docs/guides/debug-platformatic-db
+[17:56:00.807] WARN (people-service/8615): No tables found in the database. Are you connected to the right database? Did you forget to run your migrations? This guide can help with debugging Platformatic DB: https://docs.platformatic.dev/docs/reference/troubleshooting#database-connection-issues
 ```
 
 <!-- SCREENSHOT: start-the-runtime-app-01.png -->
@@ -181,7 +187,7 @@ Created person: {
 [18:06:05] INFO: seeding complete
 ```
 
-> You can learn more about seeding the database for a Platformatic DB app [in this guide](https://docs.platformatic.dev/docs/reference/db/seed).
+> You can learn more about seeding the database for a Platformatic DB app [in this guide](/docs/reference/db/seed).
 
 ### Test the People application
 
@@ -840,7 +846,7 @@ If we open up the API documentation for our Media application at http://127.0.0.
 
 ![Make the Composed Media Application API Read Only - 01](./build-modular-monolith-images/make-the-composed-media-service-api-read-only-01.png)
 
-> As well as allowing us to ignore specific routes, Platformatic Gateway also supports aliasing for route paths and the renaming of route response fields. See the [Gateway OpenAPI](https://docs.platformatic.dev/docs/reference/gateway/configuration?utm_campaign=Build%20and%20deploy%20a%20modular%20monolith%20with%20Platformatic&utm_medium=blog&utm_source=Platformatic%20Blog#openapi-configuration) documentation to learn more.
+> As well as allowing us to ignore specific routes, Platformatic Gateway also supports aliasing for route paths and the renaming of route response fields. See the [Gateway OpenAPI](/docs/reference/gateway/configuration#openapi-configuration) documentation to learn more.
 
 ### Add People data to Media application responses
 
@@ -901,7 +907,7 @@ app.platformatic.addGatewayOnRouteHook('/books/', ['GET'], function (routeOption
 
 With the code above, when Gateway registers the `GET` route for `/books/` in the composed API, it will call the `onRoute` hook function. Then when the Media application receives a response for that route from the downstream application, it will run our `onGatewayResponse` callback function. We can add code inside the `onGatewayResponse` which modifies the response that is returned back to the client that made the original request.
 
-> To get a clearer picture of how this works, take a look at our [Gateway API modification](https://docs.platformatic.dev/docs/reference/gateway/api-modification/?utm_campaign=Build%20and%20deploy%20a%20modular%20monolith%20with%20Platformatic&utm_medium=blog&utm_source=Platformatic%20Blog) documentation.
+> To get a clearer picture of how this works, take a look at our [Gateway API modification](/docs/reference/gateway/api-modification) documentation.
 
 Let's now apply what we've just learnt about Gateway hooks and callbacks. First, let's add the following code inside the `peopleDataPlugin` function in `web/media-application/plugin.js`:
 
@@ -1056,7 +1062,7 @@ curl localhost:3042/movies/3 | grep 'Name'
 
 ### Configure a service proxy to debug the People application API
 
-Our Media application is composing the Books and Movies applications into an API, and the Media application is then exposed by the Library app. But what if we want to test or debug the People application API during development? Fortunately, Platformatic Gateway provides a service proxy feature ([`applications[].proxy`](https://docs.platformatic.dev/docs/reference/gateway/configuration#gateway)) which we can use to help us do this.
+Our Media application is composing the Books and Movies applications into an API, and the Media application is then exposed by the Library app. But what if we want to test or debug the People application API during development? Fortunately, Platformatic Gateway provides a service proxy feature ([`applications[].proxy`](/docs/reference/gateway/configuration#gateway)) which we can use to help us do this.
 
 Let's try this out by adding another application to the `applications` in `platformatic.json`:
 

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -9,7 +9,7 @@ A capability is essentially a Node.js package that implements the Platformatic c
 - **Single Capability Applications**: Simple applications with one primary function (e.g., a Next.js frontend or a database API)
 - **Multi-Capability Applications**: Complex applications that combine multiple capabilities (e.g., a database backend with a React frontend and an API gateway)
 
-Each Watt project can define a set of application, each using its own capability by defining them in the main `watt.json` file via the [autoload](../reference/runtime/configuration.md#autoload) or the [applications](reference/runtime/configuration.md#application) properties.
+Each Watt project can define a set of application, each using its own capability by defining them in the main `watt.json` file via the [autoload](../reference/runtime/configuration.md#autoload) or the [applications](../reference/runtime/configuration.md#application) properties.
 
 Each application gets its own folder and the capability is determined by looking at the `$schema` property of the application `watt.json`.
 

--- a/docs/guides/frameworks.md
+++ b/docs/guides/frameworks.md
@@ -112,5 +112,5 @@ All framework integrations provide:
 - **Migrating an existing app?** See [Running Your Project in Watt](/docs/getting-started/port-your-app)
 - **Framework-specific issues?** Check the individual framework reference pages above
 - **Technical details?** Browse the complete [Reference Documentation](../reference/) 
-- **Step-by-step tutorials?** Visit our [Learning Tutorials](../learn/)
+- **Step-by-step tutorials?** Visit our [Learning Tutorials](../learn/beginner/crud-application.md)
 - **Community support?** Join our [Discord Community](https://discord.gg/platformatic)

--- a/docs/guides/generate-frontend-code-to-consume-platformatic-rest-api.md
+++ b/docs/guides/generate-frontend-code-to-consume-platformatic-rest-api.md
@@ -6,7 +6,7 @@ import NewApiProjectInstructions from '../getting-started/new-api-project-instru
 
 Platformatic apps expose REST APIs that provide provide CRUD (Create, Read,
 Update, Delete) functionality for each entity (see the
-[Introduction to the REST API](https://docs.platformatic.dev/docs/reference/sql-openapi/overview)
+[Introduction to the REST API](/docs/reference/sql-openapi/overview)
 documentation for more information on the REST API) by default.
 
 In this guide, you will learn how to create a new Platformatic guide with Watt, Frontend Client, add a frontend to consume your Platformatic REST API.

--- a/docs/guides/profiling-with-watt.md
+++ b/docs/guides/profiling-with-watt.md
@@ -393,7 +393,7 @@ After profiling your application:
 
 For more advanced performance optimization techniques, consider:
 
-- [Monitoring](monitoring.md)
+- [Metrics](metrics.md)
 - [Caching with Watt Guide](cache-with-platformatic-watt.md)
 - [Node.js Performance Best Practices](https://nodejs.org/en/docs/guides/simple-profiling/)
 

--- a/docs/guides/watt-architecture-patterns.md
+++ b/docs/guides/watt-architecture-patterns.md
@@ -155,6 +155,8 @@ use metrics, tracing, and profiling to tune worker counts.
 
 ## Related Guides
 
+- [Watt Architecture](../concepts/watt-architecture.md) — the reasoning behind the runtime design
+- [The Modular Monolith](../concepts/modular-monolith.md) — when to keep applications together, and when to split them out
 - [Build and deploy a modular monolith](./build-modular-monolith.md)
 - [Use Watt with multiple repository applications](./use-watt-multiple-repository.md)
 - [Dynamic Workers](./dynamic-workers.md)

--- a/docs/learn/migrations/from-express.md
+++ b/docs/learn/migrations/from-express.md
@@ -1,0 +1,330 @@
+---
+title: Migrate from Express
+label: From Express
+---
+
+# Migrate an Express Application to Watt
+
+This guide takes an existing Express application and moves it into Watt in stages. Each stage is
+useful on its own and leaves you with a working application, so you can stop at whichever one gives
+you what you need.
+
+| Stage | What you change | What you get |
+| --- | --- | --- |
+| 1. Wrap | Nothing | Watt logging, metrics, management API, `wattpm` commands |
+| 2. Hand over the server | Remove `app.listen`, export `build` | Mesh addressing, coordinated startup and shutdown |
+| 3. Split | Move code into multiple applications | Isolation, per-application scaling |
+
+Nothing about your routes, middleware, or error handlers changes at any stage. Express stays Express.
+
+## The application we are starting from
+
+A typical Express service — routes, a `listen` call at the bottom, nothing unusual:
+
+```js
+// index.js
+import express from 'express'
+
+const app = express()
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' })
+})
+
+app.get('/users/:id', (req, res) => {
+  res.json({ id: req.params.id, name: 'Ada Lovelace' })
+})
+
+const port = process.env.PORT ?? 3000
+app.listen(port, () => {
+  console.log(`listening on ${port}`)
+})
+```
+
+## Stage 1: Wrap it, change nothing
+
+Run the Watt creator from the root of your existing project:
+
+```bash
+npm create wattpm
+```
+
+It detects that the directory already contains a Node.js application and offers to wrap it:
+
+```
+Hello YOURNAME, welcome to Watt!
+? This folder seems to already contain a Node.js application. Do you want to wrap into Watt? yes
+- Installing @platformatic/runtime using npm ...
+INFO: .env written!
+INFO: .env.sample written!
+INFO: package.json written!
+INFO: watt.json written!
+INFO: Installing dependencies for the project using npm ...
+INFO: You are all set! Run `npm start` to start your project.
+```
+
+This writes a `watt.json` that treats your project as a single `@platformatic/node` application:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.0.0.json",
+  "runtime": {
+    "logger": {
+      "level": "{PLT_SERVER_LOGGER_LEVEL}"
+    },
+    "managementApi": "{PLT_MANAGEMENT_API}"
+  }
+}
+```
+
+Start it:
+
+```bash
+npx wattpm dev
+```
+
+Your `app.listen()` call still runs. Watt notices the server your application started and adopts it:
+
+```
+Starting the worker 0 of the application "legacy-express"...
+listening on 3000
+Started the worker 0 of the application "legacy-express"...
+Platformatic is now listening at http://127.0.0.1:3000
+```
+
+Your routes work exactly as before, and your `console.log` output is captured into the structured log
+stream. You now have Watt's logging, metrics, health probes, and management API without having
+touched a line of application code.
+
+:::note
+The wrap step does not rewrite your `package.json` `start` script. If it was `node index.js`, it
+still is. Change it to `wattpm start` (and add `"dev": "wattpm dev"`) when you want `npm start` to go
+through Watt.
+:::
+
+## Stage 2: Let Watt own the server
+
+Stage 1 works, but your application is still opening its own TCP socket. Exporting a `build` function
+instead hands the server to Watt, which is what unlocks the rest of the platform.
+
+Delete the `listen` call and export the app:
+
+```js
+// index.js
+import express from 'express'
+
+export function build () {
+  const app = express()
+
+  app.get('/health', (req, res) => {
+    res.json({ status: 'ok' })
+  })
+
+  app.get('/users/:id', (req, res) => {
+    res.json({ id: req.params.id, name: 'Ada Lovelace' })
+  })
+
+  return app
+}
+```
+
+Return the Express app itself — not an `http.Server`. Watt recognises it and wires it up.
+
+What this buys you:
+
+- **No TCP for internal traffic.** Only the entrypoint gets a real socket. Everything else is reached
+  over the [mesh](../../concepts/multithread-model.md), which is a message between threads rather
+  than a network round trip.
+- **Coordinated lifecycle.** Watt starts your application in dependency order and shuts it down
+  gracefully rather than pulling the socket out from under in-flight requests.
+- **Restarts and health checks.** See [Application Lifecycle](../../concepts/application-lifecycle.md).
+
+The name can be `build` or `create`; both are recognised.
+
+## Stage 3: Use the runtime logger
+
+Your application's own logger still works, but routing it through Watt means every application's logs
+land in one stream, already tagged with the application id and worker index:
+
+```js
+import { getLogger } from '@platformatic/globals'
+import express from 'express'
+
+export function build () {
+  const app = express()
+  const logger = getLogger()
+
+  app.get('/users/:id', (req, res) => {
+    logger.info({ id: req.params.id }, 'fetching user')
+    res.json({ id: req.params.id, name: 'Ada Lovelace' })
+  })
+
+  return app
+}
+```
+
+Which produces:
+
+```json
+{"level":30,"name":"api","worker":0,"id":"42","msg":"fetching user"}
+```
+
+`getLogger()` returns a [Pino](https://getpino.io) logger, so if you were already using Pino the call
+signatures are unchanged. See [Logging](../../guides/logging.md) for the full configuration surface.
+
+## Stage 4: Split into multiple applications
+
+This is the stage that pays for the previous ones. Move each Express application into its own
+directory under `web/`:
+
+```
+my-project/
+├── package.json          # "workspaces": ["web/*"]
+├── watt.json             # runtime configuration
+└── web/
+    ├── api/              # the Express application
+    │   ├── package.json
+    │   ├── watt.json
+    │   └── index.js
+    └── notifier/
+        ├── package.json
+        ├── watt.json
+        └── index.js
+```
+
+The runtime configuration picks up everything under `web/` and names one application as the
+entrypoint:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/wattpm/3.0.0.json",
+  "entrypoint": "api",
+  "autoload": { "path": "web" },
+  "server": { "hostname": "127.0.0.1", "port": 3042 },
+  "logger": { "level": "info" }
+}
+```
+
+Each application gets a minimal `watt.json` naming its capability:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.0.0.json"
+}
+```
+
+Applications call each other over the mesh, using the directory name as the hostname:
+
+```js
+app.get('/users/:id', async (req, res) => {
+  const response = await fetch(`http://notifier.plt.local/greeting/${req.params.id}`)
+  const { greeting } = await response.json()
+
+  res.json({ id: req.params.id, name: 'Ada Lovelace', greeting })
+})
+```
+
+No port, no service registry, no environment variable holding an address. The application id is the
+address.
+
+This is ordinary `fetch` against an ordinary URL, which is the point: if you later extract `notifier`
+into its own deployment, this call site changes only in hostname. See
+[The Modular Monolith](../../concepts/modular-monolith.md).
+
+## Putting an application behind a gateway
+
+When an Express application is not the entrypoint, it usually sits behind a
+[gateway](../../reference/gateway/overview.md) that exposes it under a prefix.
+
+Declare the prefix on the application:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.0.0.json",
+  "application": {
+    "basePath": "/orders"
+  }
+}
+```
+
+and let the gateway pick it up:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/gateway/3.0.0.json",
+  "gateway": {
+    "applications": [{ "id": "orders" }],
+    "refreshTimeout": 1000
+  }
+}
+```
+
+:::caution[The prefix is stripped before your application sees it]
+
+By default the gateway removes the prefix on the way through. A request for `/orders/health` arrives
+at your Express app as `/health`.
+
+This is what you want when migrating: **your existing routes keep working unchanged**. Do not add the
+prefix to your route definitions — if you register `/orders/health`, the incoming `/health` will not
+match it and you will get a 404 that looks like a routing bug.
+
+If your application genuinely needs the full path — because it builds absolute URLs, or generates
+links that must include the prefix — set `absoluteUrl` and prefix your routes explicitly:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.0.0.json",
+  "application": { "basePath": "/orders" },
+  "node": { "absoluteUrl": true }
+}
+```
+
+```js
+import { cleanBasePath } from '@platformatic/basic'
+import { getBasePath } from '@platformatic/globals'
+
+const prefix = getBasePath({ throwOnMissing: false }) ?? ''
+
+app.get(cleanBasePath(`${prefix}/health`), (req, res) => {
+  res.json({ status: 'ok' })
+})
+```
+
+Pick one mode or the other. Mixing them — `absoluteUrl` off with prefixed routes, or on with
+unprefixed routes — produces 404s in both directions.
+:::
+
+## Production
+
+```bash
+npm run build   # wattpm build
+npm run start   # wattpm start
+```
+
+`wattpm build` runs each application's build step, if it has one. For a plain Express application
+there is usually nothing to build, but running it keeps the command identical across a project that
+also contains frontends.
+
+## Things that catch people out
+
+- **`process.env.PORT` no longer decides anything.** Watt assigns ports. The entrypoint's public port
+  comes from `server.port` in the runtime configuration; non-entrypoint applications normally have no
+  port at all.
+- **In-memory state is per worker.** If you give an application multiple workers, each has its own
+  heap. Sessions, caches, and rate-limit counters need a shared store — exactly as they would across
+  containers. See [The Multithread Model](../../concepts/multithread-model.md).
+- **`process.exit()` takes down the whole runtime.** Threads share a process. Throw or return an
+  error instead.
+- **`process.cwd()` is the runtime root**, not your application directory. Resolve paths relative to
+  `import.meta.dirname`.
+- **Only the entrypoint is reachable from outside.** This is a feature — a non-entrypoint application
+  does not open a listening socket — but it does mean you cannot curl it directly. Use
+  `wattpm inject` or route through the gateway.
+
+## Related reading
+
+- [Migrate from Fastify](./from-fastify.md) — the same journey, Fastify specifics
+- [Running Your Project in Watt](../../getting-started/port-your-app.md) — the short version
+- [Node.js capability reference](../../reference/node/overview.md) — `build`/`create`, `absoluteUrl`, background applications
+- [The Modular Monolith](../../concepts/modular-monolith.md) — why splitting this way stays reversible
+- [Watt Architecture Patterns](../../guides/watt-architecture-patterns.md) — how to draw the boundaries

--- a/docs/learn/migrations/from-fastify.md
+++ b/docs/learn/migrations/from-fastify.md
@@ -1,0 +1,326 @@
+---
+title: Migrate from Fastify
+label: From Fastify
+---
+
+# Migrate a Fastify Application to Watt
+
+Fastify applications have the shortest path into Watt of any framework, because Watt is built on
+Fastify. Your plugins, decorators, hooks, schemas, and `@fastify/*` packages all keep working
+untouched — the only things that change are who calls `listen()` and where the logger comes from.
+
+This guide moves an existing Fastify service into Watt in stages. Each stage leaves you with a
+working application.
+
+## The application we are starting from
+
+```js
+// index.js
+import fastify from 'fastify'
+
+const app = fastify({ logger: true })
+
+app.get('/health', async () => {
+  return { status: 'ok' }
+})
+
+app.get('/orders/:id', async request => {
+  return { id: request.params.id, total: 42 }
+})
+
+await app.listen({ port: process.env.PORT ?? 3000 })
+```
+
+## Stage 1: Wrap it, change nothing
+
+From the root of your existing project:
+
+```bash
+npm create wattpm
+```
+
+It detects the existing application and offers to wrap it:
+
+```
+Hello YOURNAME, welcome to Watt!
+? This folder seems to already contain a Node.js application. Do you want to wrap into Watt? yes
+INFO: watt.json written!
+INFO: You are all set! Run `npm start` to start your project.
+```
+
+```bash
+npx wattpm dev
+```
+
+Your `listen()` call still runs and Watt adopts the server it created. Routes behave identically, and
+you immediately get Watt's structured logging, metrics, health probes, and management API.
+
+This stage is worth doing on its own if all you want is the operational surface. Everything below is
+about integrating more deeply.
+
+## Stage 2: Export the app instead of listening
+
+Hand the server to Watt by exporting a `build` function and removing the `listen` call:
+
+```js
+// index.js
+import fastify from 'fastify'
+
+export function build () {
+  const app = fastify({ logger: true })
+
+  app.get('/health', async () => {
+    return { status: 'ok' }
+  })
+
+  app.get('/orders/:id', async request => {
+    return { id: request.params.id, total: 42 }
+  })
+
+  return app
+}
+```
+
+Return the Fastify instance. Do not call `listen()`, and do not call `ready()` — Watt handles both.
+
+If your application is already structured as `app.js` (builds and returns the instance) plus
+`server.js` (calls `listen`), which is the layout `fastify-cli` and the
+[Fastify demo](https://github.com/fastify/demo) use, then you already have this. Point Watt at your
+`app.js` and delete `server.js` from the startup path.
+
+What changes as a result:
+
+- Only the entrypoint opens a TCP socket. Other applications are reached over the
+  [mesh](../../concepts/multithread-model.md).
+- Watt starts and stops your application in dependency order, closing it gracefully.
+- Crashes and unhealthy workers are supervised — see
+  [Application Lifecycle](../../concepts/application-lifecycle.md).
+
+Both `build` and `create` are recognised as the export name.
+
+## Stage 3: Use the runtime logger
+
+Replace `logger: true` with the runtime's logger instance so that your application's logs join the
+same stream as every other application's:
+
+```js
+import { getLogger } from '@platformatic/globals'
+import fastify from 'fastify'
+
+export function build () {
+  const app = fastify({ loggerInstance: getLogger() })
+
+  app.get('/orders/:id', async request => {
+    request.log.info({ id: request.params.id }, 'fetching order')
+    return { id: request.params.id, total: 42 }
+  })
+
+  return app
+}
+```
+
+Note `loggerInstance`, not `logger` — Fastify accepts an existing logger object under that option,
+while `logger` takes configuration. `getLogger()` returns a Pino instance, which is what Fastify uses
+natively, so `request.log`, `app.log`, child loggers, and serializers all behave as they always did.
+
+Log lines now carry the application id and worker index:
+
+```json
+{"level":30,"name":"orders","worker":0,"reqId":"req-1","msg":"fetching order"}
+```
+
+Fastify's automatic request logging still applies, so you get `incoming request` and
+`request completed` lines per route without configuring anything.
+
+Configuration — levels, redaction, transports, shipping to Elasticsearch or an OTLP collector — moves
+to the runtime, where it applies to every application at once. See [Logging](../../guides/logging.md).
+
+## Stage 4: Split into multiple applications
+
+Move each Fastify service into its own directory under `web/`:
+
+```
+my-project/
+├── package.json          # "workspaces": ["web/*"]
+├── watt.json             # runtime configuration
+└── web/
+    ├── gateway/
+    │   ├── package.json
+    │   └── watt.json
+    └── orders/
+        ├── package.json
+        ├── watt.json
+        └── index.js
+```
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/wattpm/3.0.0.json",
+  "entrypoint": "gateway",
+  "autoload": { "path": "web" },
+  "server": { "hostname": "127.0.0.1", "port": 3042 },
+  "logger": { "level": "info" }
+}
+```
+
+Each Fastify application declares the Node.js capability:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.0.0.json"
+}
+```
+
+Applications reach each other by id:
+
+```js
+const response = await fetch('http://inventory.plt.local/stock/42')
+const { available } = await response.json()
+```
+
+This is the same `fetch` you would use against a remote service, so extracting an application into
+its own deployment later is a hostname change rather than a rewrite. See
+[The Modular Monolith](../../concepts/modular-monolith.md).
+
+:::note
+Watt starts applications in dependency order. A gateway automatically declares the applications it
+composes as its dependencies, so `orders` is fully started before `gateway` begins — you will see
+exactly that ordering in the startup logs, without configuring anything.
+:::
+
+## Putting an application behind a gateway
+
+Declare the prefix on the application:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.0.0.json",
+  "application": {
+    "basePath": "/orders"
+  }
+}
+```
+
+and list it in the gateway:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/gateway/3.0.0.json",
+  "gateway": {
+    "applications": [{ "id": "orders" }],
+    "refreshTimeout": 1000
+  }
+}
+```
+
+:::caution[The prefix is stripped before your application sees it]
+
+By default the gateway removes the prefix. `GET /orders/health` arrives at your Fastify app as
+`GET /health`.
+
+For a migration this is exactly right — **your existing routes keep working unchanged**. Do not
+re-register them under the prefix. If you do, Fastify will report:
+
+```json
+{"message":"Route GET:/health not found","error":"Not Found","statusCode":404}
+```
+
+which is the giveaway that the app is looking for a prefixed route while the gateway has already
+removed the prefix.
+
+If the application needs the full path — it builds absolute URLs, or serves an OpenAPI document whose
+paths must match what clients see — set `absoluteUrl` and register routes under the base path:
+
+```json
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.0.0.json",
+  "application": { "basePath": "/orders" },
+  "node": { "absoluteUrl": true }
+}
+```
+
+```js
+import { getBasePath } from '@platformatic/globals'
+
+export function build () {
+  const app = fastify({ loggerInstance: getLogger() })
+  const prefix = getBasePath({ throwOnMissing: false }) ?? ''
+
+  app.register(
+    async instance => {
+      instance.get('/health', async () => ({ status: 'ok' }))
+      instance.get('/:id', async request => ({ id: request.params.id, total: 42 }))
+    },
+    { prefix }
+  )
+
+  return app
+}
+```
+
+Fastify's `register` with a `prefix` is the natural fit here — it applies the base path to a whole
+plugin without touching individual route definitions.
+:::
+
+## Exposing your OpenAPI schema to the gateway
+
+If you use `@fastify/swagger`, publishing the schema lets the gateway compose your routes into a
+unified API rather than just proxying them:
+
+```js
+import { getLogger, setOpenapiSchema } from '@platformatic/globals'
+import fastifySwagger from '@fastify/swagger'
+import fastify from 'fastify'
+
+export async function build () {
+  const app = fastify({ loggerInstance: getLogger() })
+
+  await app.register(fastifySwagger, {
+    openapi: {
+      openapi: '3.0.0',
+      info: { title: 'Orders API', version: '1.0.0' }
+    }
+  })
+
+  app.addHook('onReady', async () => {
+    setOpenapiSchema(app.swagger())
+  })
+
+  return app
+}
+```
+
+See [API modification](../../reference/gateway/api-modification.md) for what the gateway can do once
+it has the schema.
+
+## What carries over unchanged
+
+Worth stating explicitly, because it is most of your codebase:
+
+- Every `@fastify/*` plugin — `@fastify/cors`, `@fastify/jwt`, `@fastify/helmet`, and the rest
+- Your own plugins, decorators, and hooks
+- JSON Schema validation and serialization
+- `fastify-plugin` and the encapsulation model
+- Error handlers, `setErrorHandler`, `setNotFoundHandler`
+- `app.inject()` in your tests — your existing test suite needs no changes if it builds the app and
+  injects into it
+
+## Things that catch people out
+
+- **`logger: true` versus `loggerInstance`.** Passing `logger: true` gives you a second, separate
+  logger writing its own stream. Use `loggerInstance: getLogger()`.
+- **Do not call `listen()` or `ready()`** once you export `build`. Watt does both.
+- **`process.env.PORT` is not consulted.** The entrypoint's port comes from `server.port` in the
+  runtime configuration; other applications normally have no port.
+- **In-memory state is per worker.** Multiple workers means multiple heaps — caches and counters need
+  a shared store. See [The Multithread Model](../../concepts/multithread-model.md).
+- **`process.exit()` kills the whole runtime**, not just your application.
+- **`process.cwd()` is the runtime root.** Resolve paths from `import.meta.dirname`.
+
+## Related reading
+
+- [Migrate from Express](./from-express.md) — the same journey, Express specifics
+- [Running Your Project in Watt](../../getting-started/port-your-app.md) — the short version
+- [Node.js capability reference](../../reference/node/overview.md) — `build`/`create`, `absoluteUrl`, OpenAPI
+- [Application Lifecycle](../../concepts/application-lifecycle.md) — startup ordering and supervision
+- [API Gateway](../../reference/gateway/overview.md) — composing applications

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -558,9 +558,11 @@ Watt uses [Prometheus](https://prometheus.io/) client libraries for metrics coll
 
 ## Next Steps
 
+- **[Watt Architecture](../concepts/watt-architecture.md)**: Why the platform is designed this way, and what it trades away
+- **[The Multithread Model](../concepts/multithread-model.md)**: What worker-thread isolation does and does not give you
 - **[Configuration Guide](../reference/wattpm/configuration.md)**: Learn how to configure Watt applications
 - **[Application Mesh Details](../reference/runtime/multithread-architecture.md)**: Deep dive into inter-application communication
-- **[Deployment Patterns](../guides/deployment/)**: Production deployment strategies
+- **[Deployment Patterns](../guides/deployment/dockerize-a-watt-app.md)**: Production deployment strategies
 - **[Monitoring Setup](../guides/metrics.md)**: Setting up monitoring stack
 
 This architecture enables teams to build distributed applications with the simplicity of monoliths and the flexibility of microservices, making Watt ideal for teams who want to move fast without sacrificing architectural quality.

--- a/docs/reference/db/jwt-auth0.md
+++ b/docs/reference/db/jwt-auth0.md
@@ -1,7 +1,7 @@
 # Configure JWT with Auth0
 
 [Auth0](https://auth0.com/) is a powerful authentication and authorization service provider that can be integrated with Platformatic DB through [JSON Web Tokens](https://jwt.io/) (JWT) tokens. 
-When a user is authenticated, Auth0 creates a JWT token with all necessary security information and custom claims (like the `X-PLATFORMATIC-ROLE`, see [User Metadata](../reference/db/authorization/introduction#user-metadata)) and signs the token. 
+When a user is authenticated, Auth0 creates a JWT token with all necessary security information and custom claims (like the `X-PLATFORMATIC-ROLE`, see [User Metadata](./authorization/user-roles-metadata.md#user-metadata)) and signs the token. 
 
 Platformatic DB needs the correct public key to verify the JWT signature. 
 The fastest way is to leverage [JWKS](https://www.rfc-editor.org/rfc/rfc7517), since Auth0 exposes a [JWKS](https://www.rfc-editor.org/rfc/rfc7517) endpoint for each tenant.

--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -525,7 +525,7 @@ The OpenAPI configuration file is a JSON file that is used to customize the Open
   - **`resolver`** (`object`) - The resolver to retrieve a list of objects - should return a list - and should accept as an arguments a list of primary keys or foreign keys.
     - **`name`** (`string`, **required**) - The name of the resolver.
     - **`argsAdapter (partialResults)`** (`function` or `string`) - The function invoked with a subset of the result of the initial query, where `partialResults` is an array of the parent node. It should return an object to be used as argument for `resolver` query. Can be a function or a [metaline](https://github.com/platformatic/metaline) string.
-      **Default:** if missing, the `defaultArgsAdapter` function will be used; if that is missing too, a [generic one](lib/utils.js#L3) will be used.
+      **Default:** if missing, the `defaultArgsAdapter` function will be used; if that is missing too, a [generic one](https://github.com/platformatic/graphql-composer/blob/main/lib/utils.js) will be used.
     - **`partialResults`** (`function` or `string`) - The function to adapt the subset of the result to be passed to `argsAdapter` - usually is needed only on resolvers of `fkeys` and `many`. Can be a function or a [metaline](https://github.com/platformatic/metaline) string.
   - **`pkey`** (`string`, **required**) - The primary key field to identify the entity.
   - **`fkeys`** (`array of objects`) an array to describe the foreign keys of the entities, for example `fkeys: [{ type: 'Author', field: 'authorId' }]`.

--- a/docs/reference/runtime/multithread-architecture.md
+++ b/docs/reference/runtime/multithread-architecture.md
@@ -2,6 +2,12 @@
 
 This document describes the multithread system architecture in Platformatic Runtime, which enables horizontal scaling of applications through worker threads.
 
+:::note
+This is the component-level reference. If you are looking for *why* Watt uses worker threads, what
+isolation they actually provide, and how that shapes application design, read
+[The Multithread Model](../../concepts/multithread-model.md) first.
+:::
+
 ## Overview
 
 Platformatic Runtime implements a sophisticated multithread architecture that allows applications to be scaled horizontally by running multiple worker instances. This system is built on Node.js Worker Threads and provides automatic load balancing, health monitoring, and fault tolerance.

--- a/docs/reference/sql-mapper/entities/hooks.md
+++ b/docs/reference/sql-mapper/entities/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Entity hooks are a way to wrap the [API methods](../api) for an entity and add custom behaviour.
+Entity hooks are a way to wrap the [API methods](./api.md) for an entity and add custom behaviour.
 
 The Platformatic DB SQL Mapper provides an `addEntityHooks(entityName, spec)` function that can be used to add hooks for an entity.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -42,6 +42,12 @@ const sidebars = {
           label: 'Tutorials',
           collapsed: true,
           items: ['learn/beginner/crud-application', 'learn/beginner/environment-variables']
+        },
+        {
+          type: 'category',
+          label: 'Migrations',
+          collapsed: true,
+          items: ['learn/migrations/from-express', 'learn/migrations/from-fastify']
         }
       ]
     },
@@ -104,6 +110,19 @@ const sidebars = {
             'guides/debugging-with-repl'
           ]
         }
+      ]
+    },
+
+    // Concepts - Why Watt works the way it does (Diátaxis: Understanding-oriented)
+    {
+      type: 'category',
+      label: 'Concepts',
+      collapsed: true,
+      items: [
+        'concepts/watt-architecture',
+        'concepts/multithread-model',
+        'concepts/application-lifecycle',
+        'concepts/modular-monolith'
       ]
     },
 


### PR DESCRIPTION
Completes the final phase of the documentation restructure. All four Diátaxis quadrants now exist and every page is reachable from `docs/sidebars.js`.

## `docs/concepts/` — the missing Explanation quadrant

New top-level sidebar category, placed between How-to Guides and Reference.

| Page | Covers |
| --- | --- |
| `watt-architecture.md` | Why a thread per application; why `.plt.local` is not a network call; what the runtime owns; an explicit "what this architecture is not good at" section |
| `multithread-model.md` | Threads vs processes vs single event loop; an isolated/not-isolated table; shared-nothing consequences; the process-boundary failure mode |
| `application-lifecycle.md` | The two nested lifecycles; dependency-level startup; why shutdown stops the entrypoint first; crash restart vs unhealthy replacement |
| `modular-monolith.md` | What the term means, why the boundaries are enforced rather than conventional, the full trade table, explicit "when to stop" criteria |

The pre-existing explanation-flavoured pages (`guides/watt-architecture-patterns.md`, `reference/runtime/multithread-architecture.md`, `overview/architecture-overview.md`) were **left in place and cross-linked** rather than moved. They are genuinely how-to and reference content; what was missing was the understanding-oriented layer above them.

## `docs/learn/migrations/` — Express and Fastify

Staged guides: wrap with zero changes → export `build` → runtime logger → split into multiple applications. Each stage leaves a working application, so a reader can stop wherever they get what they need.

## These were executed, not written from the seed doc

Phase 5 taught us that an unverified guide is a guide with bugs in it — the quick start had two blocking ones once actually run. So:

- Wrapped a real Express 5 app with `create-wattpm`. Zero code changes, `GET /health` → 200.
- Built a two-application project; `GET /users/42` returned data fetched over `notifier.plt.local`.
- Put a Fastify application behind a gateway and exercised the prefix behaviour both ways.

### The finding most worth having written down

**The gateway strips its prefix before the request reaches the application.** `GET /orders/health` arrives as `GET /health`.

For a migration this is exactly right — your existing routes keep working untouched. But if you *do* add the prefix to your route definitions you get:

```json
{"message":"Route GET:/health not found","error":"Not Found","statusCode":404}
```

which reads like a routing bug rather than a configuration mismatch. `node.absoluteUrl: true` inverts the behaviour and *requires* prefixed routes. Mixing the two modes fails in both directions.

This was documented nowhere outside `packages/node/test/fixtures/`. Both migration guides now carry it as a `:::caution`.

## Claims read from source, not paraphrased

| Claim | Checked against |
| --- | --- |
| Dependency-level startup, parallel within a level | `runtime.js` `startApplications` → `topologicalSort` + `topologicalLevels`; observed live as `orders` before `gateway` |
| A gateway declares its composed applications as dependencies | `gateway/lib/capability.js` `getDependencies()` |
| Shutdown stops the entrypoint first | `runtime.js` `stop()` |
| 5 bootstrap attempts; 5000 ms dev / immediate production | `MAX_BOOTSTRAP_ATTEMPTS`, `IMMEDIATE_RESTART_MAX_THRESHOLD`, `config.js` |
| Health defaults (30 s, 30 s, 10 checks, 0.99 ELU, 4 GB) | `foundation/lib/schema.js` `health` |
| Round-robin has a randomised start offset | `worker/round-robin-map.js` |
| `.plt.local` is a MessagePort hop, not DNS | `worker/interceptors.js` `wire({ domain: '.plt.local' })` |

## Two plan items closed as "will not do"

- **TypeScript guide split.** The commands it was designed around — `plt service compile`, `plt runtime compile` — no longer exist anywhere in `packages/cli`, `packages/wattpm/lib/commands/`, or `packages/wattpm-utils/lib/commands/`. The single 108-line file is now the correct shape; splitting it would manufacture two thin pages from one coherent one.
- **Example gallery.** The plan's own condition was "if and only if the examples are CI-tested". There is no `examples/` directory and no CI job referencing one, so the precondition is unmet.

## Link fixes, beyond scope

Phase 4 claimed zero broken links. A stricter sweep — one that also rejects links resolving to a bare directory with no page behind it — found seven survivors:

| Link | File | Fix |
| --- | --- | --- |
| `reference/runtime/configuration.md#application` | `guides/capabilities.md` | missing `../` |
| `monitoring.md` | `guides/profiling-with-watt.md` | → `metrics.md` |
| `../reference/db/authorization/introduction#user-metadata` | `reference/db/jwt-auth0.md` | → `./authorization/user-roles-metadata.md#user-metadata` |
| `lib/utils.js#L3` | `reference/gateway/configuration.md` | → graphql-composer GitHub URL |
| `../api` | `reference/sql-mapper/entities/hooks.md` | → `./api.md` |
| `../learn/` | `guides/frameworks.md` | bare directory |
| `../guides/deployment/` | `overview/architecture-overview.md` | bare directory |

Remaining `docs.platformatic.dev/docs/...` self-links were converted to routes (dropping `utm_*` params), except one inside a quoted log transcript — which was itself **stale**, still showing the pre-Phase-4 `guides/debug-platformatic-db` URL while `packages/db/lib/application.js` now emits `reference/troubleshooting#database-connection-issues`. Transcripts of program output are documentation too, and they drift silently.

## Verification

- 137 `.md` files on disk, 132 sidebar entries — the difference is exactly the four MDX partials plus `getting-started/issues.md`, all deliberately excluded
- Zero broken links, zero links resolving to a bare directory, zero self-links outside quoted program output
- `docs/sidebars.js` parses; no missing targets

## Still open after this PR

1. **`learn/beginner/crud-application.md` is unverified** — it needs a database, so it was never run. Given the quick start's track record, it should be treated as unverified rather than assumed working.
2. **Product follow-up, not a docs fix.** The runtime reports `exited prematurely with error code 1` without the child's stderr, even at `PLT_SERVER_LOGGER_LEVEL=trace`. Recovering the real Next.js error in Phase 5 required bypassing Watt entirely. Surfacing child stderr on startup failure would turn a bisect into a glance. Recorded in the plan; not filed as an issue.