### PR TITLE
fix(runtime): make the two configuration loads of a worker agree

### DIFF
--- a/packages/runtime/fixtures/missing-env-fallback/applications/app-a/package.json
+++ b/packages/runtime/fixtures/missing-env-fallback/applications/app-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "app-a",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@platformatic/service": "workspace:*"
+  }
+}

--- a/packages/runtime/fixtures/missing-env-fallback/applications/app-a/platformatic.json
+++ b/packages/runtime/fixtures/missing-env-fallback/applications/app-a/platformatic.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/3.0.0.json",
+  "plugins": {
+    "paths": [
+      {
+        "path": "plugin.js",
+        "options": {
+          "resolvedBaseUrl": "{PLT_SOME_BASE_URL}",
+          "resolvedClientId": "{PLT_SOME_CLIENT_ID}",
+          "cacheUrl": "valkey://{VALKEY_URL}"
+        }
+      }
+    ]
+  }
+}

--- a/packages/runtime/fixtures/missing-env-fallback/applications/app-a/plugin.js
+++ b/packages/runtime/fixtures/missing-env-fallback/applications/app-a/plugin.js
@@ -1,0 +1,9 @@
+export default async function (app, options) {
+  app.get('/options', async () => {
+    return {
+      resolvedBaseUrl: options.resolvedBaseUrl,
+      resolvedClientId: options.resolvedClientId,
+      cacheUrl: options.cacheUrl
+    }
+  })
+}

