### PR TITLE
feat(service): add server.errorHandler to shape errors of every route

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -296,6 +296,12 @@
 
 **Message:** Cannot send a message to service "%s": %s
 
+## @platformatic/service
+
+### PLT_SERVICE_INVALID_ERROR_HANDLER
+
+**Message:** The module %s configured as server.errorHandler does not export a function.
+
 ## @platformatic/sql-events
 
 ### PLT_SQL_EVENTS_OBJECT_IS_REQUIRED_UNDER_THE_DATA_PROPERTY

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -75,6 +75,44 @@ An object with the following settings:
 - **`requestIdLogLabel`** (`string`) -- Defines the label used for the request identifier when logging the request. default: `'reqId'`
 - **`jsonShorthand`** (`boolean`) -- default: `true` -- visit [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#jsonshorthand) for more details
 - **`trustProxy`** (`boolean` or `integer` or `string` or `String[]`) -- default: `false` -- visit [fastify docs](https://www.fastify.io/docs/latest/Reference/Server/#trustproxy) for more details
+- **`errorHandler`** (`string`) -- path to a file (relative to the configuration file) or the name of an installed package whose default export is a [Fastify error handler](https://fastify.dev/docs/latest/Reference/Server/#seterrorhandler).
+
+  The handler is installed on the root instance before any route is registered, so it applies to every
+  route of the application, including the ones registered by the capability itself: the auto-generated
+  CRUD routes of [Platformatic DB](../db/configuration.md), the GraphQL endpoint and the health check.
+  Plugins can still call `setErrorHandler` to override it inside their own encapsulation context.
+
+  This is the supported way to enforce a single error envelope and to sanitize `5xx` bodies, which
+  otherwise expose the original `error.message` (including database driver messages) of the routes the
+  application did not write.
+
+  _Example_
+
+  ```json
+  {
+    "server": {
+      ...
+      "errorHandler": "./lib/error-handler.js"
+    }
+  }
+  ```
+
+  ```js
+  // lib/error-handler.js
+  export default function errorHandler (error, request, reply) {
+    const statusCode = error.statusCode ?? 500
+
+    request.log.error({ err: error }, 'request errored')
+
+    reply.status(statusCode).send({
+      statusCode,
+      code: error.code,
+      message: statusCode >= 500 ? 'Internal Server Error' : error.message
+    })
+  }
+  ```
+
+  A module exporting the handler as a named `errorHandler` export is supported as well.
 
 :::tip
 

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -172,6 +172,10 @@ export interface PlatformaticComposerConfig {
       strictPreflight?: boolean;
       hideOptionsRoute?: boolean;
     };
+    /**
+     * Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.
+     */
+    errorHandler?: string;
   };
   types?: {
     autogenerate?: boolean;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -561,6 +561,19 @@
             }
           },
           "additionalProperties": false
+        },
+        "errorHandler": {
+          "description": "Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.",
+          "anyOf": [
+            {
+              "type": "string",
+              "resolveModule": true
+            },
+            {
+              "type": "string",
+              "resolvePath": true
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -189,6 +189,10 @@ export interface PlatformaticDatabaseConfig {
       strictPreflight?: boolean;
       hideOptionsRoute?: boolean;
     };
+    /**
+     * Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.
+     */
+    errorHandler?: string;
   };
   db: {
     connectionString: string;

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -562,6 +562,19 @@
             }
           },
           "additionalProperties": false
+        },
+        "errorHandler": {
+          "description": "Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.",
+          "anyOf": [
+            {
+              "type": "string",
+              "resolveModule": true
+            },
+            {
+              "type": "string",
+              "resolvePath": true
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/db/test/error-handler.test.js
+++ b/packages/db/test/error-handler.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { createBasicPages, createFromConfig, getConnectionInfo } from './helper.js'
+
+const errorHandlerPath = join(import.meta.dirname, 'fixtures', 'error-handler', 'sanitizing-error-handler.js')
+
+async function createApp (t, errorHandler) {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo()
+
+  const app = await createFromConfig(t, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' },
+      errorHandler
+    },
+    db: {
+      ...connectionInfo,
+      async onDatabaseLoad (db, sql) {
+        await createBasicPages(db, sql)
+      }
+    }
+  })
+
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+
+  await app.start({ listen: true })
+
+  // Make the auto-generated CRUD routes fail the same way a broken schema would.
+  const { db, sql } = app.getApplication().platformatic
+  await db.query(sql`DROP TABLE pages`)
+
+  return app
+}
+
+test('server.errorHandler covers the auto-generated CRUD routes', async t => {
+  const app = await createApp(t, errorHandlerPath)
+
+  const res = await request(`${app.url}/pages`)
+  assert.equal(res.statusCode, 500)
+  assert.deepEqual(await res.body.json(), {
+    envelope: true,
+    statusCode: 500,
+    message: 'Internal Server Error'
+  })
+})
+
+test('without server.errorHandler the auto-generated CRUD routes leak the driver message', async t => {
+  const app = await createApp(t, undefined)
+
+  const res = await request(`${app.url}/pages`)
+  assert.equal(res.statusCode, 500)
+
+  const body = await res.body.json()
+  assert.equal(body.statusCode, 500)
+  assert.equal(body.error, 'Internal Server Error')
+  assert.ok(body.message.includes('pages'), `expected the driver message, got ${body.message}`)
+})

--- a/packages/db/test/fixtures/error-handler/sanitizing-error-handler.js
+++ b/packages/db/test/fixtures/error-handler/sanitizing-error-handler.js
@@ -1,0 +1,10 @@
+export default function errorHandler (error, request, reply) {
+  const statusCode = error.statusCode ?? 500
+
+  reply.status(statusCode).send({
+    envelope: true,
+    statusCode,
+    // 5xx bodies never expose the original message, which may carry table and constraint names.
+    message: statusCode >= 500 ? 'Internal Server Error' : error.message
+  })
+}

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -639,7 +639,15 @@ export const fastifyServer = {
     },
     http2: server.properties.http2,
     https: server.properties.https,
-    cors
+    cors,
+    errorHandler: {
+      description:
+        'Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.',
+      anyOf: [
+        { type: 'string', resolveModule: true },
+        { type: 'string', resolvePath: true }
+      ]
+    }
   },
   additionalProperties: false
 }

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -172,6 +172,10 @@ export interface PlatformaticGatewayConfig {
       strictPreflight?: boolean;
       hideOptionsRoute?: boolean;
     };
