### PR TITLE
fix(service,db): load mercurius and graphql only when GraphQL is used

### DIFF
--- a/packages/db/lib/commands/print-schema.js
+++ b/packages/db/lib/commands/print-schema.js
@@ -1,5 +1,4 @@
 import { abstractLogger, kMetadata, loadConfiguration } from '@platformatic/foundation'
-import { printSchema as printGraphqlSchema } from 'graphql'
 import { create } from '../../index.js'
 import { transform } from '../config.js'
 import { schema } from '../schema.js'
@@ -23,6 +22,8 @@ export async function printSchema (logger, configFile, args, { colorette: { bold
     await app.start({ listen: true })
     output = JSON.stringify(app.getApplication().swagger(), null, 2)
   } else {
+    // graphql is only needed for this command: do not load it when the package is imported
+    const { printSchema: printGraphqlSchema } = await import('graphql')
     output = printGraphqlSchema(app.getApplication().graphql.schema)
   }
 

--- a/packages/db/test/lazy-graphql.test.js
+++ b/packages/db/test/lazy-graphql.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert'
+import { registerHooks } from 'node:module'
+import { test } from 'node:test'
+
+// Record the URL of every module resolved from now on. This must run before
+// @platformatic/db is imported, which is why the import below is dynamic.
+const resolvedUrls = []
+registerHooks({
+  resolve (specifier, context, next) {
+    const result = next(specifier, context)
+    resolvedUrls.push(result.url)
+    return result
+  }
+})
+
+test('importing @platformatic/db does not load graphql or mercurius', async () => {
+  await import('../index.js')
+
+  const loaded = resolvedUrls.filter(url => /\/node_modules\/(graphql|mercurius)\//.test(url))
+  assert.deepStrictEqual(loaded, [])
+})

--- a/packages/service/lib/capability.js
+++ b/packages/service/lib/capability.js
@@ -9,7 +9,6 @@ import {
 import { getTracerProvider } from '@platformatic/globals'
 import { addPinoInstrumentation, telemetry } from '@platformatic/telemetry'
 import fastify from 'fastify'
-import { printSchema } from 'graphql'
 import { randomUUID } from 'node:crypto'
 import { hostname } from 'node:os'
 import pino from 'pino'
@@ -208,7 +207,13 @@ export class ServiceCapability extends BaseCapability {
   async getGraphqlSchema () {
     await this.init()
     await this.#app.ready()
-    return this.#app.graphql ? printSchema(this.#app.graphql.schema) : null
+    if (!this.#app.graphql) {
+      return null
+    }
+
+    // graphql is already loaded by mercurius at this point, so the import is served from the module cache
+    const { printSchema } = await import('graphql')
+    return printSchema(this.#app.graphql.schema)
   }
 
   async updateContext (context) {

--- a/packages/service/lib/plugins/graphql.js
+++ b/packages/service/lib/plugins/graphql.js
@@ -1,6 +1,5 @@
 import { deepmerge } from '@platformatic/foundation'
 import fp from 'fastify-plugin'
-import mercurius from 'mercurius'
 
 // For some unknown reason, c8 is not detecting any of this
 // despite being covered by test/graphql.test.js
@@ -28,6 +27,8 @@ async function setupGraphQLPlugin (app, options) {
     }
   })
 
+  // Loaded on demand: mercurius and graphql are only needed when GraphQL is enabled
+  const { default: mercurius } = await import('mercurius')
   app.register(mercurius, graphqlOptions)
 }
 

--- a/packages/service/test/capability/lazy-graphql.test.js
+++ b/packages/service/test/capability/lazy-graphql.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert'
+import { registerHooks } from 'node:module'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+// Record the URL of every module resolved from now on. This must run before any
+// Platformatic module is imported, which is why every import below is dynamic,
+// and the file relies on the default per-file process isolation of node:test.
+const resolvedUrls = []
+registerHooks({
+  resolve (specifier, context, next) {
+    const result = next(specifier, context)
+    resolvedUrls.push(result.url)
+    return result
+  }
+})
+
+const { create } = await import('../../index.js')
+const { createFromConfig } = await import('../helper.js')
+
+const GRAPHQL_MODULES = /\/node_modules\/(graphql|mercurius)\//
+
+function graphqlModulesLoaded () {
+  return resolvedUrls.some(url => GRAPHQL_MODULES.test(url))
+}
+
+test('mercurius and graphql are not loaded when graphql is disabled', async t => {
+  assert.ok(!graphqlModulesLoaded(), 'mercurius or graphql were loaded by importing @platformatic/service')
+
+  const capability = await create(join(import.meta.dirname, '..', 'fixtures', 'directories'))
+  t.after(() => capability.stop())
+  await capability.start({ listen: true })
+
+  assert.strictEqual(await capability.getGraphqlSchema(), null)
+  assert.ok(!graphqlModulesLoaded(), 'mercurius and graphql must not be loaded')
+})
+
+test('mercurius and graphql are loaded when graphql is enabled', async t => {
+  const capability = await createFromConfig(t, {
+    server: { hostname: '127.0.0.1', port: 0, logger: { level: 'fatal' } },
+    service: { graphql: true },
+    plugins: { paths: [join(import.meta.dirname, '..', 'fixtures', 'hello-world-resolver.js')] },
+    watch: false
+  })
+  t.after(() => capability.stop())
+  await capability.start({ listen: true })
+
+  assert.strictEqual(await capability.getGraphqlSchema(), 'type Query {\n  hello: String\n}')
+  assert.ok(resolvedUrls.some(url => /\/node_modules\/mercurius\//.test(url)), 'mercurius must be loaded')
+  assert.ok(resolvedUrls.some(url => /\/node_modules\/graphql\//.test(url)), 'graphql must be loaded')
+})


### PR DESCRIPTION
## What

`@platformatic/service` imports `mercurius` at module load (`lib/plugins/graphql.js`) and `printSchema` from `graphql` in `lib/capability.js`. Both are only needed when `service.graphql` is enabled, which is not the default, so every service and db worker in a runtime pays for the two packages without using them. `@platformatic/db` additionally imports `graphql` at module load for the `print-schema` CLI command (`lib/commands/print-schema.js`), which is re-exported from the package index.

This PR moves the three imports to the places that need them:

- `mercurius` is imported inside the GraphQL plugin, which only runs when `service.graphql` is enabled;
- `printSchema` is imported inside `getGraphqlSchema()`, after the early return for applications without a GraphQL schema. When GraphQL is enabled, `graphql` is already in the module cache by then (mercurius depends on it), so the import is free;
- in `@platformatic/db`, `printSchema` is imported inside the `print-schema` command when the `graphql` type is requested.

No configuration change and no behaviour change for applications with GraphQL enabled or for the CLI command. `db-core` already loads `@platformatic/sql-graphql` on demand.

## Why (numbers)

Node v24.15.0, macOS, Apple Silicon. `heapUsed` after `gc(); gc(); sleep(200); gc()` under `node --expose-gc`.

Service booted from `packages/service/test/fixtures/directories` (GraphQL disabled) with `create()` + `start({ listen: true })`, `isProduction: true`, 5 runs:

| | heapUsed (MB) | RSS (MB) | boot (ms) |
| --- | --- | --- | --- |
| main (`8d3a1f2be`) | 29.70 / 29.71 / 29.71 / 29.70 / 29.71 | 175.5 / 176.0 / 175.5 / 175.5 / 175.3 | 561 / 536 / 494 / 492 / 483 |
| this PR | 25.87 / 25.87 / 25.88 / 25.86 / 25.86 | 162.5 / 159.6 / 160.0 / 164.5 / 159.9 | 471 / 487 / 494 / 498 / 510 |

`import('@platformatic/db')` alone (what a db worker loads before configuration), 3 runs:

| | heapUsed (MB) |
| --- | --- |
| main | 28.75 / 28.75 / 28.75 |
| this PR | 24.78 / 24.78 / 24.78 |

About 3.8 MB of heap per service worker and 4.0 MB per db worker that do not use GraphQL; boot time is within noise (median 494 ms in both cases).

## Tests

- new `packages/service/test/capability/lazy-graphql.test.js`: a `node:module` `registerHooks` resolve hook records the URL of every module resolved after the test file starts; with GraphQL disabled nothing under `node_modules/graphql/` or `node_modules/mercurius/` is loaded and `getGraphqlSchema()` returns `null`; with GraphQL enabled both are loaded and the printed schema is unchanged. The first test guards that it runs before any GraphQL-enabled application is created in the process. It fails on `main`.
- new `packages/db/test/lazy-graphql.test.js`: importing `@platformatic/db` under the same hook loads neither package. It fails on `main`.
- existing `packages/service/test/graphql.test.js`, `test/capability/get-graphql-schema.test.js` and `packages/db/test/cli/schema.test.js` (covers `print-schema graphql`) unchanged and green.

## Checklist

- [x] `packages/service` full `npm test` green, `packages/db` `test/cli/schema.test.js` and the new test green, lint clean in both packages
- [x] No schema, types or docs change (no user-facing option)
- [x] DCO sign-off, single commit