--- a/packages/runtime/fixtures/missing-env-fallback/platformatic.json
+++ b/packages/runtime/fixtures/missing-env-fallback/platformatic.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.0.0.json",
+  "entrypoint": "app-a",
+  "watch": false,
+  "strictEnv": "warn",
+  "restartOnError": false,
+  "gracefulShutdown": {
+    "application": 1000,
+    "runtime": 1000
+  },
+  "applications": [
+    {
+      "id": "app-a",
+      "path": "./applications/app-a"
+    }
+  ],
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "logger": {
+    "level": "info"
+  }
+}

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -140,10 +140,14 @@ export class Controller extends EventEmitter {
       }
 
       if (appConfig.config) {
-        // Parse the configuration file the first time to obtain the schema
+        // Parse the configuration file the first time to obtain the schema. This load is thrown away:
+        // the capability loads the configuration again below and that is the configuration the
+        // application actually runs on. This one only has to yield $schema and module, so it must not
+        // diverge from the second load in any way the user can observe: it deliberately applies no
+        // onMissingEnv fallback and emits no strictEnv report, both of which are left to the load the
+        // application is built from.
         const unvalidatedConfig = await loadConfiguration(appConfig.config, null, {
-          onMissingEnv: this.#context.fetchApplicationUrl,
-          strictEnv: this.#context.strictEnv
+          strictEnv: false
         })
         const pkg = await loadConfigurationModule(appConfig.path, unvalidatedConfig)
         this.capability = await pkg.create(appConfig.path, appConfig.config, this.#context)

--- a/packages/runtime/test/missing-env-fallback.test.js
+++ b/packages/runtime/test/missing-env-fallback.test.js
@@ -1,0 +1,62 @@
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { createRuntime, readLogs } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+const configFile = join(fixturesDir, 'missing-env-fallback', 'platformatic.json')
+
+function missingWarnings (logs) {
+  return logs.filter(
+    log => typeof log.msg === 'string' && log.msg.includes('environment variables which are not set')
+  )
+}
+
+test('the configuration the application runs on is not altered by the application URL fallback', async t => {
+  const runtime = await createRuntime(configFile)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+
+  const { statusCode, body } = await runtime.inject('app-a', { method: 'GET', url: '/options' })
+  strictEqual(statusCode, 200)
+
+  // A missing variable is empty regardless of whether its name ends with _URL. In particular
+  // `cacheUrl` shows why the fallback must not reach this load: the variable is a fragment of a
+  // connection string, so substituting an application URL would produce `valkey://http://app-a.plt.local`.
+  deepStrictEqual(JSON.parse(body), {
+    resolvedBaseUrl: '',
+    resolvedClientId: '',
+    cacheUrl: 'valkey://'
+  })
+})
+
+test('missing environment variables are reported once per application', async t => {
+  const context = {}
+  const runtime = await createRuntime(configFile, null, context)
+
+  t.after(async () => {
+    await runtime.close()
+  })
+
+  await runtime.start()
+  await runtime.close()
+
+  const logs = await readLogs(context.logsPath, 0)
+  const missing = missingWarnings(logs)
+
+  // Before, the throwaway load reported the _URL variables as replaced by a fallback value and the
+  // real load reported them as not set, so the same application warned twice, contradicting itself.
+  strictEqual(missing.length, 1)
+
+  // The single report lists every variable that is actually missing from the running configuration.
+  for (const name of ['PLT_SOME_BASE_URL', 'PLT_SOME_CLIENT_ID', 'VALKEY_URL']) {
+    strictEqual(missing[0].msg.includes(name), true, `expected ${name} in: ${missing[0].msg}`)
+  }
+
+  strictEqual(missing[0].msg.includes('fallback'), false)
+})


### PR DESCRIPTION
Fixes #5068.

## Problem

Every application is configured twice inside its worker:

```js
// packages/runtime/lib/worker/controller.js
const unvalidatedConfig = await loadConfiguration(appConfig.config, null, {
  onMissingEnv: this.#context.fetchApplicationUrl,   // first load
  strictEnv: this.#context.strictEnv
})
const pkg = await loadConfigurationModule(appConfig.path, unvalidatedConfig)
this.capability = await pkg.create(appConfig.path, appConfig.config, this.#context)  // second load
```

The first load exists only to pick the configuration module and is thrown away. The second one, performed by the capability, is the configuration the application actually runs on — and it never received `onMissingEnv`, because every capability forwards the worker context to `loadConfiguration` verbatim (`...context`) and on the context the callback is stored as `fetchApplicationUrl`.

With `strictEnv` this made a single application warn twice, milliseconds apart and contradicting itself: the first load listing a missing `*_URL` variable as replaced by a fallback value (the report added in #5026), the second listing the very same variable as simply not set.

## Solution

The two loads are made to agree — by aligning the **first** one with the second, not the other way around.

The first load only has to yield `$schema` and `module`, neither of which contains an environment placeholder, so it now applies no `onMissingEnv` fallback and emits no `strictEnv` report. Every variable is therefore reported exactly once, by the load whose values the application actually receives, and no value the application sees changes.

## Why not direction 2 from the issue

The issue suggests passing `onMissingEnv: context.fetchApplicationUrl` down into the capability `loadConfiguration` wrappers so both loads resolve the same way. I implemented that first, and it is not viable — it broke `packages/next` in CI. The callback is:

```js
function fetchApplicationUrl (application, key) {
  if (!key.endsWith('_URL') || !application.id) {
    return null
  }
  return getApplicationUrl(application.id)   // the *current* application, whatever the variable is named
}
```

It keys off the `_URL` suffix alone and ignores the variable name entirely, so applied to a real configuration it corrupts every `_URL` variable that is not an application reference. `packages/next/test/fixtures/caching-adapter` has

```json
"url": "valkey://{VALKEY_URL}"
```

`VALKEY_URL` is deliberately unset in CI, so today it resolves to `valkey://`, which iovalkey reads as "default host and port". With the fallback applied it becomes `valkey://http://frontend.plt.local` and the adapter test fails. The same defect makes the fallback wrong for the case it was presumably written for: `{PLT_WITH_LOGGER_URL}` in `packages/runtime/fixtures/monorepo/serviceApp` would resolve to `http://serviceApp.plt.local` — the *current* application, not `with-logger`.

Because the fallback has only ever run on a throwaway load, none of this has been observable until now. Making it observable is a separate design change: it would need to resolve the target application from the variable name and only fire when that application actually exists in the runtime. That is deliberately out of scope here, and the fixture below pins the current behaviour so the naive fallback cannot be re-introduced unnoticed.

Direction 1 (not loading twice at all) was also left out: passing the parsed object to `create` changes the signature contract of every capability, re-runs environment replacement over already-replaced values, and loses `kMetadata.path`, which the watcher and the management API depend on.

## Tests

`packages/runtime/test/missing-env-fallback.test.js`, with a fixture based on the one in the issue — an application whose plugin options reference unset `PLT_SOME_BASE_URL`, `PLT_SOME_CLIENT_ID` and `valkey://{VALKEY_URL}`, with `strictEnv: "warn"` at the runtime level:

- the missing-variables warning is emitted **once**, and lists every variable that is genuinely missing from the running configuration. This fails on `main` (3 warnings instead of 1).
- the values the application receives are unchanged, `valkey://{VALKEY_URL}` included. This fails against the direction-2 attempt with exactly the CI failure above (`valkey://http://app-a.plt.local`).

Full `packages/runtime` suite: 433/433 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012h4pp2kRNvCySUukXJKwnR