+    /**
+     * Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.
+     */
+    errorHandler?: string;
   };
   gateway?: {
     applications?: {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -561,6 +561,19 @@
             }
           },
           "additionalProperties": false
+        },
+        "errorHandler": {
+          "description": "Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.",
+          "anyOf": [
+            {
+              "type": "string",
+              "resolveModule": true
+            },
+            {
+              "type": "string",
+              "resolvePath": true
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -172,6 +172,10 @@ export interface PlatformaticServiceConfig {
       strictPreflight?: boolean;
       hideOptionsRoute?: boolean;
     };
+    /**
+     * Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.
+     */
+    errorHandler?: string;
   };
   plugins?: {
     [k: string]: unknown;

--- a/packages/service/index.js
+++ b/packages/service/index.js
@@ -59,5 +59,7 @@ export const skipTelemetryHooks = true
 
 export { platformaticService } from './lib/application.js'
 export { ServiceCapability } from './lib/capability.js'
+export * from './lib/errors.js'
+export * as errors from './lib/errors.js'
 export { applyTestHelperCustomizations, Generator } from './lib/generator.js'
 export { packageJson, schema, schemaComponents, version } from './lib/schema.js'

--- a/packages/service/lib/capability.js
+++ b/packages/service/lib/capability.js
@@ -14,6 +14,7 @@ import { randomUUID } from 'node:crypto'
 import { hostname } from 'node:os'
 import pino from 'pino'
 import { platformaticService } from './application.js'
+import { loadErrorHandler } from './error-handler.js'
 import { setupRoot } from './plugins/root.js'
 import { version } from './schema.js'
 
@@ -37,13 +38,23 @@ export class ServiceCapability extends BaseCapability {
     this.#basePath = ensureTrailingSlash(cleanBasePath(config.basePath ?? this.applicationId))
 
     // Create the application
+    const { errorHandler, ...serverOptions } = this.serverConfig ?? {}
+
     this.#app = fastify({
-      ...this.serverConfig,
+      ...serverOptions,
       ...this.fastifyOptions,
       genReqId () {
         return randomUUID()
       }
     })
+
+    // The error handler is installed on the root instance before anything else is registered so that
+    // every route inherits it, including the ones registered by the capability itself, like the
+    // auto-generated CRUD routes of @platformatic/db. Plugins can still override it in their own
+    // encapsulation context.
+    if (errorHandler) {
+      this.#app.setErrorHandler(await loadErrorHandler(errorHandler))
+    }
 
     // Add hook to set Connection: close during graceful shutdown.
     // This must be added BEFORE plugins are registered, because if a plugin

--- a/packages/service/lib/error-handler.js
+++ b/packages/service/lib/error-handler.js
@@ -1,0 +1,24 @@
+import { pathToFileURL } from 'node:url'
+import { InvalidErrorHandlerError } from './errors.js'
+
+/**
+ * Loads the error handler configured via `server.errorHandler`.
+ *
+ * The value is already resolved to an absolute path (or to the entrypoint of an installed package)
+ * by the `resolveModule`/`resolvePath` schema keywords, so here it only has to be imported.
+ */
+export async function loadErrorHandler (path) {
+  const loaded = await import(pathToFileURL(path))
+  let handler = typeof loaded.default !== 'undefined' ? loaded.default : loaded
+
+  // Also support `export function errorHandler` and `module.exports = { errorHandler }`.
+  if (handler && typeof handler !== 'function' && typeof handler.errorHandler === 'function') {
+    handler = handler.errorHandler
+  }
+
+  if (typeof handler !== 'function') {
+    throw new InvalidErrorHandlerError(path)
+  }
+
+  return handler
+}

--- a/packages/service/lib/errors.js
+++ b/packages/service/lib/errors.js
@@ -1,0 +1,8 @@
+import createError from '@fastify/error'
+
+export const ERROR_PREFIX = 'PLT_SERVICE'
+
+export const InvalidErrorHandlerError = createError(
+  `${ERROR_PREFIX}_INVALID_ERROR_HANDLER`,
+  'The module %s configured as server.errorHandler does not export a function.'
+)

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -561,6 +561,19 @@
             }
           },
           "additionalProperties": false
