### PR TITLE
fix(runtime): resolve {PLT_<APPLICATION>_URL} against the applications that exist

### DIFF
--- a/docs/reference/service/configuration.md
+++ b/docs/reference/service/configuration.md
@@ -379,3 +379,30 @@ PLT_SERVER_LOGGER_LEVEL=debug wattpm dev
 ### PLT_ROOT
 
 The `{PLT_ROOT}` placeholder is automatically set to the directory containing the configuration file, so it can be used to configure relative paths.
+
+### Referencing another application
+
+Inside a runtime, `{PLT_<APPLICATION>_URL}` resolves to the internal URL of the named application even
+when no environment variable defines it, so applications can reach each other without a variable per
+pair. `<APPLICATION>` is the application id uppercased with dashes turned into underscores, which is
+the same prefix its generated variables use: the application `with-logger` owns `{PLT_WITH_LOGGER_URL}`
+and resolves to `http://with-logger.plt.local`.
+
+```json
+{
+  "clients": [
+    {
+      "serviceId": "with-logger",
+      "url": "{PLT_WITH_LOGGER_URL}"
+    }
+  ]
+}
+```
+
+Only applications that actually exist in the runtime are resolved this way, and setting the variable
+yourself always wins. Any other placeholder whose name happens to end in `_URL` is left alone and
+resolves to an empty string as usual, so a connection string such as `valkey://{VALKEY_URL}` or a DSN
+such as `{PLT_DATABASE_URL}` is never rewritten into an application URL.
+
+With [`strictEnv`](../runtime/configuration.md) enabled, a placeholder resolved this way is reported
+as replaced by a fallback value rather than as missing.

--- a/packages/foundation/index.d.ts
+++ b/packages/foundation/index.d.ts
@@ -370,5 +370,6 @@ export declare const schemaComponents: Record<string, JSONSchemaType<any>>
 // String types
 export declare function findNearestString (strings: string[], target: string): string | null
 export declare function match (actual: any, expected: any): boolean
+export declare function convertApplicationNameToPrefix (applicationName: string): string
 export declare function escapeRegexp (raw: string): string
 export declare function parseMemorySize (size: string): number

--- a/packages/foundation/lib/string.js
+++ b/packages/foundation/lib/string.js
@@ -54,6 +54,18 @@ export function match (actual, expected) {
   return true
 }
 
+/**
+ * Convert an application name into the prefix used by its environment variables, so that the
+ * application "with-logger" owns PLT_WITH_LOGGER_*. This is the convention generators follow when
+ * they emit variables for an application, and the one the runtime uses to recognise a reference to
+ * an application, like {PLT_WITH_LOGGER_URL}.
+ * @param {string} applicationName - The application name
+ * @returns {string} The environment variable prefix
+ */
+export function convertApplicationNameToPrefix (applicationName) {
+  return applicationName.replace(/-/g, '_').toUpperCase()
+}
+
 // Once we drop Node < 24, remove this in favor of Regexp.escape which is more accurate
 export function escapeRegexp (raw) {
   return raw.replaceAll(/([!$()*+./:=?[\\\]^{|}])/g, '\\$1')

--- a/packages/generators/lib/utils.js
+++ b/packages/generators/lib/utils.js
@@ -1,3 +1,4 @@
+import { convertApplicationNameToPrefix } from '@platformatic/foundation'
 import { EOL } from 'node:os'
 import { join } from 'node:path'
 import { setTimeout } from 'timers/promises'
@@ -20,9 +21,9 @@ export function stripVersion (version) {
   return version
 }
 
-export function convertApplicationNameToPrefix (applicationName) {
-  return applicationName.replace(/-/g, '_').toUpperCase()
-}
+// Kept as a re-export: the convention now lives in @platformatic/foundation, so that the runtime can
+// recognise application references without depending on the generators.
+export { convertApplicationNameToPrefix }
 
 export function addPrefixToString (input, prefix) {
   if (!prefix) {

--- a/packages/runtime/fixtures/missing-env-fallback/applications/app-a/platformatic.json
+++ b/packages/runtime/fixtures/missing-env-fallback/applications/app-a/platformatic.json
@@ -7,7 +7,8 @@
         "options": {
           "resolvedBaseUrl": "{PLT_SOME_BASE_URL}",
           "resolvedClientId": "{PLT_SOME_CLIENT_ID}",
-          "cacheUrl": "valkey://{VALKEY_URL}"
+          "cacheUrl": "valkey://{VALKEY_URL}",
+          "peerUrl": "{PLT_APP_B_URL}"
         }
       }
     ]

--- a/packages/runtime/fixtures/missing-env-fallback/applications/app-a/plugin.js
+++ b/packages/runtime/fixtures/missing-env-fallback/applications/app-a/plugin.js
@@ -3,7 +3,8 @@ export default async function (app, options) {
     return {
       resolvedBaseUrl: options.resolvedBaseUrl,
       resolvedClientId: options.resolvedClientId,
-      cacheUrl: options.cacheUrl
+      cacheUrl: options.cacheUrl,
+      peerUrl: options.peerUrl
     }
   })
 }

