### PR TITLE
fix(next): store Map type of Next.js cache entries

### DIFF
--- a/packages/next/lib/caching/valkey-common.js
+++ b/packages/next/lib/caching/valkey-common.js
@@ -122,10 +122,63 @@ export function getPlatformaticMeta () {
   }
 }
 
+// msgpackr has no wire-level distinction between a plain object and a Map (both encode
+// as the same msgpack "map" type), and it packs Map instances natively before any custom
+// extension is consulted. Next.js cache entries can carry Map fields (e.g. segmentData for
+// Cache Components / "use cache" pages), so we tag Map instances before packing and restore
+// them after unpacking to round-trip them without affecting plain objects elsewhere.
+const MAP_TYPE_TAG = 'Map'
+
+function markMaps (value) {
+  if (value instanceof Map) {
+    const entries = []
+    for (const [key, entryValue] of value) {
+      entries.push([markMaps(key), markMaps(entryValue)])
+    }
+    return { __type: MAP_TYPE_TAG, entries }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(markMaps)
+  }
+
+  if (value !== null && typeof value === 'object' && value.constructor === Object) {
+    const result = {}
+    for (const key of Object.keys(value)) {
+      result[key] = markMaps(value[key])
+    }
+    return result
+  }
+
+  return value
+}
+
+function unmarkMaps (value) {
+  if (value !== null && typeof value === 'object') {
+    if (Array.isArray(value)) {
+      return value.map(unmarkMaps)
+    }
+
+    if (value.constructor === Object) {
+      if (value.__type === MAP_TYPE_TAG) {
+        return new Map(value.entries.map(([key, entryValue]) => [unmarkMaps(key), unmarkMaps(entryValue)]))
+      }
+
+      const result = {}
+      for (const key of Object.keys(value)) {
+        result[key] = unmarkMaps(value[key])
+      }
+      return result
+    }
+  }
+
+  return value
+}
+
 export function serialize (data) {
-  return msgpackr.pack(data).toString('base64url')
+  return msgpackr.pack(markMaps(data)).toString('base64url')
 }
 
 export function deserialize (data) {
-  return msgpackr.unpack(Buffer.from(data, 'base64url'))
+  return unmarkMaps(msgpackr.unpack(Buffer.from(data, 'base64url')))
 }

--- a/packages/next/lib/caching/valkey-common.js
+++ b/packages/next/lib/caching/valkey-common.js
@@ -52,7 +52,12 @@ export function ensureRedis () {
 
 export function ensureMsgpackr () {
   if (!msgpackr) {
-    msgpackr = require('msgpackr')
+    const { Packr } = require('msgpackr')
+    // A fresh Packr instance (unlike msgpackr's default pack/unpack singleton, which hardcodes
+    // useRecords: false) uses the record extension for plain objects, which keeps them
+    // distinguishable on the wire from Map instances, preserving Map identity round-trip.
+    // moreTypes additionally preserves Set/RegExp/Error, should they ever appear in cache data.
+    msgpackr = new Packr({ moreTypes: true })
   }
 }
 
@@ -122,63 +127,10 @@ export function getPlatformaticMeta () {
   }
 }
 
-// msgpackr has no wire-level distinction between a plain object and a Map (both encode
-// as the same msgpack "map" type), and it packs Map instances natively before any custom
-// extension is consulted. Next.js cache entries can carry Map fields (e.g. segmentData for
-// Cache Components / "use cache" pages), so we tag Map instances before packing and restore
-// them after unpacking to round-trip them without affecting plain objects elsewhere.
-const MAP_TYPE_TAG = 'Map'
-
-function markMaps (value) {
-  if (value instanceof Map) {
-    const entries = []
-    for (const [key, entryValue] of value) {
-      entries.push([markMaps(key), markMaps(entryValue)])
-    }
-    return { __type: MAP_TYPE_TAG, entries }
-  }
-
-  if (Array.isArray(value)) {
-    return value.map(markMaps)
-  }
-
-  if (value !== null && typeof value === 'object' && value.constructor === Object) {
-    const result = {}
-    for (const key of Object.keys(value)) {
-      result[key] = markMaps(value[key])
-    }
-    return result
-  }
-
-  return value
-}
-
-function unmarkMaps (value) {
-  if (value !== null && typeof value === 'object') {
-    if (Array.isArray(value)) {
-      return value.map(unmarkMaps)
-    }
-
-    if (value.constructor === Object) {
-      if (value.__type === MAP_TYPE_TAG) {
-        return new Map(value.entries.map(([key, entryValue]) => [unmarkMaps(key), unmarkMaps(entryValue)]))
-      }
-
-      const result = {}
-      for (const key of Object.keys(value)) {
-        result[key] = unmarkMaps(value[key])
-      }
-      return result
-    }
-  }
-
-  return value
-}
-
 export function serialize (data) {
-  return msgpackr.pack(markMaps(data)).toString('base64url')
+  return msgpackr.pack(data).toString('base64url')
 }
 
 export function deserialize (data) {
-  return unmarkMaps(msgpackr.unpack(Buffer.from(data, 'base64url')))
+  return msgpackr.unpack(Buffer.from(data, 'base64url'))
 }

--- a/packages/next/test/caching/valkey-isr.test.js
+++ b/packages/next/test/caching/valkey-isr.test.js
@@ -1057,6 +1057,38 @@ test('can be used without the runtime - standalone mode', async t => {
   ])
 })
 
+test('should preserve Map identity for values like segmentData across the Valkey round trip', async t => {
+  const logger = {
+    trace: () => {},
+    error: (obj, msg) => { console.log('cache error', msg, obj) }
+  }
+
+  const valkey = new Redis(await getValkeyUrl(resolve(fixturesDir, configuration)))
+  await cleanupCache(valkey)
+
+  t.after(async () => {
+    await cleanupCache(valkey)
+    await valkey.disconnect()
+  })
+
+  const handler = new CacheHandler({ standalone: true, store: valkey, prefix: valkeyPrefix, logger })
+  const key = `${valkeyPrefix}:segment-data`
+
+  const segmentData = new Map([
+    ['/foo', { rsc: Buffer.from('foo') }],
+    ['/bar', { rsc: Buffer.from('bar') }]
+  ])
+
+  await handler.set(key, { html: 'content', segmentData }, { revalidate: 120, tags: ['first'] })
+  const cached = await handler.get(key)
+
+  ok(cached.value.segmentData instanceof Map)
+  deepStrictEqual(Array.from(cached.value.segmentData.keys()), ['/foo', '/bar'])
+  deepStrictEqual(cached.value.segmentData.get('/foo').rsc, Buffer.from('foo'))
+  deepStrictEqual(cached.value.segmentData.get('/bar').rsc, Buffer.from('bar'))
+  deepStrictEqual(cached.value.html, 'content')
+})
+
 test('should cache static pages with revalidate: false (force-static / SSG)', async t => {
   const logs = []
   const logsPromise = Promise.withResolvers()


### PR DESCRIPTION
Fixes: #5057 

Next.js cache entries can carry Map fields (e.g. segmentData for Cache Components / "use cache" pages), so we tag Map instances before packing and restore them after unpacking to preserve Map instance.

This fix was inspired by https://github.com/vercel/next.js/pull/95346

Assisted-by: Claude Code:claude-sonnet-5