### PR TITLE
feat(gateway): add openapi.validation option to skip request validation for proxied routes

### DIFF
--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -405,6 +405,28 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
 - **`file`** (`string`) - A path to the OpenAPI specification file. Use this or `url` option to specify the OpenAPI specification.
 - **`prefix`** (`string`) - A prefix for the OpenAPI specification. All application routes will be prefixed with this value.
 - **`config`** (`string`) - A path to the OpenAPI configuration file. This file is used to customize the [OpenAPI](#openapi-configuration)specification.
+- **`validation`** (`string`, default: `"full"`) - Whether the gateway validates incoming requests against the OpenAPI schema of the application before proxying them.
+  - `"full"` compiles a validator for the body, params, querystring and headers of every documented operation and answers `400` at the gateway when a request does not match.
+  - `"none"` compiles no validator. Requests that pass Fastify parsing are forwarded to the upstream application as they are, with no coercion of querystring or params values at the gateway. Use it when the upstream already validates its input: compiling a validator for every operation costs memory and boot time in every worker, which adds up in a gateway that composes many large specifications.
+
+  The composed OpenAPI specification is the same in both modes. Deferring schema compilation to the first request belongs in Fastify core; see [fastify/fastify#6977](https://github.com/fastify/fastify/pull/6977). This option covers the gateway-specific case of not validating proxied requests at all, when validation is already performed by the upstream application.
+
+  ```json
+  {
+    "gateway": {
+      "applications": [
+        {
+          "id": "api",
+          "origin": "http://127.0.0.1:3051",
+          "openapi": {
+            "url": "/documentation/json",
+            "validation": "none"
+          }
+        }
+      ]
+    }
+  }
+  ```
 
 ### OpenAPI Configuration
 

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -3601,6 +3601,15 @@
                   "config": {
                     "type": "string",
                     "resolvePath": true
+                  },
+                  "validation": {
+                    "type": "string",
+                    "enum": [
+                      "full",
+                      "none"
+                    ],
+                    "default": "full",
+                    "description": "Whether the gateway validates incoming requests against the OpenAPI schema of the application before proxying them. \"full\" compiles a validator for the body, params, querystring and headers of every operation and answers 400 at the gateway when a request does not match. \"none\" compiles no validator: requests that pass Fastify parsing are forwarded to the upstream application as they are, which stays responsible for validating them."
                   }
                 },
                 "anyOf": [

--- a/packages/gateway/lib/openapi-generator.js
+++ b/packages/gateway/lib/openapi-generator.js
@@ -175,17 +175,27 @@ async function openApiGatewayPlugin (app, { opts, generated }) {
   })
 }
 
