### PR TITLE
fix(gateway): keep body-less response status codes in the composed OpenAPI document

### DIFF
--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -289,7 +289,7 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
 
 - **`refreshTimeout`** (`number`) - The number of milliseconds to wait for check for changes in the applications. If not specified, the default value is `1000`; set to `0` to disable. This is only supported if the Gateway is running within a [Platformatic Runtime](../runtime/overview.md).
 
-- **`addEmptySchema`** (`boolean`) - If true, the gateway will add an empty response schema to the composed OpenAPI specification. Default is `false`.
+- **`addEmptySchema`** (`boolean`) - Deprecated, it no longer has any effect. Responses which declare no body - a `204`, a `304`, or any other status code whose response object has no `content` - always keep their status code in the composed OpenAPI specification, and are documented without a body.
 
 - **`handler`** (`string`) - Path to a JavaScript or TypeScript module that exports a custom proxy handler, either as `handler` or as the default export. The handler receives `(request, reply, dest, options)`, where `dest` is the rewritten proxy destination and `options` are the reply options passed to `reply.from()`. By default, proxied requests call `reply.from(dest, options)`; use this option to customize that behavior.
 

--- a/packages/gateway/lib/openapi-generator.js
+++ b/packages/gateway/lib/openapi-generator.js
@@ -152,7 +152,7 @@ async function openApiGatewayPlugin (app, { opts, generated }) {
   const openApiGlue = await import('@platformatic/fastify-openapi-glue')
 
   try {
-    await registerOpenApiGlue(app, openApiGlue, opts, apiByApiRoutes)
+    await registerOpenApiGlue(app, openApiGlue, apiByApiRoutes)
   } catch (error) {
     // The glue rejects the whole composed specification with a generic error.
     // Re-validate each downstream schema separately so the error names the
@@ -175,10 +175,10 @@ async function openApiGatewayPlugin (app, { opts, generated }) {
   })
 }
 
-async function registerOpenApiGlue (app, openApiGlue, opts, apiByApiRoutes) {
+async function registerOpenApiGlue (app, openApiGlue, apiByApiRoutes) {
   await app.register(openApiGlue, {
     specification: app.composedOpenApiSchema,
-    addEmptySchema: opts.addEmptySchema,
+    addEmptySchema: true,
     operationResolver: (operationId, method, openApiPath) => {
       const { origin, prefix, schema } = apiByApiRoutes[openApiPath]
       const originPath = schema[originPathSymbol]

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -54,7 +54,7 @@
     "@fastify/view": "^12.0.0",
     "@platformatic/basic": "workspace:*",
     "@platformatic/dynamic-buffer": "^0.4.0",
-    "@platformatic/fastify-openapi-glue": "^5.1.0",
+    "@platformatic/fastify-openapi-glue": "^5.2.0",
     "@platformatic/foundation": "workspace:*",
     "@platformatic/globals": "workspace:*",
     "@platformatic/graphql-composer": "^0.11.0",

--- a/packages/gateway/test/openapi/empty-body-responses.test.js
+++ b/packages/gateway/test/openapi/empty-body-responses.test.js
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createBasicApplication, createFromConfig } from '../helper.js'
+
+async function composeBasicApplication (t, gatewayOptions = {}) {
+  const api = await createBasicApplication(t)
+
+  api.get(
+    '/no-content',
+    {
+      schema: {
+        response: {
+          204: { type: 'null' }
+        }
+      }
+    },
+    async (req, reply) => reply.code(204).send()
+  )
+
+  api.get(
+    '/mixed',
+    {
+      schema: {
+        response: {
+          200: { type: 'object', properties: { text: { type: 'string' } } },
+          204: { type: 'null' }
+        }
+      }
+    },
+    async () => ({ text: 'Some text' })
+  )
+
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      ...gatewayOptions,
+      applications: [
+        {
+          id: 'api',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json'
+          }
+        }
+      ]
+    }
+  })
+
+  await gateway.start({ listen: true })
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  })
+  assert.equal(statusCode, 200)
+
+  return { schema: JSON.parse(body), gateway }
+}
+
+test('should keep the status codes of responses which declare no body', async t => {
+  const { schema } = await composeBasicApplication(t)
+
+  const responses = schema.paths['/empty'].get.responses
+
+  assert.deepEqual(Object.keys(responses).sort(), ['204', '302'])
+  assert.equal(responses['204'].content, undefined)
+  assert.equal(responses['302'].content, undefined)
+})
+
+test('should not alter responses which declare a body', async t => {
+  const { schema } = await composeBasicApplication(t)
+
+  const responses = schema.paths['/object'].get.responses
+
+  assert.deepEqual(Object.keys(responses), ['200'])
+  assert.deepEqual(responses['200'].content['application/json'].schema, {
+    type: 'object',
+    properties: { text: { type: 'string' } },
+    required: ['text']
+  })
+})
+
+test('should keep both the body-less and the described responses of an operation', async t => {
+  const { schema } = await composeBasicApplication(t)
+
+  const responses = schema.paths['/mixed'].get.responses
+
+  assert.deepEqual(Object.keys(responses).sort(), ['200', '204'])
+  assert.deepEqual(responses['200'].content['application/json'].schema, {
+    type: 'object',
+    properties: { text: { type: 'string' } }
+  })
+  assert.equal(responses['204'].content, undefined)
+})
+
+test('should not change the body-less responses when the deprecated addEmptySchema is set', async t => {
+  const { schema } = await composeBasicApplication(t, { addEmptySchema: true })
+
+  const responses = schema.paths['/empty'].get.responses
+
+  assert.deepEqual(Object.keys(responses).sort(), ['204', '302'])
+  assert.equal(responses['204'].content, undefined)
+  assert.equal(responses['302'].content, undefined)
+})
+
+test('should proxy a body-less response as it is', async t => {
+  const { gateway } = await composeBasicApplication(t)
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/no-content'
+  })
+
+  assert.equal(statusCode, 204)
+  assert.equal(body, '')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,8 +755,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@platformatic/fastify-openapi-glue':
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.0
+        version: 5.2.0
       '@platformatic/foundation':
         specifier: workspace:*
         version: link:../foundation