+        },
+        "errorHandler": {
+          "description": "Path to a file or name of a package whose default export is a Fastify error handler. It is installed on the root instance before any route is registered, so it also covers the routes registered by the capability itself, such as the auto generated CRUD routes of @platformatic/db. Plugins can still override it for their own encapsulation context.",
+          "anyOf": [
+            {
+              "type": "string",
+              "resolveModule": true
+            },
+            {
+              "type": "string",
+              "resolvePath": true
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/service/test/error-handler.test.js
+++ b/packages/service/test/error-handler.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { buildConfig, createFromConfig } from './helper.js'
+
+const fixturesDir = join(import.meta.dirname, 'fixtures')
+const plugins = { paths: [join(fixturesDir, 'throwing-plugin.js')] }
+
+function buildServerConfig (errorHandler) {
+  return { hostname: '127.0.0.1', port: 0, logger: { level: 'fatal' }, errorHandler }
+}
+
+test('server.errorHandler shapes the errors of the application routes', async t => {
+  const app = await createFromConfig(
+    t,
+    buildConfig({ server: buildServerConfig(join(fixturesDir, 'error-handler.js')), plugins })
+  )
+
+  t.after(() => app.stop())
+  await app.start({ listen: true })
+
+  const failure = await request(`${app.url}/boom`)
+  assert.strictEqual(failure.statusCode, 500)
+  assert.deepStrictEqual(await failure.body.json(), {
+    envelope: true,
+    statusCode: 500,
+    message: 'Internal Server Error'
+  })
+
+  const notFound = await request(`${app.url}/not-found`)
+  assert.strictEqual(notFound.statusCode, 404)
+  assert.deepStrictEqual(await notFound.body.json(), { envelope: true, statusCode: 404, message: 'nope' })
+})
+
+test('server.errorHandler does not prevent plugins from overriding it in their own context', async t => {
+  const app = await createFromConfig(
+    t,
+    buildConfig({ server: buildServerConfig(join(fixturesDir, 'error-handler.js')), plugins })
+  )
+
+  t.after(() => app.stop())
+  await app.start({ listen: true })
+
+  const res = await request(`${app.url}/scoped/boom`)
+  assert.strictEqual(res.statusCode, 500)
+  assert.deepStrictEqual(await res.body.json(), { envelope: 'scoped' })
+})
+
+test('server.errorHandler supports modules exporting a named errorHandler function', async t => {
+  const app = await createFromConfig(
+    t,
+    buildConfig({ server: buildServerConfig(join(fixturesDir, 'named-error-handler.js')), plugins })
+  )
+
+  t.after(() => app.stop())
+  await app.start({ listen: true })
+
+  const res = await request(`${app.url}/boom`)
+  assert.strictEqual(res.statusCode, 500)
+  assert.deepStrictEqual(await res.body.json(), { envelope: 'named' })
+})
+
+test('server.errorHandler throws if the module does not export a function', async t => {
+  await assert.rejects(
+    createFromConfig(
+      t,
+      buildConfig({ server: buildServerConfig(join(fixturesDir, 'invalid-error-handler.js')), plugins })
+    ),
+    {
+      code: 'PLT_SERVICE_INVALID_ERROR_HANDLER'
+    }
+  )
+})
+
+test('the default error handler is used when server.errorHandler is not set', async t => {
+  const app = await createFromConfig(t, buildConfig({ server: buildServerConfig(undefined), plugins }))
+
+  t.after(() => app.stop())
+  await app.start({ listen: true })
+
+  const res = await request(`${app.url}/boom`)
+  assert.strictEqual(res.statusCode, 500)
+  assert.deepStrictEqual(await res.body.json(), {
+    statusCode: 500,
+    error: 'Internal Server Error',
+    message: 'relation "public.users" does not exist'
+  })
+})

--- a/packages/service/test/fixtures/error-handler.js
+++ b/packages/service/test/fixtures/error-handler.js
@@ -1,0 +1,10 @@
+export default function errorHandler (error, request, reply) {
+  const statusCode = error.statusCode ?? 500
+
+  reply.status(statusCode).send({
+    envelope: true,
+    statusCode,
+    // 5xx bodies never expose the original message.
+    message: statusCode >= 500 ? 'Internal Server Error' : error.message
+  })
+}

--- a/packages/service/test/fixtures/invalid-error-handler.js
+++ b/packages/service/test/fixtures/invalid-error-handler.js
@@ -1,0 +1,1 @@
+export default { notAFunction: true }

--- a/packages/service/test/fixtures/named-error-handler.js
+++ b/packages/service/test/fixtures/named-error-handler.js
@@ -1,0 +1,3 @@
+export function errorHandler (error, request, reply) {
+  reply.status(error.statusCode ?? 500).send({ envelope: 'named' })
+}

--- a/packages/service/test/fixtures/throwing-plugin.js
+++ b/packages/service/test/fixtures/throwing-plugin.js
@@ -1,0 +1,21 @@
+export default async function (app) {
+  app.get('/boom', async () => {
+    throw new Error('relation "public.users" does not exist')
+  })
+
+  app.get('/not-found', async () => {
+    const error = new Error('nope')
+    error.statusCode = 404
+    throw error
+  })
+
+  app.register(async scoped => {
+    scoped.setErrorHandler((error, request, reply) => {
+      reply.status(error.statusCode ?? 500).send({ envelope: 'scoped' })
+    })
+
+    scoped.get('/scoped/boom', async () => {
+      throw new Error('boom')
+    })
+  })
+}


### PR DESCRIPTION
Fixes #5069.

## Problem

Fastify routes capture the error handler of the context that registers them, at registration time. The auto-generated CRUD routes of `@platformatic/db` are registered by `db-core`/`sql-openapi` **before** any user plugin runs, each entity in its own encapsulated child context. A `setErrorHandler` call from a user plugin is therefore a sibling context and can never attach to them.

The consequences reported in the issue:

- 5xx bodies of the CRUD routes leak the original `error.message` (database driver messages, table and constraint names) with no way to sanitize them;
- an application ends up with two error formats, the shaped one on hand-written routes and the Fastify default on the routes it did not write;
- there was no configuration escape hatch anywhere in the `@platformatic/*` schemas.

## Solution

This implements direction 1 from the issue: a config-level error handler.

`server.errorHandler` takes a path to a file (relative to the configuration file) or the name of an installed package, whose default export — or a named `errorHandler` export — is a Fastify error handler. It is installed on the root instance right after the Fastify instance is created and before anything is registered, so every route inherits it:

- the auto-generated CRUD routes of `@platformatic/db`,
- the GraphQL endpoint, the health check and the root route,
- every user route.

Plugins can still call `setErrorHandler` themselves to override it inside their own encapsulation context, so the existing per-plugin behaviour is unchanged.

```json
{
  "server": {
    "errorHandler": "./lib/error-handler.js"
  }
}
```

```js
// lib/error-handler.js
export default function errorHandler (error, request, reply) {
  const statusCode = error.statusCode ?? 500

  request.log.error({ err: error }, 'request errored')

  reply.status(statusCode).send({
    statusCode,
    code: error.code,
    message: statusCode >= 500 ? 'Internal Server Error' : error.message
  })
}
```

The option lives in the shared `fastifyServer` schema, so it is available to `@platformatic/service`, `@platformatic/db` and `@platformatic/gateway` alike. A module that does not export a function fails at boot with `PLT_SERVICE_INVALID_ERROR_HANDLER`.

## Tests

- `packages/db/test/error-handler.test.js` — asserts the handler covers the auto-generated CRUD routes, plus the counter-test showing that without it the driver message is exposed. Verified on both PostgreSQL and SQLite.
- `packages/service/test/error-handler.test.js` — user routes, 4xx pass-through, plugin-level override, the named-export form, the invalid-module error and the unchanged default behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012h4pp2kRNvCySUukXJKwnR