--- a/packages/runtime/fixtures/missing-env-fallback/applications/app-b/package.json
+++ b/packages/runtime/fixtures/missing-env-fallback/applications/app-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "app-b",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@platformatic/service": "workspace:*"
+  }
+}

--- a/packages/runtime/fixtures/missing-env-fallback/applications/app-b/platformatic.json
+++ b/packages/runtime/fixtures/missing-env-fallback/applications/app-b/platformatic.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/3.0.0.json"
+}

--- a/packages/runtime/fixtures/missing-env-fallback/platformatic.json
+++ b/packages/runtime/fixtures/missing-env-fallback/platformatic.json
@@ -12,6 +12,10 @@
     {
       "id": "app-a",
       "path": "./applications/app-a"
+    },
+    {
+      "id": "app-b",
+      "path": "./applications/app-b"
     }
   ],
   "server": {

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -1,4 +1,5 @@
 import {
+  convertApplicationNameToPrefix,
   ensureLoggableError,
   FileWatcher,
   kHandledError,
@@ -28,12 +29,27 @@ import { ApplicationAlreadyStartedError, exitCodes, RuntimeNotStartedError } fro
 import { getApplicationUrl } from '../utils.js'
 import { markAsPlatformaticDispatcher, refreshGlobalDispatcher } from './interceptors.js'
 
-function fetchApplicationUrl (application, key) {
-  if (!key.endsWith('_URL') || !application.id) {
-    return null
+/**
+ * Resolves {PLT_<APPLICATION>_URL} placeholders that no environment variable defines, so that
+ * applications can reference each other without the user having to set a variable per pair.
+ *
+ * The mapping is built forwards, from the ids of the applications that actually exist in the runtime
+ * to the variable name each of them owns. Parsing the variable name instead would be ambiguous, both
+ * because the id to prefix conversion is not reversible ("with-logger" and "with_logger" share a
+ * prefix) and because plenty of _URL variables do not name an application at all: a connection string
+ * fragment like {VALKEY_URL} or a DSN like {PLT_DATABASE_URL} must keep resolving to nothing rather
+ * than silently becoming an HTTP URL.
+ */
+function buildApplicationUrlResolver (applications) {
+  const urls = new Map()
+
+  for (const { id } of applications ?? []) {
+    if (id) {
+      urls.set(`PLT_${convertApplicationNameToPrefix(id)}_URL`, getApplicationUrl(id))
+    }
   }
 
-  return getApplicationUrl(application.id)
+  return key => urls.get(key) ?? null
 }
 
 function handleUnhandled (app, event, listeners, timeout, err, ...args) {
@@ -78,6 +94,8 @@ export class Controller extends EventEmitter {
     this.capability = null
     this.#fileWatcher = null
 
+    const onMissingEnv = buildApplicationUrlResolver(runtimeConfig.applications)
+
     this.#context = {
       controller: this,
       runtimeConfig: this.runtimeConfig,
@@ -95,7 +113,10 @@ export class Controller extends EventEmitter {
       worker: workerData?.worker,
       resourceLimits: workerData?.resourceLimits,
       hasManagementApi: !!runtimeConfig.managementApi,
-      fetchApplicationUrl: fetchApplicationUrl.bind(null, applicationConfig),
+      fetchApplicationUrl: onMissingEnv,
+      // Capabilities spread the whole context into their loadConfiguration call, which is what makes
+      // the configuration they load resolve application references like the throwaway load below.
+      onMissingEnv,
       strictEnv: runtimeConfig.strictEnv
     }
   }
@@ -143,10 +164,11 @@ export class Controller extends EventEmitter {
         // Parse the configuration file the first time to obtain the schema. This load is thrown away:
         // the capability loads the configuration again below and that is the configuration the
         // application actually runs on. This one only has to yield $schema and module, so it must not
-        // diverge from the second load in any way the user can observe: it deliberately applies no
-        // onMissingEnv fallback and emits no strictEnv report, both of which are left to the load the
-        // application is built from.
+        // diverge from the second load in any way the user can observe: it resolves environment
+        // variables identically, and leaves the strictEnv report to the load the application is
+        // built from, which would otherwise be duplicated for every application.
         const unvalidatedConfig = await loadConfiguration(appConfig.config, null, {
+          onMissingEnv: this.#context.onMissingEnv,
           strictEnv: false
         })
         const pkg = await loadConfigurationModule(appConfig.path, unvalidatedConfig)

--- a/packages/runtime/test/missing-env-fallback.test.js
+++ b/packages/runtime/test/missing-env-fallback.test.js
@@ -7,13 +7,19 @@ const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
 
 const configFile = join(fixturesDir, 'missing-env-fallback', 'platformatic.json')
 
-function missingWarnings (logs) {
-  return logs.filter(
-    log => typeof log.msg === 'string' && log.msg.includes('environment variables which are not set')
-  )
+function warningsOf (logs, kind) {
+  const fallback = 'have been replaced by a fallback value'
+
+  return logs.filter(log => {
+    if (typeof log.msg !== 'string' || !log.msg.includes('environment variables which are not set')) {
+      return false
+    }
+
+    return kind === 'fallback' ? log.msg.includes(fallback) : !log.msg.includes(fallback)
+  })
 }
 
-test('the configuration the application runs on is not altered by the application URL fallback', async t => {
+test('a placeholder naming another application resolves to its URL, and nothing else does', async t => {
   const runtime = await createRuntime(configFile)
 
   t.after(async () => {
@@ -25,17 +31,20 @@ test('the configuration the application runs on is not altered by the applicatio
   const { statusCode, body } = await runtime.inject('app-a', { method: 'GET', url: '/options' })
   strictEqual(statusCode, 200)
 
-  // A missing variable is empty regardless of whether its name ends with _URL. In particular
-  // `cacheUrl` shows why the fallback must not reach this load: the variable is a fragment of a
-  // connection string, so substituting an application URL would produce `valkey://http://app-a.plt.local`.
   deepStrictEqual(JSON.parse(body), {
+    // app-b exists in the runtime, so PLT_APP_B_URL is the application it owns.
+    peerUrl: 'http://app-b.plt.local',
+    // No application is named "some-base" or "some-client-id", so these stay empty rather than
+    // silently becoming the URL of an unrelated application.
     resolvedBaseUrl: '',
     resolvedClientId: '',
+    // VALKEY_URL is a fragment of a connection string, not an application reference. Resolving it
+    // would produce `valkey://http://app-a.plt.local`, which is what broke packages/next before.
     cacheUrl: 'valkey://'
   })
 })
 
-test('missing environment variables are reported once per application', async t => {
+test('each missing environment variable is reported exactly once', async t => {
   const context = {}
   const runtime = await createRuntime(configFile, null, context)
 
@@ -47,16 +56,18 @@ test('missing environment variables are reported once per application', async t 
   await runtime.close()
 
   const logs = await readLogs(context.logsPath, 0)
-  const missing = missingWarnings(logs)
 
-  // Before, the throwaway load reported the _URL variables as replaced by a fallback value and the
-  // real load reported them as not set, so the same application warned twice, contradicting itself.
+  // The application is configured twice per worker, but only the load it actually runs on reports.
+  const missing = warningsOf(logs, 'missing').filter(log => log.name === 'app-a')
   strictEqual(missing.length, 1)
 
-  // The single report lists every variable that is actually missing from the running configuration.
   for (const name of ['PLT_SOME_BASE_URL', 'PLT_SOME_CLIENT_ID', 'VALKEY_URL']) {
     strictEqual(missing[0].msg.includes(name), true, `expected ${name} in: ${missing[0].msg}`)
   }
 
-  strictEqual(missing[0].msg.includes('fallback'), false)
+  // A variable the runtime resolved for the user is still surfaced, separately, as a fallback.
+  const fallback = warningsOf(logs, 'fallback').filter(log => log.name === 'app-a')
+  strictEqual(fallback.length, 1)
+  strictEqual(fallback[0].msg.includes('PLT_APP_B_URL'), true)
+  strictEqual(missing[0].msg.includes('PLT_APP_B_URL'), false)
 })


### PR DESCRIPTION
Fixes #5085.

## Problem

#5083 left `fetchApplicationUrl` with no consumer, because it could not be applied to the configuration an application actually runs on. It had two independent defects:

```js
function fetchApplicationUrl (application, key) {
  if (!key.endsWith('_URL') || !application.id) {
    return null
  }
  return getApplicationUrl(application.id)   // the *current* application, whatever the variable is named
}
```

1. **The `_URL` suffix is not a reliable signal.** `packages/next/test/fixtures/caching-adapter` uses `valkey://{VALKEY_URL}`, where the variable is a *fragment* of a connection string — the sibling fixture spells the intended value out as `VALKEY_URL=localhost:6379`. Applying the fallback produced `valkey://http://frontend.plt.local` and failed the adapter test.
2. **It resolved the wrong application.** `packages/runtime/fixtures/monorepo/serviceApp` has a client `{PLT_WITH_LOGGER_URL}` with `serviceId: "with-logger"`. The fallback returned `http://serviceApp.plt.local` — the application doing the lookup, not the one named.

## Solution

The mapping is now built **forwards**, from the ids of the applications the runtime actually has to the variable each of them owns:

```js
for (const { id } of applications ?? []) {
  urls.set(`PLT_${convertApplicationNameToPrefix(id)}_URL`, getApplicationUrl(id))
}
```

A placeholder resolves only when it names a real application. This fixes both defects at once, and sidesteps the concern the issue raised about reverse-parsing the variable name being ambiguous — `with-logger` and `with_logger` share a prefix, so parsing could never be unambiguous, while forward matching never needs to.

`convertApplicationNameToPrefix` is the convention the generators already follow when emitting `PLT_<PREFIX>_*` variables for an application, and matches the one already documented for URLs (`PLT_MOVIES_URL` for the application `movies`, in the distributed tracing guide).

| Placeholder | Before | After |
|---|---|---|
| `{PLT_WITH_LOGGER_URL}`, application `with-logger` exists | `''` | `http://with-logger.plt.local` |
| `valkey://{VALKEY_URL}` | `valkey://` | `valkey://` |
| `{PLT_DATABASE_URL}`, no such application | `''` | `''` |

Because the resolver is now safe on the real load, it is applied to both configuration loads of a worker, so they resolve environment variables identically — the property #5083 established — and applications can reference each other without the user setting a variable per pair. Setting the variable yourself still wins, and a placeholder resolved this way is reported by `strictEnv` as replaced by a fallback value rather than as missing, which is what #5026 added the report for.

`convertApplicationNameToPrefix` moves from `@platformatic/generators` to `@platformatic/foundation`, so the runtime worker can share the convention without depending on the generators. It is re-exported from `@platformatic/generators`, so that package's public API is unchanged.

## Tests

`packages/runtime/test/missing-env-fallback.test.js` gains a second application and asserts both directions in one fixture:

- `{PLT_APP_B_URL}` resolves to `http://app-b.plt.local`;
- `valkey://{VALKEY_URL}` stays `valkey://`, and `{PLT_SOME_BASE_URL}` / `{PLT_SOME_CLIENT_ID}` stay empty — so the regression that broke `packages/next` is covered by the runtime suite rather than only by `packages/next`;
- each variable is still reported exactly once, with the resolved one reported separately as a fallback.

Local runs: `packages/runtime` 438/438, `packages/foundation` 363/363, `packages/generators` 53/53, `packages/create-wattpm` unit 20/20.

## Docs

`docs/reference/service/configuration.md` gains a "Referencing another application" section under environment variable placeholders, documenting the convention, the "only applications that exist" guard, and the `strictEnv` interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012h4pp2kRNvCySUukXJKwnR
