### PR TITLE
feat(gateway): let a gateway opt out of restarting on application changes

### DIFF
--- a/docs/reference/gateway/configuration.md
+++ b/docs/reference/gateway/configuration.md
@@ -289,6 +289,12 @@ Configure `@platformatic/gateway` specific settings such as `applications` or `r
 
 - **`refreshTimeout`** (`number`) - The number of milliseconds to wait for check for changes in the applications. If not specified, the default value is `1000`; set to `0` to disable. This is only supported if the Gateway is running within a [Platformatic Runtime](../runtime/overview.md).
 
+- **`restartOnApplicationChange`** (`boolean`) - Whether to restart the Gateway when an application is added to or removed from the Runtime, so it can recompose its routes. Default is `true`, and that is what you want for a Gateway that proxies applications registered in the Runtime.
+
+  Set it to `false` only for a Gateway that does **not** route from the application registry — one that resolves its upstreams some other way, such as from shared state written by a Runtime extension. Restarting an application replaces its workers one at a time: with two or more workers and `SO_REUSEPORT` the listening socket survives, but with a single worker (the default, and the only option where `SO_REUSEPORT` is unavailable) the Runtime has no open port until the replacement worker has booted. For a Gateway that has nothing to recompose, that window is pure downtime.
+
+  Opting out means a newly added application is **not** proxied until the Gateway is restarted by something else. This is only supported if the Gateway is running within a [Platformatic Runtime](../runtime/overview.md).
+
 - **`addEmptySchema`** (`boolean`) - Deprecated, it no longer has any effect. Responses which declare no body - a `204`, a `304`, or any other status code whose response object has no `content` - always keep their status code in the composed OpenAPI specification, and are documented without a body.
 
 - **`handler`** (`string`) - Path to a JavaScript or TypeScript module that exports a custom proxy handler, either as `handler` or as the default export. The handler receives `(request, reply, dest, options)`, where `dest` is the rewritten proxy destination and `options` are the reply options passed to `reply.from()`. By default, proxied requests call `reply.from(dest, options)`; use this option to customize that behavior.

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -1255,6 +1255,10 @@ export interface PlatformaticComposerConfig {
     addEmptySchema?: boolean;
     refreshTimeout?: number;
     /**
+     * Restart the gateway when an application is added to or removed from the runtime, so it can recompose its routes. Set to false for a gateway that does not route from the application registry — restarting it closes its listening socket, which for a single-worker entrypoint means the runtime has no open port until the replacement worker boots.
+     */
+    restartOnApplicationChange?: boolean;
+    /**
      * Content types that should be passed through without parsing to enable proxying
      */
     passthroughContentTypes?: string[];

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -4543,6 +4543,11 @@
           "minimum": 0,
           "default": 1000
         },
+        "restartOnApplicationChange": {
+          "type": "boolean",
+          "default": true,
+          "description": "Restart the gateway when an application is added to or removed from the runtime, so it can recompose its routes. Set to false for a gateway that does not route from the application registry — restarting it closes its listening socket, which for a single-worker entrypoint means the runtime has no open port until the replacement worker boots."
+        },
         "passthroughContentTypes": {
           "type": "array",
           "items": {

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -444,6 +444,10 @@ export interface PlatformaticGatewayConfig {
     addEmptySchema?: boolean;
     refreshTimeout?: number;
     /**
+     * Restart the gateway when an application is added to or removed from the runtime, so it can recompose its routes. Set to false for a gateway that does not route from the application registry — restarting it closes its listening socket, which for a single-worker entrypoint means the runtime has no open port until the replacement worker boots.
+     */
+    restartOnApplicationChange?: boolean;
+    /**
      * Content types that should be passed through without parsing to enable proxying
      */
     passthroughContentTypes?: string[];

--- a/packages/gateway/lib/capability.js
+++ b/packages/gateway/lib/capability.js
@@ -43,8 +43,13 @@ export class GatewayCapability extends ServiceCapability {
     // Only register the runtime event handler once. start() can be called
     // multiple times (first with listen:false, then listen:true) so guard
     // against duplicate registrations.
+    //
+    // Not registered at all when `restartOnApplicationChange` is false: a
+    // gateway that does not route from the application registry has nothing to
+    // recompose, and the restart is pure downtime for it. Skipping the
+    // subscription rather than the notify keeps it off the ITC entirely.
     const itc = getITC({ throwOnMissing: false })
-    if (!this.#runtimeEventHandler && itc) {
+    if (this.config.gateway?.restartOnApplicationChange !== false && !this.#runtimeEventHandler && itc) {
       this.#runtimeEventHandler = this.#handleRuntimeEvent.bind(this)
       itc.on('runtime:event', this.#runtimeEventHandler)
     }
@@ -108,6 +113,11 @@ export class GatewayCapability extends ServiceCapability {
     return replaceEnv(application.origin, this.config[kMetadata].env).endsWith('.plt.local')
   }
 
+  // The runtime resolves `request:restart` by replacing this application's
+  // workers one at a time. With two or more workers and SO_REUSEPORT that is
+  // seamless; with ONE — the default, and forced wherever reusePort is
+  // unavailable — the listening socket closes for the length of a worker boot.
+  // `restartOnApplicationChange: false` is how a gateway opts out of that.
   #handleRuntimeEvent ({ event }) {
     if (event === 'application:added' || event === 'application:removed') {
       const itc = getITC()

--- a/packages/gateway/lib/schema.js
+++ b/packages/gateway/lib/schema.js
@@ -282,6 +282,15 @@ export const gateway = {
     graphql: graphqlComposerOptions,
     addEmptySchema: { type: 'boolean', default: false },
     refreshTimeout: { type: 'integer', minimum: 0, default: 1000 },
+    restartOnApplicationChange: {
+      type: 'boolean',
+      default: true,
+      description:
+        'Restart the gateway when an application is added to or removed from the runtime, so it can recompose ' +
+        'its routes. Set to false for a gateway that does not route from the application registry — restarting ' +
+        'it closes its listening socket, which for a single-worker entrypoint means the runtime has no open port ' +
+        'until the replacement worker boots.'
+    },
     passthroughContentTypes: {
       type: 'array',
       items: { type: 'string' },

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1550,6 +1550,11 @@
           "minimum": 0,
           "default": 1000
         },
+        "restartOnApplicationChange": {
+          "type": "boolean",
+          "default": true,
+          "description": "Restart the gateway when an application is added to or removed from the runtime, so it can recompose its routes. Set to false for a gateway that does not route from the application registry — restarting it closes its listening socket, which for a single-worker entrypoint means the runtime has no open port until the replacement worker boots."
+        },
         "passthroughContentTypes": {
           "type": "array",
           "items": {

--- a/packages/gateway/test/capability/get-config.test.js
+++ b/packages/gateway/test/capability/get-config.test.js
@@ -30,6 +30,7 @@ test('get application config via capability api', async t => {
       applications: [],
       refreshTimeout: 1000,
       addEmptySchema: false,
+      restartOnApplicationChange: true,
       passthroughContentTypes: ['multipart/form-data', 'application/octet-stream']
     },
     plugins: {

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/backend/index.mjs
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/backend/index.mjs
@@ -1,0 +1,11 @@
+import fastify from 'fastify'
+
+export function create () {
+  const app = fastify()
+
+  app.get('/hello', async () => {
+    return { from: 'backend' }
+  })
+
+  return app
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/backend/package.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/backend/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/backend/platformatic.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/backend/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.6.0.json",
+  "logger": {
+    "level": "info"
+  }
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/extra-service/index.mjs
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/extra-service/index.mjs
@@ -1,0 +1,11 @@
+import fastify from 'fastify'
+
+export function create () {
+  const app = fastify()
+
+  app.get('/hello', async () => {
+    return { from: 'extra-service' }
+  })
+
+  return app
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/extra-service/package.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/extra-service/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/extra-service/platformatic.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/extra-service/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.6.0.json",
+  "logger": {
+    "level": "info"
+  }
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/frontend/index.mjs
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/frontend/index.mjs
@@ -1,0 +1,11 @@
+import fastify from 'fastify'
+
+export function create () {
+  const app = fastify()
+
+  app.get('/hello', async () => {
+    return { from: 'frontend' }
+  })
+
+  return app
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/frontend/package.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/frontend/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/frontend/platformatic.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/frontend/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.6.0.json",
+  "logger": {
+    "level": "info"
+  }
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/gateway/platformatic.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/gateway/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/gateway/2.6.0.json",
+  "server": {
+    "logger": {
+      "level": "info"
+    }
+  },
+  "gateway": {
+    "restartOnApplicationChange": false
+  }
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/package.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/packages/runtime/fixtures/gateway-no-restart-on-change/platformatic.json
+++ b/packages/runtime/fixtures/gateway-no-restart-on-change/platformatic.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.6.0.json",
+  "server": {
+    "hostname": "127.0.0.1"
+  },
+  "watch": false,
+  "managementApi": true,
+  "restartOnError": 500,
+  "reuseTcpPorts": false,
+  "autoload": {
+    "path": ".",
+    "exclude": ["extra-service"]
+  },
+  "logger": {
+    "level": "debug"
+  }
+}

--- a/packages/runtime/test/gateway-restart-on-application-change.test.js
+++ b/packages/runtime/test/gateway-restart-on-application-change.test.js
@@ -1,0 +1,170 @@
+import { deepStrictEqual, ok, strictEqual } from 'node:assert'
+import { once } from 'node:events'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { prepareApplication } from '../index.js'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+// `gateway.restartOnApplicationChange` (default true).
+//
+// A gateway recomposes its routes by restarting itself when an application is
+// added or removed. `restartApplication` replaces workers one at a time, so
+// with two or more workers and SO_REUSEPORT the restart is seamless — but with
+// ONE worker, which is the default and is forced wherever reusePort is
+// unavailable, the listening socket closes for the length of a worker boot.
+//
+// For a gateway that does not route from the application registry at all, that
+// restart buys nothing and costs the runtime its only open port. The option
+// lets such a gateway opt out. It defaults to true, so nothing changes for a
+// gateway that does compose the registry.
+
+async function addExtraApplication (runtime) {
+  return await runtime.addApplications(
+    [
+      await prepareApplication(runtime.getRuntimeConfig(true), {
+        id: 'extra-service',
+        path: './extra-service'
+      })
+    ],
+    true
+  )
+}
+
+// Drives requests through the gateway until stopped, recording every outcome.
+// A restart that closes the socket shows up here as ECONNREFUSED, which is the
+// symptom the option exists to remove — a status-code check alone would miss it.
+function keepRequesting (url) {
+  const results = { ok: 0, failures: [] }
+  // A holder rather than a bare `let`: stop() flips it from outside the loop,
+  // which a plain variable makes look unmodified to static analysis.
+  const state = { running: true }
+
+  const loop = (async () => {
+    while (state.running) {
+      try {
+        const res = await request(`${url}/backend/hello`)
+        await res.body.text()
+        if (res.statusCode === 200) {
+          results.ok++
+        } else {
+          results.failures.push(`HTTP ${res.statusCode}`)
+        }
+      } catch (err) {
+        results.failures.push(err.code ?? err.message)
+      }
+    }
+  })()
+
+  return {
+    results,
+    async stop () {
+      state.running = false
+      await loop
+    }
+  }
+}
+
+test('a gateway with restartOnApplicationChange disabled keeps serving when an application is added', async t => {
+  const runtime = await createRuntime(join(fixturesDir, 'gateway-no-restart-on-change'), null)
+  t.after(() => runtime.close())
+
+  const url = await runtime.start()
+  const originalPort = new URL(url).port
+
+  const restarts = []
+  runtime.on('application:restarted', id => restarts.push(id))
+
+  {
+    const res = await request(`${url}/backend/hello`)
+    strictEqual(res.statusCode, 200)
+    deepStrictEqual(await res.body.json(), { from: 'backend' })
+  }
+
+  const traffic = keepRequesting(url)
+
+  const started = once(runtime, 'application:started')
+  await addExtraApplication(runtime)
+  await started
+
+  // Longer than a worker boot: a restart that was going to happen has had
+  // ample time to, and the traffic loop above would have caught its window.
+  await new Promise(resolve => setTimeout(resolve, 2000))
+  await traffic.stop()
+
+  strictEqual(
+    restarts.filter(id => id === 'gateway').length,
+    0,
+    'the gateway must not restart when it has opted out of recomposing on application changes'
+  )
+
+  ok(traffic.results.ok > 0, 'the traffic loop must have made requests')
+  deepStrictEqual(
+    traffic.results.failures.slice(0, 5),
+    [],
+    `${traffic.results.failures.length} of ${traffic.results.ok + traffic.results.failures.length} requests failed while an application was added`
+  )
+
+  strictEqual(new URL(runtime.getUrl()).port, originalPort, 'the entrypoint never changed port')
+
+  {
+    const res = await request(`${runtime.getUrl()}/frontend/hello`)
+    strictEqual(res.statusCode, 200, 'existing routes still work')
+    deepStrictEqual(await res.body.json(), { from: 'frontend' })
+  }
+})
+
+test('opting out means the new application is NOT composed until something else restarts the gateway', async t => {
+  // The cost of the option, asserted rather than left implicit. Recomposing on
+  // application changes is exactly what the restart is for, so a gateway that
+  // opts out must be one that does not route from the registry — which is why
+  // the default is true.
+  const runtime = await createRuntime(join(fixturesDir, 'gateway-no-restart-on-change'), null)
+  t.after(() => runtime.close())
+
+  const url = await runtime.start()
+
+  const started = once(runtime, 'application:started')
+  await addExtraApplication(runtime)
+  await started
+  await new Promise(resolve => setTimeout(resolve, 2000))
+
+  const res = await request(`${url}/extra-service/hello`)
+  await res.body.text()
+  strictEqual(
+    res.statusCode,
+    404,
+    'the added application is not proxied: the gateway never recomposed, which is what opting out means'
+  )
+
+  // An explicit restart still composes it, so the option withholds the
+  // automatic restart rather than breaking composition itself.
+  const restarted = once(runtime, 'application:restarted')
+  await runtime.restartApplication('gateway')
+  await restarted
+
+  const afterRestart = await request(`${runtime.getUrl()}/extra-service/hello`)
+  strictEqual(afterRestart.statusCode, 200, 'an explicit restart composes it')
+  deepStrictEqual(await afterRestart.body.json(), { from: 'extra-service' })
+})
+
+test('the default is unchanged: a gateway still restarts on an application change', async t => {
+  // The guard on the default. The option is only safe to add because every
+  // existing gateway keeps the behaviour it has today.
+  const runtime = await createRuntime(join(fixturesDir, 'gateway-restart-port'), null)
+  t.after(() => runtime.close())
+
+  await runtime.start()
+
+  const restarted = once(runtime, 'application:restarted')
+  const started = once(runtime, 'application:started')
+  await addExtraApplication(runtime)
+  await started
+  await restarted
+
+  const res = await request(`${runtime.getUrl()}/extra-service/hello`)
+  strictEqual(res.statusCode, 200, 'the default still composes a newly added application')
+  deepStrictEqual(await res.body.json(), { from: 'extra-service' })
+})


### PR DESCRIPTION
## The problem

A gateway recomposes its routes by **restarting itself** whenever an application is added to or removed from the runtime (`capability.js` → `request:restart`).

`restartApplication` replaces workers one at a time, so with two or more workers and `SO_REUSEPORT` the listening socket survives. With **one** worker — the default, and the only option wherever `SO_REUSEPORT` is unavailable — the runtime has no open port until the replacement worker has booted.

For a gateway that does **not** route from the application registry, that restart recomposes nothing and costs the runtime its only port.

## Where this bites

`watt-skew-protection` registers each deployed version as a runtime application and routes to them from shared state a runtime extension publishes — never from the application registry. Every deploy therefore restarts its entrypoint for nothing.

Measured on a single-worker gateway: **two windows of ~630 ms each per activation** (a promotion is a remove followed by an add), during which the pod's only socket is closed. Under 200 concurrent sessions that was ~60% of requests failing, mostly `ECONNREFUSED` rather than 503s.

## The change

`gateway.restartOnApplicationChange`, **default `true`**.

When false, the runtime-event handler is **not subscribed at all**, rather than subscribed and then ignored — so nothing reaches the ITC either.

## What the tests pin

Three, in `packages/runtime/test/gateway-restart-on-application-change.test.js`:

1. **With the option off, adding an application drops no request.** Traffic runs through the gateway across the add and every response is checked — a transport failure from a closed socket is what this is looking for, and a status-code assertion alone would miss it.
2. **The cost of opting out, asserted rather than implied.** The newly added application is *not* proxied (404) until something else restarts the gateway — and an explicit `restartApplication` still composes it. That is exactly why this must not be the default.
3. **The default is unchanged.** A gateway that composes the registry still restarts and still picks up the new application.

Tests 1 and 2 fail without the capability change; test 3 passes either way, which is the point of it.

## Risk

Additive and default-on, so no existing gateway changes behaviour. `composer` re-exports the gateway schema, so its generated `schema.json` / `config.d.ts` are regenerated here too.

Pre-existing failures in `packages/gateway` (Valkey tests needing a running Redis, a `vite` version mismatch) are unchanged: 93 pass / 7 fail on clean `main`, 94 / 6 on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
