### PR TITLE
chore: merge main into v4

### DIFF
--- a/docs/guides/logger/applications/next/package.json
+++ b/docs/guides/logger/applications/next/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "next": "16.2.6",
+    "next": "16.2.11",
     "@platformatic/next": ">=3.0.0"
   }
 }

--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -289,7 +289,7 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
 
 - **`refreshTimeout`** (`number`) - The number of milliseconds to wait for check for changes in the applications. If not specified, the default value is `1000`; set to `0` to disable. This is only supported if the Gateway is running within a [Platformatic Runtime](../runtime/overview.md).
 
-- **`addEmptySchema`** (`boolean`) - If true, the gateway will add an empty response schema to the composed OpenAPI specification. Default is `false`.
+- **`addEmptySchema`** (`boolean`) - Deprecated, it no longer has any effect. Responses which declare no body - a `204`, a `304`, or any other status code whose response object has no `content` - always keep their status code in the composed OpenAPI specification, and are documented without a body.
 
 - **`handler`** (`string`) - Path to a JavaScript or TypeScript module that exports a custom proxy handler, either as `handler` or as the default export. The handler receives `(request, reply, dest, options)`, where `dest` is the rewritten proxy destination and `options` are the reply options passed to `reply.from()`. By default, proxied requests call `reply.from(dest, options)`; use this option to customize that behavior.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "platformatic",
   "type": "module",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "private": true,
   "scripts": {
     "test": "pnpm -r --workspace-concurrency=1 --if-present test",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/astro",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Astro Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/astro/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/astro/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Astro Config",
   "type": "object",

--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -513,7 +513,7 @@ export class BaseCapability extends EventEmitter {
     }
   }
 
