### PR TITLE
fix(runtime): detect overlapping application ports when loading the configuration

### DIFF
--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -160,6 +160,10 @@
 
 **Message:** Port %d is already in use by applications "%s" and "%s"
 
+### PLT_RUNTIME_APPLICATIONS_PORTS_OVERLAP
+
+**Message:** The applications "%s" (%s) and "%s" (%s) are both configured to listen on port %d. Applications cannot share a port: change one of the ports or make them listen on different hostnames.
+
 ### PLT_RUNTIME_WORKER_EADDR_IN_USE
 
 **Message:** Port %d is already in use by another worker of the application "%s". Multiple workers can share a port only when the reusePort feature is available in your OS, otherwise set "server.portAssignment" to "perWorkerIncrement" in the application configuration or use a single worker.

--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -14,6 +14,7 @@ import { createRequire } from 'node:module'
 import { isAbsolute, join, resolve as resolvePath } from 'node:path'
 
 import {
+  ApplicationsPortsOverlapError,
   InspectAndInspectBrkError,
   InspectorHostError,
   InspectorPortError,
@@ -212,6 +213,102 @@ export function parseInspectorOptions (config, inspect, inspectBreak) {
   config.watch = false
 }
 
+// Set by prepareApplication so that transform can check for port overlaps without loading the
+// application configurations a second time. Removed as soon as the check is done.
+const kDeclaredListener = Symbol('plt.runtime.config.declaredListener')
+
+const hostnameWildcards = new Set(['0.0.0.0', '::', '[::]'])
+
+// The listener an application declares in its own configuration, when it can be determined without
+// starting it. A port coming from an environment variable which was not replaced, an ephemeral port
+// and a missing server block all yield null, in which case only the start time check applies.
+function declaredListener (applicationConfig) {
+  const server = applicationConfig?.server
+
+  if (!server) {
+    return null
+  }
+
+  const port = Number(server.port)
+
+  if (!Number.isInteger(port) || port <= 0) {
+    return null
+  }
+
+  return { port, hostname: server.hostname, perWorker: server.portAssignment === 'perWorkerIncrement' }
+}
+
+// Two declared listeners can only be compared when both hostnames are known. When a hostname is
+// omitted the capability picks its own default, so unless the other side is a wildcard - which
+// overlaps with anything - the comparison is left to the start time check.
+function declaredListenersOverlap (first, second) {
+  const hostname = first.hostname?.toLowerCase()
+  const otherHostname = second.hostname?.toLowerCase()
+
+  // A wildcard overlaps with any other hostname, known or not
+  if (hostnameWildcards.has(hostname) || hostnameWildcards.has(otherHostname)) {
+    return true
+  }
+
+  // Both applications rely on the same capability default, so they do collide
+  if (typeof hostname === 'undefined' && typeof otherHostname === 'undefined') {
+    return true
+  }
+
+  // Only one of the two defaults is unknown, so nothing can be concluded here
+  if (typeof hostname === 'undefined' || typeof otherHostname === 'undefined') {
+    return false
+  }
+
+  return hostname === otherHostname
+}
+
+function describeDeclaredPorts (listener) {
+  const { port, last } = listener
+  return port === last ? `port ${port}` : `ports ${port}-${last}, one per worker`
+}
+
+// Rejects applications whose declared ports overlap before any of them is started, so that the
+// failure does not depend on which worker happens to report its URL first. This is best effort:
+// applications whose port cannot be determined here are checked when their workers start.
+function verifyApplicationsPorts (applications) {
+  const listeners = []
+
+  for (const application of applications) {
+    const listener = application[kDeclaredListener]
+    delete application[kDeclaredListener]
+
+    // Dynamic scaling changes how many ports the application ends up using, so leave it to the start time check
+    if (!listener || application.workers?.dynamic) {
+      continue
+    }
+
+    const workers = listener.perWorker ? (application.workers?.static ?? 1) : 1
+    listeners.push({ ...listener, id: application.id, last: listener.port + workers - 1 })
+  }
+
+  for (let i = 0; i < listeners.length; i++) {
+    for (let j = i + 1; j < listeners.length; j++) {
+      const first = listeners[i]
+      const second = listeners[j]
+
+      const port = Math.max(first.port, second.port)
+
+      if (port > Math.min(first.last, second.last) || !declaredListenersOverlap(first, second)) {
+        continue
+      }
+
+      throw new ApplicationsPortsOverlapError(
+        first.id,
+        describeDeclaredPorts(first),
+        second.id,
+        describeDeclaredPorts(second),
+        port
+      )
+    }
+  }
+}
+
 export async function prepareApplication (config, application, defaultWorkers) {
   // We need to have absolute paths here, ot the `loadConfig` will fail
   // Make sure we don't resolve if env var was not replaced
@@ -234,6 +331,10 @@ export async function prepareApplication (config, application, defaultWorkers) {
 
       if (application.config) {
         const applicationConfig = await loadConfiguration(application.config)
+
+        // Recorded before loading the capability so that it survives a capability which cannot be resolved
+        application[kDeclaredListener] = declaredListener(applicationConfig)
+
         pkg = await loadConfigurationModule(application.path, applicationConfig)
 
         application.type = extractModuleFromSchemaUrl(applicationConfig, true).module
@@ -411,6 +512,8 @@ export async function transform (config, _, context) {
   for (let i = 0; i < applications.length; ++i) {
     await prepareApplication(config, applications[i], defaultWorkers)
   }
+
+  verifyApplicationsPorts(applications)
 
   if (typeof config.metrics === 'boolean') {
     config.metrics = {

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -15,6 +15,10 @@ export const AddressInUseError = createError(
   `${ERROR_PREFIX}_EADDR_IN_USE`,
   'Port %d is already in use by applications "%s" and "%s"'
 )
+export const ApplicationsPortsOverlapError = createError(
+  `${ERROR_PREFIX}_APPLICATIONS_PORTS_OVERLAP`,
+  'The applications "%s" (%s) and "%s" (%s) are both configured to listen on port %d. Applications cannot share a port: change one of the ports or make them listen on different hostnames.'
+)
 export const WorkerAddressInUseError = createError(
   `${ERROR_PREFIX}_WORKER_EADDR_IN_USE`,
   'Port %d is already in use by another worker of the application "%s". Multiple workers can share a port only when the reusePort feature is available in your OS, otherwise set "server.portAssignment" to "perWorkerIncrement" in the application configuration or use a single worker.'

--- a/packages/runtime/test/ports.test.js
+++ b/packages/runtime/test/ports.test.js
@@ -77,12 +77,81 @@ test('applications without server.port use ITC only', async t => {
   strictEqual(response.statusCode, 200)
 })
 
-test('runtime stops when applications listen on the same port', async t => {
+test('runtime refuses to load when applications declare the same port', async t => {
   const root = await createTemporaryDirectory(t, 'duplicate-port')
   const port = await getPort()
   const server = { hostname: '127.0.0.1', port }
   const first = await createApplication(root, 'first', server)
   const second = await createApplication(root, 'second', server)
+
+  // The ports are declared in the configurations, so the conflict is reported before anything starts
+  await rejects(
+    () => createTestRuntime(t, [first, second]),
+    error => {
+      strictEqual(error.cause?.code, 'PLT_RUNTIME_APPLICATIONS_PORTS_OVERLAP')
+      match(error.message, new RegExp(`"first" \\(port ${port}\\) and "second" \\(port ${port}\\)`))
+      match(error.message, new RegExp(`listen on port ${port}`))
+      return true
+    }
+  )
+})
+
+test('runtime refuses to load when an application declares a port inside a per-worker range', async t => {
+  const root = await createTemporaryDirectory(t, 'per-worker-range')
+  const port = await getPort()
+
+  // first occupies port .. port + 2, so second collides on its second worker
+  const first = await createApplication(root, 'first', {
+    hostname: '127.0.0.1',
+    port,
+    portAssignment: 'perWorkerIncrement'
+  })
+  first.workers = 3
+  const second = await createApplication(root, 'second', { hostname: '127.0.0.1', port: port + 1 })
+
+  await rejects(
+    () => createTestRuntime(t, [first, second]),
+    error => {
+      strictEqual(error.cause?.code, 'PLT_RUNTIME_APPLICATIONS_PORTS_OVERLAP')
+      match(error.message, new RegExp(`"first" \\(ports ${port}-${port + 2}, one per worker\\)`))
+      match(error.message, new RegExp(`listen on port ${port + 1}`))
+      return true
+    }
+  )
+})
+
+test('applications can listen next to a per-worker range', async t => {
+  const root = await createTemporaryDirectory(t, 'next-to-per-worker-range')
+  const port = await getPort()
+
+  const first = await createApplication(root, 'first', {
+    hostname: '127.0.0.1',
+    port,
+    portAssignment: 'perWorkerIncrement'
+  })
+  first.workers = 2
+  // first only reaches port + 1
+  const second = await createApplication(root, 'second', { hostname: '127.0.0.1', port: port + 2 })
+
+  const runtime = await createTestRuntime(t, [first, second])
+  t.after(() => runtime.close())
+
+  const urls = await runtime.start(true)
+  strictEqual(new URL(urls['first:0']).port, String(port))
+  strictEqual(new URL(urls['first:1']).port, String(port + 1))
+  strictEqual(new URL(urls['second:0']).port, String(port + 2))
+})
+
+test('ports which are not declared in the configuration are still checked when applications start', async t => {
+  const root = await createTemporaryDirectory(t, 'duplicate-port-from-env')
+  const port = await getPort()
+
+  // The port is only known inside the worker, so the load time check cannot see it
+  const first = await createApplication(root, 'first', { hostname: '127.0.0.1', port: '{HTTP_PORT}' })
+  first.env = { HTTP_PORT: String(port) }
+  const second = await createApplication(root, 'second', { hostname: '127.0.0.1', port: '{HTTP_PORT}' })
+  second.env = { HTTP_PORT: String(port) }
+
   const runtime = await createTestRuntime(t, [first, second])
 
   await rejects(
@@ -96,6 +165,25 @@ test('runtime stops when applications listen on the same port', async t => {
       return true
     }
   )
+})
+
+test('applications using dynamic workers are not checked when loading', async t => {
+  const root = await createTemporaryDirectory(t, 'dynamic-workers-ports')
+  const port = await getPort()
+
+  // The number of workers, and thus the range, changes while running
+  const first = await createApplication(root, 'first', {
+    hostname: '127.0.0.1',
+    port,
+    portAssignment: 'perWorkerIncrement'
+  })
+  first.workers = { dynamic: true, minimum: 1, maximum: 3 }
+  const second = await createApplication(root, 'second', { hostname: '127.0.0.1', port: port + 1 })
+
+  const runtime = await createTestRuntime(t, [first, second])
+  t.after(() => runtime.close())
+
+  ok(runtime)
 })
 
 test('applications can listen on the same port on different hosts', async t => {


### PR DESCRIPTION
Fixes #5087 — the point left open by #5075 (and by #5074 before it).

## Problem

Port collision between applications is detected only when a worker starts and reports its URL. `#getPortOwner` (`runtime.js:4964`) skips workers without `kWorkerUrl`, so it only knows about workers that have **already reported**. With `server.portAssignment: perWorkerIncrement` an application occupies a *range*, and the outcome depends on start order.

Application `a`: `workers: 3`, `port: 3000`, `perWorkerIncrement` → occupies 3000–3002. Application `b`: `port: 3001`.

| start order | outcome |
| --- | --- |
| `a:1` reports 3001 first | `b` rejected with `PLT_RUNTIME_EADDR_IN_USE` — useful |
| `b:0` reports 3001 first | `b` starts fine; `a:1` dies. **The misconfigured application boots, the correct one fails** |

The existing tests encoded the non-determinism by accepting either error:

```js
ok(error.code === 'EADDRINUSE' || error.code === 'PLT_RUNTIME_EADDR_IN_USE', error.message)
```

Neither message names the range, so "port 3001 is in use by a" leaves the operator to work out that `a` was configured for 3000 and reaches 3001 because it has three workers.

## Why this is now possible

#5075 recorded "the runtime does not know capability configurations at load time". That holds for the worker-side configuration, but the runtime already reads each application's configuration **file** in the main thread — `prepareApplication` (`config.js:236`) calls `loadConfiguration(application.config)` for capability detection and discards it. The `server` block is right there, and `application.workers` is resolved by then. No extra I/O.

## Fix

`verifyApplicationsPorts()` runs in `transform` after all applications are prepared:

- the declared listener is captured in `prepareApplication` from the configuration it already loads, **before** `loadConfigurationModule`, so it survives a capability that cannot be resolved;
- an application declaring a literal port occupies that port, or `port … port + workers - 1` with `perWorkerIncrement`;
- overlapping ranges between two applications raise the new `PLT_RUNTIME_APPLICATIONS_PORTS_OVERLAP`, naming both applications, both ranges and the conflicting port:

```
The applications "first" (ports 3000-3002, one per worker) and "second" (port 3001)
are both configured to listen on port 3001. Applications cannot share a port:
change one of the ports or make them listen on different hostnames.
```

**Best effort and purely additive.** These yield no verdict and keep relying on the unchanged start-time check: a port from an environment variable (`{PORT}` does not coerce to an integer), `port: 0`, a missing `server` block, an application using **dynamic workers** (the range changes while running), and a hostname omitted by only one side (the capability default is not known here). A wildcard hostname on either side overlaps with anything; two omitted hostnames share the same default and do collide.

## Tests

`packages/runtime/test/ports.test.js`, 8/8:

- refuses to load when two applications declare the same port
- refuses to load when an application declares a port inside a per-worker range (the issue's scenario)
- allows an application listening immediately *next to* a per-worker range
- **ports which are not declared in the configuration are still checked when applications start** — keeps the start-time path covered, with the original either-error assertion
- applications using dynamic workers are not checked when loading
- the pre-existing same-port-different-hosts and env-var-port tests, unchanged

`runtime stops when applications listen on the same port` became `runtime refuses to load when applications declare the same port` and now asserts the exact error, since the failure moved earlier and is deterministic.

`multiple-workers` suite 78 pass / 1 skip / 0 fail; `config.test.js` and `per-worker-port.test.js` unaffected. No fixture in the repo declares the same literal port twice, so nothing else changes behaviour.

Assisted-by: Claude Code:claude-opus-5[1m]