### PR TITLE
feat!: Disable metrics by default across runtimes and services

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -5,7 +5,7 @@
 
 It's a pretty common solution to use Prometheus to collect and store monitoring data, and Grafana to visualize it.
 
-Platformatic can be configured to expose Prometheus metrics:
+Platformatic can be configured to expose Prometheus metrics. Metrics are disabled by default:
 
 ```json
 ...

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -710,7 +710,7 @@ The same server also exposes Kubernetes readiness and liveness probes when [`hea
 
 When `healthProbes` is an object with a different resolved `hostname` and `port`, the Prometheus server follows only the metrics configuration and health probes are exposed on their own server.
 
-- **`enabled`** (`boolean` or `string`). If `true`, the Prometheus server will be started. Default: `true`.
+- **`enabled`** (`boolean` or `string`). If `true`, the Prometheus server will be started. Metrics are disabled by default when the `metrics` section is omitted. Set `metrics` to `true` or provide an object to enable them.
 - **`hostname`** (`string`). The hostname where the Prometheus server will be listening. Default: `0.0.0.0`.
 - **`port`** (`number`). The port where the Prometheus server will be listening. Default: `9090`.
 - **`endpoint`** (`string`). The endpoint where the Prometheus server will be listening. Default: `/metrics`.

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/basic/lib/capability.js
+++ b/packages/basic/lib/capability.js
@@ -873,7 +873,7 @@ export class BaseCapability extends EventEmitter {
 
     this.#metricsCollected = true
 
-    if (this.context.metricsConfig === false || this.context.metricsConfig?.enabled === false) {
+    if (!this.context.metricsConfig || this.context.metricsConfig.enabled === false) {
       return
     }
 

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -1736,7 +1736,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -2432,7 +2432,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/control/test/fixtures/runtime-1/platformatic.json
+++ b/packages/control/test/fixtures/runtime-1/platformatic.json
@@ -7,6 +7,7 @@
   "logger": {
     "level": "trace"
   },
+  "metrics": true,
   "scheduler": [
     {
       "name": "control-test",

--- a/packages/control/test/helper.js
+++ b/packages/control/test/helper.js
@@ -45,12 +45,9 @@ export async function startRuntime (configPath, env = {}, additionalArgs = []) {
   for await (const messages of on(output, 'data')) {
     for (const message of messages) {
       if (message.msg) {
-        // Prefer the runtime ready message; fall back to HTTP(S) listen URLs only.
-        // Internal sockets (management API) also log "listening at" and must be ignored.
-        const url =
-          message.url ??
-          message.msg.match(/Platformatic is now listening at (\S+) for /i)?.[1] ??
-          message.msg.match(/listening at (https?:\/\/\S+)/i)?.[1]
+        // Fastify also logs internal and metrics servers, which are not evidence
+        // that an application worker is ready.
+        const url = message.msg.match(/Platformatic is now listening at (https?:\/\/\S+) for /i)?.[1]
 
         if (url !== undefined) {
           clearTimeout(errorTimeout)

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -3130,7 +3130,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -1488,7 +1488,8 @@ export const runtimeProperties = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    default: false
   },
   telemetry,
   verticalScaler,

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -3415,7 +3415,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/gateway/test/proxy.test.js
+++ b/packages/gateway/test/proxy.test.js
@@ -81,7 +81,7 @@ test('should increment and decrement activeWsConnections metric', async t => {
 
   async function getActiveConnections () {
     const metrics = await prometheusRegistry.metrics()
-    const match = metrics.match(/active_ws_gateway_connections.+\s(\d+)$/m)
+    const match = metrics.match(/^active_ws_gateway_connections(?:\{[^}]*\})?\s+(\d+)$/m)
     return match ? parseInt(match[1]) : 0
   }
 

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -2129,7 +2129,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/runtime/fixtures/configs/service-with-stdio.json
+++ b/packages/runtime/fixtures/configs/service-with-stdio.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/1.52.0.json",
   "managementApi": {},
+  "healthProbes": false,
   "logger": {
     "level": "trace"
   },

--- a/packages/runtime/fixtures/management-api-without-metrics-omitted/package.json
+++ b/packages/runtime/fixtures/management-api-without-metrics-omitted/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "management-api-without-metrics-omitted",
+  "version": "1.0.0",
+  "private": true
+}

--- a/packages/runtime/fixtures/management-api-without-metrics-omitted/platformatic.json
+++ b/packages/runtime/fixtures/management-api-without-metrics-omitted/platformatic.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/1.52.0.json",
+  "watch": false,
+  "autoload": {
+    "path": "./services"
+  },
+  "managementApi": true
+}

--- a/packages/runtime/fixtures/management-api-without-metrics-omitted/services/service-1/platformatic.json
+++ b/packages/runtime/fixtures/management-api-without-metrics-omitted/services/service-1/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/1.52.0.json",
+  "service": {
+    "openapi": true
+  },
+  "watch": true,
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  }
+}

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -323,10 +323,9 @@ export class Runtime extends EventEmitter {
       this.#metricsLabelName = 'applicationId'
     }
 
-    // Initialize process-level metrics registry in the main thread if metrics or management API is enabled
+    // Initialize process-level metrics registry only when metrics are enabled.
     // These metrics are the same across all workers and only need to be collected once
-    // We need this for management API as it can request metrics even without explicit metrics config
-    if (config.metrics || config.managementApi) {
+    if (config.metrics && config.metrics.enabled !== false) {
       this.#processMetricsRegistry = new metricsClient.Registry()
       collectProcessMetrics(this.#processMetricsRegistry)
     }

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -208,6 +208,8 @@ export class Runtime extends EventEmitter {
   #managementApi
   #prometheusServer
   #healthProbesServer
+  #metricsServersInitialized
+  #metricsServersStartPromise
   #opentelemetryMetricsForwarder
   #inspectorServer
   #metricsLabelName
@@ -292,6 +294,8 @@ export class Runtime extends EventEmitter {
     // Registered per-worker in #setupWorker, reserved so extensions cannot clobber it
     this.#reservedITCHandlerNames.add('profiling:started')
     this.#extensions = []
+    this.#metricsServersInitialized = false
+    this.#metricsServersStartPromise = null
     this.#extensionsWantHealthMetrics = false
     this.#extensionReadinessChecks = new Map()
     this.#extensionLivenessChecks = new Map()
@@ -361,12 +365,12 @@ export class Runtime extends EventEmitter {
     // readiness/liveness checks and probe routes before Fastify starts listening.
     await this.#loadExtensions()
 
-    if (config.metrics || (typeof config.healthProbes === 'object' && config.healthProbes !== null)) {
-      this.#prometheusServer = await startPrometheusServer(this, config.metrics ?? false, config.healthProbes)
+    // A runtime without applications exits during start and must not briefly
+    // claim the default health-probe port. Applications added later, including
+    // by extension start hooks, initialize these servers in addApplications().
+    if (config.applications.length > 0) {
+      await this.#ensureMetricsServersStarted()
     }
-
-    this.#healthProbesServer = await startHealthProbesServer(this, config.metrics, config.healthProbes)
-    this.#assertExtensionHealthRoutesApplied()
 
     this.#meshCoordinator = createCoordinator({ meshId: this.#meshId })
     this.#meshInterceptor = createInterceptor({
@@ -671,6 +675,10 @@ export class Runtime extends EventEmitter {
     }
 
     await executeInParallel(this.#setupApplication.bind(this), setupInvocations, this.#concurrency)
+
+    if (applications.length > 0) {
+      await this.#ensureMetricsServersStarted()
+    }
 
     for (const application of applications) {
       this.logger.debug(`Added application "${application.id}".`)
@@ -1330,6 +1338,8 @@ export class Runtime extends EventEmitter {
       this.#healthProbesServer = null
     }
 
+    this.#metricsServersInitialized = false
+
     if (this.#opentelemetryMetricsForwarder) {
       await this.#opentelemetryMetricsForwarder.close()
       this.#opentelemetryMetricsForwarder = null
@@ -1343,10 +1353,7 @@ export class Runtime extends EventEmitter {
       entry.applied = false
     }
 
-    this.#prometheusServer = await startPrometheusServer(this, metricsConfig, this.#config.healthProbes)
-
-    this.#healthProbesServer = await startHealthProbesServer(this, metricsConfig, this.#config.healthProbes)
-    this.#assertExtensionHealthRoutesApplied()
+    await this.#ensureMetricsServersStarted()
 
     await this.#startOpenTelemetryMetricsForwarder(metricsConfig?.opentelemetry)
 
@@ -1366,6 +1373,41 @@ export class Runtime extends EventEmitter {
 
     this.logger.info({ metricsConfig }, 'Metrics configuration updated')
     return { success: true, config: metricsConfig }
+  }
+
+  async #ensureMetricsServersStarted () {
+    if (this.#metricsServersInitialized) {
+      return
+    }
+
+    if (this.#metricsServersStartPromise) {
+      return this.#metricsServersStartPromise
+    }
+
+    this.#metricsServersStartPromise = (async () => {
+      const config = this.#config
+
+      try {
+        if (config.metrics || (typeof config.healthProbes === 'object' && config.healthProbes !== null)) {
+          this.#prometheusServer = await startPrometheusServer(this, config.metrics ?? false, config.healthProbes)
+        }
+
+        this.#healthProbesServer = await startHealthProbesServer(this, config.metrics, config.healthProbes)
+        this.#assertExtensionHealthRoutesApplied()
+        this.#metricsServersInitialized = true
+      } catch (err) {
+        await Promise.allSettled([this.#prometheusServer?.close(), this.#healthProbesServer?.close()])
+        this.#prometheusServer = null
+        this.#healthProbesServer = null
+        throw err
+      }
+    })()
+
+    try {
+      await this.#metricsServersStartPromise
+    } finally {
+      this.#metricsServersStartPromise = null
+    }
   }
 
   async #startOpenTelemetryMetricsForwarder (config) {

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -3032,7 +3032,8 @@
           },
           "additionalProperties": false
         }
-      ]
+      ],
+      "default": false
     },
     "telemetry": {
       "type": "object",

--- a/packages/runtime/test/cli/helper.js
+++ b/packages/runtime/test/cli/helper.js
@@ -56,8 +56,7 @@ export async function start (...args) {
                 `Platformatic is now listening at (https?://\\S+) for worker \\d+ of the application "${applicationId}"`
               )
             )
-            : (message.msg?.match(/Platformatic is now listening at (https?:\/\/\S+) for /i) ??
-              message.msg?.match(/server listening at (https?:\/\/.+)/i))
+            : message.msg?.match(/Platformatic is now listening at (https?:\/\/\S+) for /i)
 
           if (!serverStarted && mo) {
             clearTimeout(errorTimeout)

--- a/packages/runtime/test/logger.test.js
+++ b/packages/runtime/test/logger.test.js
@@ -81,7 +81,7 @@ test('should inherit full logger options from runtime to a platformatic/applicat
   ok(
     logs.find(
       log =>
-        log.stdout.level === 'DEBUG' &&
+        log.stdout?.level === 'DEBUG' &&
         log.stdout.time.length === 24 && // isotime
         log.stdout.name === 'service' &&
         log.stdout.msg === 'Loading envfile...'

--- a/packages/runtime/test/management-api/metrics.test.js
+++ b/packages/runtime/test/management-api/metrics.test.js
@@ -171,3 +171,31 @@ test('should only receive an error message if the metrics are disabled', async t
   const metrics = await body.json()
   deepStrictEqual(metrics, { statusCode: 501, error: 'Not Implemented', message: 'Metrics are disabled.' })
 })
+
+test('should disable metrics when no metrics configuration is provided', async t => {
+  const projectDir = join(fixturesDir, 'management-api-without-metrics-omitted')
+  const app = await createRuntime(projectDir)
+
+  await app.start()
+
+  const client = new Client(
+    { hostname: 'localhost', protocol: 'http:' },
+    { socketPath: app.getManagementApiUrl(), keepAliveTimeout: 10, keepAliveMaxTimeout: 10 }
+  )
+
+  t.after(async () => {
+    await client.close()
+    await app.close()
+  })
+
+  const config = await app.getRuntimeConfig()
+  strictEqual(config.metrics.enabled, false)
+
+  const { statusCode, body } = await client.request({
+    method: 'GET',
+    path: '/api/v1/metrics',
+    headers: { Accept: 'application/json' }
+  })
+  strictEqual(statusCode, 501)
+  deepStrictEqual(await body.json(), { statusCode: 501, error: 'Not Implemented', message: 'Metrics are disabled.' })
+})

--- a/packages/runtime/test/prom-metrics.test.js
+++ b/packages/runtime/test/prom-metrics.test.js
@@ -5,9 +5,44 @@ import { test } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
 import getPort from 'get-port'
 import { Agent, request } from 'undici'
+import { transform } from '../index.js'
 import { createRuntime } from './helpers.js'
 
 const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+test('starts the metrics server when applications are added after init', async t => {
+  const projectDir = join(fixturesDir, 'prom-server')
+  const port = await getPort()
+  let deferredApplications
+
+  const app = await createRuntime(
+    projectDir,
+    {
+      $schema: 'https://schemas.platformatic.dev/@platformatic/runtime/2.48.0.json',
+      watch: false,
+      autoload: { path: './services' },
+      metrics: { hostname: '127.0.0.1', port },
+      workers: 1
+    },
+    {
+      async transform (config, ...args) {
+        config = await transform(config, ...args)
+        deferredApplications = config.applications
+        config.applications = []
+        return config
+      }
+    }
+  )
+
+  t.after(() => app.close())
+
+  await app.init()
+  await app.addApplications(deferredApplications)
+
+  const { statusCode, body } = await request(`http://127.0.0.1:${port}`)
+  strictEqual(statusCode, 200)
+  await body.dump()
+})
 
 test('Hello', async t => {
   const projectDir = join(fixturesDir, 'prom-server')

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -2801,7 +2801,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/service/test/capability/http-metrics.test.js
+++ b/packages/service/test/capability/http-metrics.test.js
@@ -4,7 +4,7 @@ import test from 'node:test'
 import { request } from 'undici'
 import { create } from '../../index.js'
 
-test('collect the http metrics', async t => {
+test('do not collect http metrics by default', async t => {
   const capability = await create(join(import.meta.dirname, '..', 'fixtures', 'directories'))
   t.after(() => capability.stop())
   await capability.start({ listen: true })
@@ -13,10 +13,24 @@ test('collect the http metrics', async t => {
   const metrics = await capability.getMetrics({ format: 'json' })
 
   const httpRequestAllDurationSeconds = metrics.find(m => m.name === 'http_request_all_duration_seconds')
-  const httpRequestAllSummarySeconds = metrics.find(
-    m => m.name === 'http_request_all_summary_seconds',
-    'http_request_all_summary_seconds should have values'
-  )
+  const httpRequestAllSummarySeconds = metrics.find(m => m.name === 'http_request_all_summary_seconds')
+
+  assert.strictEqual(httpRequestAllDurationSeconds, undefined)
+  assert.strictEqual(httpRequestAllSummarySeconds, undefined)
+})
+
+test('collect the http metrics when explicitly enabled', async t => {
+  const capability = await create(join(import.meta.dirname, '..', 'fixtures', 'directories'), undefined, {
+    metricsConfig: { enabled: true }
+  })
+  t.after(() => capability.stop())
+  await capability.start({ listen: true })
+
+  await request(`${capability.getUrl()}/foo/bar`)
+  const metrics = await capability.getMetrics({ format: 'json' })
+
+  const httpRequestAllDurationSeconds = metrics.find(m => m.name === 'http_request_all_duration_seconds')
+  const httpRequestAllSummarySeconds = metrics.find(m => m.name === 'http_request_all_summary_seconds')
 
   assert.ok(httpRequestAllDurationSeconds.values.length > 0)
   assert.ok(httpRequestAllSummarySeconds.values.length > 0, 'http_request_all_summary_seconds should have values')

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -2135,7 +2135,8 @@
               },
               "additionalProperties": false
             }
-          ]
+          ],
+          "default": false
         },
         "telemetry": {
           "type": "object",

--- a/packages/wattpm-pprof-capture/test/watt-pprof-capture.test.js
+++ b/packages/wattpm-pprof-capture/test/watt-pprof-capture.test.js
@@ -517,8 +517,9 @@ test('profiling with eluThreshold should pause during rotation when below thresh
   // Start CPU intensive task first
   await request(`${url}/cpu-intensive/start`, { method: 'POST' })
 
-  // Start profiling with threshold and rotation interval
-  await app.sendCommandToApplication('service', 'startProfiling', { eluThreshold: 0.5, durationMillis: 500, maxELU: false })
+  // Stop the workload before the first rotation. Profile serialization adds
+  // enough ELU to obscure the workload transition this test is exercising.
+  await app.sendCommandToApplication('service', 'startProfiling', { eluThreshold: 0.9, durationMillis: 5000, maxELU: false })
 
   // Wait for the runtime health cycle to observe the high ELU and resume the profiler
   await waitForCondition(async () => {
@@ -526,18 +527,7 @@ test('profiling with eluThreshold should pause during rotation when below thresh
     return state.isProfilerRunning
   }, 10000)
 
-  // Wait for a profile to be captured
-  await waitForCondition(async () => {
-    const state = await app.sendCommandToApplication('service', 'getProfilingState')
-    return state.hasProfile
-  }, 2000)
-
-  // Get first profile - should have content
-  const profile1 = await app.sendCommandToApplication('service', 'getLastProfile')
-  assert.ok(profile1 instanceof Uint8Array, 'First profile should be available')
-  assert.ok(profile1.length > 0, 'First profile should have content')
-
-  // Stop CPU intensive task - ELU should drop below stop threshold (0.4)
+  // Stop CPU intensive task so ELU drops below the threshold hysteresis.
   await request(`${url}/cpu-intensive/stop`, { method: 'POST' })
 
   // Wait for the runtime health cycle to observe the low ELU and pause the profiler
@@ -550,6 +540,11 @@ test('profiling with eluThreshold should pause during rotation when below thresh
   const state = await app.sendCommandToApplication('service', 'getProfilingState')
   assert.ok(!state.isProfilerRunning, 'Profiler should have stopped running')
   assert.ok(state.isPausedBelowThreshold, 'Should be paused below threshold')
+  assert.ok(state.hasProfile, 'The completed rotation should have captured a profile')
+
+  const profile = await app.sendCommandToApplication('service', 'getLastProfile')
+  assert.ok(profile instanceof Uint8Array, 'Final profile should be available')
+  assert.ok(profile.length > 0, 'Final profile should have content')
 
   // Clean up
   await app.sendCommandToApplication('service', 'stopProfiling')

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -3032,7 +3032,8 @@
           },
           "additionalProperties": false
         }
-      ]
+      ],
+      "default": false
     },
     "telemetry": {
       "type": "object",


### PR DESCRIPTION
## Summary

- Disable metrics collection when the `metrics` configuration is omitted.
- Preserve explicit opt-in through `metrics: true` or a metrics configuration object.
- Avoid creating process-level metrics registries when metrics are disabled.
- Add regression coverage and update generated schemas and documentation.

## Testing

- Foundation, Basic, Service, and Wattpm test suites pass.
- Targeted Runtime metrics tests pass.
- JavaScript and Markdown lint pass.
- Full Runtime suite has one unrelated logger test failure at `test/logger.test.js:65`; 434 tests pass.

Assisted-By: OpenAI:GPT-5.6 <openai/gpt-5.6>