### PR TITLE
fix(wattpm-utils): compare canonical paths in the import checks

### DIFF
--- a/packages/wattpm-utils/lib/commands/external.js
+++ b/packages/wattpm-utils/lib/commands/external.js
@@ -249,21 +249,31 @@ async function importApplication (logger, configurationFile, id, path, url, bran
 
   // If there is a locale path
   if (path) {
+    const canonicalPath = canonicalize(path)
     let autoloadPath = config.autoload?.path
 
-    // If we already autoload this path, there is nothing to do
+    // If we already autoload this path, there is nothing to do.
+    // Autoload only claims the direct children of its directory which are not excluded, so
+    // containment at any depth is not the right test.
     if (autoloadPath) {
-      autoloadPath = resolve(root, autoloadPath)
-      if (path.startsWith(autoloadPath)) {
+      autoloadPath = canonicalize(resolve(root, autoloadPath))
+
+      const isAutoloaded =
+        dirname(canonicalPath) === autoloadPath && !(config.autoload.exclude ?? []).includes(basename(canonicalPath))
+
+      if (isAutoloaded) {
         logger.warn('The path is already autoloaded as an application.')
         return
       }
     }
 
-    // If the path is within the application repository
-    if (path.startsWith(root)) {
+    // If the path is within the application repository. The root itself qualifies, as the
+    // configuration file might be the application one rather than the runtime one.
+    const canonicalRoot = canonicalize(root)
+
+    if (canonicalPath === canonicalRoot || isPathInside(canonicalRoot, canonicalPath)) {
       // If the path is already defined as an application, there is nothing to do
-      if (config.applications.some(s => s.path === path)) {
+      if (config.applications.some(s => s.path && canonicalize(s.path) === canonicalPath)) {
         logger.warn('The path is already defined as an application.')
         return
       }

--- a/packages/wattpm-utils/test/import.test.js
+++ b/packages/wattpm-utils/test/import.test.js
@@ -217,6 +217,117 @@ test('import - should not do anything when the local folder is already an autolo
   ok(importProcess.stdout.includes('The path is already autoloaded as an application.'))
 })
 
+test('import - should import a sibling of the autoload directory', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+  t.after(() => safeRemove(rootDir))
+
+  const configurationFile = resolve(rootDir, 'watt.json')
+  const originalFileContents = await loadRawConfigurationFile(configurationFile)
+
+  // web-legacy is not autoloaded, its name merely starts with the autoload directory
+  const path = join('web-legacy', 'other')
+  const absolute = resolve(rootDir, path)
+  await createDirectory(absolute)
+  await writeFile(resolve(absolute, 'index.js'), '', 'utf-8')
+
+  changeWorkingDirectory(t, rootDir)
+  const importProcess = await wattpmUtils('import', absolute)
+
+  ok(!importProcess.stdout.includes('The path is already autoloaded as an application.'))
+
+  deepStrictEqual(await loadRawConfigurationFile(configurationFile), {
+    ...originalFileContents,
+    web: [{ id: 'other', path }]
+  })
+})
+
+test('import - should import a directory nested deeper than the autoloaded applications', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+  t.after(() => safeRemove(rootDir))
+
+  const configurationFile = resolve(rootDir, 'watt.json')
+  const originalFileContents = await loadRawConfigurationFile(configurationFile)
+
+  // Autoload only claims the direct children of web, not this
+  const path = join('web', 'main', 'nested')
+  const absolute = resolve(rootDir, path)
+  await createDirectory(absolute)
+  await writeFile(resolve(absolute, 'index.js'), '', 'utf-8')
+
+  changeWorkingDirectory(t, rootDir)
+  const importProcess = await wattpmUtils('import', absolute)
+
+  ok(!importProcess.stdout.includes('The path is already autoloaded as an application.'))
+
+  deepStrictEqual(await loadRawConfigurationFile(configurationFile), {
+    ...originalFileContents,
+    web: [{ id: 'nested', path }]
+  })
+})
+
+test('import - should import an excluded child of the autoload directory', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+  t.after(() => safeRemove(rootDir))
+
+  const configurationFile = resolve(rootDir, 'watt.json')
+  const contents = await loadRawConfigurationFile(configurationFile)
+  contents.autoload.exclude = ['excluded']
+  await saveConfigurationFile(configurationFile, contents)
+
+  const path = join('web', 'excluded')
+  const absolute = resolve(rootDir, path)
+  await createDirectory(absolute)
+  await writeFile(resolve(absolute, 'index.js'), '', 'utf-8')
+
+  changeWorkingDirectory(t, rootDir)
+  const importProcess = await wattpmUtils('import', absolute)
+
+  ok(!importProcess.stdout.includes('The path is already autoloaded as an application.'))
+
+  deepStrictEqual(await loadRawConfigurationFile(configurationFile), {
+    ...contents,
+    web: [{ id: 'excluded', path }]
+  })
+})
+
+test('import - should use an environment variable for a sibling of the project directory', async t => {
+  const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
+  t.after(() => safeRemove(rootDir))
+
+  const configurationFile = resolve(rootDir, 'watt.json')
+  const originalFileContents = await loadRawConfigurationFile(configurationFile)
+
+  // The sibling name starts with the project directory, so a string prefix test considers it inside
+  const directory = `${rootDir}-legacy`
+  t.after(() => safeRemove(directory))
+  await createDirectory(directory)
+  await writeFile(resolve(directory, 'index.js'), '', 'utf-8')
+
+  await executeCommand('git', 'init', { cwd: directory })
+  await executeCommand('git', 'remote', 'add', 'origin', 'git@github.com:hello/world.git', { cwd: directory })
+
+  const id = basename(directory)
+  const envVariable = applicationToEnvVariable(id)
+
+  changeWorkingDirectory(t, rootDir)
+  await wattpmUtils('import', directory)
+
+  // The application is outside the project, so it must keep its URL and go through an env variable
+  deepStrictEqual(await loadRawConfigurationFile(configurationFile), {
+    ...originalFileContents,
+    web: [
+      {
+        id,
+        path: `{${envVariable}}`,
+        url: 'git@github.com:hello/world.git'
+      }
+    ]
+  })
+
+  deepStrictEqual(await readFile(resolve(rootDir, '.env'), 'utf-8'), `RUNTIME_ENV=foo\n${envVariable}=${directory}\n`)
+  deepStrictEqual(await readFile(resolve(rootDir, '.env.sample'), 'utf-8'), `${envVariable}=\n`)
+})
+
 test('import - should not do anything when the local folder is already a defined application', async t => {
   const { root: rootDir } = await prepareRuntime(t, 'main', false, 'watt.json')
   t.after(() => safeRemove(rootDir))


### PR DESCRIPTION
Fixes #5084

Follow-up to #5080, which fixed the same class of defect in `resolveApplications`; this one reuses the `canonicalize()` / `isPathInside()` helpers that PR added.

## Problem

`importApplication` decided two things with `startsWith`, so a sibling sharing a name prefix passed both checks:

```js
if (path.startsWith(autoloadPath)) { /* "already autoloaded" */ }
if (path.startsWith(root))         { /* "inside the repository" */ }
```

**Autoload check** — with `autoload.path: "web"`, `wattpm import ./web-legacy/other` warned *"The path is already autoloaded as an application"* and left the configuration untouched. It isn't autoloaded. The same false positive fired for anything nested deeper than one level (`web/main/nested`), which autoload never claims, and for an explicitly `exclude`d child.

**Repository check** — importing `../proj-legacy/api`, a sibling of the project root with a Git remote, wrote:

```jsonc
{ "id": "api", "path": "../proj-legacy/api" }
```

against the correct result for an equivalent directory that doesn't share the prefix:

```jsonc
{ "id": "api2", "path": "{PLT_APPLICATION_API2_PATH}", "url": "git@github.com:hello/world.git" }
```

So besides the `../` escaping path, **the Git URL was dropped** — the in-repository branch pushes `{id, path}` only, which is right for a directory versioned with the project and wrong here — and no `.env` / `.env.sample` entry was created. `wattpm resolve` could never restore that application.

## Fix

- Canonicalise the paths (`realpath`), so symlinks are resolved on both sides.
- Autoload claims the **non-excluded direct children** of its directory, so the accurate predicate is `dirname(canonicalPath) === autoloadPath` plus an `exclude` lookup — not containment at any depth.
- The repository check uses `isPathInside()`'s `relative()` boundary. The root itself still qualifies, since the configuration file may be the application one rather than the runtime one (`import .` from inside an application).
- The "already defined as an application" lookup compares canonical paths instead of exact strings, so a symlinked path no longer slips past it into a duplicate entry.

## Tests

Four tests in `packages/wattpm-utils/test/import.test.js`, all of which fail without this change:

- a sibling of the autoload directory (`web-legacy/other`) is imported rather than skipped
- a directory nested deeper than the autoloaded applications (`web/main/nested`) is imported
- an `exclude`d child of the autoload directory is imported
- a sibling of the project root goes through an environment variable and **keeps its URL**

Full `import.test.js` (33/33) passes, as does `resolve.test.js` (16/16).

Assisted-by: Claude Code:claude-opus-5[1m]