### PR TITLE
feat(sql-openapi): support contains, contained and overlaps for array fields

### DIFF
--- a/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
+++ b/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
@@ -271,6 +271,14 @@
               "type": "string"
             },
             "in": "query",
+            "name": "where.tags.overlaps",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
             "name": "where.title.eq",
             "required": false
           },
@@ -639,6 +647,14 @@
             },
             "in": "query",
             "name": "where.tags.any",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "where.tags.overlaps",
             "required": false
           },
           {

--- a/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
+++ b/packages/sql-openapi/.snapshots/fc0944aa1ec1756e986c31ce837e6031/0.json
@@ -271,6 +271,22 @@
               "type": "string"
             },
             "in": "query",
+            "name": "where.tags.contains",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "where.tags.contained",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
             "name": "where.tags.overlaps",
             "required": false
           },
@@ -647,6 +663,22 @@
             },
             "in": "query",
             "name": "where.tags.any",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "where.tags.contains",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "where.tags.contained",
             "required": false
           },
           {

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -17,6 +17,7 @@ export function generateArgs (entity, ignore) {
         const key = baseKey + modifier
         acc[key] = { type: mapSQLTypeToOpenAPIType(field.sqlType) }
       }
+      acc[baseKey + 'overlaps'] = { type: 'string' }
     } else {
       for (const modifier of ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike']) {
         const key = baseKey + modifier
@@ -174,7 +175,8 @@ export function rootEntityRoutes (
             const [, field, modifier] = key.split('.')
             where[field] ||= {}
             let value = query[key]
-            if (modifier === 'in' || modifier === 'nin') {
+            const isArrayField = entity.camelCasedFields[field]?.isArray
+            if (modifier === 'in' || modifier === 'nin' || (isArrayField && modifier === 'overlaps')) {
               // TODO handle escaping of ,
               value = query[key].split(',')
               if (mapSQLTypeToOpenAPIType(entity.camelCasedFields[field].sqlType) === 'integer') {
@@ -331,7 +333,8 @@ export function rootEntityRoutes (
             const [, field, modifier] = key.split('.')
             where[field] ||= {}
             let value = query[key]
-            if (modifier === 'in' || modifier === 'nin') {
+            const isArrayField = entity.camelCasedFields[field]?.isArray
+            if (modifier === 'in' || modifier === 'nin' || (isArrayField && modifier === 'overlaps')) {
               // TODO handle escaping of ,
               value = query[key].split(',')
               if (mapSQLTypeToOpenAPIType(entity.camelCasedFields[field].sqlType) === 'integer') {

--- a/packages/sql-openapi/lib/shared.js
+++ b/packages/sql-openapi/lib/shared.js
@@ -2,6 +2,9 @@ import { mapSQLTypeToOpenAPIType } from '@platformatic/sql-json-schema-mapper'
 import { buildCursorUtils } from './cursor.js'
 import * as errors from './errors.js'
 
+// Array-to-array comparators take a comma-separated list of values
+const arrayFieldListModifiers = ['contains', 'contained', 'overlaps']
+
 export function generateArgs (entity, ignore) {
   const sortedEntityFields = Object.keys(entity.fields).sort()
 
@@ -17,7 +20,9 @@ export function generateArgs (entity, ignore) {
         const key = baseKey + modifier
         acc[key] = { type: mapSQLTypeToOpenAPIType(field.sqlType) }
       }
-      acc[baseKey + 'overlaps'] = { type: 'string' }
+      for (const modifier of arrayFieldListModifiers) {
+        acc[baseKey + modifier] = { type: 'string' }
+      }
     } else {
       for (const modifier of ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike']) {
         const key = baseKey + modifier
@@ -176,7 +181,7 @@ export function rootEntityRoutes (
             where[field] ||= {}
             let value = query[key]
             const isArrayField = entity.camelCasedFields[field]?.isArray
-            if (modifier === 'in' || modifier === 'nin' || (isArrayField && modifier === 'overlaps')) {
+            if (modifier === 'in' || modifier === 'nin' || (isArrayField && arrayFieldListModifiers.includes(modifier))) {
               // TODO handle escaping of ,
               value = query[key].split(',')
               if (mapSQLTypeToOpenAPIType(entity.camelCasedFields[field].sqlType) === 'integer') {
@@ -334,7 +339,7 @@ export function rootEntityRoutes (
             where[field] ||= {}
             let value = query[key]
             const isArrayField = entity.camelCasedFields[field]?.isArray
-            if (modifier === 'in' || modifier === 'nin' || (isArrayField && modifier === 'overlaps')) {
+            if (modifier === 'in' || modifier === 'nin' || (isArrayField && arrayFieldListModifiers.includes(modifier))) {
               // TODO handle escaping of ,
               value = query[key].split(',')
               if (mapSQLTypeToOpenAPIType(entity.camelCasedFields[field].sqlType) === 'integer') {

--- a/packages/sql-openapi/test/arrays.test.js
+++ b/packages/sql-openapi/test/arrays.test.js
@@ -273,3 +273,94 @@ test('expose arrays', { skip: !isPg }, async t => {
     )
   }
 })
+
+test('filter arrays with overlaps', { skip: !isPg }, async t => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+      await db.query(sql`CREATE TABLE pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(42) NOT NULL,
+      tags VARCHAR(42)[] NOT NULL
+    );`)
+    }
+  })
+  app.register(sqlOpenAPI)
+  t.after(async () => {
+    await app.close()
+  })
+
+  await app.ready()
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json'
+    })
+    const properties = res.json().paths['/pages/'].get.parameters.map(p => p.name)
+    equal(properties.includes('where.tags.overlaps'), true, 'where.tags.overlaps is documented')
+  }
+
+  for (const page of [
+    { title: 'First', tags: ['foo', 'bar'] },
+    { title: 'Second', tags: ['bar', 'baz'] },
+    { title: 'Third', tags: ['qux'] }
+  ]) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pages',
+      body: page
+    })
+    equal(res.statusCode, 200, 'POST /pages status code')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/pages?where.tags.overlaps=foo'
+    })
+    equal(res.statusCode, 200, 'GET /pages?where.tags.overlaps=foo status code')
+    same(
+      res.json().map(p => p.title),
+      ['First'],
+      'overlaps with a single value only matches pages containing it'
+    )
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/pages?where.tags.overlaps=foo,baz&orderby.id=asc'
+    })
+    equal(res.statusCode, 200, 'GET /pages?where.tags.overlaps=foo,baz status code')
+    same(
+      res.json().map(p => p.title),
+      ['First', 'Second'],
+      'overlaps with multiple values matches pages containing any of them'
+    )
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/pages?where.tags.overlaps=nope'
+    })
+    equal(res.statusCode, 200, 'GET /pages?where.tags.overlaps=nope status code')
+    same(res.json(), [], 'overlaps with no matching value returns an empty list')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/pages?where.tags.overlaps=bar,qux&fields=title',
+      body: {
+        title: 'Updated',
+        tags: ['updated']
+      }
+    })
+    equal(res.statusCode, 200, 'PUT /pages?where.tags.overlaps=bar,qux status code')
+    equal(res.json().length, 3, 'updateMany with overlaps updates all matching pages')
+  }
+})