-  async startWithCommand (command, loader, scripts) {
+  async startWithCommand (command, loader, scripts, { urlFromScript = false } = {}) {
     const config = this.config
     const basePath = config.application?.basePath ? cleanBasePath(config.application?.basePath) : ''
 
@@ -522,7 +522,8 @@ export class BaseCapability extends EventEmitter {
       logger: this.logger,
       loader,
       context,
-      scripts
+      scripts,
+      urlFromScript
     })
 
     this.setupChildManagerEventsForwarding(this.childManager)

--- a/packages/basic/lib/worker/child-manager.js
+++ b/packages/basic/lib/worker/child-manager.js
@@ -46,6 +46,7 @@ export class ChildManager extends ITC {
   #loader
   #context
   #scripts
+  #urlFromScript
   #logger
   #server
   #websocketServer
@@ -59,10 +60,11 @@ export class ChildManager extends ITC {
   #dataPath
 
   constructor (opts) {
-    let { loader, context, scripts, handlers, ...itcOpts } = opts
+    let { loader, context, scripts, urlFromScript, handlers, ...itcOpts } = opts
 
     context ??= {}
     scripts ??= []
+    urlFromScript ??= false
 
     super({
       ...itcOpts,
@@ -73,6 +75,7 @@ export class ChildManager extends ITC {
     this.#loader = loader
     this.#context = context
     this.#scripts = scripts
+    this.#urlFromScript = urlFromScript
     this.#originalNodeOptions = process.env.NODE_OPTIONS
     this.#logger = getLogger()
     this.#server = createServer(this.#childProcessFetchHandler.bind(this))
@@ -154,7 +157,8 @@ export class ChildManager extends ITC {
         {
           data: this.#context,
           loader: ensureFileUrl(this.#loader),
-          scripts: this.#scripts.map(s => ensureFileUrl(s))
+          scripts: this.#scripts.map(s => ensureFileUrl(s)),
+          urlFromScript: this.#urlFromScript
         },
         null,
         2

--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -109,8 +109,9 @@ export class ChildProcess extends ITC {
   #otlpBridge
   #pendingMessages
   #replStream
+  #urlFromScript
 
-  constructor (executable) {
+  constructor (executable, { urlFromScript = false } = {}) {
     const events = getEvents()
 
     super({
@@ -176,6 +177,7 @@ export class ChildProcess extends ITC {
     const protocol = platform() === 'win32' ? 'ws+unix:' : 'ws+unix://'
     this.#socket = new WebSocket(`${protocol}${getSocketPath(process.env.PLT_MANAGER_ID)}`)
     this.#pendingMessages = []
+    this.#urlFromScript = urlFromScript
     this.#metricsRegistry = new client.Registry()
 
     this.listen()
@@ -644,6 +646,14 @@ export class ChildProcess extends ITC {
       asyncEnd: ({ server }) => {
         tracingChannel('net.server.listen').unsubscribe(subscribers)
 
+        // When a script reports the app URL itself (urlFromScript), ignore the
+        // tracing-channel listen here (which fires for listhen/get-port-please's
+        // throwaway probe) to avoid reporting a stale URL that races the real
+        // server's startup.
+        if (this.#urlFromScript) {
+          return
+        }
+
         const address = server.address()
 
         // Unix socket, do nothing
@@ -840,7 +850,7 @@ async function main () {
   const executable = basename(process.argv[1] ?? '')
 
   const dataPath = resolve(tmpdir(), 'platformatic', 'runtimes', `${process.env.PLT_MANAGER_ID}.json`)
-  const { data, loader, scripts } = JSON.parse(await readFile(dataPath))
+  const { data, loader, scripts, urlFromScript } = JSON.parse(await readFile(dataPath))
 
   // Enable compile cache early before loading user modules
   await setupCompileCache(data)
@@ -866,7 +876,7 @@ async function main () {
     process.chdir(root)
   }
 
-  const childProcess = new ChildProcess(executable)
+  const childProcess = new ChildProcess(executable, { urlFromScript })
   updateGlobals({ itc: childProcess })
   events.target = childProcess
 }

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/basic",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Basic",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/basic/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/basic/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Basic Config",
   "type": "object",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformatic",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic CLI",
   "type": "module",
   "bin": {

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/composer",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Composer",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/composer/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/composer/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Composer Config",
   "type": "object",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/control",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Control",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/create-platformatic/package.json
+++ b/packages/create-platformatic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-platformatic",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Create platformatic application interactive tool",
   "repository": {
     "type": "git",

--- a/packages/create-wattpm/package.json
+++ b/packages/create-wattpm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-wattpm",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Create platformatic application interactive tool",
   "repository": {
     "type": "git",

--- a/packages/db-authorization/package.json
+++ b/packages/db-authorization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db-authorization",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic DB authorization",
   "main": "index.js",
   "type": "module",

--- a/packages/db-core/package.json
+++ b/packages/db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db-core",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic DB core",
   "main": "index.js",
   "type": "module",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/db",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic DB",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/db/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/db/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Database Config",
   "type": "object",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/foundation",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Foundation",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -36,7 +36,7 @@
     "pino": "^9.9.0",
     "pino-pretty": "^13.0.0",
     "semver": "^7.6.3",
-    "undici": "7.28.0",
+    "undici": "^7.28.0",
     "yaml": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/gateway/lib/openapi-generator.js
+++ b/packages/gateway/lib/openapi-generator.js
@@ -152,7 +152,7 @@ async function openApiGatewayPlugin (app, { opts, generated }) {
   const openApiGlue = await import('@platformatic/fastify-openapi-glue')
 
   try {
-    await registerOpenApiGlue(app, openApiGlue, opts, apiByApiRoutes)
+    await registerOpenApiGlue(app, openApiGlue, apiByApiRoutes)
   } catch (error) {
     // The glue rejects the whole composed specification with a generic error.
     // Re-validate each downstream schema separately so the error names the
@@ -175,10 +175,10 @@ async function openApiGatewayPlugin (app, { opts, generated }) {
   })
 }
 
-async function registerOpenApiGlue (app, openApiGlue, opts, apiByApiRoutes) {
+async function registerOpenApiGlue (app, openApiGlue, apiByApiRoutes) {
   await app.register(openApiGlue, {
     specification: app.composedOpenApiSchema,
-    addEmptySchema: opts.addEmptySchema,
+    addEmptySchema: true,
     operationResolver: (operationId, method, openApiPath) => {
       const { origin, prefix, schema } = apiByApiRoutes[openApiPath]
       const originPath = schema[originPathSymbol]

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -54,7 +54,7 @@
     "@fastify/view": "^12.0.0",
     "@platformatic/basic": "workspace:*",
     "@platformatic/dynamic-buffer": "^0.4.0",
-    "@platformatic/fastify-openapi-glue": "^5.1.0",
+    "@platformatic/fastify-openapi-glue": "^5.2.0",
     "@platformatic/foundation": "workspace:*",
     "@platformatic/globals": "workspace:*",
     "@platformatic/graphql-composer": "^0.11.0",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/gateway",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Gateway",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/gateway/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/gateway/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Gateway Config",
   "type": "object",

--- a/packages/gateway/test/openapi/empty-body-responses.test.js
+++ b/packages/gateway/test/openapi/empty-body-responses.test.js
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createBasicApplication, createFromConfig } from '../helper.js'
+
+async function composeBasicApplication (t, gatewayOptions = {}) {
+  const api = await createBasicApplication(t)
+
+  api.get(
+    '/no-content',
+    {
+      schema: {
+        response: {
+          204: { type: 'null' }
+        }
+      }
+    },
+    async (req, reply) => reply.code(204).send()
+  )
+
+  api.get(
+    '/mixed',
+    {
+      schema: {
+        response: {
+          200: { type: 'object', properties: { text: { type: 'string' } } },
+          204: { type: 'null' }
+        }
+      }
+    },
+    async () => ({ text: 'Some text' })
+  )
+
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      ...gatewayOptions,
+      applications: [
+        {
+          id: 'api',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json'
+          }
+        }
+      ]
+    }
+  })
+
+  await gateway.start({ listen: true })
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  })
+  assert.equal(statusCode, 200)
+
+  return { schema: JSON.parse(body), gateway }
+}
+
+test('should keep the status codes of responses which declare no body', async t => {
+  const { schema } = await composeBasicApplication(t)
+
+  const responses = schema.paths['/empty'].get.responses
+
+  assert.deepEqual(Object.keys(responses).sort(), ['204', '302'])
+  assert.equal(responses['204'].content, undefined)
+  assert.equal(responses['302'].content, undefined)
+})
+
+test('should not alter responses which declare a body', async t => {
+  const { schema } = await composeBasicApplication(t)
+
+  const responses = schema.paths['/object'].get.responses
+
+  assert.deepEqual(Object.keys(responses), ['200'])
+  assert.deepEqual(responses['200'].content['application/json'].schema, {
+    type: 'object',
+    properties: { text: { type: 'string' } },
+    required: ['text']
+  })
+})
+
+test('should keep both the body-less and the described responses of an operation', async t => {
+  const { schema } = await composeBasicApplication(t)
+
+  const responses = schema.paths['/mixed'].get.responses
+
+  assert.deepEqual(Object.keys(responses).sort(), ['200', '204'])
+  assert.deepEqual(responses['200'].content['application/json'].schema, {
+    type: 'object',
+    properties: { text: { type: 'string' } }
+  })
+  assert.equal(responses['204'].content, undefined)
+})
+
+test('should not change the body-less responses when the deprecated addEmptySchema is set', async t => {
+  const { schema } = await composeBasicApplication(t, { addEmptySchema: true })
+
+  const responses = schema.paths['/empty'].get.responses
+
+  assert.deepEqual(Object.keys(responses).sort(), ['204', '302'])
+  assert.equal(responses['204'].content, undefined)
+  assert.equal(responses['302'].content, undefined)
+})
+
+test('should proxy a body-less response as it is', async t => {
+  const { gateway } = await composeBasicApplication(t)
+
+  const { statusCode, body } = await gateway.inject({
+    method: 'GET',
+    url: '/no-content'
+  })
+
+  assert.equal(statusCode, 204)
+  assert.equal(body, '')
+})

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/generators",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Main classes and utils for generators.",
   "main": "index.js",
   "type": "module",

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/globals",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Global Object Getter",
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/itc/package.json
+++ b/packages/itc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/itc",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic ITC",
   "main": "lib/index.js",
   "type": "module",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/metrics",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Capability Metrics",
   "main": "index.js",
   "type": "module",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/nest",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Nest.js Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/nest/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/nest/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic NestJS Config",
   "type": "object",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/next",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Next.js Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/next/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/next/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Next.js Config",
   "type": "object",

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/nitro",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Nitro Capability",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/nitro/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/nitro/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Nitro Config",
   "type": "object",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/node",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Node.js Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/node/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/node/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Node.js Config",
   "type": "object",

--- a/packages/nuxt/lib/capability.js
+++ b/packages/nuxt/lib/capability.js
@@ -17,6 +17,7 @@ import {
 import inject from 'light-my-request'
 import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { satisfies } from 'semver'
 import { readSchedulerManifest } from './scheduled-tasks.js'
 import { version } from './schema.js'
@@ -222,7 +223,10 @@ export class NuxtCapability extends BaseCapability {
     }
 
     await this.startWithCommand(
-      `node ${resolve(this.#nuxt)}/bin/nuxt.mjs dev --host ${hostname} --port ${port} --no-open${httpsArgs}`
+      `node ${resolve(this.#nuxt)}/bin/nuxt.mjs dev --host ${hostname} --port ${port} --no-open --no-fork${httpsArgs}`,
+      null,
+      [fileURLToPath(new URL('./dev-ready.js', import.meta.url))],
+      { urlFromScript: true }
     )
 
     if (https) {

--- a/packages/nuxt/lib/dev-ready.js
+++ b/packages/nuxt/lib/dev-ready.js
@@ -1,0 +1,28 @@
+// Runs inside the spawned `nuxt.mjs dev` child process, before the Nuxt CLI loads.
+//
+// Nuxt 4's dev CLI probes a random port with a throwaway `net.Server` (via
+// listhen/get-port-please) before the real server listens. The generic URL
+// capture in `packages/basic/lib/worker/child-process.js` subscribes to the
+// FIRST `net.server.listen` trace and therefore reports the probe's URL, which
+// races the real server's startup and intermittently fails with ECONNREFUSED.
+//
+// This script opts the Nuxt child into Nuxt's own dev IPC so the CLI reports
+// its real `ready` address (after the build, when the serving server is up),
+// and forwards that URL to the parent via the child-manager `url` event — the
+// same channel `startWithCommand` already waits on.
+import { getITC } from '@platformatic/globals'
+
+process.env.__NUXT__FORK = '1'
+
+process.send = function (message) {
+  if (!message || message.type !== 'nuxt:internal:dev:ready') {
+    return
+  }
+
+  const address = message.address
+  if (typeof address !== 'string' || address.length === 0) {
+    return
+  }
+
+  getITC({ throwOnMissing: false })?.notify('url', address)
+}

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/nuxt",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Nuxt Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/nuxt/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/nuxt/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Nuxt Config",
   "type": "object",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/react-router",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic React Router Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/react-router/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/react-router/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic React Router Config",
   "type": "object",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/remix",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Remix Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/remix/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/remix/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Remix Config",
   "type": "object",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/runtime",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic runtime",
   "main": "index.js",
   "type": "module",

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/runtime/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/runtime/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Runtime Config",
   "type": "object",

--- a/packages/scalar-theme/package.json
+++ b/packages/scalar-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/scalar-theme",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic's Scalar theme for @scalar/fastify-api-reference",
   "main": "theme.js",
   "types": "theme.d.ts",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/service",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Service",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -37,7 +37,7 @@
     "self-cert": "^2.0.0",
     "split2": "^4.2.0",
     "typescript": "~6.0.3",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "vscode-json-languageservice": "^5.3.9",
     "why-is-node-running": "^2.2.2",
     "yaml": "^2.4.1"

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/service/3.66.0.json",
-  "version": "3.66.0",
+  "$id": "https://schemas.platformatic.dev/@platformatic/service/3.67.0.json",
+  "version": "3.67.0",
   "title": "Platformatic Service Config",
   "type": "object",
   "properties": {

--- a/packages/sql-events/package.json
+++ b/packages/sql-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-events",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Emit events via MQEmitter",
   "main": "index.js",
   "type": "module",

--- a/packages/sql-graphql/package.json
+++ b/packages/sql-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-graphql",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Map SQL dbs to GraphQL",
   "main": "index.js",
   "type": "module",

--- a/packages/sql-json-schema-mapper/package.json
+++ b/packages/sql-json-schema-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-json-schema-mapper",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Map SQL entity to JSON schema",
   "main": "index.js",
   "type": "module",

--- a/packages/sql-mapper/package.json
+++ b/packages/sql-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-mapper",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "A data mapper utility for SQL databases",
   "main": "index.js",
   "type": "module",

--- a/packages/sql-openapi/package.json
+++ b/packages/sql-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/sql-openapi",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Map a SQL database to OpenAPI, for Fastify",
   "main": "index.js",
   "type": "module",

--- a/packages/tanstack/package.json
+++ b/packages/tanstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/tanstack",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic TanStack Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/tanstack/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/tanstack/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic TanStack Config",
   "type": "object",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/telemetry",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "OpenTelemetry integration for Platformatic",
   "main": "index.js",
   "type": "module",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/vite",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "Platformatic Vite Capability",
   "main": "index.js",
   "type": "module",

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/@platformatic/vite/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/@platformatic/vite/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Vite Config",
   "type": "object",

--- a/packages/wattpm-pprof-capture/package.json
+++ b/packages/wattpm-pprof-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/wattpm-pprof-capture",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "pprof profiling capture for wattpm",
   "main": "index.js",
   "type": "module",

--- a/packages/wattpm-utils/package.json
+++ b/packages/wattpm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wattpm-utils",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "The Node.js Application Server Utilities Commands",
   "main": "index.js",
   "type": "module",

--- a/packages/wattpm/package.json
+++ b/packages/wattpm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wattpm",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "The Node.js Application Server",
   "main": "index.js",
   "type": "module",

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.platformatic.dev/wattpm/3.66.0.json",
+  "$id": "https://schemas.platformatic.dev/wattpm/3.67.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Platformatic Runtime Config",
   "type": "object",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,8 +755,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@platformatic/fastify-openapi-glue':
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.0
+        version: 5.2.0
       '@platformatic/foundation':
         specifier: workspace:*
         version: link:../foundation
@@ -5386,8 +5386,8 @@ packages:
     resolution: {integrity: sha512-eCL++LyBjSsqalm4I67dl+gVqLSKd6gPYCieD72S5KqqAkmSAgAYNHt+lL+iVXssWPSfbuIJ5PEwpn5JVD73Xw==}
     engines: {node: '>= 22.19.0'}
 
-  '@platformatic/fastify-openapi-glue@5.1.0':
-    resolution: {integrity: sha512-R5bHPQast/w5p+I+/Y5X1r+A8Fxqn7z0etWeaSYrFkbLvvGTEFGvldu0QGXnKjHo6XQo0P2o6D6gNr5uc36ZEA==}
+  '@platformatic/fastify-openapi-glue@5.2.0':
+    resolution: {integrity: sha512-5Syxh9EHCcxwrTvqRm2jv9Lpw7AUni3EWK95/5aFtIFAtz+POxlCbMaHcz3rdAD+D44nd1ZGqWa6wZ6dKNTqlg==}
 
   '@platformatic/graphql-composer@0.11.0':
     resolution: {integrity: sha512-e3EZH1okfdQPkhTNPrijgGQrlETFVO1V5WOjxN4EJFYRlurZdmqSuJw56JgvD08TMhdRXgwQK9bAbn1ZY2YzHg==}
@@ -16525,7 +16525,7 @@ snapshots:
 
   '@platformatic/dynamic-buffer@0.4.0': {}
 
-  '@platformatic/fastify-openapi-glue@5.1.0':
+  '@platformatic/fastify-openapi-glue@5.2.0':
     dependencies:
       '@platformatic/openapi-schema-validator': 3.0.0
       fastify-plugin: 5.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,7 +122,7 @@ importers:
         version: 4.2.0
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
       ws:
         specifier: ^8.18.0
         version: 8.21.1
@@ -233,7 +233,7 @@ importers:
         version: 6.9.0
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
       ws:
         specifier: ^8.16.0
         version: 8.21.1
@@ -322,7 +322,7 @@ importers:
         version: 1.22.12
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
       which:
         specifier: ^3.0.1
         version: 3.0.1
@@ -537,7 +537,7 @@ importers:
         version: 6.0.3
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
       vscode-json-languageservice:
         specifier: ^5.3.9
         version: 5.7.2
@@ -567,7 +567,7 @@ importers:
         version: 3.1.0
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@fastify/cookie':
         specifier: ^11.0.0
@@ -695,7 +695,7 @@ importers:
         version: 7.8.5
       undici:
         specifier: ^7.28.0
-        version: 7.28.0
+        version: 7.29.0
       yaml:
         specifier: ^2.4.1
         version: 2.9.0
@@ -849,7 +849,7 @@ importers:
         version: 0.3.0
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@fastify/multipart':
         specifier: ^9.2.1
@@ -928,7 +928,7 @@ importers:
         version: 9.14.0
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@types/inquirer':
         specifier: ^9.0.7
@@ -1644,7 +1644,7 @@ importers:
         version: 5.33.1
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
       undici-thread-interceptor:
         specifier: ^1.3.1
         version: 1.5.0
@@ -1876,7 +1876,7 @@ importers:
         version: 0.3.0
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@fastify/aws-lambda':
         specifier: ^5.0.0
@@ -2498,7 +2498,7 @@ importers:
         version: 6.0.3
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
 
   packages/wattpm-pprof-capture:
     dependencies:
@@ -2513,7 +2513,7 @@ importers:
         version: link:../globals
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
     devDependencies:
       '@platformatic/foundation':
         specifier: workspace:*
@@ -2593,7 +2593,7 @@ importers:
         version: 6.0.3
       undici:
         specifier: ^7.27.2
-        version: 7.28.0
+        version: 7.29.0
 
 packages:
 
@@ -12616,9 +12616,13 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   undici@8.9.0:
     resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
@@ -14604,7 +14608,7 @@ snapshots:
       fast-querystring: 1.1.2
       fastify-plugin: 6.0.0
       toad-cache: 3.7.4
-      undici: 7.28.0
+      undici: 7.29.0
 
   '@fastify/send@4.1.0':
     dependencies:
@@ -15198,7 +15202,7 @@ snapshots:
       p-map: 7.0.6
       single-user-cache: 2.1.0
       tiny-lru: 11.4.7
-      undici: 7.28.0
+      undici: 7.29.0
       use-strict: 1.0.1
       ws: 8.21.1
     transitivePeerDependencies:
@@ -16539,7 +16543,7 @@ snapshots:
       mercurius: 16.10.0(graphql@16.14.2)
       metaline: 1.1.0
       pino: 9.14.0
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16553,7 +16557,7 @@ snapshots:
       http-errors-enhanced: 4.0.2
       is-animated: 2.0.2
       sharp: 0.34.5
-      undici: 7.28.0
+      undici: 7.29.0
     optionalDependencies:
       '@platformatic/job-queue': 0.4.1
       iovalkey: 0.3.3
@@ -16586,7 +16590,7 @@ snapshots:
       long: 5.3.2
       prom-client: 15.1.3
       protobufjs: 8.7.1
-      undici: 7.28.0
+      undici: 7.29.0
 
   '@platformatic/undici-cache-memory@0.9.0': {}
 
@@ -20998,7 +21002,7 @@ snapshots:
 
   inspector-client@0.2.0:
     dependencies:
-      undici: 7.28.0
+      undici: 7.29.0
 
   int64-buffer@0.1.10: {}
 
@@ -22772,7 +22776,7 @@ snapshots:
       oxc-minify: 0.110.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       oxc-transform: 0.110.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       srvx: 0.10.1
-      undici: 7.28.0
+      undici: 7.29.0
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@22.20.1)))(ioredis@5.11.1)(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
@@ -23303,7 +23307,7 @@ snapshots:
       ultrahtml: 1.7.0
       uncrypto: 0.1.3
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))
-      undici: 8.9.0
+      undici: 8.10.0
       unhead: 3.2.3(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       unimport: 6.4.0(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.1)(rollup@4.62.4)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
@@ -25747,20 +25751,22 @@ snapshots:
     dependencies:
       async-cache-dedupe: 3.4.0
       fast-jwt: 6.3.1
-      undici: 7.28.0
+      undici: 7.29.0
 
   undici-thread-interceptor@1.5.0:
     dependencies:
       fastq: 1.20.1
       hyperid: 4.0.0
       light-my-request: 6.6.0
-      undici: 7.28.0
+      undici: 7.29.0
 
   undici-types@6.21.0: {}
 
   undici@6.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
+
+  undici@8.10.0: {}
 
   undici@8.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,7 +694,7 @@ importers:
         specifier: ^7.6.3
         version: 7.8.5
       undici:
-        specifier: 7.28.0
+        specifier: ^7.28.0
         version: 7.28.0
       yaml:
         specifier: ^2.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,8 +29,8 @@ minimumReleaseAgeExclude:
   - tar@7.5.16 || 7.5.21
   # Renovate security update: vite@7.3.5
   - vite@7.3.5
-  # Renovate security update: undici@7.28.0
-  - undici@7.28.0
+  # Renovate security update: undici@7.28.0 || 7.29.0
+  - undici@7.28.0 || 7.29.0
   # Renovate security update: @astrojs/node@11.0.2
   - "@astrojs/node@11.0.2"
   # Renovate security update: find-my-way@9.7.0


### PR DESCRIPTION
Brings `v4` up to date with `main` (through `015f11c66`, v3.67.0).

`v4` was 6 commits behind `main` and 5 ahead. The merge applied with **no conflicts**.

## Incoming from main

| Commit | Change |
| --- | --- |
| `015f11c66` | chore(deps): update undici to v7.29.0 [security] (#5066) |
| `2fd58f5fb` | fix(deps): update next to v16.2.11 [security] (#4995) |
| `f544ecc6f` | Bumped v3.67.0 |
| `085e69bd7` | fix(foundation): allow undici minor updates via `^7.28.0` (#5065) |
| `e2a905e9c` | fix(gateway): keep body-less response status codes in the composed OpenAPI document (#5053) |
| `8a45b4245` | fix(nuxt): report real dev server URL via Nuxt ready event (#5064) |

Outside version bumps and the lockfile, the merge touches only 8 files.

## Interaction with the entrypoint removal

The concern with merging into `v4` is a textually clean merge that is semantically broken, since `v4` removed `entrypoint`, the root `server` block, and per-application `server` (#5014). Checked and clear:

- The `urlFromScript` plumbing (`basic`, `nuxt`) is purely additive — it threads a flag through `ChildManager`/`ChildProcess` to suppress the tracing-channel `listen` event for listhen's throwaway probe. It reads no runtime configuration.
- `NuxtCapability#startDevelopment` derives `hostname`/`port` from `this.serverConfig`, which on `v4` is the capability-owned `server` block. Unchanged by the merge.
- `application.entrypointPort` (`packages/basic/lib/capability.js`) predates this merge and is present on both sides — it is unrelated to the removed root `entrypoint`.
- The gateway OpenAPI fix is confined to `openapi-generator.js` response handling.

## Verification

- `pnpm install` — clean
- `pnpm run build` — clean, and produces **no diff** in generated `schema.json` / `config.d.ts`
- `pnpm run lint` — clean
- Full test suite: deferred to CI on this PR

Assisted-by: Claude Code:claude-opus-5[1m]