@@ -5386,8 +5386,8 @@ packages:
     resolution: {integrity: sha512-eCL++LyBjSsqalm4I67dl+gVqLSKd6gPYCieD72S5KqqAkmSAgAYNHt+lL+iVXssWPSfbuIJ5PEwpn5JVD73Xw==}
     engines: {node: '>= 22.19.0'}
 
-  '@platformatic/fastify-openapi-glue@5.1.0':
-    resolution: {integrity: sha512-R5bHPQast/w5p+I+/Y5X1r+A8Fxqn7z0etWeaSYrFkbLvvGTEFGvldu0QGXnKjHo6XQo0P2o6D6gNr5uc36ZEA==}
+  '@platformatic/fastify-openapi-glue@5.2.0':
+    resolution: {integrity: sha512-5Syxh9EHCcxwrTvqRm2jv9Lpw7AUni3EWK95/5aFtIFAtz+POxlCbMaHcz3rdAD+D44nd1ZGqWa6wZ6dKNTqlg==}
 
   '@platformatic/graphql-composer@0.11.0':
     resolution: {integrity: sha512-e3EZH1okfdQPkhTNPrijgGQrlETFVO1V5WOjxN4EJFYRlurZdmqSuJw56JgvD08TMhdRXgwQK9bAbn1ZY2YzHg==}
@@ -16525,7 +16525,7 @@ snapshots:
 
   '@platformatic/dynamic-buffer@0.4.0': {}
 
-  '@platformatic/fastify-openapi-glue@5.1.0':
+  '@platformatic/fastify-openapi-glue@5.2.0':
     dependencies:
       '@platformatic/openapi-schema-validator': 3.0.0
       fastify-plugin: 5.1.0


### PR DESCRIPTION
# `@platformatic/gateway` reports body-less responses (204, 304, …) as `200`

## Symptom

When a composed application declares a response with no body — a `204`, a `304`, or any status
code whose OpenAPI response object has no `content` — the gateway's composed OpenAPI document does
not report that status code.

* If the operation had **only** body-less responses, they all disappear and the operation is
  documented as `200: Default Response` — a status code the application never returns.
* If the operation **also** had a response with a body, the body-less ones are silently dropped
  from the document while the others survive.

A downstream route declaring

```js
app.get('/refresh', { schema: { response: { 204: { type: 'null' } } } },
  async (req, reply) => reply.status(204).send())
```

publishes this in its own document:

```json
{ "get": { "summary": "Refresh session",
           "responses": { "204": { "description": "Default Response" } } } }
```

and the gateway composes it as:

```json
{ "get": { "summary": "Refresh session",
           "responses": { "200": { "description": "Default Response" } } } }
```

The runtime behaviour is correct — a request through the gateway still answers `204`. Only the
document is wrong, and typed clients and contract tests are generated from that document: a client
generated with `@hey-api/openapi-ts` declares `GetRefreshResponses = { 200: unknown }` for a route
which only ever answers `204`.

## Cause

`@platformatic/fastify-openapi-glue` registers the composed document as routes, and
`@fastify/swagger` regenerates the gateway's document from those routes. A response object without
`content` is dropped by the glue while registering, so the status code is not on the route to be
regenerated from — and an operation left with no response schema at all gets the
`200: Default Response` fallback.

## Fix

Fixed in the glue, as suggested in review: platformatic/fastify-openapi-glue#68 makes
`addEmptySchema` register body-less responses with a `{ type: 'null' }` schema — how Fastify spells
"this response carries no body" — instead of an empty `{}` schema, which advertises an
`application/json` body. `@fastify/swagger` turns `{ type: 'null' }` back into a response object
without `content`, so the status code round-trips.

Here, the gateway enables `addEmptySchema` unconditionally when it registers the glue. Those
response schemas only shape the document: every composed route answers with the stream
`@fastify/reply-from` proxies, and Fastify does not serialize streams. There is no reason for the
composed document to lose a status code the application document declares, so the
`addEmptySchema` gateway option is now redundant and is documented as deprecated.

One consequence worth stating: a status code an application documents without `content` is now
composed as a body-less response instead of being dropped from the document. The composed document
mirrors the application document — if an application does answer that status with a body, it is
the application document which needs the `content`.

Depends on `@platformatic/fastify-openapi-glue` 5.2.0, released with that fix and locked here.

## Tests

`packages/gateway/test/openapi/empty-body-responses.test.js`:

* body-less responses keep their status code and are documented with no content;
* responses which declare a body are unchanged;
* an operation with both a described and a body-less response keeps both;
* setting the deprecated `addEmptySchema` changes nothing;
* a proxied `204` still reaches the caller as a `204` with an empty body.
