### PR TITLE
fix(foundation): allow undici minor updates

### DIFF
--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -36,7 +36,7 @@
     "pino": "^9.9.0",
     "pino-pretty": "^13.0.0",
     "semver": "^7.6.3",
-    "undici": "7.28.0",
+    "undici": "^7.28.0",
     "yaml": "^2.4.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,7 +694,7 @@ importers:
         specifier: ^7.6.3
         version: 7.8.5
       undici:
-        specifier: 7.28.0
+        specifier: ^7.28.0
         version: 7.28.0
       yaml:
         specifier: ^2.4.1


### PR DESCRIPTION
Use `^7.28.0` for the undici dependency in the foundation package so minor version updates are allowed, matching the caret ranges used by other packages in the workspace.
