### PR TITLE
fix(runtime): reject autoload id collisions instead of merging unrelated applications

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -244,6 +244,10 @@
 
 **Message:** Invalid entrypoint: '%s' does not exist
 
+### PLT_RUNTIME_APPLICATION_ID_COLLISION
+
+**Message:** The application id "%s" is used by the autoloaded directory "%s" and by a different application defined in the configuration file via %s. Application ids must be unique.
+
 ### PLT_RUNTIME_MISSING_ENTRYPOINT
 
 **Message:** Missing application entrypoint.

--- a/packages/create-wattpm/test/cli/generic.test.js
+++ b/packages/create-wattpm/test/cli/generic.test.js
@@ -97,7 +97,7 @@ test('Support packages without generator via importing (existing applications)',
 
   let runtimeConfig = JSON.parse(await readFile(resolve(join(baseProjectDir, 'watt.json')), 'utf8'))
   const originalEnvFile = await readFile(resolve(baseProjectDir, '.env'), 'utf-8')
-  runtimeConfig.web = [{ id: 'main', path: 'services/main' }]
+  runtimeConfig.web = [{ id: 'main', path: 'web/main' }]
   runtimeConfig.startTimeout = 12345
   await writeFile(resolve(join(baseProjectDir, 'watt.json')), JSON.stringify(runtimeConfig, null, 2))
 
@@ -123,7 +123,7 @@ test('Support packages without generator via importing (existing applications)',
   deepStrictEqual(runtimeConfig.web, [
     {
       id: 'main',
-      path: 'services/main'
+      path: 'web/main'
     },
     {
       id: 'alternate',
@@ -236,7 +236,7 @@ test('Support packages without generator via copy (existing applications)', asyn
   })
 
   let runtimeConfig = JSON.parse(await readFile(resolve(join(baseProjectDir, 'watt.json')), 'utf8'))
-  runtimeConfig.web = [{ id: 'main', path: 'services/main' }]
+  runtimeConfig.web = [{ id: 'main', path: 'web/main' }]
   runtimeConfig.startTimeout = 12345
   await writeFile(resolve(join(baseProjectDir, 'watt.json')), JSON.stringify(runtimeConfig, null, 2))
 

--- a/packages/runtime/fixtures/autoload-collision/disabled-url.json
+++ b/packages/runtime/fixtures/autoload-collision/disabled-url.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "autoload": {
+    "path": "web"
+  },
+  "applications": [
+    {
+      "id": "api",
+      "url": "https://github.com/org/api",
+      "enabled": false
+    }
+  ]
+}

--- a/packages/runtime/fixtures/autoload-collision/elsewhere/api/platformatic.json
+++ b/packages/runtime/fixtures/autoload-collision/elsewhere/api/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "service": {
+    "openapi": true
+  }
+}

--- a/packages/runtime/fixtures/autoload-collision/path-collision.json
+++ b/packages/runtime/fixtures/autoload-collision/path-collision.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "autoload": {
+    "path": "web"
+  },
+  "applications": [
+    {
+      "id": "api",
+      "path": "elsewhere/api"
+    }
+  ]
+}

--- a/packages/runtime/fixtures/autoload-collision/resolved-base-path.json
+++ b/packages/runtime/fixtures/autoload-collision/resolved-base-path.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "resolvedApplicationsBasePath": "web",
+  "autoload": {
+    "path": "web"
+  },
+  "applications": [
+    {
+      "id": "api",
+      "url": "https://github.com/org/api"
+    }
+  ]
+}

--- a/packages/runtime/fixtures/autoload-collision/same-path.json
+++ b/packages/runtime/fixtures/autoload-collision/same-path.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "autoload": {
+    "path": "web"
+  },
+  "applications": [
+    {
+      "id": "api",
+      "path": "web/api",
+      "workers": 3
+    }
+  ]
+}

--- a/packages/runtime/fixtures/autoload-collision/url-collision.json
+++ b/packages/runtime/fixtures/autoload-collision/url-collision.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "autoload": {
+    "path": "web"
+  },
+  "applications": [
+    {
+      "id": "api",
+      "url": "https://github.com/org/api"
+    }
+  ]
+}

--- a/packages/runtime/fixtures/autoload-collision/web/api/platformatic.json
+++ b/packages/runtime/fixtures/autoload-collision/web/api/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.0.0.json",
+  "service": {
+    "openapi": true
+  }
+}

--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -9,11 +9,13 @@ import {
   omitProperties,
   runtimeUnwrappablePropertiesList
 } from '@platformatic/foundation'
