### PR TITLE
feat(service,gateway,sql-openapi): add `openapi.ui` option to skip the API reference UI

### DIFF
--- a/docs/reference/db/configuration.md
+++ b/docs/reference/db/configuration.md
@@ -136,6 +136,8 @@ postgres://user:password@my-database:5432/db-name
 - **`openapi`** (`boolean` or `object`, default: `true`) — Enables OpenAPI REST support.
   - If value is an object, all [OpenAPI v3](https://swagger.io/specification/) allowed properties can be passed. Also, a `prefix` property can be passed to set the OpenAPI prefix.
   - Platformatic DB uses [`@fastify/swagger`](https://github.com/fastify/fastify-swagger) under the hood to manage this configuration.
+  - `swaggerPrefix` (`string`, default: `/documentation`) sets the path under which the spec (`/json`, `/yaml`) and the API reference UI are served.
+  - `ui` (`boolean`, default: `true`) serves the interactive API reference UI under `swaggerPrefix`. Set it to `false` to keep only the spec routes: the UI is then never loaded, which saves the memory it would occupy in every worker, noticeable in runtimes with many applications where nobody opens the documentation page.
 
   Enables OpenAPI
 

--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -240,6 +240,8 @@ Configure `@platformatic/service` specific settings such as `graphql` or `openap
 - **`openapi`** (`boolean` or `object`, default: `false`) — Enables OpenAPI REST support.
   - If value is an object, all [OpenAPI v3](https://swagger.io/specification/) allowed properties can be passed. Also, a `prefix` property can be passed to set the OpenAPI prefix.
   - Platformatic Service uses [`@fastify/swagger`](https://github.com/fastify/fastify-swagger) under the hood to manage this configuration.
+  - `swaggerPrefix` (`string`, default: `/documentation`) sets the path under which the spec (`/json`, `/yaml`) and the API reference UI are served.
+  - `ui` (`boolean`, default: `true`) serves the interactive API reference UI under `swaggerPrefix`. Set it to `false` to keep only the spec routes: the UI is then never loaded, which saves the memory it would occupy in every worker, noticeable in runtimes with many applications where nobody opens the documentation page.
 
   _Examples_
 
@@ -261,6 +263,18 @@ Configure `@platformatic/service` specific settings such as `graphql` or `openap
     "service": {
       "openapi": {
         "prefix": "/api"
+      }
+    }
+  }
+  ```
+
+  Enables OpenAPI without the API reference UI (spec routes only)
+
+  ```json
+  {
+    "service": {
+      "openapi": {
+        "ui": false
       }
     }
   }

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -1166,6 +1166,10 @@ export interface PlatformaticComposerConfig {
        */
       swaggerPrefix?: string;
       /**
+       * Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served.
+       */
+      ui?: boolean;
+      /**
        * Path to an OpenAPI spec file
        */
       path?: string;

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -4333,6 +4333,11 @@
               "type": "string",
               "description": "Base URL for the OpenAPI Swagger Documentation"
             },
+            "ui": {
+              "type": "boolean",
+              "default": true,
+              "description": "Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served."
+            },
             "path": {
               "type": "string",
               "description": "Path to an OpenAPI spec file",

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -257,6 +257,10 @@ export interface PlatformaticDatabaseConfig {
            */
           swaggerPrefix?: string;
           /**
+           * Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served.
+           */
+          ui?: boolean;
+          /**
            * Path to an OpenAPI spec file
            */
           path?: string;

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -189,6 +189,11 @@ export const db = {
               type: 'string',
               description: 'Base URL for the OpenAPI Swagger Documentation'
             },
+            ui: {
+              type: 'boolean',
+              default: true,
+              description: 'Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served.'
+            },
             prefix: {
               type: 'string',
               description: 'Base URL for generated Platformatic DB routes'

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -769,6 +769,11 @@
                   "type": "string",
                   "description": "Base URL for the OpenAPI Swagger Documentation"
                 },
+                "ui": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served."
+                },
                 "path": {
                   "type": "string",
                   "description": "Path to an OpenAPI spec file",

--- a/packages/db/test/openapi-ui.test.js
+++ b/packages/db/test/openapi-ui.test.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { createFromConfig, getConnectionInfo } from './helper.js'
+
+// The option reaches @platformatic/sql-openapi through db.openapi; this file
+// pins that wiring. The API reference UI is pulled in through a dynamic
+// import, so its presence in the module graph is the observable for "it was
+// never loaded" - the point of the option, the 404 being its side effect.
+// These tests live in their own file because the check is process-wide: any
+// application started with the default configuration loads the UI for good.
+const require = createRequire(import.meta.url)
+
+function apiReferenceIsLoaded () {
+  // Normalise separators: on Windows the cache keys use backslashes.
+  return Object.keys(require.cache).some(key => key.replace(/\\/g, '/').includes('@scalar/fastify-api-reference'))
+}
+
+async function createApp (t, openapi) {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('sqlite')
+
+  const app = await createFromConfig(t, {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' }
+    },
+    db: {
+      ...connectionInfo,
+      openapi
+    }
+  })
+
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+  await app.start({ listen: true })
+
+  return app
+}
+
+test('db.openapi.ui: false keeps the spec routes and never loads the API reference UI', async t => {
+  const app = await createApp(t, { ui: false })
+
+  const json = await request(`${app.url}/documentation/json`)
+  assert.equal(json.statusCode, 200, 'json spec is served')
+  assert.ok((await json.body.json()).openapi)
+
+  const yaml = await request(`${app.url}/documentation/yaml`)
+  assert.equal(yaml.statusCode, 200, 'yaml spec is served')
+
+  const ui = await request(`${app.url}/documentation/`)
+  assert.equal(ui.statusCode, 404, 'no API reference UI')
+
+  assert.equal(apiReferenceIsLoaded(), false, 'the API reference UI is not loaded')
+})
+
+// Positive control for the assertion above: it also proves the module graph
+// check can observe the UI at all, so it cannot quietly stop measuring.
+test('db.openapi.ui defaults to true: the API reference UI is served and loaded', async t => {
+  const app = await createApp(t, {})
+
+  const ui = await request(`${app.url}/documentation/`)
+  assert.equal(ui.statusCode, 200, 'API reference UI is served')
+
+  assert.equal(apiReferenceIsLoaded(), true, 'the API reference UI is loaded')
+})

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -355,6 +355,10 @@ export interface PlatformaticGatewayConfig {
        */
       swaggerPrefix?: string;
       /**
+       * Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served.
+       */
+      ui?: boolean;
+      /**
        * Path to an OpenAPI spec file
        */
       path?: string;

--- a/packages/gateway/lib/openapi-scalar.js
+++ b/packages/gateway/lib/openapi-scalar.js
@@ -1,14 +1,19 @@
 import fp from 'fastify-plugin'
 
 async function openApiScalarPlugin (app, opts) {
-  const { default: scalarTheme } = await import('@platformatic/scalar-theme')
-  const { default: scalarApiReference } = await import('@scalar/fastify-api-reference')
-
   const routePrefix = opts.openapi?.swaggerPrefix || '/documentation'
 
   /** Serve spec file in yaml and json */
   app.get(`${routePrefix}/json`, { schema: { hide: true } }, async () => app.swagger())
   app.get(`${routePrefix}/yaml`, { schema: { hide: true } }, async () => app.swagger({ yaml: true }))
+
+  // Imported below the guard on purpose: not loading the UI is what this option buys.
+  if (opts.openapi?.ui === false) {
+    return
+  }
+
+  const { default: scalarTheme } = await import('@platformatic/scalar-theme')
+  const { default: scalarApiReference } = await import('@scalar/fastify-api-reference')
 
   await app.register(scalarApiReference, {
     logLevel: 'warn',

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1340,6 +1340,11 @@
               "type": "string",
               "description": "Base URL for the OpenAPI Swagger Documentation"
             },
+            "ui": {
+              "type": "boolean",
+              "default": true,
+              "description": "Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served."
+            },
             "path": {
               "type": "string",
               "description": "Path to an OpenAPI spec file",

--- a/packages/gateway/test/openapi/ui.test.js
+++ b/packages/gateway/test/openapi/ui.test.js
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+import { createFromConfig, createOpenApiApplication } from '../helper.js'
+
+// The API reference UI is pulled in through a dynamic import, so whether it is
+// present in the module graph is the observable for "it was never loaded" -
+// which is the point of the option, the 404 being only its side effect.
+// These tests live in their own file because the check is process-wide: any
+// gateway started with the default configuration loads the UI for good.
+const require = createRequire(import.meta.url)
+
+function apiReferenceIsLoaded () {
+  // Normalise separators: on Windows the cache keys use backslashes.
+  return Object.keys(require.cache).some(key => key.replace(/\\/g, '/').includes('@scalar/fastify-api-reference'))
+}
+
+async function createGateway (t, openapi) {
+  const api = await createOpenApiApplication(t, ['users'])
+  await api.listen({ port: 0 })
+
+  return createFromConfig(t, {
+    server: {
+      logger: {
+        level: 'fatal'
+      }
+    },
+    gateway: {
+      applications: [
+        {
+          id: 'api1',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: {
+            url: '/documentation/json'
+          }
+        }
+      ],
+      openapi
+    }
+  })
+}
+
+test('ui: false keeps the spec routes and never loads the API reference UI', async t => {
+  const gateway = await createGateway(t, { ui: false })
+
+  {
+    const { statusCode, body } = await gateway.inject({ method: 'GET', url: '/documentation/json' })
+    assert.equal(statusCode, 200)
+    assert.ok(JSON.parse(body).openapi, 'json spec is served')
+  }
+
+  {
+    const { statusCode } = await gateway.inject({ method: 'GET', url: '/documentation/yaml' })
+    assert.equal(statusCode, 200, 'yaml spec is served')
+  }
+
+  {
+    const { statusCode } = await gateway.inject({ method: 'GET', url: '/documentation/' })
+    assert.equal(statusCode, 404, 'no API reference UI')
+  }
+
+  assert.equal(apiReferenceIsLoaded(), false, 'the API reference UI is not loaded')
+})
+
+// Positive control for the assertion above: it also proves the module graph
+// check can observe the UI at all, so it cannot quietly stop measuring.
+test('ui defaults to true: the API reference UI is served and loaded', async t => {
+  const gateway = await createGateway(t, {})
+
+  const { statusCode } = await gateway.inject({ method: 'GET', url: '/documentation/' })
+  assert.equal(statusCode, 200, 'API reference UI is served')
+
+  assert.equal(apiReferenceIsLoaded(), true, 'the API reference UI is loaded')
+})

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -309,6 +309,10 @@ export interface PlatformaticServiceConfig {
            */
           swaggerPrefix?: string;
           /**
+           * Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served.
+           */
+          ui?: boolean;
+          /**
            * Path to an OpenAPI spec file
            */
           path?: string;

--- a/packages/service/lib/plugins/openapi.js
+++ b/packages/service/lib/plugins/openapi.js
@@ -45,9 +45,6 @@ async function setupOpenAPIPlugin (app, options) {
 
   await app.register(Swagger, swaggerOptions)
 
-  const { default: scalarTheme } = await import('@platformatic/scalar-theme')
-  const { default: scalarApiReference } = await import('@scalar/fastify-api-reference')
-
   const routePrefix = openapi.swaggerPrefix || '/documentation'
 
   /** Serve spec file in yaml and json */
@@ -67,6 +64,14 @@ async function setupOpenAPIPlugin (app, options) {
     },
     async () => app.swagger({ yaml: true })
   )
+
+  // Imported below the guard on purpose: not loading the UI is what this option buys.
+  if (openapi.ui === false) {
+    return
+  }
+
+  const { default: scalarTheme } = await import('@platformatic/scalar-theme')
+  const { default: scalarApiReference } = await import('@scalar/fastify-api-reference')
 
   app.register(scalarApiReference, {
     ...options,

--- a/packages/service/lib/schema.js
+++ b/packages/service/lib/schema.js
@@ -1158,6 +1158,11 @@ export const openApiBase = {
       type: 'string',
       description: 'Base URL for the OpenAPI Swagger Documentation'
     },
+    ui: {
+      type: 'boolean',
+      default: true,
+      description: 'Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served.'
+    },
     path: {
       type: 'string',
       description: 'Path to an OpenAPI spec file',

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -972,6 +972,11 @@
                   "type": "string",
                   "description": "Base URL for the OpenAPI Swagger Documentation"
                 },
+                "ui": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Serve the interactive API reference UI under the documentation prefix. The JSON and YAML spec routes are always served."
+                },
                 "path": {
                   "type": "string",
                   "description": "Path to an OpenAPI spec file",

--- a/packages/service/test/openapi-ui.test.js
+++ b/packages/service/test/openapi-ui.test.js
@@ -1,0 +1,72 @@
+import assert from 'node:assert'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { createFromConfig } from './helper.js'
+
+// The API reference UI is pulled in through a dynamic import, so whether it is
+// present in the module graph is the observable for "it was never loaded" -
+// which is the point of the option, the 404 being only its side effect.
+// These tests live in their own file because the check is process-wide: any
+// application started with the default configuration loads the UI for good.
+const require = createRequire(import.meta.url)
+
+function apiReferenceIsLoaded () {
+  // Normalise separators: on Windows the cache keys use backslashes.
+  return Object.keys(require.cache).some(key => key.replace(/\\/g, '/').includes('@scalar/fastify-api-reference'))
+}
+
+function createConfig (openapi) {
+  return {
+    server: {
+      hostname: '127.0.0.1',
+      port: 0,
+      logger: { level: 'fatal' },
+      forceCloseConnections: true
+    },
+    service: {
+      openapi: {
+        path: join(import.meta.dirname, 'fixtures', 'openapi-spec-test.json'),
+        ...openapi
+      }
+    },
+    watch: false
+  }
+}
+
+test('ui: false keeps the spec routes and never loads the API reference UI', async t => {
+  const app = await createFromConfig(t, createConfig({ ui: false }))
+  t.after(async () => {
+    await app.stop()
+  })
+  await app.start({ listen: true })
+
+  const json = await request(`${app.url}/documentation/json`)
+  assert.strictEqual(json.statusCode, 200, 'json spec is served')
+  const body = await json.body.json()
+  assert.ok(body.paths['/hello'], 'spec content')
+
+  const yaml = await request(`${app.url}/documentation/yaml`)
+  assert.strictEqual(yaml.statusCode, 200, 'yaml spec is served')
+
+  const ui = await request(`${app.url}/documentation/`)
+  assert.strictEqual(ui.statusCode, 404, 'no API reference UI')
+
+  assert.strictEqual(apiReferenceIsLoaded(), false, 'the API reference UI is not loaded')
+})
+
+// Positive control for the assertion above: it also proves the module graph
+// check can observe the UI at all, so it cannot quietly stop measuring.
+test('ui defaults to true: the API reference UI is served and loaded', async t => {
+  const app = await createFromConfig(t, createConfig())
+  t.after(async () => {
+    await app.stop()
+  })
+  await app.start({ listen: true })
+
+  const ui = await request(`${app.url}/documentation/`)
+  assert.strictEqual(ui.statusCode, 200, 'API reference UI is served')
+
+  assert.strictEqual(apiReferenceIsLoaded(), true, 'the API reference UI is loaded')
+})

--- a/packages/sql-openapi/index.js
+++ b/packages/sql-openapi/index.js
@@ -42,22 +42,26 @@ async function setupOpenAPI (app, opts) {
   const ignoreAllReverseRoutes = opts.ignoreAllReverseRoutes || false
   const paths = opts.paths || {}
 
-  const { default: scalarTheme } = await import('@platformatic/scalar-theme')
-  const { default: scalarApiReference } = await import('@scalar/fastify-api-reference')
   const routePrefix = opts.swaggerPrefix || '/documentation'
 
   app.get(`${routePrefix}/json`, { schema: { hide: true }, logLevel: 'warn' }, async () => app.swagger())
   app.get(`${routePrefix}/yaml`, { schema: { hide: true }, logLevel: 'warn' }, async () => app.swagger({ yaml: true }))
 
-  app.register(scalarApiReference, {
-    ...opts,
-    logLevel: 'warn',
-    prefix: undefined,
-    routePrefix,
-    configuration: {
-      customCss: scalarTheme.theme
-    }
-  })
+  // Imported inside the guard on purpose: not loading the UI is what this option buys.
+  if (opts.ui !== false) {
+    const { default: scalarTheme } = await import('@platformatic/scalar-theme')
+    const { default: scalarApiReference } = await import('@scalar/fastify-api-reference')
+
+    app.register(scalarApiReference, {
+      ...opts,
+      logLevel: 'warn',
+      prefix: undefined,
+      routePrefix,
+      configuration: {
+        customCss: scalarTheme.theme
+      }
+    })
+  }
 
   app.addHook('onRoute', routeOptions => {
     if (paths[routeOptions.url]) {

--- a/packages/sql-openapi/test/ui.test.js
+++ b/packages/sql-openapi/test/ui.test.js
@@ -1,0 +1,86 @@
+import sqlMapper from '@platformatic/sql-mapper'
+import fastify from 'fastify'
+import { equal, ok as pass } from 'node:assert'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+import sqlOpenAPI from '../index.js'
+import { clear, connInfo, isMysql, isSQLite } from './helper.js'
+
+// The API reference UI is pulled in through a dynamic import, so whether it is
+// present in the module graph is the observable for "it was never loaded" -
+// which is the point of the option, the 404 being only its side effect.
+// These tests live in their own file because the check is process-wide: any
+// application started with the default configuration loads the UI for good.
+const require = createRequire(import.meta.url)
+
+function apiReferenceIsLoaded () {
+  // Normalise separators: on Windows the cache keys use backslashes.
+  return Object.keys(require.cache).some(key => key.replace(/\\/g, '/').includes('@scalar/fastify-api-reference'))
+}
+
+async function createBasicPages (db, sql) {
+  if (isSQLite) {
+    await db.query(sql`CREATE TABLE pages (
+      id INTEGER PRIMARY KEY,
+      title VARCHAR(42) NOT NULL
+    );`)
+  } else if (isMysql) {
+    await db.query(sql`CREATE TABLE pages (
+      id INT NOT NULL AUTO_INCREMENT UNIQUE PRIMARY KEY,
+      title VARCHAR(42) NOT NULL
+    );`)
+  } else {
+    await db.query(sql`CREATE TABLE pages (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(42) NOT NULL
+    );`)
+  }
+}
+
+function createApp (t, opts) {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    async onDatabaseLoad (db, sql) {
+      pass('onDatabaseLoad called')
+
+      await clear(db, sql)
+      await createBasicPages(db, sql)
+    }
+  })
+  app.register(sqlOpenAPI, opts)
+  t.after(() => app.close())
+  return app
+}
+
+test('ui: false keeps the spec routes and never loads the API reference UI', async t => {
+  const app = createApp(t, { ui: false })
+  await app.ready()
+
+  {
+    const res = await app.inject({ method: 'GET', url: '/documentation/json' })
+    equal(res.statusCode, 200, 'GET /documentation/json is served')
+  }
+  {
+    const res = await app.inject({ method: 'GET', url: '/documentation/yaml' })
+    equal(res.statusCode, 200, 'GET /documentation/yaml is served')
+  }
+  {
+    const res = await app.inject({ method: 'GET', url: '/documentation/' })
+    equal(res.statusCode, 404, 'GET /documentation/ has no UI')
+  }
+
+  equal(apiReferenceIsLoaded(), false, 'the API reference UI is not loaded')
+})
+
+// Positive control for the assertion above: it also proves the module graph
+// check can observe the UI at all, so it cannot quietly stop measuring.
+test('ui defaults to true: the API reference UI is served and loaded', async t => {
+  const app = createApp(t, {})
+  await app.ready()
+
+  const res = await app.inject({ method: 'GET', url: '/documentation/' })
+  equal(res.statusCode, 200, 'GET /documentation/ serves the UI')
+
+  equal(apiReferenceIsLoaded(), true, 'the API reference UI is loaded')
+})


### PR DESCRIPTION
The Scalar API reference UI is registered unconditionally whenever OpenAPI is enabled, in three places: `@platformatic/service` (`lib/plugins/openapi.js`), `@platformatic/gateway` (`lib/openapi-scalar.js`) and `@platformatic/sql-openapi` (`index.js`). There is currently no way to keep the spec and skip the UI.

That matters in a runtime with many applications. OpenAPI has to stay enabled, because other applications and the generated clients consume the spec, but nobody ever opens the documentation page on those workers. Importing the UI costs about **11 MB of heap (~70 MB RSS) per worker thread**, and that cost is paid once per application, for something no one loads.

Reproduction on Node 24, with fastify and `@fastify/swagger` already loaded so the figure is marginal cost, three runs, stable to 0.1 MB:

```js
// node --expose-gc probe.mjs, run from packages/service
const settle = async () => { for (let i = 0; i < 5; i++) { global.gc(); await new Promise(r => setTimeout(r, 60)) } }
await import('fastify'); await import('@fastify/swagger'); await settle()
const before = process.memoryUsage()
await import('@platformatic/scalar-theme'); await import('@scalar/fastify-api-reference'); await settle()
const after = process.memoryUsage()
console.log({ heapMB: (after.heapUsed - before.heapUsed) / 1e6, rssMB: (after.rss - before.rss) / 1e6 })
// { heapMB: 11.0, rssMB: 73.0 }
```

## What this adds

`openapi.ui` (boolean, default `true`). When set to `false`, `/documentation/json` and `/documentation/yaml` keep working and the UI is neither imported nor registered, so `/documentation/` returns 404. Default behaviour is unchanged.

The option lives on the shared `openApiBase` in `packages/service/lib/schema.js`, so service, db, gateway and composer all get it, and all three registration sites honour it. In each one the dynamic `import()` moves below the guard: keeping the import above it would preserve the route behaviour and lose the whole point.

| Package | Change |
| --- | --- |
| `service` | guard in `lib/plugins/openapi.js`, `ui` on `openApiBase`, regenerated `schema.json` / `config.d.ts`, docs, tests |
| `gateway` | guard in `lib/openapi-scalar.js`, regenerated `schema.json` / `config.d.ts`, tests |
| `composer` | regenerated `schema.json` / `config.d.ts` (derived from gateway) |
| `db` | `ui` in `lib/schema.js`, regenerated files, docs, test pinning the `db.openapi` to `sql-openapi` wiring |
| `sql-openapi` | guard in `index.js`, tests |

## On the tests

The new tests assert that the UI module never enters the module graph, not only that the route returns 404. The 404 is a side effect; the memory is the feature. Without that assertion, hoisting the dynamic import back to module scope, which is the natural "why is this dynamic?" cleanup, leaves every test green while removing 100 percent of the benefit. In `service` it would be worse than the status quo, since the plugin module is statically imported by `lib/application.js` and the UI would then load even with OpenAPI disabled entirely.

Each check is paired with a positive control in the same file that asserts the module *is* loaded under the default configuration, so the assertion cannot quietly stop measuring. They live in dedicated files because the check is process wide: any application started with the default configuration loads the UI for the rest of the process.

## Notes for review

- **`ui` does not leak into the served spec.** `openapi` is spread into the `@fastify/swagger` options, so this is worth stating: I booted service, sql-openapi and gateway and the top level keys of `/documentation/json` are `openapi`, `info`, `components`, `paths`, `servers` in every case, with `ui` absent. `@fastify/swagger` rebuilds the document from known keys.
- **Naming.** I chose `ui` because the option already sits under `openapi` and matches the docs wording. `exposeRoute` exists today as a hardcoded internal default in `service` and in the `sql-openapi` types, is in no schema, and is inert with `@fastify/swagger` v9, so I deliberately did not resurrect it. Happy to rename to `swaggerUi` or `apiReference` if you prefer; it is a find and replace.
- **`swaggerPrefix` was undocumented** in both the service and db configuration references. Documented alongside `ui`.
- **The explicit `ui` block in `packages/db/lib/schema.js`** is redundant, since `...openApiBase.properties` already supplies it and removing it regenerates `schema.json` byte for byte. I kept it because `swaggerPrefix` four lines above is duplicated the same way on `main`. Glad to drop it if you would rather not carry the shadow.

## Verification

- `gateway`: 66 openapi tests and both schema tests pass; the schema drift test is what caught the regenerated artifacts
- `service`: openapi, openapi-ui and schema tests pass
- `sql-openapi`: `DB=sqlite`, 11 pass and 4 pre-existing skips
- `db`: the new wiring test passes on sqlite
- `eslint` clean on service, sql-openapi, db, gateway and composer
- `npm run build` in service, db, gateway and composer reproduces the committed `schema.json` and `config.d.ts`
- Not run locally: the postgres, mariadb and mysql matrix of sql-openapi, which needs Docker. The change is database agnostic, it only affects plugin registration, so CI covers it.

Each guard was mutation checked in both directions, including the import hoist described above.
