### PR TITLE
fix(nuxt): report real dev server URL via Nuxt ready event

### DIFF
--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -513,7 +513,7 @@ export class BaseCapability extends EventEmitter {
     }
   }
 
-  async startWithCommand (command, loader, scripts) {
+  async startWithCommand (command, loader, scripts, { urlFromScript = false } = {}) {
     const config = this.config
     const basePath = config.application?.basePath ? cleanBasePath(config.application?.basePath) : ''
 
@@ -522,7 +522,8 @@ export class BaseCapability extends EventEmitter {
       logger: this.logger,
       loader,
       context,
-      scripts
+      scripts,
+      urlFromScript
     })
 
     this.setupChildManagerEventsForwarding(this.childManager)

--- a/packages/basic/lib/worker/child-manager.js
+++ b/packages/basic/lib/worker/child-manager.js
@@ -46,6 +46,7 @@ export class ChildManager extends ITC {
   #loader
   #context
   #scripts
+  #urlFromScript
   #logger
   #server
   #websocketServer
@@ -59,10 +60,11 @@ export class ChildManager extends ITC {
   #dataPath
 
   constructor (opts) {
-    let { loader, context, scripts, handlers, ...itcOpts } = opts
+    let { loader, context, scripts, urlFromScript, handlers, ...itcOpts } = opts
 
     context ??= {}
     scripts ??= []
+    urlFromScript ??= false
 
     super({
       ...itcOpts,
@@ -73,6 +75,7 @@ export class ChildManager extends ITC {
     this.#loader = loader
     this.#context = context
     this.#scripts = scripts
+    this.#urlFromScript = urlFromScript
     this.#originalNodeOptions = process.env.NODE_OPTIONS
     this.#logger = getLogger()
     this.#server = createServer(this.#childProcessFetchHandler.bind(this))
@@ -154,7 +157,8 @@ export class ChildManager extends ITC {
         {
           data: this.#context,
           loader: ensureFileUrl(this.#loader),
-          scripts: this.#scripts.map(s => ensureFileUrl(s))
+          scripts: this.#scripts.map(s => ensureFileUrl(s)),
+          urlFromScript: this.#urlFromScript
         },
         null,
         2

--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -109,8 +109,9 @@ export class ChildProcess extends ITC {
   #otlpBridge
   #pendingMessages
   #replStream
+  #urlFromScript
 
-  constructor (executable) {
+  constructor (executable, { urlFromScript = false } = {}) {
     const events = getEvents()
 
     super({
@@ -176,6 +177,7 @@ export class ChildProcess extends ITC {
     const protocol = platform() === 'win32' ? 'ws+unix:' : 'ws+unix://'
     this.#socket = new WebSocket(`${protocol}${getSocketPath(process.env.PLT_MANAGER_ID)}`)
     this.#pendingMessages = []
+    this.#urlFromScript = urlFromScript
     this.#metricsRegistry = new client.Registry()
 
     this.listen()
@@ -644,6 +646,14 @@ export class ChildProcess extends ITC {
       asyncEnd: ({ server }) => {
         tracingChannel('net.server.listen').unsubscribe(subscribers)
 
+        // When a script reports the app URL itself (urlFromScript), ignore the
+        // tracing-channel listen here (which fires for listhen/get-port-please's
+        // throwaway probe) to avoid reporting a stale URL that races the real
+        // server's startup.
+        if (this.#urlFromScript) {
+          return
+        }
+
         const address = server.address()
 
         // Unix socket, do nothing
@@ -840,7 +850,7 @@ async function main () {
   const executable = basename(process.argv[1] ?? '')
 
   const dataPath = resolve(tmpdir(), 'platformatic', 'runtimes', `${process.env.PLT_MANAGER_ID}.json`)
-  const { data, loader, scripts } = JSON.parse(await readFile(dataPath))
+  const { data, loader, scripts, urlFromScript } = JSON.parse(await readFile(dataPath))
 
   // Enable compile cache early before loading user modules
   await setupCompileCache(data)
@@ -866,7 +876,7 @@ async function main () {
     process.chdir(root)
   }
 
-  const childProcess = new ChildProcess(executable)
+  const childProcess = new ChildProcess(executable, { urlFromScript })
   updateGlobals({ itc: childProcess })
   events.target = childProcess
 }

--- a/packages/nuxt/lib/capability.js
+++ b/packages/nuxt/lib/capability.js
@@ -17,6 +17,7 @@ import {
 import inject from 'light-my-request'
 import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { satisfies } from 'semver'
 import { readSchedulerManifest } from './scheduled-tasks.js'
 import { version } from './schema.js'
@@ -222,7 +223,10 @@ export class NuxtCapability extends BaseCapability {
     }
 
     await this.startWithCommand(
-      `node ${resolve(this.#nuxt)}/bin/nuxt.mjs dev --host ${hostname} --port ${port} --no-open${httpsArgs}`
+      `node ${resolve(this.#nuxt)}/bin/nuxt.mjs dev --host ${hostname} --port ${port} --no-open --no-fork${httpsArgs}`,
+      null,
+      [fileURLToPath(new URL('./dev-ready.js', import.meta.url))],
+      { urlFromScript: true }
     )
 
     if (https) {

--- a/packages/nuxt/lib/dev-ready.js
+++ b/packages/nuxt/lib/dev-ready.js
@@ -1,0 +1,28 @@
+// Runs inside the spawned `nuxt.mjs dev` child process, before the Nuxt CLI loads.
+//
+// Nuxt 4's dev CLI probes a random port with a throwaway `net.Server` (via
+// listhen/get-port-please) before the real server listens. The generic URL
+// capture in `packages/basic/lib/worker/child-process.js` subscribes to the
+// FIRST `net.server.listen` trace and therefore reports the probe's URL, which
+// races the real server's startup and intermittently fails with ECONNREFUSED.
+//
+// This script opts the Nuxt child into Nuxt's own dev IPC so the CLI reports
+// its real `ready` address (after the build, when the serving server is up),
+// and forwards that URL to the parent via the child-manager `url` event — the
+// same channel `startWithCommand` already waits on.
+import { getITC } from '@platformatic/globals'
+
+process.env.__NUXT__FORK = '1'
+
+process.send = function (message) {
+  if (!message || message.type !== 'nuxt:internal:dev:ready') {
+    return
+  }
+
+  const address = message.address
+  if (typeof address !== 'string' || address.length === 0) {
+    return
+  }
+
+  getITC({ throwOnMissing: false })?.notify('url', address)
+}


### PR DESCRIPTION
Fixes the flaky `nuxt - ubuntu-24.04` CI job: the `supports https server options in development mode` test intermittently fails with `connect ECONNREFUSED 127.0.0.1:<port>`.

**Root cause.** `child-process.js` subscribes to the raw `net.server.listen` tracing channel and reports the app URL on the *first* `asyncEnd`. Nuxt 4's dev CLI probes a random port with a throwaway `net.Server` (via listhen/get-port-please) before the real server listens, so the parent captures the probe's URL and unsubscribes — the real server's listen never reaches it. The test then connects in the gap between probe-close and real-listen, hitting `ECONNREFUSED`.

**Fix.** A new Nuxt-specific child-manager script (`packages/nuxt/lib/dev-ready.js`) opts the spawned `nuxt.mjs dev` into Nuxt's own dev IPC so the CLI reports its real `ready` address (after the build, when the serving server is up), and forwards that URL to the parent via the child-manager `url` event. `child-process.js` skips the tracing-channel URL in Nuxt dev so only the real ready URL is reported, and the spawn uses `--no-fork` to avoid Nuxt's warm-fork pool competing for the port.
