### PR TITLE
fix(wattpm-utils): compare canonical paths when checking application containment

### DIFF
--- a/packages/wattpm-utils/lib/commands/external.js
+++ b/packages/wattpm-utils/lib/commands/external.js
@@ -15,7 +15,7 @@ import {
 import { loadConfiguration } from '@platformatic/runtime'
 import { bold } from 'colorette'
 import { execa } from 'execa'
-import { existsSync } from 'node:fs'
+import { existsSync, lstatSync, realpathSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
@@ -25,6 +25,54 @@ import { version } from '../version.js'
 import { installDependencies } from './dependencies.js'
 
 const originCandidates = ['origin', 'upstream']
+
+// Checks the existence of a path without following symlinks, so that a dangling symlink is
+// reported as existing rather than as a free path to write into.
+function existsWithoutFollowing (path) {
+  try {
+    lstatSync(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Returns the canonical form of a path which might not exist yet: the deepest existing ancestor is
+// resolved via realpath and the missing trailing segments are appended to it.
+function canonicalize (path) {
+  let current = resolve(path)
+  let suffix = ''
+
+  while (true) {
+    try {
+      const real = realpathSync(current)
+      return suffix ? resolve(real, suffix) : real
+      /* c8 ignore next 8 - The loop always terminates on the root, which exists */
+    } catch {
+      const parent = dirname(current)
+
+      if (parent === current) {
+        return resolve(path)
+      }
+
+      suffix = suffix ? join(basename(current), suffix) : basename(current)
+      current = parent
+    }
+  }
+}
+
+// Verifies that target is strictly contained in root. A prefix test is not enough as it lacks a path
+// segment boundary and thus considers /tmp/app-evil to be inside /tmp/app.
+function isPathInside (root, target) {
+  const relativePath = relative(root, target)
+  return relativePath !== '' && !relativePath.startsWith('..') && !isAbsolute(relativePath)
+}
+
+// The containment of the application directory is verified again right before writing to it, as the
+// filesystem might have changed since the initial validation.
+function verifyApplicationDirectory (root, application) {
+  return isPathInside(canonicalize(root), canonicalize(resolve(root, application.path)))
+}
 
 function parseGitUrl (url) {
   const fragmentIndex = url.indexOf('#')
@@ -444,8 +492,8 @@ export async function resolveApplications (
     const directory = resolve(root, application.path)
 
     // If the directory already exists, it's either external or already resolved, nothing to do in both cases
-    if (!existsSync(directory)) {
-      if (!directory.startsWith(root)) {
+    if (!existsWithoutFollowing(directory)) {
+      if (!verifyApplicationDirectory(root, application)) {
         logger.warn(
           `Skipping application ${bold(application.id)} as the non existent directory ${bold(
             application.path
@@ -468,6 +516,16 @@ export async function resolveApplications (
   for (const application of toResolve) {
     const childLogger = logger.child({ name: application.id })
 
+    // Revalidate right before writing, as the filesystem might have changed since the check above
+    if (!verifyApplicationDirectory(root, application)) {
+      return logFatalError(
+        childLogger,
+        `Cannot resolve application ${bold(application.id)} as the directory ${bold(
+          application.path
+        )} is outside the project directory.`
+      )
+    }
+
     let operation
     try {
       if (application.url.startsWith('npm')) {
@@ -488,6 +546,18 @@ export async function resolveApplications (
 
   // Install dependencies
   if (!skipDependencies) {
+    // Revalidate once more, as installing runs arbitrary lifecycle scripts from the resolved directories
+    for (const application of toResolve) {
+      if (!verifyApplicationDirectory(root, application)) {
+        return logFatalError(
+          logger.child({ name: application.id }),
+          `Cannot install dependencies of the application ${bold(application.id)} as the directory ${bold(
+            application.path
+          )} is outside the project directory.`
+        )
+      }
+    }
+
     return await installDependencies(logger, root, toResolve, false, packageManager)
   }
   /* c8 ignore next - Mistakenly reported as uncovered by C8 */

--- a/packages/wattpm-utils/test/resolve.test.js
+++ b/packages/wattpm-utils/test/resolve.test.js
@@ -6,7 +6,7 @@ import {
 } from '@platformatic/foundation'
 import { deepStrictEqual, ok } from 'node:assert'
 import { existsSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { readFile, symlink } from 'node:fs/promises'
 import { relative, resolve, sep } from 'node:path'
 import { test } from 'node:test'
 import { prepareRuntime, temporaryFolder } from '../../basic/test/helper.js'
@@ -133,6 +133,60 @@ test('resolve - should throw an error when the directory outside the repo do not
       `Skipping application resolved as the non existent directory ${envValue} is outside the project directory.`
     )
   )
+})
+
+test('resolve - should not clone into a sibling directory which shares a prefix with the project directory', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+  const repo = await prepareGitRepository(t, rootDir)
+  t.after(() => safeRemove(rootDir))
+
+  changeWorkingDirectory(t, rootDir)
+  await wattpmUtils('import', rootDir, '-H', '-i', 'resolved', '{PLT_GIT_REPO_URL}')
+
+  // The sibling directory name starts with the project directory, so a string prefix test lets it through
+  const sibling = `${rootDir}-evil`
+  const envValue = resolve(sibling, 'resolved')
+  t.after(() => safeRemove(sibling))
+  await appendEnvVariable(resolve(rootDir, '.env'), 'PLT_APPLICATION_RESOLVED_PATH', envValue)
+
+  const resolveProcess = await wattpmUtils('resolve', rootDir, { reject: false })
+  ok(!resolveProcess.stdout.includes(`Cloning ${repo}`))
+  ok(
+    resolveProcess.stdout.includes(
+      `Skipping application resolved as the non existent directory ${envValue} is outside the project directory.`
+    ),
+    resolveProcess.stdout
+  )
+  ok(!existsSync(envValue))
+})
+
+test('resolve - should not clone outside the project directory through a symlink', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+  const repo = await prepareGitRepository(t, rootDir)
+  t.after(() => safeRemove(rootDir))
+
+  const outside = resolve(temporaryFolder, `outside-symlink-${process.pid}-${Date.now()}`)
+  await createDirectory(outside)
+  t.after(() => safeRemove(outside))
+
+  // The path is lexically inside the project directory, but it resolves outside of it
+  await symlink(outside, resolve(rootDir, 'linked'), 'dir')
+
+  changeWorkingDirectory(t, rootDir)
+  await wattpmUtils('import', rootDir, '-H', '-i', 'resolved', '{PLT_GIT_REPO_URL}')
+
+  const envValue = resolve(rootDir, 'linked/resolved')
+  await appendEnvVariable(resolve(rootDir, '.env'), 'PLT_APPLICATION_RESOLVED_PATH', envValue)
+
+  const resolveProcess = await wattpmUtils('resolve', rootDir, { reject: false })
+  ok(!resolveProcess.stdout.includes(`Cloning ${repo}`))
+  ok(
+    resolveProcess.stdout.includes(
+      `Skipping application resolved as the non existent directory ${envValue} is outside the project directory.`
+    ),
+    resolveProcess.stdout
+  )
+  ok(!existsSync(resolve(outside, 'resolved')))
 })
 
 test('resolve - should attempt to clone with username and password', async t => {


### PR DESCRIPTION
Fixes #5078

## Problem

`resolveApplications` guards against creating an application directory outside the project, but the check compares **strings** rather than paths:

```js
if (!directory.startsWith(root)) { /* skip */ } else { /* git clone + npm install */ }
```

With a project at `/tmp/app`:

| derived path | resolves to | `startsWith(root)` | before |
| --- | --- | --- | --- |
| `sub/x` | `/tmp/app/sub/x` | `true` | cloned — correct |
| `../../etc/x` | `/etc/x` | `false` | skipped — correct |
| `../app-evil/x` | `/tmp/app-evil/x` | `true` | **cloned — outside the project** |

`resolve()` also normalises `..` lexically without following links, so a symlink inside the root could redirect the clone and the subsequent dependency install anywhere.

## Fix

In `packages/wattpm-utils/lib/commands/external.js`:

- `canonicalize()` — `realpath` the deepest existing ancestor of the target (the target itself does not exist yet) and append the missing trailing segments, so symlinked ancestors are resolved on both sides.
- `isPathInside()` — `relative(root, target)` must be non-empty, not start with `..` and not be absolute. A prefix test has no path-segment boundary; this does.
- `existsWithoutFollowing()` — a dangling symlink now counts as an existing path instead of a free directory to write into.
- The containment is revalidated immediately before cloning/downloading and again before installing dependencies, since the ancestor chain can change between the check and the use. Both revalidations fail the command rather than silently skipping.

The user-facing warning is unchanged, so the existing message assertions still hold.

## Tests

Two tests in `packages/wattpm-utils/test/resolve.test.js`, both of which clone outside the project directory without this change:

- resolve into `<root>-evil/resolved` — a sibling sharing a prefix with the root
- resolve into `<root>/linked/resolved` where `linked` is a symlink pointing outside the root

Full `packages/wattpm-utils/test/resolve.test.js` suite passes (16/16).

Assisted-by: Claude Code:claude-opus-5[1m]