+import { realpathSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { isAbsolute, join, resolve as resolvePath } from 'node:path'
 
 import {
+  ApplicationIdCollisionError,
   InspectAndInspectBrkError,
   InspectorHostError,
   InspectorPortError,
@@ -295,6 +297,40 @@ export async function prepareApplication (config, application, defaultWorkers) {
   return application
 }
 
+function canonicalPath (path) {
+  try {
+    return realpathSync(path)
+  } catch {
+    return resolvePath(path)
+  }
+}
+
+// An autoloaded directory and an explicitly configured entry with the same id are the same application
+// only when they point to the same place: either the configured path resolves to the autoloaded
+// directory, or the entry is external and the autoloaded directory is where "resolve" would put it.
+// When they don't, returns a description of the configured entry to report in the error.
+function conflictingApplicationSource (root, resolvedApplicationsPath, existing, entryPath) {
+  if (existing.path) {
+    // The path still contains a placeholder, which means the environment variable was not replaced.
+    // There is nothing to compare in that case.
+    if (existing.path.match(/^\{.*\}$/)) {
+      return null
+    }
+
+    const existingPath = isAbsolute(existing.path) ? existing.path : resolvePath(root, existing.path)
+
+    return canonicalPath(existingPath) === canonicalPath(entryPath) ? null : `the path "${existing.path}"`
+  }
+
+  if (existing.url) {
+    const resolvedPath = join(resolvedApplicationsPath, existing.id)
+
+    return canonicalPath(resolvedPath) === canonicalPath(entryPath) ? null : `the URL "${existing.url}"`
+  }
+
+  return null
+}
+
 function isApplicationEnabled (application, environment) {
   const { enabled } = application
 
@@ -378,7 +414,11 @@ export async function transform (config, _, context) {
     const { exclude = [], mappings = {} } = config.autoload
     let { path } = config.autoload
 
-    path = resolvePath(config[kMetadata].root, path)
+    // Capture these before the loop, as config is shadowed in its body
+    const root = config[kMetadata].root
+    const resolvedApplicationsPath = resolvePath(root, config.resolvedApplicationsBasePath ?? 'external')
+
+    path = resolvePath(root, path)
     const entries = await readdir(path, { withFileTypes: true })
 
     for (let i = 0; i < entries.length; ++i) {
@@ -403,7 +443,21 @@ export async function transform (config, _, context) {
       const existingApplicationId = applications.findIndex(application => application.id === id)
 
       if (existingApplicationId !== -1) {
-        applications[existingApplicationId] = { ...application, ...applications[existingApplicationId] }
+        const existing = applications[existingApplicationId]
+
+        // Merging on the id alone can boot local code where the configuration named a repository, as
+        // the autoloaded path survives next to the configured url. Reject the duplicate instead: an id
+        // is the mesh hostname, the injected PLT_<ID>_URL name, the metrics label and the argument of
+        // "wattpm inject", so two different applications cannot share one.
+        if (isApplicationEnabled(existing, environment)) {
+          const source = conflictingApplicationSource(root, resolvedApplicationsPath, existing, entryPath)
+
+          if (source) {
+            throw new ApplicationIdCollisionError(id, entryPath, source)
+          }
+        }
+
+        applications[existingApplicationId] = { ...application, ...existing }
       } else {
         applications.push(application)
       }

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -102,6 +102,10 @@ export const InvalidEntrypointError = createError(
   `${ERROR_PREFIX}_INVALID_ENTRYPOINT`,
   "Invalid entrypoint: '%s' does not exist"
 )
+export const ApplicationIdCollisionError = createError(
+  `${ERROR_PREFIX}_APPLICATION_ID_COLLISION`,
+  'The application id "%s" is used by the autoloaded directory "%s" and by a different application defined in the configuration file via %s. Application ids must be unique.'
+)
 export const MissingEntrypointError = createError(
   `${ERROR_PREFIX}_MISSING_ENTRYPOINT`,
   'Missing application entrypoint.'

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -2,7 +2,7 @@ import { loadConfiguration as databaseLoadConfiguration } from '@platformatic/db
 import { deepStrictEqual, ok, rejects, strictEqual, throws } from 'node:assert'
 import { dirname, join, resolve } from 'node:path'
 import { test } from 'node:test'
-import { wrapInRuntimeConfig } from '../index.js'
+import { loadConfiguration, wrapInRuntimeConfig } from '../index.js'
 import { parseInspectorOptions } from '../lib/config.js'
 import { createRuntime } from './helpers.js'
 
@@ -533,4 +533,42 @@ test('prepareApplication should handle multiple services with url but no path ef
   // because they should skip capability detection entirely (no file operations)
   // With the bug, each service would trigger a glob operation on the temp directory
   ok(elapsed < 50, `Processing 16 url-only services should be fast (took ${elapsed.toFixed(2)}ms, expected < 50ms)`)
+})
+
+test('autoload - merges an explicit entry which points to the autoloaded directory', async t => {
+  const config = await loadConfiguration(join(fixturesDir, 'autoload-collision', 'same-path.json'))
+
+  strictEqual(config.applications.length, 1)
+  strictEqual(config.applications[0].id, 'api')
+  strictEqual(config.applications[0].path, join(fixturesDir, 'autoload-collision', 'web', 'api'))
+  strictEqual(config.applications[0].workers.static, 3)
+})
+
+test('autoload - merges an external entry when the autoloaded directory is where it is resolved', async t => {
+  const config = await loadConfiguration(join(fixturesDir, 'autoload-collision', 'resolved-base-path.json'))
+
+  strictEqual(config.applications.length, 1)
+  strictEqual(config.applications[0].id, 'api')
+  strictEqual(config.applications[0].path, join(fixturesDir, 'autoload-collision', 'web', 'api'))
+  strictEqual(config.applications[0].url, 'https://github.com/org/api')
+})
+
+test('autoload - throws when the id of an autoloaded directory is used by an external application', async t => {
+  await rejects(
+    () => loadConfiguration(join(fixturesDir, 'autoload-collision', 'url-collision.json')),
+    /The application id "api" is used by the autoloaded directory ".+" and by a different application defined in the configuration file via the URL "https:\/\/github.com\/org\/api"./
+  )
+})
+
+test('autoload - throws when the id of an autoloaded directory is used by another local application', async t => {
+  await rejects(
+    () => loadConfiguration(join(fixturesDir, 'autoload-collision', 'path-collision.json')),
+    /The application id "api" is used by the autoloaded directory ".+" and by a different application defined in the configuration file via the path ".+\/elsewhere\/api"./
+  )
+})
+
+test('autoload - does not report a collision with a disabled application', async t => {
+  const config = await loadConfiguration(join(fixturesDir, 'autoload-collision', 'disabled-url.json'))
+
+  strictEqual(config.applications.length, 0)
 })

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -563,7 +563,7 @@ test('autoload - throws when the id of an autoloaded directory is used by an ext
 test('autoload - throws when the id of an autoloaded directory is used by another local application', async t => {
   await rejects(
     () => loadConfiguration(join(fixturesDir, 'autoload-collision', 'path-collision.json')),
-    /The application id "api" is used by the autoloaded directory ".+" and by a different application defined in the configuration file via the path ".+\/elsewhere\/api"./
+    /The application id "api" is used by the autoloaded directory ".+" and by a different application defined in the configuration file via the path ".+[\\/]elsewhere[\\/]api"./
   )
 })
 

--- a/packages/wattpm-utils/test/import.test.js
+++ b/packages/wattpm-utils/test/import.test.js
@@ -224,7 +224,7 @@ test('import - should not do anything when the local folder is already a defined
   const configurationFile = resolve(rootDir, 'watt.json')
 
   const contents = await loadRawConfigurationFile(configurationFile)
-  contents.web = [{ id: 'main', path: 'main' }]
+  contents.web = [{ id: 'other', path: 'main' }]
   await saveConfigurationFile(configurationFile, contents)
   await createDirectory(resolve(rootDir, 'main'))
   await writeFile(resolve(rootDir, 'main/index.js'), '', 'utf-8')


### PR DESCRIPTION
Fixes #5079

## Problem

When `autoload` discovers a directory whose id matches an existing explicit entry, the two are merged on **id alone** — nothing checks that they refer to the same application:

```js
applications[existingApplicationId] = { ...application, ...applications[existingApplicationId] }
```

The merge is shallow and per-key, so an autoloaded local `path` survives next to an explicit `url`:

```jsonc
{
  "autoload": { "path": "web" },
  "applications": [{ "id": "api", "url": "https://github.com/org/api" }]
}
```

with `web/api/` also present yields `{ id: 'api', path: 'web/api', url: '…' }`. `wattpm resolve` then skips the remote ("the path already exists") and the runtime boots the local directory while the configuration names a repository. The only diagnostic reads like a benign no-op.

## Fix

In `packages/runtime/lib/config.js`, merge only when the two entries denote the same application:

- the configured `path` canonically resolves (`realpath`) to the autoloaded directory, or
- the entry is external and the autoloaded directory is exactly where `resolve` would clone it (`<resolvedApplicationsBasePath>/<id>`), which is the legitimate case when the two paths coincide.

Otherwise throw `PLT_RUNTIME_APPLICATION_ID_COLLISION`, naming both sources — an id is the mesh hostname, the injected `PLT_<ID>_URL` name, the metrics label and `wattpm inject`'s argument, so two distinct applications cannot share one.

Two cases keep merging as before:

- entries with neither `path` nor `url` — the ones synthesised from `verticalScaler.applications`, which only carry settings
- explicitly disabled entries, which are dropped right afterwards anyway

`resolvedApplicationsBasePath` and the root are captured before the autoload loop, since `config` is shadowed inside its body.

## Tests

Five tests in `packages/runtime/test/config.test.js` over a new `fixtures/autoload-collision` tree, covering both collisions (url and path) and the three merges that must keep working. `config.test.js`, `applications-enabled.test.js`, `entrypoint.test.js` (47/47) and `worker-scaler-1/2.test.js` (26/26) all pass.

Assisted-by: Claude Code:claude-opus-5[1m]