### PR TITLE
feat: bake deployment IDs into framework builds

### DIFF
--- a/docs/reference/next/configuration.md
+++ b/docs/reference/next/configuration.md
@@ -106,6 +106,16 @@ Configures Next.js. Supported object properties:
   - **`timeout`** (`number` or `string`): Timeout in milliseconds used for image fetch/optimization operations. Default: `30000`.
   - **`maxAttempts`** (`number` or `string`): Maximum retry attempts for optimization jobs. Default: `3`.
 
+## Skew protection
+
+When `PLT_DEPLOYMENT_ID` is set during the build, Platformatic sets Next.js `deploymentId` automatically unless it is already configured. You can also configure it directly in `next.config.js`:
+
+```js
+module.exports = {
+  deploymentId: process.env.PLT_DEPLOYMENT_ID
+}
+```
+
 <RuntimeInCapabilities />
 
 <Issues />

--- a/docs/reference/nuxt/overview.md
+++ b/docs/reference/nuxt/overview.md
@@ -44,6 +44,18 @@ Nuxt uses Vite internally, but Platformatic Nuxt is not a plain Vite application
 
 When using the `commands` property, the command is responsible for starting an HTTP server. Platformatic will integrate the external application in the runtime and select the server port used by the runtime.
 
+## Skew protection
+
+To include the deployment ID in client assets and server-rendered HTML, add the Platformatic skew module to `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@platformatic/nuxt/skew']
+})
+```
+
+The module is enabled when `PLT_DEPLOYMENT_ID` is set during the build.
+
 ## Integrating with other Watt applications
 
 If the Nuxt development server needs to be reached by other applications in the Watt mesh network, configure Vite allowed hosts in `nuxt.config`:

