### PR TITLE
feat(runtime): add build hooks for runtime extensions

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -46,7 +46,7 @@ in the **runtime main thread**. Extensions can observe and control the whole run
 the `Runtime` object and an ITC (Inter-Thread Communication) facade which allows them to register
 custom commands that applications can invoke from their worker threads.
 
-`extensions` can be a path, an object with `path` and `options` properties, or an array of either:
+`extensions` can be a path, an object with `path`, `options`, and `build` properties, or an array of either:
 
 ```json
 {
@@ -211,6 +211,13 @@ The setup function receives a context object with the following properties:
 
 The setup function can optionally return an object with awaited lifecycle hooks:
 
+- **`preBuild(context)`** - Called before an application capability is built. `context` contains
+  `applicationId` and the absolute `applicationPath`.
+- **`onBuild(context, build)`** - Wraps the application capability build. Call and await `build()` to
+  continue the build. The hook may perform work immediately before and after it, or omit the call to
+  replace the capability build. Its return value becomes the build result.
+- **`postBuild(context, result)`** - Called after a successful application build with the final result
+  returned by the `onBuild` hook chain.
 - **`start()`** - Called once applications have been prepared and registered, and **before** the
   originally configured applications start accepting traffic. Runtime awaits every extension `start`
   hook. An extension may add and start dynamic applications here; those applications are excluded from
@@ -223,17 +230,32 @@ The setup function can optionally return an object with awaited lifecycle hooks:
 - **`close()`** - Called when the runtime is being closed, after applications have stopped. The
   extension metrics registry is cleared after `close`.
 
-When multiple extensions are configured, they are set up and started in registration order. `stop` and
-`close` run in reverse registration order. Each of `stop` and `close` is invoked at most once per
-Runtime life, including repeated `stop`/`close` calls and failed-start cleanup paths. Existing
-extensions that only return `close()` keep their previous behavior. Health checks and routes registered
-by an extension are cleaned up with it.
+When multiple extensions are configured, they are set up and started in registration order.
+`preBuild` runs in registration order. `onBuild` hooks are nested middleware with the first registered
+extension outermost. `postBuild`, `stop`, and `close` run in reverse registration order. Each of `stop`
+and `close` is invoked at most once per Runtime life, including repeated `stop`/`close` calls and
+failed-start cleanup paths. Existing extensions that only return `close()` keep their previous
+behavior. Health checks and routes registered by an extension are cleaned up with it.
 
 Listening to Runtime `EventEmitter` events is not a substitute for these hooks: `emit()` does not await
 asynchronous listeners. Lifecycle ordering is enforced by Runtime itself so it covers signal handling,
 internal failure cleanup, and future lifecycle entry points.
 
-Extensions are not loaded when building the applications (for example via `wattpm build`).
+Extensions are not loaded when building applications unless their object configuration explicitly
+sets `"build": true`. Build-enabled extensions are set up before application workers are created,
+receive the build hooks above for every application, and are closed when the build Runtime closes.
+Their `start` and `stop` hooks are not called during a build.
+
+```json
+{
+  "extensions": [
+    {
+      "path": "./build-extension.js",
+      "build": true
+    }
+  ]
+}
+```
 
 For a complete worked example — enabling continuous profiling on every worker when it starts (or is
 restarted) and shipping the captured profiles — see the

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticAstroConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticAstroConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -17,6 +17,7 @@ export interface PlatformaticBasicConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -25,6 +26,7 @@ export interface PlatformaticBasicConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -48,6 +48,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -73,6 +77,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -193,6 +193,7 @@ export interface PlatformaticComposerConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -201,6 +202,7 @@ export interface PlatformaticComposerConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -732,6 +732,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -757,6 +761,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -526,6 +526,7 @@ export interface PlatformaticDatabaseConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -534,6 +535,7 @@ export interface PlatformaticDatabaseConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1430,6 +1430,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -1455,6 +1459,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -111,6 +111,10 @@ const extension = {
         options: {
           type: 'object',
           additionalProperties: true
+        },
+        build: {
+          type: 'boolean',
+          default: false
         }
       }
     }

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -460,6 +460,7 @@ export interface PlatformaticGatewayConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -468,6 +469,7 @@ export interface PlatformaticGatewayConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1715,6 +1715,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -1740,6 +1744,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticNestJSConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticNestJSConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticNextJsConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticNextJsConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/nitro/config.d.ts
+++ b/packages/nitro/config.d.ts
@@ -136,6 +136,7 @@ export interface PlatformaticNitroConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -144,6 +145,7 @@ export interface PlatformaticNitroConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -441,6 +441,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -466,6 +470,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticNodeJsConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticNodeJsConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticNuxtConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticNuxtConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticReactRouterConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticReactRouterConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticRemixConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticRemixConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -17,6 +17,7 @@ export type PlatformaticRuntimeConfig = {
         options?: {
           [k: string]: unknown;
         };
+        build?: boolean;
       }
     | (
         | string
@@ -25,6 +26,7 @@ export type PlatformaticRuntimeConfig = {
             options?: {
               [k: string]: unknown;
             };
+            build?: boolean;
           }
       )[];
   entrypoint?: string;

--- a/packages/runtime/fixtures/extensions/extension-build-1.js
+++ b/packages/runtime/fixtures/extensions/extension-build-1.js
@@ -1,0 +1,22 @@
+export default async function setup () {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  events.push({ event: 'setup', extension: 'build-first' })
+
+  return {
+    preBuild (context) {
+      events.push({ event: 'preBuild', extension: 'build-first', context })
+    },
+    async onBuild (context, build) {
+      events.push({ event: 'onBuild:before', extension: 'build-first', context })
+      const result = await build()
+      events.push({ event: 'onBuild:after', extension: 'build-first', context })
+      return { ...result, first: true }
+    },
+    postBuild (context, result) {
+      events.push({ event: 'postBuild', extension: 'build-first', context, result })
+    },
+    close () {
+      events.push({ event: 'close', extension: 'build-first' })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-build-2.js
+++ b/packages/runtime/fixtures/extensions/extension-build-2.js
@@ -1,0 +1,22 @@
+export default async function setup () {
+  const events = (globalThis.__pltExtensionEvents ??= [])
+  events.push({ event: 'setup', extension: 'build-second' })
+
+  return {
+    preBuild (context) {
+      events.push({ event: 'preBuild', extension: 'build-second', context })
+    },
+    async onBuild (context, build) {
+      events.push({ event: 'onBuild:before', extension: 'build-second', context })
+      const result = await build()
+      events.push({ event: 'onBuild:after', extension: 'build-second', context })
+      return { ...result, second: true }
+    },
+    postBuild (context, result) {
+      events.push({ event: 'postBuild', extension: 'build-second', context, result })
+    },
+    close () {
+      events.push({ event: 'close', extension: 'build-second' })
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-build-failures.js
+++ b/packages/runtime/fixtures/extensions/extension-build-failures.js
@@ -1,0 +1,27 @@
+export default async function setup ({ options }) {
+  const { name } = options
+
+  function record (event, context, hook = event) {
+    globalThis.__pltExtensionEvents.push({ event, extension: name, context })
+
+    const failure = globalThis.__pltExtensionFailure
+    if (failure?.extension === name && failure.hook === hook) {
+      throw new Error(`${hook} failure from ${name}`)
+    }
+  }
+
+  return {
+    preBuild (context) {
+      record('preBuild', context)
+    },
+    async onBuild (context, build) {
+      record('onBuild:before', context, 'onBuild')
+      const result = await build()
+      record('onBuild:after', context)
+      return result
+    },
+    postBuild (context) {
+      record('postBuild', context)
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/extension-build-twice.js
+++ b/packages/runtime/fixtures/extensions/extension-build-twice.js
@@ -1,0 +1,8 @@
+export default async function setup () {
+  return {
+    async onBuild (context, build) {
+      await build()
+      return build()
+    }
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-build-failures.json
+++ b/packages/runtime/fixtures/extensions/platformatic-build-failures.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.65.0.json",
+  "entrypoint": "a",
+  "extensions": [
+    {
+      "path": "extension-build-failures.js",
+      "options": {
+        "name": "first"
+      },
+      "build": true
+    },
+    {
+      "path": "extension-build-failures.js",
+      "options": {
+        "name": "second"
+      },
+      "build": true
+    }
+  ],
+  "autoload": {
+    "path": "./services",
+    "exclude": ["b", "crash-on-start"]
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/fixtures/extensions/platformatic-build-twice.json
+++ b/packages/runtime/fixtures/extensions/platformatic-build-twice.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.32.0.json",
+  "entrypoint": "a",
+  "autoload": {
+    "path": "./services"
+  },
+  "extensions": [
+    {
+      "path": "./extension-build-twice.js",
+      "build": true
+    }
+  ]
+}

--- a/packages/runtime/fixtures/extensions/platformatic-build.json
+++ b/packages/runtime/fixtures/extensions/platformatic-build.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.65.0.json",
+  "entrypoint": "a",
+  "extensions": [
+    {
+      "path": "extension-build-1.js",
+      "build": true
+    },
+    {
+      "path": "extension-build-2.js",
+      "build": true
+    }
+  ],
+  "autoload": {
+    "path": "./services",
+    "exclude": ["b", "crash-on-start"]
+  },
+  "logger": {
+    "level": "error"
+  }
+}

--- a/packages/runtime/index.d.ts
+++ b/packages/runtime/index.d.ts
@@ -344,7 +344,20 @@ export interface RuntimeExtensionContext {
   health: RuntimeExtensionHealth
 }
 
+export interface RuntimeExtensionBuildContext {
+  applicationId: string
+  applicationPath: string
+}
+
+export type RuntimeExtensionBuild = () => Promise<unknown>
+
 export interface RuntimeExtensionInstance {
+  preBuild?: (context: RuntimeExtensionBuildContext) => void | Promise<void>
+  onBuild?: (
+    context: RuntimeExtensionBuildContext,
+    build: RuntimeExtensionBuild
+  ) => unknown | Promise<unknown>
+  postBuild?: (context: RuntimeExtensionBuildContext, result: unknown) => void | Promise<void>
   start?: () => void | Promise<void>
   stop?: () => void | Promise<void>
   close?: () => void | Promise<void>

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -191,6 +191,11 @@ export const DuplicateITCHandlerNameError = createError(
   'The ITC command "%s" has already been registered'
 )
 
+export const RuntimeExtensionBuildAlreadyCalledError = createError(
+  `${ERROR_PREFIX}_EXTENSION_BUILD_ALREADY_CALLED`,
+  'The build function can only be called once by each runtime extension.'
+)
+
 export const MetricFamilyCollisionError = createError(
   `${ERROR_PREFIX}_METRIC_FAMILY_COLLISION`,
   'Extension "%s" registered metric family "%s" which collides with %s'

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -54,6 +54,7 @@ import {
   MissingPprofCapture,
   ReservedITCHandlerNameError,
   RuntimeAbortedError,
+  RuntimeExtensionBuildAlreadyCalledError,
   WorkerInterceptorJoinTimeoutError,
   WorkerNotFoundError
 } from './errors.js'
@@ -921,19 +922,63 @@ export class Runtime extends EventEmitter {
 
   async buildApplication (id) {
     const application = await this.#getApplicationById(id)
+    const applicationConfig = this.#applications.get(id)
+    const context = Object.freeze({
+      applicationId: id,
+      applicationPath: applicationConfig.path
+    })
 
     this.emitAndNotify('application:building', id)
-    try {
-      await sendViaITC(application, 'build')
-      this.emitAndNotify('application:built', id)
-    } catch (e) {
-      // The application exports no meta, return an empty object
-      if (e.code === 'PLT_ITC_HANDLER_NOT_FOUND') {
-        return {}
-      }
-
-      throw e
+    for (const extension of this.#extensions) {
+      await extension.instance?.preBuild?.(context)
     }
+
+    let buildHandlerMissing = false
+    const build = this.#extensions.reduceRight(
+      (next, extension) => {
+        if (typeof extension.instance?.onBuild !== 'function') {
+          return next
+        }
+
+        return () => {
+          let called = false
+          const build = () => {
+            if (called) {
+              throw new RuntimeExtensionBuildAlreadyCalledError()
+            }
+
+            called = true
+            return next()
+          }
+
+          return extension.instance.onBuild(context, build)
+        }
+      },
+      async () => {
+        try {
+          return await sendViaITC(application, 'build')
+        } catch (e) {
+          // The application exports no meta, return an empty object
+          if (e.code === 'PLT_ITC_HANDLER_NOT_FOUND') {
+            buildHandlerMissing = true
+            return {}
+          }
+
+          throw e
+        }
+      }
+    )
+
+    const result = await build()
+
+    for (const extension of [...this.#extensions].reverse()) {
+      await extension.instance?.postBuild?.(context, result)
+    }
+
+    if (!buildHandlerMissing) {
+      this.emitAndNotify('application:built', id)
+    }
+    return result
   }
 
   async startApplicationProfiling (id, options = {}, ensureStarted = true) {
@@ -4343,8 +4388,7 @@ export class Runtime extends EventEmitter {
   async #loadExtensions () {
     let extensions = this.#config.extensions
 
-    // Do not load extensions when building applications
-    if (!extensions || this.#context.build) {
+    if (!extensions) {
       return
     }
 
@@ -4353,7 +4397,14 @@ export class Runtime extends EventEmitter {
     }
 
     for (const extension of extensions) {
-      const { path, options } = typeof extension === 'string' ? { path: extension } : extension
+      const { path, options, build } = typeof extension === 'string' ? { path: extension } : extension
+
+      // Runtime extensions historically were not loaded by `wattpm build`.
+      // Preserve that behavior unless an extension explicitly opts into the
+      // build lifecycle.
+      if (this.#context.build && !build) {
+        continue
+      }
 
       let imported
       try {

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -42,6 +42,10 @@
             "options": {
               "type": "object",
               "additionalProperties": true
+            },
+            "build": {
+              "type": "boolean",
+              "default": false
             }
           }
         },
@@ -67,6 +71,10 @@
                   "options": {
                     "type": "object",
                     "additionalProperties": true
+                  },
+                  "build": {
+                    "type": "boolean",
+                    "default": false
                   }
                 }
               }

--- a/packages/runtime/test/extensions.test.js
+++ b/packages/runtime/test/extensions.test.js
@@ -2,15 +2,131 @@ import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import { request } from 'undici'
+import { RuntimeExtensionBuildAlreadyCalledError } from '../lib/errors.js'
 import { createRuntime } from './helpers.js'
 
 const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
 
 function cleanExtensionGlobals () {
   globalThis.__pltExtensionEvents = []
+  globalThis.__pltExtensionFailure = undefined
   globalThis.__pltExtensionItc = undefined
   globalThis.__pltExtensionSharedContext = undefined
 }
+
+test('extensions opt into ordered build hooks', async t => {
+  cleanExtensionGlobals()
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-build.json')
+  const app = await createRuntime(configFile, undefined, { build: true })
+  await app.init()
+
+  t.after(() => app.close())
+
+  const builtApplications = []
+  app.on('application:built', id => builtApplications.push(id))
+  const result = await app.buildApplication('a')
+
+  const context = {
+    applicationId: 'a',
+    applicationPath: join(fixturesDir, 'extensions', 'services', 'a')
+  }
+  deepStrictEqual(result, { first: true, second: true })
+  deepStrictEqual(builtApplications, ['a'])
+  deepStrictEqual(globalThis.__pltExtensionEvents, [
+    { event: 'setup', extension: 'build-first' },
+    { event: 'setup', extension: 'build-second' },
+    { event: 'preBuild', extension: 'build-first', context },
+    { event: 'preBuild', extension: 'build-second', context },
+    { event: 'onBuild:before', extension: 'build-first', context },
+    { event: 'onBuild:before', extension: 'build-second', context },
+    { event: 'onBuild:after', extension: 'build-second', context },
+    { event: 'onBuild:after', extension: 'build-first', context },
+    { event: 'postBuild', extension: 'build-second', context, result },
+    { event: 'postBuild', extension: 'build-first', context, result }
+  ])
+})
+
+test('extensions remain disabled during builds unless explicitly enabled', async t => {
+  cleanExtensionGlobals()
+
+  const configFile = join(fixturesDir, 'extensions', 'platformatic.runtime.json')
+  const app = await createRuntime(configFile, undefined, { build: true })
+  await app.init()
+
+  t.after(() => app.close())
+
+  await app.buildApplication('a')
+  deepStrictEqual(globalThis.__pltExtensionEvents, [])
+})
+
+test('an extension cannot invoke the underlying build more than once', async t => {
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-build-twice.json')
+  const app = await createRuntime(configFile, undefined, { build: true })
+  await app.init()
+
+  t.after(() => app.close())
+
+  await rejects(
+    app.buildApplication('a'),
+    new RuntimeExtensionBuildAlreadyCalledError()
+  )
+})
+
+test('build hook failures abort the remaining lifecycle', async t => {
+  const configFile = join(fixturesDir, 'extensions', 'platformatic-build-failures.json')
+  const context = {
+    applicationId: 'a',
+    applicationPath: join(fixturesDir, 'extensions', 'services', 'a')
+  }
+
+  const cases = [
+    {
+      failure: { extension: 'first', hook: 'preBuild' },
+      events: [
+        { event: 'preBuild', extension: 'first', context }
+      ]
+    },
+    {
+      failure: { extension: 'second', hook: 'onBuild' },
+      events: [
+        { event: 'preBuild', extension: 'first', context },
+        { event: 'preBuild', extension: 'second', context },
+        { event: 'onBuild:before', extension: 'first', context },
+        { event: 'onBuild:before', extension: 'second', context }
+      ]
+    },
+    {
+      failure: { extension: 'second', hook: 'postBuild' },
+      events: [
+        { event: 'preBuild', extension: 'first', context },
+        { event: 'preBuild', extension: 'second', context },
+        { event: 'onBuild:before', extension: 'first', context },
+        { event: 'onBuild:before', extension: 'second', context },
+        { event: 'onBuild:after', extension: 'second', context },
+        { event: 'onBuild:after', extension: 'first', context },
+        { event: 'postBuild', extension: 'second', context }
+      ]
+    }
+  ]
+
+  for (const testCase of cases) {
+    await t.test(`${testCase.failure.hook} failure`, async t => {
+      cleanExtensionGlobals()
+      globalThis.__pltExtensionFailure = testCase.failure
+
+      const app = await createRuntime(configFile, undefined, { build: true })
+      t.after(() => app.close())
+      await app.init()
+
+      await rejects(
+        app.buildApplication('a'),
+        new Error(`${testCase.failure.hook} failure from ${testCase.failure.extension}`)
+      )
+      deepStrictEqual(globalThis.__pltExtensionEvents, testCase.events)
+    })
+  }
+})
 
 test('extensions receive the runtime, the ITC facade, the logger, the options and the root', async t => {
   cleanExtensionGlobals()

--- a/packages/runtime/test/types/index.tst.ts
+++ b/packages/runtime/test/types/index.tst.ts
@@ -13,6 +13,8 @@ import {
   type InjectParams,
   type InjectResponse,
   type RuntimeExtension,
+  type RuntimeExtensionBuild,
+  type RuntimeExtensionBuildContext,
   type RuntimeExtensionContext,
   type RuntimeExtensionInstance,
   type RuntimeExtensionMetrics,
@@ -290,6 +292,15 @@ test('RuntimeExtension', () => {
   expect(extension).type.toBe<RuntimeExtension>()
 
   const instance: RuntimeExtensionInstance = {}
+  expect(instance.preBuild).type.toBe<
+    ((context: RuntimeExtensionBuildContext) => void | Promise<void>) | undefined
+  >()
+  expect(instance.onBuild).type.toBe<
+    ((context: RuntimeExtensionBuildContext, build: RuntimeExtensionBuild) => unknown | Promise<unknown>) | undefined
+  >()
+  expect(instance.postBuild).type.toBe<
+    ((context: RuntimeExtensionBuildContext, result: unknown) => void | Promise<void>) | undefined
+  >()
   expect(instance.start).type.toBe<(() => void | Promise<void>) | undefined>()
   expect(instance.stop).type.toBe<(() => void | Promise<void>) | undefined>()
   expect(instance.close).type.toBe<(() => void | Promise<void>) | undefined>()

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -348,6 +348,7 @@ export interface PlatformaticServiceConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -356,6 +357,7 @@ export interface PlatformaticServiceConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1101,6 +1101,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -1126,6 +1130,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticTanStackConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticTanStackConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -137,6 +137,7 @@ export interface PlatformaticViteConfig {
           options?: {
             [k: string]: unknown;
           };
+          build?: boolean;
         }
       | (
           | string
@@ -145,6 +146,7 @@ export interface PlatformaticViteConfig {
               options?: {
                 [k: string]: unknown;
               };
+              build?: boolean;
             }
         )[];
     basePath?: string;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -447,6 +447,10 @@
                 "options": {
                   "type": "object",
                   "additionalProperties": true
+                },
+                "build": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -472,6 +476,10 @@
                       "options": {
                         "type": "object",
                         "additionalProperties": true
+                      },
+                      "build": {
+                        "type": "boolean",
+                        "default": false
                       }
                     }
                   }

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -17,6 +17,7 @@ export type PlatformaticRuntimeConfig = {
         options?: {
           [k: string]: unknown;
         };
+        build?: boolean;
       }
     | (
         | string
@@ -25,6 +26,7 @@ export type PlatformaticRuntimeConfig = {
             options?: {
               [k: string]: unknown;
             };
+            build?: boolean;
           }
       )[];
   entrypoint?: string;

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -42,6 +42,10 @@
             "options": {
               "type": "object",
               "additionalProperties": true
+            },
+            "build": {
+              "type": "boolean",
+              "default": false
             }
           }
         },
@@ -67,6 +71,10 @@
                   "options": {
                     "type": "object",
                     "additionalProperties": true
+                  },
+                  "build": {
+                    "type": "boolean",
+                    "default": false
                   }
                 }
               }

--- a/packages/wattpm/test/build.test.js
+++ b/packages/wattpm/test/build.test.js
@@ -1,6 +1,7 @@
 import { safeRemove, saveConfigurationFile } from '@platformatic/foundation'
 import { deepStrictEqual, ok } from 'node:assert'
 import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { prepareRuntime } from '../../basic/test/helper.js'
@@ -17,6 +18,15 @@ test('build - should build the application', async t => {
   await wattpm('build', buildDir)
 
   ok(existsSync(resolve(applicationDir, 'dist/index.js')))
+  deepStrictEqual(
+    (await readFile(resolve(buildDir, 'build-hooks.log'), 'utf8')).trim().split('\n'),
+    [
+      'preBuild:main',
+      'onBuild:before:main',
+      'onBuild:after:main',
+      'postBuild:main'
+    ]
+  )
 })
 
 test('build - should build the application from an application file', async t => {

--- a/packages/wattpm/test/fixtures/build/build-extension.js
+++ b/packages/wattpm/test/fixtures/build/build-extension.js
@@ -1,0 +1,21 @@
+import { appendFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export default async function setup ({ root }) {
+  const log = join(root, 'build-hooks.log')
+
+  return {
+    async preBuild ({ applicationId }) {
+      await appendFile(log, `preBuild:${applicationId}\n`)
+    },
+    async onBuild ({ applicationId }, build) {
+      await appendFile(log, `onBuild:before:${applicationId}\n`)
+      const result = await build()
+      await appendFile(log, `onBuild:after:${applicationId}\n`)
+      return result
+    },
+    async postBuild ({ applicationId }) {
+      await appendFile(log, `postBuild:${applicationId}\n`)
+    }
+  }
+}

--- a/packages/wattpm/test/fixtures/build/watt.json
+++ b/packages/wattpm/test/fixtures/build/watt.json
@@ -7,6 +7,12 @@
     "level": "info"
   },
   "entrypoint": "main",
+  "extensions": [
+    {
+      "path": "build-extension.js",
+      "build": true
+    }
+  ],
   "autoload": {
     "path": "web"
   }


### PR DESCRIPTION
## Description

Allow runtime extensions to opt into the `wattpm build` lifecycle.

Extensions configured with `build: true` are loaded before application workers are created and can implement three awaited hooks:

- `preBuild(context)`
- `onBuild(context, build)`
- `postBuild(context, result)`

`onBuild` hooks compose as middleware, with the first registered extension as the outermost wrapper. They can wrap, transform, or replace the underlying application build. The final result is passed to `postBuild` hooks in reverse registration order.

The build context contains the application ID and absolute application path.

Existing string extensions and object extensions without `build: true` remain disabled during builds, preserving existing behavior.

Each `onBuild` continuation can only be invoked once. Duplicate calls fail with `PLT_RUNTIME_EXTENSION_BUILD_ALREADY_CALLED`.

Build-enabled extensions are closed with the runtime, while their `start` and `stop` hooks are not invoked during builds.

## Motivation

Runtime extensions can already integrate with the runtime lifecycle, but they are not loaded during application builds.

This change adds an explicit, backward-compatible integration point for extensions that need to prepare, wrap, observe, or transform application builds without requiring application-specific wiring.

## Testing

Added coverage for:

- Build-hook ordering and middleware composition.
- Explicit build opt-in and backward compatibility.
- Propagation of transformed build results to `postBuild`.
- Duplicate build-continuation calls.
- `preBuild`, `onBuild`, and `postBuild` failure behavior.
- Public TypeScript interfaces.
- A real `wattpm build` integration fixture.

Validation:

- Runtime extension tests: 31/31.
- Runtime type tests: 49/49, 144 assertions.
- WATT build tests: 4/4.
- Changed-package lint: 18/18 packages.
- `git diff --check`.
