### PR TITLE
fix(gateway): build welcome page URLs from origin and pathname

### DIFF
--- a/packages/gateway/public/index.njk
+++ b/packages/gateway/public/index.njk
@@ -68,13 +68,23 @@
     </div>
 
     <script>
-      let currentPath = window.location.pathname
-      const href = window.location.href.replace(/\/$/, '')
+      // Build URLs from origin + pathname, never from window.location.href.
+      // href carries the query string and fragment, so concatenating a service
+      // path onto it folds that path INTO the query instead of appending to it:
+      // at "/?dpl=v1" the old `href + '/next/'` produced "/?dpl=v1/next/", which
+      // requests the root again with a mangled query. Any URL with a query hits
+      // this; skew protection puts `?dpl=<version>` on the URL routinely.
+      const basePath = window.location.pathname.replace(/\/$/, '')
+      const baseUrl = window.location.origin + basePath
+      // Trailing slash restored so relative asset paths resolve under the mount
+      // point: "" -> "/", "/my-app" -> "/my-app/". Concatenating a bare pathname
+      // produced "/my-appimages/..." when the gateway was mounted on a prefix.
+      const currentPath = basePath + '/'
       {% for key, value in services %}
         {% if key === 'proxy' %}
           {% if value.services.length %}
             {% for svc in value.services %}
-        document.getElementById('{{ key }}-{{ svc.id}}-external-link').href = href + '{{ svc.externalLink }}'
+        document.getElementById('{{ key }}-{{ svc.id}}-external-link').href = baseUrl + '{{ svc.externalLink }}'
             {% endfor %}
           {% endif %}
         {% endif %}

--- a/packages/gateway/test/openapi/root-endpoint.test.js
+++ b/packages/gateway/test/openapi/root-endpoint.test.js
@@ -200,20 +200,27 @@ test('should have links to composed applications', async t => {
   assert.ok(content.includes('<div class="service-path">/internal/service3</div>'))
 
   assert.ok(
-    content.includes("document.getElementById('proxy-service1-external-link').href = href + '/internal/service1/'")
+    content.includes("document.getElementById('proxy-service1-external-link').href = baseUrl + '/internal/service1/'")
   )
   assert.ok(
-    content.includes("document.getElementById('proxy-service2-external-link').href = href + '/internal/service2/'")
+    content.includes("document.getElementById('proxy-service2-external-link').href = baseUrl + '/internal/service2/'")
   )
   assert.ok(
-    content.includes("document.getElementById('proxy-service3-external-link').href = href + '/internal/service3/'")
+    content.includes("document.getElementById('proxy-service3-external-link').href = baseUrl + '/internal/service3/'")
   )
 
   assert.ok(content.includes('<div class="service-path">/service1</div>'))
   assert.ok(content.includes('<div class="service-path">/service2</div>'))
   assert.ok(content.includes('<div class="service-path">/service3</div>'))
 
-  assert.ok(content.includes("const href = window.location.href.replace(/\\/$/, '')"))
+  // Links are built from origin + pathname, never from window.location.href:
+  // href carries the query string, so concatenating a service path onto it
+  // folds that path into the query (at "/?dpl=v1" the old code produced
+  // "/?dpl=v1/internal/service1/"). See packages/gateway/public/index.njk.
+  assert.ok(content.includes("const basePath = window.location.pathname.replace(/\\/$/, '')"))
+  assert.ok(content.includes('const baseUrl = window.location.origin + basePath'))
+  // The buggy form specifically: href includes the query string.
+  assert.ok(!content.includes('const href = window.location.href'))
 })
 
 test('should honour openapi.swaggerPrefix in the root page and spec routes', async t => {


### PR DESCRIPTION
The gateway welcome page built its links by string-concatenating `window.location.href`, which carries the query string and fragment. Appending a service path to it folds that path **into the query** instead of onto the path.

```js
const href = window.location.href.replace(/\/$/, '')
document.getElementById('proxy-next-external-link').href = href + '/next/'
```

At `https://example.com/` that happens to work, because there is no query to get in the way. With any query it breaks:

```
https://example.com/?dpl=v1  +  /next/   ->  https://example.com/?dpl=v1/next/
```

The result is a valid URL, so the browser navigates happily -- to the gateway root again, with `dpl=v1/next/` as the parameter value. Nothing errors; the link simply goes somewhere else.

Fixed by building from origin and pathname, which is what the link actually needs:

```js
const basePath = window.location.pathname.replace(/\/$/, '')
const baseUrl = window.location.origin + basePath
```

### Also fixes the logo on prefix-mounted gateways

The same block did `currentPath + 'images/...'` with `currentPath = window.location.pathname`, which is only correct when the path ends in a slash. A gateway mounted at `/my-app` produced `/my-appimages/platformatic-logo-light.svg`, so the logo silently 404'd. `currentPath` is now `basePath + '/'`, which normalises `/` and `/my-app` alike.