--- a/docs/reference/react-router/overview.md
+++ b/docs/reference/react-router/overview.md
@@ -97,6 +97,20 @@ If you want provide a custom entrypoint which will be used in `@react-router/nod
 
    This file serves as the SSR entrypoint for the server build and is referenced in the Vite configuration.
 
+## Skew protection
+
+React Router uses a user-provided Vite configuration. To tag assets, add the shared plugin:
+
+```ts
+import { platformaticSkewPlugin } from '@platformatic/vite/skew-plugin'
+
+export default defineConfig({
+  plugins: [platformaticSkewPlugin()]
+})
+```
+
+The plugin is enabled when `PLT_DEPLOYMENT_ID` is set during the build.
+
 ## Architecture
 
 When starting React Router in development mode, production mode or by using the `commands` property, Platformatic will choose a random port for the HTTP server and it will override any user or application setting.

--- a/docs/reference/remix/overview.md
+++ b/docs/reference/remix/overview.md
@@ -42,6 +42,20 @@ When running in production mode, a custom Fastify server will serve the built ap
 
 In both modes if the application uses the `commands` property then it's responsible to start a HTTP server. The Platformatic runtime will modify the server port replacing it with a random port and then it will integrate the external application in the runtime.
 
+## Skew protection
+
+Remix uses a user-provided Vite configuration. To tag assets, add the shared plugin:
+
+```ts
+import { platformaticSkewPlugin } from '@platformatic/vite/skew-plugin'
+
+export default defineConfig({
+  plugins: [platformaticSkewPlugin()]
+})
+```
+
+The plugin is enabled when `PLT_DEPLOYMENT_ID` is set during the build.
+
 ## HTTPS
 
 When a Remix application is the Watt entrypoint, configure HTTPS in the runtime `server.https` object:

--- a/docs/reference/vite/overview.md
+++ b/docs/reference/vite/overview.md
@@ -42,6 +42,18 @@ When running in production mode, a custom Fastify server will serve the built ap
 
 In both modes if the application uses the `commands` property then it's responsible to start a HTTP server. The Platformatic runtime will modify the server port replacing it with a random port and then it will integrate the external application in the runtime.
 
+## Skew protection
+
+When `PLT_DEPLOYMENT_ID` is set during a build, Platformatic automatically adds `?dpl=` to client asset URLs and dynamic imports. The same Vite plugin is available for custom build commands and other Vite-based integrations:
+
+```js
+import { platformaticSkewPlugin } from '@platformatic/vite/skew-plugin'
+
+export default {
+  plugins: [platformaticSkewPlugin()]
+}
+```
+
 ## HTTPS
 
 When a Vite application is the Watt entrypoint, configure HTTPS in the runtime `server.https` object:

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -1,5 +1,5 @@
 import { kMetadata } from '@platformatic/foundation'
-import { getBasePath, getConfig, getLogger, getNextVersion, getNotifyConfig } from '@platformatic/globals'
+import { getBasePath, getConfig, getLogger, getNextVersion, getNotifyConfig, isBuilding } from '@platformatic/globals'
 import { resolve as resolvePath } from 'node:path'
 import { getCacheHandlerPath, NextCapability } from './lib/capability.js'
 import { loadConfiguration } from './lib/config.js'
@@ -80,6 +80,11 @@ export async function enhanceNextConfig (nextConfig, ...args) {
   if (config.next?.trailingSlash && typeof nextConfig.trailingSlash === 'undefined') {
     nextConfig.trailingSlash = true
     modifications.push(['trailingSlash', 'enabled'])
+  }
+
+  if (typeof nextConfig.deploymentId === 'undefined' && process.env.PLT_DEPLOYMENT_ID && isBuilding({ throwOnMissing: false }) === true) {
+    nextConfig.deploymentId = process.env.PLT_DEPLOYMENT_ID
+    modifications.push(['deploymentId', 'PLT_DEPLOYMENT_ID'])
   }
 
   if (modifications.length > 0) {

--- a/packages/next/test/index.test.js
+++ b/packages/next/test/index.test.js
@@ -99,6 +99,42 @@ describe('keyFor', () => {
 })
 
 describe('enhanceNextConfig with caching', () => {
+  test('sets deploymentId from the build environment', async () => {
+    const originalDeploymentId = process.env.PLT_DEPLOYMENT_ID
+    process.env.PLT_DEPLOYMENT_ID = 'dpl-test'
+
+    try {
+      setupGlobal()
+      updateGlobals({ isBuilding: true })
+      const nextConfig = await enhanceNextConfig({})
+      strictEqual(nextConfig.deploymentId, 'dpl-test')
+    } finally {
+      if (originalDeploymentId === undefined) {
+        delete process.env.PLT_DEPLOYMENT_ID
+      } else {
+        process.env.PLT_DEPLOYMENT_ID = originalDeploymentId
+      }
+    }
+  })
+
+  test('does not override an explicitly configured deploymentId', async () => {
+    const originalDeploymentId = process.env.PLT_DEPLOYMENT_ID
+    process.env.PLT_DEPLOYMENT_ID = 'dpl-test'
+
+    try {
+      setupGlobal()
+      updateGlobals({ isBuilding: true })
+      const nextConfig = await enhanceNextConfig({ deploymentId: 'dpl-explicit' })
+      strictEqual(nextConfig.deploymentId, 'dpl-explicit')
+    } finally {
+      if (originalDeploymentId === undefined) {
+        delete process.env.PLT_DEPLOYMENT_ID
+      } else {
+        process.env.PLT_DEPLOYMENT_ID = originalDeploymentId
+      }
+    }
+  })
+
   test('adds ISR caching handler', async () => {
     setupGlobal()
     const nextConfig = await enhanceNextConfig({})

--- a/packages/nuxt/lib/skew/module.js
+++ b/packages/nuxt/lib/skew/module.js
@@ -1,0 +1,41 @@
+import { addDeploymentId, platformaticSkewPlugin } from '@platformatic/vite/skew-plugin'
+
+const htmlParts = ['head', 'bodyPrepend', 'body', 'bodyAppend']
+
+function transformHtmlPart (part, deploymentId) {
+  if (Array.isArray(part)) {
+    return part.map(value => typeof value === 'string' ? transformHtmlPart(value, deploymentId) : value)
+  }
+
+  if (typeof part !== 'string') {
+    return part
+  }
+
+  return part.replace(/<(script|link)\b[^>]*>/gi, tag => {
+    return tag.replace(/\b(src|href)(\s*=\s*)(["'])([^"']*)\3/i, (attribute, name, equals, quote, url) => {
+      return `${name}${equals}${quote}${addDeploymentId(url, deploymentId)}${quote}`
+    })
+  })
+}
+
+export default function skewModule (_options, nuxt) {
+  const deploymentId = process.env.PLT_DEPLOYMENT_ID
+  if (!deploymentId) {
+    return
+  }
+
+  nuxt.hook('vite:extendConfig', viteConfig => {
+    viteConfig.plugins ??= []
+    viteConfig.plugins.push(platformaticSkewPlugin(deploymentId))
+  })
+
+  nuxt.hook('render:html', html => {
+    for (const part of htmlParts) {
+      if (part in html) {
+        html[part] = transformHtmlPart(html[part], deploymentId)
+      }
+    }
+  })
+}
+
+export { transformHtmlPart }

--- a/packages/nuxt/skew.js
+++ b/packages/nuxt/skew.js
@@ -1,0 +1,1 @@
+export { default, transformHtmlPart } from './lib/skew/module.js'

--- a/packages/vite/index.d.ts
+++ b/packages/vite/index.d.ts
@@ -1,3 +1,4 @@
+import type { Plugin } from 'vite'
 import { BaseCapability, BaseContext, BaseOptions } from '@platformatic/basic'
 import { Configuration, ConfigurationOptions } from '@platformatic/foundation'
 import { JSONSchemaType } from 'ajv'
@@ -46,3 +47,8 @@ export declare const schema: JSONSchemaType<PlatformaticViteConfig>
 export declare const schemaComponents: { vite: JSONSchemaType<object> }
 export declare const version: string
 export declare const supportedVersions: string[]
+
+export declare function addDeploymentId (url: string, deploymentId: string): string
+export declare function platformaticSkewPlugin (deploymentId?: string): Plugin | undefined
+export declare const skewPlugin: typeof platformaticSkewPlugin
+export declare const deploymentIdEnv: 'PLT_DEPLOYMENT_ID'

--- a/packages/vite/index.js
+++ b/packages/vite/index.js
@@ -65,4 +65,5 @@ export async function create (configOrRoot, sourceOrConfig, context) {
 }
 
 export * from './lib/capability.js'
+export { addDeploymentId, deploymentIdEnv, platformaticSkewPlugin, skewPlugin } from './lib/skew-plugin.js'
 export { packageJson, schema, schemaComponents, version } from './lib/schema.js'

--- a/packages/vite/lib/capability.js
+++ b/packages/vite/lib/capability.js
@@ -15,6 +15,7 @@ import { ensureLoggableError, sanitizeHTTPSOptions } from '@platformatic/foundat
 import { getLogger, updateGlobals } from '@platformatic/globals'
 import { NodeCapability } from '@platformatic/node'
 import fastify from 'fastify'
+import { platformaticSkewPlugin } from './skew-plugin.js'
 import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
@@ -120,6 +121,7 @@ export class ViteCapability extends BaseCapability {
     try {
       updateGlobals({ isBuilding: true })
 
+      const skewPlugin = platformaticSkewPlugin()
       const buildOptions = {
         root: this.root,
         base: basePath,
@@ -130,6 +132,7 @@ export class ViteCapability extends BaseCapability {
           outDir: config.application.outputDirectory
         },
         plugins: [
+          skewPlugin,
           {
             name: 'platformatic-build',
             configResolved: config => {
@@ -137,7 +140,7 @@ export class ViteCapability extends BaseCapability {
               outDir = resolve(this.root, config.build.outDir)
             }
           }
-        ]
+        ].filter(Boolean)
       }
 
       // createBuilder was added in Vite 6 and might be needed for multi environment frameworks like TanStack
@@ -244,6 +247,7 @@ export class ViteCapability extends BaseCapability {
       typeof backlog === 'number' ? { backlog } : {}
     )
     const { createServer } = await importFile(resolve(this.#vite, 'dist/node/index.js'))
+    const skewPlugin = platformaticSkewPlugin()
 
     // Create the server and listen
     this.#app = await createServer({
@@ -254,6 +258,7 @@ export class ViteCapability extends BaseCapability {
       logLevel: this.logger.level,
       clearScreen: false,
       optimizeDeps: { force: false },
+      plugins: skewPlugin ? [skewPlugin] : undefined,
       server: serverOptions
     })
 
@@ -425,6 +430,7 @@ export class ViteSSRCapability extends NodeCapability {
     try {
       updateGlobals({ isBuilding: true })
 
+      const skewPlugin = platformaticSkewPlugin()
       const buildOptions = {
         root: resolve(this.root, clientDirectory),
         base: basePath,
@@ -436,6 +442,7 @@ export class ViteSSRCapability extends NodeCapability {
           ssrManifest: true
         },
         plugins: [
+          skewPlugin,
           {
             name: 'platformatic-build',
             configResolved: config => {
@@ -443,7 +450,7 @@ export class ViteSSRCapability extends NodeCapability {
               clientOutDir = resolve(this.root, clientDirectory, config.build.outDir)
             }
           }
-        ]
+        ].filter(Boolean)
       }
 
       // createBuilder was added in Vite 6 and might be needed for multi environment frameworks like TanStack

--- a/packages/vite/lib/skew-plugin.js
+++ b/packages/vite/lib/skew-plugin.js
@@ -8,16 +8,23 @@ function isAssetUrl (url) {
 }
 
 export function addDeploymentId (url, deploymentId) {
-  if (!isAssetUrl(url) || /(?:[?&])dpl(?:=|&|$)/i.test(url)) {
+  if (!isAssetUrl(url)) {
     return url
   }
 
-  const hashIndex = url.indexOf('#')
-  const hash = hashIndex === -1 ? '' : url.slice(hashIndex)
-  const withoutHash = hashIndex === -1 ? url : url.slice(0, hashIndex)
-  const separator = withoutHash.includes('?') ? (withoutHash.endsWith('?') || withoutHash.endsWith('&') ? '' : '&') : '?'
+  try {
+    const parsedUrl = new URL(url, 'http://platformatic.local')
+    if (parsedUrl.searchParams.has('dpl')) {
+      return url
+    }
 
-  return `${withoutHash}${separator}dpl=${encodeURIComponent(deploymentId)}${hash}`
+    parsedUrl.searchParams.set('dpl', deploymentId)
+    const pathEnd = url.search(/[?#]/)
+    const path = pathEnd === -1 ? url : url.slice(0, pathEnd)
+    return `${path}${parsedUrl.search}${parsedUrl.hash}`
+  } catch {
+    return url
+  }
 }
 
 function transformHtmlAssetUrls (html, deploymentId) {

--- a/packages/vite/lib/skew-plugin.js
+++ b/packages/vite/lib/skew-plugin.js
@@ -1,0 +1,143 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const deploymentIdEnvironmentVariable = 'PLT_DEPLOYMENT_ID'
+
+function isAssetUrl (url) {
+  return url && !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(url)
+}
+
+export function addDeploymentId (url, deploymentId) {
+  if (!isAssetUrl(url) || /(?:[?&])dpl(?:=|&|$)/i.test(url)) {
+    return url
+  }
+
+  const hashIndex = url.indexOf('#')
+  const hash = hashIndex === -1 ? '' : url.slice(hashIndex)
+  const withoutHash = hashIndex === -1 ? url : url.slice(0, hashIndex)
+  const separator = withoutHash.includes('?') ? (withoutHash.endsWith('?') || withoutHash.endsWith('&') ? '' : '&') : '?'
+
+  return `${withoutHash}${separator}dpl=${encodeURIComponent(deploymentId)}${hash}`
+}
+
+function transformHtmlAssetUrls (html, deploymentId) {
+  return html.replace(/<(script|link)\b[^>]*>/gi, tag => {
+    return tag.replace(/\b(src|href)(\s*=\s*)(["'])([^"']*)\3/i, (attribute, name, equals, quote, url) => {
+      return `${name}${equals}${quote}${addDeploymentId(url, deploymentId)}${quote}`
+    })
+  })
+}
+
+const manifestAssetFields = new Set(['file', 'css', 'assets'])
+
+function transformManifestValue (value, deploymentId, isAsset = false, isRoot = false) {
+  if (typeof value === 'string') {
+    return isAsset || isRoot ? addDeploymentId(value, deploymentId) : value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => transformManifestValue(item, deploymentId, isAsset || isRoot))
+  }
+
+  if (value && typeof value === 'object') {
+    for (const [key, item] of Object.entries(value)) {
+      const itemIsAsset = manifestAssetFields.has(key) || (isRoot && (typeof item === 'string' || Array.isArray(item)))
+      value[key] = transformManifestValue(item, deploymentId, itemIsAsset)
+    }
+  }
+
+  return value
+}
+
+function transformManifest (source, deploymentId) {
+  try {
+    const manifest = JSON.parse(source)
+    return JSON.stringify(transformManifestValue(manifest, deploymentId, false, true))
+  } catch {
+    return source
+  }
+}
+
+/**
+ * Adds the deployment ID to client asset URLs for Watt skew protection.
+ *
+ * The plugin is intentionally disabled when PLT_DEPLOYMENT_ID is not set so
+ * that local builds retain Vite's normal output and URL behaviour.
+ */
+export function platformaticSkewPlugin (deploymentId = process.env[deploymentIdEnvironmentVariable]) {
+  if (!deploymentId) {
+    return undefined
+  }
+
+  const serializedDeploymentId = JSON.stringify(deploymentId)
+
+  return {
+    name: 'platformatic-skew',
+
+    config () {
+      return {
+        define: {
+          'import.meta.env.PLT_DEPLOYMENT_ID': serializedDeploymentId,
+          'process.env.PLT_DEPLOYMENT_ID': serializedDeploymentId
+        }
+      }
+    },
+
+    renderDynamicImport (options) {
+      // Dynamic imports in the server bundle are resolved by Node and must not
+      // be routed through the browser's deployment-aware URL handling.
+      if (options.ssr || !options.targetModuleId) {
+        return undefined
+      }
+
+      return {
+        left: `import((url => { url.searchParams.set('dpl', ${serializedDeploymentId}); return url })(new URL(`,
+        right: ', import.meta.url)))'
+      }
+    },
+
+    transformIndexHtml (html) {
+      return transformHtmlAssetUrls(html, deploymentId)
+    },
+
+    generateBundle (_options, bundle) {
+      for (const output of Object.values(bundle)) {
+        if (output.type !== 'asset' || !/manifest[^/]*\.json$/i.test(output.fileName)) {
+          continue
+        }
+
+        const source = typeof output.source === 'string'
+          ? output.source
+          : Buffer.isBuffer(output.source)
+            ? output.source.toString()
+            : new TextDecoder().decode(output.source)
+        output.source = transformManifest(source, deploymentId)
+      }
+    },
+
+    async writeBundle (options) {
+      // Vite writes its SSR manifest after generateBundle, so it is not
+      // available in the output bundle on all supported Vite versions.
+      if (!options.dir) {
+        return
+      }
+
+      for (const file of ['.vite/ssr-manifest.json', 'ssr-manifest.json', '.vite/manifest.json', 'manifest.json']) {
+        const path = join(options.dir, file)
+        try {
+          const source = await readFile(path, 'utf8')
+          await writeFile(path, transformManifest(source, deploymentId))
+        } catch (error) {
+          if (error.code !== 'ENOENT') {
+            throw error
+          }
+        }
+      }
+    }
+  }
+}
+
+export const skewPlugin = platformaticSkewPlugin
+export const deploymentIdEnv = deploymentIdEnvironmentVariable
+
+export default platformaticSkewPlugin

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,6 +4,19 @@
   "description": "Platformatic Vite Capability",
   "main": "index.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    },
+    "./skew-plugin": {
+      "types": "./skew-plugin.d.ts",
+      "import": "./skew-plugin.js",
+      "default": "./skew-plugin.js"
+    },
+    "./*": "./*"
+  },
   "scripts": {
     "test": "npm run test:types && node --test --test-reporter=cleaner-spec-reporter --test-concurrency=1 --test-timeout=2000000 test/*.test.js test/**/*.test.js",
     "test:types": "tstyche",

--- a/packages/vite/skew-plugin.d.ts
+++ b/packages/vite/skew-plugin.d.ts
@@ -1,0 +1,7 @@
+import type { Plugin } from 'vite'
+
+export declare function addDeploymentId (url: string, deploymentId: string): string
+export declare function platformaticSkewPlugin (deploymentId?: string): Plugin | undefined
+export declare const skewPlugin: typeof platformaticSkewPlugin
+export declare const deploymentIdEnv: 'PLT_DEPLOYMENT_ID'
+export default platformaticSkewPlugin

--- a/packages/vite/skew-plugin.js
+++ b/packages/vite/skew-plugin.js
@@ -1,0 +1,7 @@
+export {
+  addDeploymentId,
+  deploymentIdEnv,
+  platformaticSkewPlugin,
+  skewPlugin
+} from './lib/skew-plugin.js'
+export { default } from './lib/skew-plugin.js'

--- a/packages/vite/test/skew-plugin.test.js
+++ b/packages/vite/test/skew-plugin.test.js
@@ -1,0 +1,70 @@
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import test from 'node:test'
+import { addDeploymentId, platformaticSkewPlugin } from '../skew-plugin.js'
+
+test('does not create a plugin without a deployment ID', () => {
+  strictEqual(platformaticSkewPlugin(''), undefined)
+  strictEqual(platformaticSkewPlugin(null), undefined)
+})
+
+test('adds deployment IDs while preserving query strings and hashes', () => {
+  strictEqual(addDeploymentId('/assets/app.js', 'dpl/test'), '/assets/app.js?dpl=dpl%2Ftest')
+  strictEqual(addDeploymentId('/assets/app.js?v=1#hash', 'dpl-1'), '/assets/app.js?v=1&dpl=dpl-1#hash')
+  strictEqual(addDeploymentId('https://example.com/app.js', 'dpl-1'), 'https://example.com/app.js')
+  strictEqual(addDeploymentId('/assets/app.js?dpl=old', 'dpl-1'), '/assets/app.js?dpl=old')
+})
+
+test('defines the deployment ID and rewrites HTML asset URLs', () => {
+  const plugin = platformaticSkewPlugin('dpl-1')
+  const config = plugin.config()
+  strictEqual(config.define['import.meta.env.PLT_DEPLOYMENT_ID'], JSON.stringify('dpl-1'))
+  strictEqual(config.define['process.env.PLT_DEPLOYMENT_ID'], JSON.stringify('dpl-1'))
+
+  const html = plugin.transformIndexHtml('<script type="module" src="/assets/app.js"></script><link rel="stylesheet" href="/assets/app.css?v=1#x">')
+  strictEqual(html, '<script type="module" src="/assets/app.js?dpl=dpl-1"></script><link rel="stylesheet" href="/assets/app.css?v=1&dpl=dpl-1#x">')
+})
+
+test('rewrites client dynamic imports but not server imports', () => {
+  const plugin = platformaticSkewPlugin('dpl-1')
+  const result = plugin.renderDynamicImport({ targetModuleId: '/app/chunk.js', ssr: false })
+  strictEqual(result.left.startsWith('import((url =>'), true)
+  strictEqual(result.right, ', import.meta.url)))')
+  strictEqual(plugin.renderDynamicImport({ targetModuleId: '/app/chunk.js', ssr: true }), undefined)
+})
+
+test('rewrites asset URLs in manifests', () => {
+  const plugin = platformaticSkewPlugin('dpl-1')
+  const output = { type: 'asset', fileName: '.vite/ssr-manifest.json', source: JSON.stringify({ entry: ['assets/app.js'], css: ['assets/app.css'] }) }
+  plugin.generateBundle({}, { [output.fileName]: output })
+  deepStrictEqual(JSON.parse(output.source), {
+    entry: ['assets/app.js?dpl=dpl-1'],
+    css: ['assets/app.css?dpl=dpl-1']
+  })
+})
+
+test('does not rewrite manifest entry names or import references', () => {
+  const plugin = platformaticSkewPlugin('dpl-1')
+  const output = {
+    type: 'asset',
+    fileName: 'manifest.json',
+    source: JSON.stringify({
+      'src/main.js': {
+        file: 'assets/main.js',
+        name: 'main',
+        imports: ['_shared'],
+        css: ['assets/main.css']
+      },
+      _shared: { file: 'assets/shared.js' }
+    })
+  }
+  plugin.generateBundle({}, { [output.fileName]: output })
+  deepStrictEqual(JSON.parse(output.source), {
+    'src/main.js': {
+      file: 'assets/main.js?dpl=dpl-1',
+      name: 'main',
+      imports: ['_shared'],
+      css: ['assets/main.css?dpl=dpl-1']
+    },
+    _shared: { file: 'assets/shared.js?dpl=dpl-1' }
+  })
+})


### PR DESCRIPTION
Implements #5049 by adding deployment-aware asset URLs to Vite builds, SSR manifests, and Nuxt-rendered HTML when PLT_DEPLOYMENT_ID is set. Next.js deploymentId configuration and framework documentation are included, with a shared plugin available for React Router, Remix, and custom Vite builds.