+// Used for the routes of an application configured with `validation: "none"`:
+// no validator is compiled for them and requests are forwarded without being
+// matched against the operation schema, the upstream stays responsible for
+// validating them. Deferring the compilation itself to the first request is
+// a Fastify concern, see https://github.com/fastify/fastify/pull/6977.
+function skipValidatorCompiler () {
+  return () => true
+}
+
 async function registerOpenApiGlue (app, openApiGlue, apiByApiRoutes) {
   await app.register(openApiGlue, {
     specification: app.composedOpenApiSchema,
     addEmptySchema: true,
     operationResolver: (operationId, method, openApiPath) => {
-      const { origin, prefix, schema } = apiByApiRoutes[openApiPath]
+      const { origin, prefix, schema, validation } = apiByApiRoutes[openApiPath]
       const originPath = schema[originPathSymbol]
 
       const mapRoutePath = createPathMapper(originPath, openApiPath, prefix)
 
       return {
+        ...(validation === 'none' ? { validatorCompiler: skipValidatorCompiler } : {}),
         config: { openApiPath },
         handler: (req, reply) => {
           const routePath = req.raw.url.split('?')[0]
@@ -294,7 +304,8 @@ export async function openApiGenerator (app, opts) {
       apiByApiRoutes[prefix + path] = {
         origin,
         prefix,
-        schema: schema.paths[path]
+        schema: schema.paths[path],
+        validation: openapi.validation ?? 'full'
       }
     }
 

--- a/packages/gateway/lib/schema.js
+++ b/packages/gateway/lib/schema.js
@@ -22,7 +22,14 @@ export const openApiApplication = {
     url: { type: 'string' },
     file: { type: 'string', resolvePath: true },
     prefix: { type: 'string' },
-    config: { type: 'string', resolvePath: true }
+    config: { type: 'string', resolvePath: true },
+    validation: {
+      type: 'string',
+      enum: ['full', 'none'],
+      default: 'full',
+      description:
+        'Whether the gateway validates incoming requests against the OpenAPI schema of the application before proxying them. "full" compiles a validator for the body, params, querystring and headers of every operation and answers 400 at the gateway when a request does not match. "none" compiles no validator: requests that pass Fastify parsing are forwarded to the upstream application as they are, which stays responsible for validating them.'
+    }
   },
   anyOf: [{ required: ['url'] }, { required: ['file'] }],
   additionalProperties: false

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -608,6 +608,15 @@
                   "config": {
                     "type": "string",
                     "resolvePath": true
+                  },
+                  "validation": {
+                    "type": "string",
+                    "enum": [
+                      "full",
+                      "none"
+                    ],
+                    "default": "full",
+                    "description": "Whether the gateway validates incoming requests against the OpenAPI schema of the application before proxying them. \"full\" compiles a validator for the body, params, querystring and headers of every operation and answers 400 at the gateway when a request does not match. \"none\" compiles no validator: requests that pass Fastify parsing are forwarded to the upstream application as they are, which stays responsible for validating them."
                   }
                 },
                 "anyOf": [

--- a/packages/gateway/test/openapi/fixtures/plugins/fields.js
+++ b/packages/gateway/test/openapi/fixtures/plugins/fields.js
@@ -1,0 +1,10 @@
+export default async function (app) {
+  // Echo what the gateway parsed from the querystring: the `fields` splitting
+  // happens in a preValidation hook that must survive `validation: "none"`.
+  app.platformatic.addGatewayOnRouteHook('/internal/users/{id}', ['GET'], routeOptions => {
+    routeOptions.onSend = async (req, reply) => {
+      reply.status(200)
+      return JSON.stringify({ fields: req.query.fields })
+    }
+  })
+}

--- a/packages/gateway/test/openapi/fixtures/plugins/recording-validator.js
+++ b/packages/gateway/test/openapi/fixtures/plugins/recording-validator.js
@@ -1,0 +1,10 @@
+// Replaces the validator compiler of the instance with one that records which
+// route and http part it compiles a validator for, then accepts everything.
+export default async function (app) {
+  globalThis.recordedValidatorCompiles = []
+
+  app.setValidatorCompiler(({ url, httpPart }) => {
+    globalThis.recordedValidatorCompiles.push(`${url} ${httpPart}`)
+    return () => true
+  })
+}

--- a/packages/gateway/test/openapi/validation.test.js
+++ b/packages/gateway/test/openapi/validation.test.js
@@ -1,0 +1,321 @@
+import Swagger from '@fastify/swagger'
+import fastify from 'fastify'
+import assert from 'node:assert/strict'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { createFromConfig, createOpenApiApplication } from '../helper.js'
+
+// An upstream that documents strict schemas but never enforces them, so that
+// whether a request reached it (and with which payload) is observable.
+async function createLenientUpstream (t) {
+  const app = fastify({ logger: false, keepAliveTimeout: 10, forceCloseConnections: true })
+  const received = []
+
+  await app.register(Swagger, { openapi: { info: { title: 'Lenient', version: '0.1.0' } } })
+  app.get('/documentation/json', { schema: { hide: true } }, async () => app.swagger())
+
+  const lenient = {
+    validatorCompiler: () => () => true,
+    serializerCompiler: () => JSON.stringify
+  }
+
+  app.post(
+    '/echo',
+    {
+      ...lenient,
+      schema: {
+        body: { type: 'object', required: ['name'], additionalProperties: false, properties: { name: { type: 'string' } } },
+        response: { 200: { type: 'object', properties: { name: { type: 'string' } } } }
+      }
+    },
+    async req => {
+      received.push({ url: req.url, body: req.body })
+      return req.body
+    }
+  )
+
+  app.get(
+    '/items',
+    {
+      ...lenient,
+      schema: {
+        querystring: { type: 'object', properties: { limit: { type: 'integer' } } },
+        response: { 200: { type: 'object', properties: { limit: { type: 'integer' } } } }
+      }
+    },
+    async req => {
+      received.push({ url: req.url, query: { ...req.query } })
+      return { limit: req.query.limit }
+    }
+  )
+
+  // Documents a required header with an uppercase name.
+  app.get(
+    '/secure',
+    {
+      ...lenient,
+      schema: {
+        headers: { type: 'object', required: ['X-Token'], properties: { 'X-Token': { type: 'string' } } },
+        response: { 200: { type: 'object', properties: { ok: { type: 'boolean' } } } }
+      }
+    },
+    async () => ({ ok: true })
+  )
+
+  // Answers with a status and a shape the specification does not document.
+  app.get(
+    '/reject',
+    { ...lenient, schema: { response: { 200: { type: 'object', properties: { ok: { type: 'boolean' } } } } } },
+    async (req, reply) => {
+      reply.code(422)
+      return { problems: ['name is taken'], hint: 1 }
+    }
+  )
+
+  // The response carries a property the schema does not document: the proxy
+  // streams it as it is.
+  app.get(
+    '/extra',
+    {
+      ...lenient,
+      schema: { response: { 200: { type: 'object', properties: { id: { type: 'number' } } } } }
+    },
+    async () => ({ id: 1, extra: 'kept' })
+  )
+
+  t.after(() => app.close())
+  await app.listen({ port: 0 })
+
+  return { origin: 'http://127.0.0.1:' + app.server.address().port, received }
+}
+
+async function createGateway (t, origin, openapi, plugins) {
+  return createFromConfig(t, {
+    server: { logger: { level: 'fatal' } },
+    gateway: {
+      applications: [{ id: 'api1', origin, openapi: { url: '/documentation/json', ...openapi } }]
+    },
+    plugins
+  })
+}
+
+test('validation defaults to "full": invalid requests are rejected by the gateway', async t => {
+  const upstream = await createLenientUpstream(t)
+  const gateway = await createGateway(t, upstream.origin, {})
+
+  {
+    // fastify's ajv coerces scalars (42 -> "42"), so use a payload no coercion can rescue.
+    const { statusCode, body } = await gateway.inject({ method: 'POST', url: '/echo', payload: { name: { nested: true } } })
+    assert.equal(statusCode, 400)
+    assert.equal(JSON.parse(body).code, 'FST_ERR_VALIDATION')
+  }
+
+  {
+    const { statusCode } = await gateway.inject({ method: 'GET', url: '/items?limit=abc' })
+    assert.equal(statusCode, 400)
+  }
+
+  assert.deepEqual(upstream.received, [], 'the upstream never sees the invalid requests')
+
+  // Positive control: a valid request still goes through.
+  const { statusCode, body } = await gateway.inject({ method: 'POST', url: '/echo', payload: { name: 'ok' } })
+  assert.equal(statusCode, 200)
+  assert.deepEqual(JSON.parse(body), { name: 'ok' })
+})
+
+test('validation: "none" forwards invalid requests to the upstream as they are', async t => {
+  const upstream = await createLenientUpstream(t)
+  const gateway = await createGateway(t, upstream.origin, { validation: 'none' })
+
+  {
+    const { statusCode, body } = await gateway.inject({ method: 'POST', url: '/echo', payload: { name: { nested: true } } })
+    assert.equal(statusCode, 200)
+    assert.deepEqual(JSON.parse(body), { name: { nested: true } })
+  }
+
+  {
+    const { statusCode, body } = await gateway.inject({ method: 'GET', url: '/items?limit=abc' })
+    assert.equal(statusCode, 200)
+    assert.deepEqual(JSON.parse(body), { limit: 'abc' }, 'no coercion happens at the gateway')
+  }
+
+  assert.deepEqual(upstream.received, [
+    { url: '/echo', body: { name: { nested: true } } },
+    { url: '/items?limit=abc', query: { limit: 'abc' } }
+  ])
+})
+
+test('validation: "none" keeps the fields query splitting and the prefix mapping', async t => {
+  const api = await createOpenApiApplication(t, ['users'])
+  const seen = []
+  api.addHook('onRequest', async req => {
+    if (!req.url.startsWith('/documentation/')) {
+      seen.push(req.url)
+    }
+  })
+  await api.listen({ port: 0 })
+
+  const gateway = await createFromConfig(t, {
+    server: { logger: { level: 'fatal' } },
+    gateway: {
+      applications: [
+        {
+          id: 'api1',
+          origin: 'http://127.0.0.1:' + api.server.address().port,
+          openapi: { url: '/documentation/json', prefix: '/internal', validation: 'none' }
+        }
+      ]
+    },
+    plugins: {
+      paths: [join(import.meta.dirname, './fixtures/plugins/fields.js')]
+    }
+  })
+
+  const { statusCode, body } = await gateway.inject({ method: 'GET', url: '/internal/users/1?fields=id,name' })
+  assert.equal(statusCode, 200)
+  assert.deepEqual(JSON.parse(body), { fields: ['id', 'name'] }, 'fields is still split at the gateway')
+  assert.deepEqual(seen, ['/users/1?fields=id,name'], 'the prefix is stripped and the raw query forwarded')
+})
+
+for (const format of ['json', 'yaml']) {
+  test(`the composed OpenAPI document (${format}) is identical in both validation modes`, async t => {
+    const upstream = await createLenientUpstream(t)
+    const full = await createGateway(t, upstream.origin, {})
+    const none = await createGateway(t, upstream.origin, { validation: 'none' })
+
+    const fullDocument = await full.inject({ method: 'GET', url: `/documentation/${format}` })
+    const noneDocument = await none.inject({ method: 'GET', url: `/documentation/${format}` })
+
+    assert.equal(fullDocument.statusCode, 200)
+    assert.equal(noneDocument.statusCode, 200)
+    assert.equal(noneDocument.body, fullDocument.body)
+
+    // Positive control: the document still describes the request schemas.
+    assert.ok(fullDocument.body.includes('/echo'), 'the operations are documented')
+  })
+}
+
+for (const openapi of [{}, { validation: 'none' }]) {
+  test(`the upstream response is proxied unchanged (${JSON.stringify(openapi)})`, async t => {
+    const upstream = await createLenientUpstream(t)
+    const gateway = await createGateway(t, upstream.origin, openapi)
+
+    const { statusCode, body } = await gateway.inject({ method: 'GET', url: '/extra' })
+    assert.equal(statusCode, 200)
+    assert.deepEqual(JSON.parse(body), { id: 1, extra: 'kept' })
+  })
+}
+
+test('validation is a per-application setting', async t => {
+  const strict = await createLenientUpstream(t)
+  const lenient = await createLenientUpstream(t)
+
+  const gateway = await createFromConfig(t, {
+    server: { logger: { level: 'fatal' } },
+    gateway: {
+      applications: [
+        { id: 'strict', origin: strict.origin, openapi: { url: '/documentation/json', prefix: '/strict' } },
+        { id: 'lenient', origin: lenient.origin, openapi: { url: '/documentation/json', prefix: '/lenient', validation: 'none' } }
+      ]
+    }
+  })
+
+  const payload = { name: { nested: true } }
+
+  {
+    const { statusCode } = await gateway.inject({ method: 'POST', url: '/strict/echo', payload })
+    assert.equal(statusCode, 400)
+    assert.deepEqual(strict.received, [])
+  }
+
+  {
+    const { statusCode, body } = await gateway.inject({ method: 'POST', url: '/lenient/echo', payload })
+    assert.equal(statusCode, 200)
+    assert.deepEqual(JSON.parse(body), payload)
+    assert.deepEqual(lenient.received, [{ url: '/echo', body: payload }])
+  }
+})
+
+test('validation: "none" returns the upstream status and body unchanged', async t => {
+  const upstream = await createLenientUpstream(t)
+  const gateway = await createGateway(t, upstream.origin, { validation: 'none' })
+
+  const direct = await request(upstream.origin + '/reject')
+  const directBody = await direct.body.text()
+  assert.equal(direct.statusCode, 422)
+
+  const { statusCode, body } = await gateway.inject({ method: 'GET', url: '/reject' })
+  assert.equal(statusCode, 422, 'the undocumented status is passed through')
+  assert.equal(body, directBody)
+})
+
+test('no validator is compiled for the routes of a "none" application', async t => {
+  const strict = await createLenientUpstream(t)
+  const lenient = await createLenientUpstream(t)
+
+  const gateway = await createFromConfig(t, {
+    server: { logger: { level: 'fatal' } },
+    gateway: {
+      applications: [
+        { id: 'strict', origin: strict.origin, openapi: { url: '/documentation/json', prefix: '/strict' } },
+        { id: 'lenient', origin: lenient.origin, openapi: { url: '/documentation/json', prefix: '/lenient', validation: 'none' } }
+      ]
+    },
+    plugins: {
+      paths: [{ path: join(import.meta.dirname, './fixtures/plugins/recording-validator.js'), encapsulate: false }]
+    }
+  })
+  await gateway.start({ listen: false })
+
+  const compiles = globalThis.recordedValidatorCompiles
+  delete globalThis.recordedValidatorCompiles
+
+  assert.ok(compiles.length > 0, 'validators are compiled at startup for the "full" application')
+  assert.ok(compiles.includes('/strict/echo body'))
+  assert.deepEqual(compiles.filter(entry => entry.startsWith('/lenient')), [], 'none for the "none" application')
+})
+
+test('a required header documented with an uppercase name', async t => {
+  const upstream = await createLenientUpstream(t)
+  const full = await createGateway(t, upstream.origin, {})
+  const none = await createGateway(t, upstream.origin, { validation: 'none' })
+
+  for (const headers of [{ 'x-token': 't' }, { 'X-Token': 't' }]) {
+    for (const gateway of [full, none]) {
+      const { statusCode } = await gateway.inject({ method: 'GET', url: '/secure', headers })
+      assert.equal(statusCode, 200, `present header ${JSON.stringify(headers)}`)
+    }
+  }
+
+  const missingFull = await full.inject({ method: 'GET', url: '/secure' })
+  assert.equal(missingFull.statusCode, 400)
+  assert.match(missingFull.body, /required property 'x-token'/)
+
+  const missingNone = await none.inject({ method: 'GET', url: '/secure' })
+  assert.equal(missingNone.statusCode, 200, 'not validated at the gateway')
+})
+
+test('an additional property is stripped in "full" and forwarded in "none"', async t => {
+  const payload = { name: 'x', extra: 1 }
+
+  {
+    // Observed on 3.68.0: fastify's default ajv options remove additional
+    // properties instead of rejecting the body.
+    const upstream = await createLenientUpstream(t)
+    const gateway = await createGateway(t, upstream.origin, {})
+    const { statusCode, body } = await gateway.inject({ method: 'POST', url: '/echo', payload })
+    assert.equal(statusCode, 200)
+    assert.deepEqual(JSON.parse(body), { name: 'x' })
+    assert.deepEqual(upstream.received, [{ url: '/echo', body: { name: 'x' } }], 'the extra property never reaches the upstream')
+  }
+
+  {
+    const upstream = await createLenientUpstream(t)
+    const gateway = await createGateway(t, upstream.origin, { validation: 'none' })
+    const { statusCode, body } = await gateway.inject({ method: 'POST', url: '/echo', payload })
+    assert.equal(statusCode, 200)
+    assert.deepEqual(JSON.parse(body), payload)
+    assert.deepEqual(upstream.received, [{ url: '/echo', body: payload }], 'the body is forwarded untouched')
+  }
+})


### PR DESCRIPTION
# feat(gateway): add `openapi.validation` option to skip request validation for proxied routes

## What

A gateway that composes OpenAPI documents registers one fastify route per upstream operation with the operation's full schema, so fastify compiles an ajv request validator for every proxied operation at startup and validates every request before proxying it. A gateway in front of applications that already validate their own input pays for the same check twice: in memory, in boot time and per request.

This PR adds a per-application `openapi.validation` option:

- `"full"` (default): unchanged behaviour, every proxied operation validates the request at the gateway;
- `"none"`: no request validator is compiled for that application's routes. Requests that pass Fastify parsing but do not match the operation schema are forwarded to the upstream, which answers with its own error. Parsing errors, body limits, unknown-route 404s and gateway hooks still apply.

The composed document at `/documentation/json` and `/documentation/yaml` is byte-identical in both modes.

Deferring schema compilation to the first request belongs in Fastify core; see fastify/fastify#6977. This option covers the gateway-specific case of not validating proxied requests at all, when validation is already performed by the upstream application.

## Why (numbers)

Measured on a gateway composing 20 OpenAPI documents (9.9 MB of JSON, 707 paths, 1209 operations, 1769 fastify routes including the auto-exposed HEAD routes and the documentation routes). `heapUsed` after forced GCs once the gateway is listening, boot = `create()` + `start()`. 3 runs each, medians; raw values and the measurement method are below. The workload is an internal set of documents, so the absolute numbers are not reproducible from the repository; the per-route cost is.

| Configuration                        | heapUsed | Δ heap | boot  | Δ boot |
| ------------------------------------ | -------- | ------ | ----- | ------ |
| 3.68.0                               | 177.6 MB |        | 8.6 s |        |
| this PR, default (`validation: full`) | 177.9 MB | +0.3 MB (noise) | 8.0 s | -0.6 s (noise) |
| this PR, `validation: "none"`        | 116.0 MB | -61.6 MB | 1.25 s | -7.4 s |

Per route in 3.68.0: about 35 KB of generated validator source retained for the life of the process and about 4 ms of compile time, for a check the upstream application repeats. The response serializers (about 9 KB per route) are still compiled at startup in both modes; deferring them is what fastify/fastify#6977 covers.

## Behaviour with `validation: "none"`

- Schema-invalid requests are answered by the upstream (its status, its error shape) instead of the gateway's 400.
- No query coercion or `additionalProperties` handling at the gateway for those routes; the `fields` query splitting the gateway performs itself keeps working.
- Unknown routes are still 404 at the gateway; parsing errors, `bodyLimit`, content-type handling and every gateway hook are unchanged.

## Implementation

Routes of a `"none"` application are registered with a route-level `validatorCompiler` that returns an always-true validator, so fastify compiles nothing for them. Everything else in the glue is untouched; no new dependencies.

## Tests

- default: a schema-invalid body gets the gateway 400, with a positive control
- `"none"`: the same body, a body with an unknown property under `additionalProperties: false`, and a non-numeric integer query parameter are forwarded unchanged, no coercion and no `additionalProperties` handling (the upstream records what it received); in `"full"` fastify's default `removeAdditional` strips the unknown property before proxying
- `"none"`: `fields` splitting and prefixes keep working
- `/documentation/json` and `/documentation/yaml` identical between the two modes
- a documented GET proxies the upstream body unchanged in both modes
- two applications in one gateway, one `"full"` one `"none"`: the same invalid body gets a gateway 400 on the first and the upstream's answer on the second
- `"none"`: an upstream custom error (status and body) comes back unchanged
- a recording validator compiler counts zero compilations for the `"none"` application and a positive number for the `"full"` one
- an uppercase required header is accepted in either case in both modes; when missing, `"full"` answers 400 and `"none"` forwards

## Measurement method

- Node v24.15.0, macOS 25.5 (Darwin), Apple Silicon laptop, otherwise idle.
- Gateway config: 20 applications with `openapi.file` pointing at the documents, `origin: http://127.0.0.1:1` (never contacted), `refreshTimeout: 0`, `isProduction: true`, `server.port: 0`, logger `warn`.
- Procedure: `create(root, config)` then `start({ listen: true })`; boot is the wall time of both; heapUsed is `process.memoryUsage().heapUsed` after `gc(); gc(); await sleep(200); gc()` under `node --expose-gc`.
- Raw values (heapUsed MB / boot ms, 3 runs):
  - 3.68.0 (unpatched package, same config and counter, installed files byte-identical to the v3.68.0 tag): 177.6 / 177.6 / 177.6, 8716 / 8431 / 8609
  - this PR, default: 177.9 / 177.9 / 177.9, 8046 / 8159 / 8039; after one request to 10 % of the operations: 181.0 / 181.0 / 181.0
  - this PR, `"none"`: 116.0 / 116.0 / 116.0, 1253 / 1241 / 1252; after one request to 10 % of the operations: 117.6 / 117.6 / 117.6
- The 20 documents are an internal workload and are not in the repository. The numbers scale with route count: about 35 KB of generated validator source and 4 ms of compile per route in 3.68.0, so any gateway can be estimated from its `printRoutes()` count.

## Checklist

- [x] `packages/gateway`: `test/openapi/validation.test.js` 12/12, hooks 6/6, routes-composition 15/15, fields-renaming 4/4, `test:types` 20 assertions, lint clean; the full `pnpm test` has 5 pre-existing failures on this machine (2 need a running Valkey, 3 in `empty-body-responses.test.js` fail identically on unpatched main)
- [x] `schema.json` and `packages/composer/schema.json` regenerated with the package build, `test/schema.test.js` 2/2
- [x] docs updated (`docs/reference/gateway/configuration.md`)
- [x] DCO sign-off, single commit
