### PR TITLE
fix(foundation): load undici, yaml, toml, json5, pino-pretty and boring-name-generator on first use

### DIFF
--- a/packages/foundation/lib/cli.js
+++ b/packages/foundation/lib/cli.js
@@ -1,9 +1,9 @@
 import Deepmerge from '@fastify/deepmerge'
 import { bgGreen, black, bold, green, isColorSupported } from 'colorette'
+import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import { parseArgs as nodeParseArgs } from 'node:util'
 import { pino } from 'pino'
-import pinoPretty from 'pino-pretty'
 import { findConfigurationFileRecursive, loadConfigurationModule, saveConfigurationFile } from './configuration.js'
 import { hasJavascriptFiles } from './file-system.js'
 import { setPinoTimestamp } from './logger.js'
@@ -120,6 +120,8 @@ export function createCliLogger (level, noPretty = false, loggerConfig = {}) {
   if (noPretty) {
     process.env.PLT_PRETTY_PRINT = 'false'
   } else {
+    // Loaded on first use: only CLI processes need the pretty printer
+    const pinoPretty = createRequire(import.meta.url)('pino-pretty')
     pretty = pinoPretty({
       colorize: process.env.NO_COLOR !== 'true',
       customPrettifiers: {

--- a/packages/foundation/lib/configuration.js
+++ b/packages/foundation/lib/configuration.js
@@ -1,12 +1,9 @@
-import toml from '@iarna/toml'
 import Ajv from 'ajv'
 import jsonPatch from 'fast-json-patch'
-import JSON5 from 'json5'
 import { readFile, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { dirname, extname, isAbsolute, parse, resolve } from 'node:path'
 import { parseEnv } from 'node:util'
-import { parse as rawParseYAML, stringify as stringifyYAML } from 'yaml'
 import {
   AddAModulePropertyToTheConfigOrAddAKnownSchemaError,
   CannotParseConfigFileError,
@@ -20,8 +17,33 @@ import { isFileAccessible } from './file-system.js'
 import { loadModule, splitModuleFromVersion } from './module.js'
 import { kEnvFileFallbackKeys, kMetadata } from './symbols.js'
 
-const { parse: parseJSON5, stringify: rawStringifyJSON5 } = JSON5
-const { parse: parseTOML, stringify: stringifyTOML } = toml
+// The parsers for the non JSON formats are loaded on first use so that
+// importing this module does not pay for formats that are never used.
+const lazyRequire = createRequire(import.meta.url)
+
+function parseJSON5 (...args) {
+  return lazyRequire('json5').parse(...args)
+}
+
+function rawStringifyJSON5 (...args) {
+  return lazyRequire('json5').stringify(...args)
+}
+
+function parseTOML (...args) {
+  return lazyRequire('@iarna/toml').parse(...args)
+}
+
+function stringifyTOML (...args) {
+  return lazyRequire('@iarna/toml').stringify(...args)
+}
+
+function rawParseYAML (...args) {
+  return lazyRequire('yaml').parse(...args)
+}
+
+function stringifyYAML (...args) {
+  return lazyRequire('yaml').stringify(...args)
+}
 
 const kReplaceEnvIgnore = Symbol('plt.foundation.replaceEnvIgnore')
 

--- a/packages/foundation/lib/file-system.js
+++ b/packages/foundation/lib/file-system.js
@@ -1,7 +1,7 @@
-import generateName from 'boring-name-generator'
 import { EventEmitter } from 'node:events'
 import { existsSync } from 'node:fs'
 import { access, chmod, glob, mkdir, rm, watch } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { platform, tmpdir } from 'node:os'
 import { join, matchesGlob, resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -15,6 +15,8 @@ export function removeDotSlash (path) {
 }
 
 export function generateDashedName () {
+  // Loaded on first use: only generators need it
+  const generateName = createRequire(import.meta.url)('boring-name-generator')
   return generateName().dashed.replace(/\s+/g, '')
 }
 

--- a/packages/foundation/lib/module.js
+++ b/packages/foundation/lib/module.js
@@ -2,7 +2,6 @@ import { existsSync } from 'node:fs'
 import { readFile, readdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { request } from 'undici'
 import { hasJavascriptFiles } from './file-system.js'
 import { kFailedImport } from './symbols.js'
 
@@ -43,6 +42,7 @@ export const applicationTypes = [
 ]
 
 export async function getLatestNpmVersion (pkg) {
+  const { request } = await import('undici')
   const res = await request(`https://registry.npmjs.org/${pkg}`)
   if (res.statusCode === 200) {
     const json = await res.body.json()

--- a/packages/foundation/test/lazy-dependencies.test.js
+++ b/packages/foundation/test/lazy-dependencies.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert'
+import { registerHooks } from 'node:module'
+import { test } from 'node:test'
+
+// Record the URL of every module resolved from now on. This must run before
+// @platformatic/foundation is imported, which is why the import below is dynamic.
+const resolvedUrls = []
+registerHooks({
+  resolve (specifier, context, next) {
+    const result = next(specifier, context)
+    resolvedUrls.push(result.url)
+    return result
+  }
+})
+
+const LAZY_DEPENDENCIES = ['undici', 'yaml', '@iarna/toml', 'json5', 'pino-pretty', 'boring-name-generator']
+
+function loaded (name) {
+  const matcher = new RegExp(`/node_modules/${name}/`)
+  return resolvedUrls.some(url => matcher.test(url))
+}
+
+const foundation = await import('../index.js')
+
+test('importing @platformatic/foundation does not load the dependencies that are only needed on demand', () => {
+  for (const name of LAZY_DEPENDENCIES) {
+    assert.ok(!loaded(name), `${name} must not be loaded by importing @platformatic/foundation`)
+  }
+})
+
+test('the format parsers are loaded on first use', () => {
+  assert.deepStrictEqual(foundation.getParser('config.yaml')('a: 1'), { a: 1 })
+  assert.ok(loaded('yaml'))
+  assert.ok(!loaded('json5') && !loaded('@iarna/toml'))
+
+  assert.deepStrictEqual(foundation.getParser('config.json5')('{ a: 1 }'), { a: 1 })
+  assert.ok(loaded('json5'))
+
+  assert.deepStrictEqual(foundation.getParser('config.toml')('a = 1'), { a: 1 })
+  assert.ok(loaded('@iarna/toml'))
+
+  // Extra arguments are still forwarded to the underlying parser
+  assert.ok(foundation.getParser('config.yaml')('a: 1', undefined, { mapAsMap: true }) instanceof Map)
+  assert.deepStrictEqual(foundation.getParser('config.json5')('{ a: 1 }', (key, value) => (key === 'a' ? 2 : value)), { a: 2 })
+
+  assert.strictEqual(foundation.getStringifier('config.yaml')({ a: 1 }), 'a: 1\n')
+  assert.strictEqual(foundation.getStringifier('config.json5')({ a: 1 }), '{\n  a: 1,\n}')
+  assert.strictEqual(foundation.getStringifier('config.toml')({ a: 1 }), 'a = 1\n')
+})
+
+test('boring-name-generator is loaded on first use', () => {
+  assert.match(foundation.generateDashedName(), /^[a-z]+(-[a-z]+)+$/)
+  assert.ok(loaded('boring-name-generator'))
+})
+
+test('pino-pretty is loaded on first use', () => {
+  const logger = foundation.createCliLogger('info')
+  assert.strictEqual(logger.level, 'info')
+  assert.ok(loaded('pino-pretty'))
+})


### PR DESCRIPTION
## What

`@platformatic/foundation` is imported by every Platformatic package, so whatever it loads at module load time is paid by every worker of a runtime. Six of its dependencies are only needed in specific situations:

| Dependency | Only needed by |
| --- | --- |
| `undici` | `getLatestNpmVersion()` (npm registry check used by the generators) |
| `yaml`, `@iarna/toml`, `json5` | configuration files in that format (`getParser` / `getStringifier`) |
| `pino-pretty` | `createCliLogger()` (CLI processes) |
| `boring-name-generator` | `generateDashedName()` (generators) |

This PR loads each of them on first use. The parsers, stringifiers, the CLI logger and the name generator keep their synchronous signatures by using `createRequire(import.meta.url)` (the pattern `configuration.js` already uses for user modules); `getLatestNpmVersion` is async and uses a dynamic import. No public API changes, no configuration change; `package.json` dependencies are unchanged since all six are still used.

## Why (numbers)

Node v24.15.0, macOS, Apple Silicon, `heapUsed` after `gc(); gc(); sleep(200); gc()` under `node --expose-gc`, 3 runs each.

`import('@platformatic/foundation')` alone:

| | heapUsed (MB) |
| --- | --- |
| main (`8d3a1f2be`) | 14.52 / 14.53 / 14.52 |
| this PR | 6.88 / 6.88 / 6.88 |

Ablation on main by stubbing one dependency at a time: undici -4.8, boring-name-generator -1.5, yaml -0.8, pino-pretty -0.4, @iarna/toml -0.2, json5 -0.1.

Inside a runtime (`@platformatic/runtime` with two `@platformatic/service` applications, worker `heapUsed` read from a route after two forced GCs, 2.5 s after start):

| | worker heapUsed (MB) | process RSS (MB) |
| --- | --- | --- |
| main | 33.13 / 33.13 / 33.14 and 33.00 / 32.99 / 33.00 | 374 / 372 / 368 |
| this PR | 30.37 / 30.37 / 30.38 and 30.24 / 30.24 / 30.24 | 356 / 340 / 343 |

About -2.8 MB per worker. `undici` is still loaded inside a runtime worker by the runtime itself (`lib/worker/main.js`), so the worker saving comes from the other five (a `@platformatic/node` application still loads `json5` through its own capability); the full -7.6 MB applies to processes that only import foundation, such as the CLI and the generators.

## Tests

- new `packages/foundation/test/lazy-dependencies.test.js`: a `node:module` `registerHooks` resolve hook records every resolved URL; importing the package loads none of the six; `getParser` / `getStringifier` for yaml, json5 and toml load their parser on first call and produce the expected output; extra arguments (yaml `mapAsMap` options, json5 reviver) are still forwarded to the underlying parser; `generateDashedName()` loads `boring-name-generator`; `createCliLogger()` loads `pino-pretty`. The first test fails on `main`.
- existing `configuration.test.js`, `cli.test.js`, `file-system.test.js`, `module.test.js` unchanged and green (the yaml configuration loading, the CLI logger and `getLatestNpmVersion` are already covered there).

## Checklist

- [x] `packages/foundation` full `npm test` (including `test:types`) green, lint clean
- [x] No schema, types or docs change
- [x] DCO sign-off, single commit