--- a/packages/sql-openapi/test/arrays.test.js
+++ b/packages/sql-openapi/test/arrays.test.js
@@ -274,7 +274,7 @@ test('expose arrays', { skip: !isPg }, async t => {
   }
 })
 
-test('filter arrays with overlaps', { skip: !isPg }, async t => {
+test('filter arrays with contains, contained and overlaps', { skip: !isPg }, async t => {
   const app = fastify()
   app.register(sqlMapper, {
     ...connInfo,
@@ -300,7 +300,9 @@ test('filter arrays with overlaps', { skip: !isPg }, async t => {
       url: '/documentation/json'
     })
     const properties = res.json().paths['/pages/'].get.parameters.map(p => p.name)
-    equal(properties.includes('where.tags.overlaps'), true, 'where.tags.overlaps is documented')
+    for (const modifier of ['contains', 'contained', 'overlaps']) {
+      equal(properties.includes(`where.tags.${modifier}`), true, `where.tags.${modifier} is documented`)
+    }
   }
 
   for (const page of [
@@ -349,6 +351,58 @@ test('filter arrays with overlaps', { skip: !isPg }, async t => {
     })
     equal(res.statusCode, 200, 'GET /pages?where.tags.overlaps=nope status code')
     same(res.json(), [], 'overlaps with no matching value returns an empty list')
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/pages?where.tags.contains=bar&orderby.id=asc'
+    })
+    equal(res.statusCode, 200, 'GET /pages?where.tags.contains=bar status code')
+    same(
+      res.json().map(p => p.title),
+      ['First', 'Second'],
+      'contains with a single value matches pages containing it'
+    )
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/pages?where.tags.contains=foo,bar'
+    })
+    equal(res.statusCode, 200, 'GET /pages?where.tags.contains=foo,bar status code')
+    same(
+      res.json().map(p => p.title),
+      ['First'],
+      'contains with multiple values only matches pages containing all of them'
+    )
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/pages?where.tags.contained=foo,bar,baz&orderby.id=asc'
+    })
+    equal(res.statusCode, 200, 'GET /pages?where.tags.contained=foo,bar,baz status code')
+    same(
+      res.json().map(p => p.title),
+      ['First', 'Second'],
+      'contained matches pages whose tags are a subset of the values'
+    )
+  }
+
+  {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/pages?where.tags.contained=qux'
+    })
+    equal(res.statusCode, 200, 'GET /pages?where.tags.contained=qux status code')
+    same(
+      res.json().map(p => p.title),
+      ['Third'],
+      'contained with a single value only matches pages with no other tags'
+    )
   }
 
   {


### PR DESCRIPTION
Closes #5061.

Exposes the `contains`, `contained` and `overlaps` modifiers for array fields in the generated querystring schema and splits their comma-separated values in the list (GET) and updateMany (PUT) handlers, mirroring the `in`/`nin` handling. Adds discriminating tests (multiple rows) so a dropped filter can no longer pass unnoticed.

Full `@platformatic/sql-openapi` suite passes locally against PostgreSQL, MariaDB, MySQL 5.7, MySQL 8 and SQLite, plus the type tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)