### PR TITLE
feat(db): add usePrimaryKeySqlType to expose keys using their SQL type

### DIFF
--- a/docs/reference/sql-mapper/entities/fields.md
+++ b/docs/reference/sql-mapper/entities/fields.md
@@ -16,8 +16,21 @@ These objects contain the following properties:
 - `isNullable`: Whether the field can be `null` or not
 - `primaryKey`: Whether the field is the primary key or not
 - `foreignKey`: Whether the field is a foreign key or not
-- `stringifyOutput`: Whether the field is converted to a string in mapper output because it references a primary key
+- `stringifyOutput`: Whether the field is exposed as a string in the mapper output, the JSON schemas and the generated types
 - `camelcase`: The _camel cased_ value of the field
+
+## Key types on the wire
+
+By default primary keys are exposed as strings whatever their SQL type, and the foreign keys referencing them follow, so that comparing the two stays type-stable. A `serial`/`int4` key is therefore returned as `"1"` rather than `1`.
+
+Set `usePrimaryKeySqlType: true` in the `db` section of the configuration to derive the exposed type of every column from its own SQL type instead. Keys are then no longer special-cased: an `int4` key is returned as `1`, while types that cannot be represented as a JSON number without losing precision (`bigint`, `int8`, `numeric`, `decimal`) stay strings.
+
+Two things only line up with the option enabled:
+
+- the request and response schemas of a route agree, so a value read from a response can be sent straight back
+- a database view and the table behind it expose the same column with the same type, since views carry no primary key or constraint to special-case
+
+The option defaults to `false` because turning it on changes the type of every integer key on the wire and in the generated types.
 
 ## Example
 Given this SQL Schema (for PostgreSQL):

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -208,6 +208,10 @@ export interface PlatformaticDatabaseConfig {
           [k: string]: unknown;
         };
     poolSize?: number;
+    /**
+     * Derive the exposed type of every column from its SQL type. When false (the default), primary keys and the foreign keys referencing them are always exposed as strings, even when their SQL type is a JSON-safe number such as int4.
+     */
+    usePrimaryKeySqlType?: boolean;
     idleTimeoutMilliseconds?: number;
     queueTimeoutMilliseconds?: number;
     acquireLockTimeoutMilliseconds?: number;

--- a/packages/db/lib/schema.js
+++ b/packages/db/lib/schema.js
@@ -53,6 +53,12 @@ export const db = {
     poolSize: {
       type: 'integer'
     },
+    usePrimaryKeySqlType: {
+      type: 'boolean',
+      default: false,
+      description:
+        'Derive the exposed type of every column from its SQL type. When false (the default), primary keys and the foreign keys referencing them are always exposed as strings, even when their SQL type is a JSON-safe number such as int4.'
+    },
     idleTimeoutMilliseconds: {
       type: 'integer'
     },

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -623,6 +623,11 @@
         "poolSize": {
           "type": "integer"
         },
+        "usePrimaryKeySqlType": {
+          "type": "boolean",
+          "default": false,
+          "description": "Derive the exposed type of every column from its SQL type. When false (the default), primary keys and the foreign keys referencing them are always exposed as strings, even when their SQL type is a JSON-safe number such as int4."
+        },
         "idleTimeoutMilliseconds": {
           "type": "integer"
         },

--- a/packages/db/test/capability/get-config.test.js
+++ b/packages/db/test/capability/get-config.test.js
@@ -34,7 +34,8 @@ test('get application config via capability api', async t => {
   assert.deepStrictEqual(capabilityConfig, {
     application: {},
     db: {
-      ...connectionInfo
+      ...connectionInfo,
+      usePrimaryKeySqlType: false
     },
     plugins: {
       paths: [join(workingDir, 'routes')]

--- a/packages/db/test/use-primary-key-sql-type.test.js
+++ b/packages/db/test/use-primary-key-sql-type.test.js
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { request } from 'undici'
+import { createFromConfig, getConnectionInfo } from './helper.js'
+
+async function createApp (t, connectionInfo, dbOptions) {
+  const app = await createFromConfig(t, {
+    server: { hostname: '127.0.0.1', port: 0, logger: { level: 'fatal' } },
+    db: {
+      ...connectionInfo,
+      ...dbOptions,
+      async onDatabaseLoad (db, sql) {
+        await db.query(sql`CREATE TABLE categories (
+          id INTEGER PRIMARY KEY,
+          name VARCHAR(42)
+        );`)
+        await db.query(sql`CREATE TABLE pages (
+          id INTEGER PRIMARY KEY,
+          title VARCHAR(42),
+          category_id INTEGER REFERENCES categories(id)
+        );`)
+      }
+    }
+  })
+
+  await app.start({ listen: true })
+  return app
+}
+
+test('usePrimaryKeySqlType is honoured through the db configuration', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('sqlite')
+
+  const app = await createApp(t, connectionInfo, { usePrimaryKeySqlType: true })
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+
+  const created = await request(`${app.url}/categories`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 1, name: 'fiction' })
+  })
+  assert.equal(created.statusCode, 200)
+  assert.deepEqual(await created.body.json(), { id: 1, name: 'fiction' })
+
+  const page = await request(`${app.url}/pages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 1, title: 'a page', categoryId: 1 })
+  })
+  assert.equal(page.statusCode, 200)
+  assert.deepEqual(await page.body.json(), { id: 1, title: 'a page', categoryId: 1 })
+})
+
+test('primary keys stay strings without the option', async t => {
+  const { connectionInfo, dropTestDB } = await getConnectionInfo('sqlite')
+
+  const app = await createApp(t, connectionInfo, {})
+  t.after(async () => {
+    await app.stop()
+    await dropTestDB()
+  })
+
+  const created = await request(`${app.url}/categories`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 1, name: 'fiction' })
+  })
+  assert.equal(created.statusCode, 200)
+  assert.deepEqual(await created.body.json(), { id: '1', name: 'fiction' })
+})

--- a/packages/sql-graphql/lib/relationship.js
+++ b/packages/sql-graphql/lib/relationship.js
@@ -43,11 +43,15 @@ export function establishRelations (app, relations, resolvers, loaders, queryTop
         current.fields[lowered] = { type: foreign.type }
         loaders[current.type] = loaders[current.type] || {}
         const key = camelcase(foreign_column_name)
+        // The loaded rows are matched by strict equality, so the key has to be
+        // built the same way the foreign column is exposed by the mapper.
+        const stringifyKey = foreign.entity.fields[foreign_column_name]?.stringifyOutput
         loaders[current.type][lowered] = {
           loader (queries, ctx) {
             const keys = []
             for (const { obj } of queries) {
-              const value = obj[originalField] != null ? obj[originalField].toString() : null
+              const raw = obj[originalField]
+              const value = raw == null ? null : stringifyKey ? raw.toString() : raw
 
               keys.push([{ key, value }])
             }

--- a/packages/sql-graphql/test/relation-key-types.test.js
+++ b/packages/sql-graphql/test/relation-key-types.test.js
@@ -1,0 +1,115 @@
+import sqlMapper from '@platformatic/sql-mapper'
+import fastify from 'fastify'
+import { deepEqual as same, equal } from 'node:assert'
+import { test } from 'node:test'
+import sqlGraphQL from '../index.js'
+import { clear, connInfo, isMysql, isSQLite } from './helper.js'
+
+async function createApp (t, usePrimaryKeySqlType) {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    usePrimaryKeySqlType,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+
+      if (isMysql) {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            contact_id INTEGER NOT NULL,
+            contact_code INTEGER NOT NULL,
+            FOREIGN KEY (contact_id) REFERENCES contacts(id),
+            FOREIGN KEY (contact_code) REFERENCES contacts(external_code)
+          );
+        `)
+      } else if (isSQLite) {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id INTEGER PRIMARY KEY,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id INTEGER PRIMARY KEY,
+            contact_id INTEGER NOT NULL REFERENCES contacts(id),
+            contact_code INTEGER NOT NULL REFERENCES contacts(external_code)
+          );
+        `)
+      } else {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id SERIAL PRIMARY KEY,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id SERIAL PRIMARY KEY,
+            contact_id INTEGER NOT NULL REFERENCES contacts(id),
+            contact_code INTEGER NOT NULL REFERENCES contacts(external_code)
+          );
+        `)
+      }
+
+      await db.query(sql`INSERT INTO contacts (external_code) VALUES (42);`)
+      await db.query(sql`INSERT INTO registrations (contact_id, contact_code) VALUES (1, 42);`)
+    }
+  })
+  app.register(sqlGraphQL)
+  t.after(() => app.close())
+  await app.ready()
+  return app
+}
+
+async function query (app) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: {
+      query: `{
+        registrations {
+          id
+          contact { id externalCode }
+          contactCode { id externalCode }
+        }
+      }`
+    }
+  })
+  equal(res.statusCode, 200, res.body)
+  return res.json()
+}
+
+// A foreign key pointing at a UNIQUE column that is not a primary key: the
+// referenced column is not stringified, so the loader must not stringify the key
+// it looks it up with.
+test('relations to a non primary key column resolve', async t => {
+  const app = await createApp(t, false)
+  const { data, errors } = await query(app)
+
+  same(errors, undefined)
+  same(data.registrations, [
+    {
+      id: '1',
+      contact: { id: '1', externalCode: 42 },
+      contactCode: { id: '1', externalCode: 42 }
+    }
+  ])
+})
+
+test('relations resolve with usePrimaryKeySqlType', async t => {
+  const app = await createApp(t, true)
+  const { data, errors } = await query(app)
+
+  same(errors, undefined)
+  // GraphQL exposes keys as ID, which serializes to a string whatever the mapper
+  // returns, so the output is the same as with the option turned off.
+  same(data.registrations, [
+    {
+      id: '1',
+      contact: { id: '1', externalCode: 42 },
+      contactCode: { id: '1', externalCode: 42 }
+    }
+  ])
+})

--- a/packages/sql-json-schema-mapper/index.js
+++ b/packages/sql-json-schema-mapper/index.js
@@ -76,7 +76,7 @@ function mapSQLTypeToOpenAPISchema (field, output) {
   }
 
   let type = mapSQLTypeToOpenAPIType(field.sqlType)
-  if (output && (field.primaryKey || field.stringifyOutput) && (type === 'integer' || type === 'number')) {
+  if (output && field.stringifyOutput && (type === 'integer' || type === 'number')) {
     type = 'string'
   }
 
@@ -194,8 +194,8 @@ function renderProperties (
       types = [type]
     }
 
-    // The mapper returns primary keys and marked foreign keys as strings
-    if (fieldDefinitions[name]?.primaryKey || fieldDefinitions[name]?.stringifyOutput) {
+    // The mapper returns fields marked with `stringifyOutput` as strings
+    if (fieldDefinitions[name]?.stringifyOutput) {
       types = Array.from(new Set(types.map(t => (t === 'integer' || t === 'number' ? 'string' : t))))
     }
 

--- a/packages/sql-json-schema-mapper/test/simple.test.js
+++ b/packages/sql-json-schema-mapper/test/simple.test.js
@@ -125,7 +125,8 @@ test('output schemas stringify numeric primary and referencing foreign keys', ()
         camelcase: 'id',
         sqlType: 'integer',
         isNullable: false,
-        primaryKey: true
+        primaryKey: true,
+        stringifyOutput: true
       },
       contactId: {
         camelcase: 'contactId',

--- a/packages/sql-json-schema-mapper/test/types.test.js
+++ b/packages/sql-json-schema-mapper/test/types.test.js
@@ -19,7 +19,7 @@ function referenceTest (name, obj, opts = {}) {
       return `${prefix}: ${members.join(' | ')};`
     })
     const cloned = structuredClone(obj)
-    const ours = mapOpenAPItoTypes(cloned, { id: { primaryKey: true } })
+    const ours = mapOpenAPItoTypes(cloned, { id: { primaryKey: true, stringifyOutput: true } })
     notEqual(cloned, obj)
     same(cloned, obj)
     same(ours.trim(), reference.trim())
@@ -226,7 +226,7 @@ test('bytea fields are mapped to Buffer type', async t => {
   }
 
   const fieldDefinitions = {
-    id: { primaryKey: true },
+    id: { primaryKey: true, stringifyOutput: true },
     content: { sqlType: 'bytea' },
     metadata: { sqlType: 'text' }
   }
@@ -269,7 +269,7 @@ test('numeric primary keys are mapped to string type', async t => {
   }
 
   const fieldDefinitions = {
-    id: { primaryKey: true, sqlType: 'integer' },
+    id: { primaryKey: true, stringifyOutput: true, sqlType: 'integer' },
     age: { sqlType: 'integer' },
     contactId: { foreignKey: true, stringifyOutput: true, sqlType: 'integer' },
     externalCode: { foreignKey: true, sqlType: 'integer' },

--- a/packages/sql-mapper/index.d.ts
+++ b/packages/sql-mapper/index.d.ts
@@ -60,8 +60,8 @@ export interface DBEntityField {
    */
   foreignKey?: boolean,
   /**
-   * An option that is true if a foreign key field is stringified in mapper output
-   * because it references a primary key.
+   * An option that is true if the field is exposed as a string in the mapper
+   * output, the JSON schemas and the generated types.
    */
   stringifyOutput?: boolean,
   /**
@@ -468,7 +468,14 @@ export interface SQLMapperPluginOptions extends BasePoolOptions {
    * Query caching Configuration
    * @default false
    */
-  cache?: cacheOptions
+  cache?: cacheOptions,
+  /**
+   * Derive the exposed type of every column from its SQL type. When false, primary
+   * keys and the foreign keys referencing them are always exposed as strings, even
+   * when their SQL type is a JSON-safe number such as int4.
+   * @default false
+   */
+  usePrimaryKeySqlType?: boolean
 }
 
 export interface Entities {

--- a/packages/sql-mapper/index.js
+++ b/packages/sql-mapper/index.js
@@ -84,11 +84,40 @@ function physicalEntityKey (schema, table) {
   return `${schema ?? ''}\0${table}`
 }
 
-function markForeignKeysReferencingPrimaryKeys (entities) {
+// SQL types whose values cannot be represented as a JSON number without losing
+// precision, so they are exposed as strings. Types such as `uuid` or `varchar`
+// are not listed: the drivers already return them as strings.
+const STRING_OUTPUT_SQL_TYPES = new Set(['int8', 'bigint', 'bigint unsigned', 'numeric', 'decimal'])
+
+// `stringifyOutput` is the single source of truth for "this field is exposed as a
+// string": the mapper output (see lib/entity.js), the JSON schemas and the
+// generated types all derive from it.
+function markStringifiedOutputFields (entities, usePrimaryKeySqlType) {
+  if (usePrimaryKeySqlType) {
+    // Decide per column, from its own SQL type. Primary and foreign keys get no
+    // special treatment, so an `int4` key stays a number and a table and a view
+    // exposing the same column agree.
+    for (const entity of Object.values(entities)) {
+      for (const field of Object.values(entity.fields)) {
+        if (STRING_OUTPUT_SQL_TYPES.has(field.sqlType)) {
+          field.stringifyOutput = true
+        }
+      }
+    }
+    return
+  }
+
+  // Legacy behaviour: every primary key is stringified regardless of its SQL
+  // type, and foreign keys referencing one follow so that comparisons between
+  // the two stay type-stable.
   const entitiesByTable = new Map()
 
   for (const entity of Object.values(entities)) {
     entitiesByTable.set(physicalEntityKey(entity.schema, entity.table), entity)
+
+    for (const key of entity.primaryKeys) {
+      entity.fields[key].stringifyOutput = true
+    }
   }
 
   for (const entity of Object.values(entities)) {
@@ -252,7 +281,8 @@ export async function connect ({
   cache,
   idleTimeoutMilliseconds,
   queueTimeoutMilliseconds,
-  acquireLockTimeoutMilliseconds
+  acquireLockTimeoutMilliseconds,
+  usePrimaryKeySqlType = false
 }) {
   if (typeof autoTimestamp === 'boolean' && autoTimestamp === true) {
     autoTimestamp = defaultAutoTimestampFields
@@ -418,7 +448,7 @@ export async function connect ({
       }
     }
 
-    markForeignKeysReferencingPrimaryKeys(entities)
+    markStringifiedOutputFields(entities, usePrimaryKeySqlType)
 
     const res = {
       db,

--- a/packages/sql-mapper/lib/entity.js
+++ b/packages/sql-mapper/lib/entity.js
@@ -127,7 +127,7 @@ function createMapper (
       }
 
       if (
-        (primaryKeys.has(key) || fields[key]?.stringifyOutput) &&
+        fields[key]?.stringifyOutput &&
         value !== null &&
         value !== undefined &&
         !(value instanceof Date) &&

--- a/packages/sql-mapper/test/entity.test.js
+++ b/packages/sql-mapper/test/entity.test.js
@@ -1616,3 +1616,146 @@ test('date columns are returned as YYYY-MM-DD strings', { skip: !isPg }, async (
   const [found] = await pageEntity.find({ where: { publishDate: { eq: '2023-06-01' } } })
   equal(found.publishDate, '2023-06-01')
 })
+
+test('usePrimaryKeySqlType exposes keys using their own SQL type', async () => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+
+    if (isMysql) {
+      // MySQL's SERIAL is a BIGINT UNSIGNED, so spell the integer key out
+      await db.query(sql`
+        CREATE TABLE categories (
+          id INTEGER PRIMARY KEY AUTO_INCREMENT,
+          name VARCHAR(42)
+        );
+        CREATE TABLE pages (
+          id INTEGER PRIMARY KEY AUTO_INCREMENT,
+          title VARCHAR(42),
+          category_id INTEGER,
+          FOREIGN KEY (category_id) REFERENCES categories(id)
+        );
+      `)
+    } else if (isSQLite) {
+      await db.query(sql`CREATE TABLE categories (
+        id INTEGER PRIMARY KEY,
+        name VARCHAR(42)
+      );`)
+      await db.query(sql`CREATE TABLE pages (
+        id INTEGER PRIMARY KEY,
+        title VARCHAR(42),
+        category_id INTEGER REFERENCES categories(id)
+      );`)
+    } else {
+      await db.query(sql`CREATE TABLE categories (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(42)
+      );`)
+      await db.query(sql`CREATE TABLE pages (
+        id SERIAL PRIMARY KEY,
+        title VARCHAR(42),
+        category_id INTEGER REFERENCES categories(id)
+      );`)
+    }
+  }
+
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {},
+    usePrimaryKeySqlType: true
+  })
+
+  const categoryEntity = mapper.entities.category
+  const pageEntity = mapper.entities.page
+
+  // An int4 primary key survives JSON, so it is not marked for stringification,
+  // and neither is the foreign key referencing it.
+  strictEqual(categoryEntity.fields.id.stringifyOutput, undefined)
+  strictEqual(pageEntity.fields.id.stringifyOutput, undefined)
+  strictEqual(pageEntity.fields.category_id.stringifyOutput, undefined)
+
+  const [category] = await categoryEntity.insert({ inputs: [{ name: 'fiction' }] })
+  strictEqual(typeof category.id, 'number')
+
+  const [page] = await pageEntity.insert({ inputs: [{ title: 'a page', categoryId: category.id }] })
+  strictEqual(typeof page.id, 'number')
+  strictEqual(typeof page.categoryId, 'number')
+  strictEqual(page.categoryId, category.id, 'the foreign key compares equal to the primary key')
+
+  const [found] = await pageEntity.find({ where: { id: { eq: page.id } } })
+  strictEqual(typeof found.id, 'number')
+  strictEqual(typeof found.categoryId, 'number')
+})
+
+test('usePrimaryKeySqlType keeps wide primary keys as strings', async () => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+
+    await db.query(sql`CREATE TABLE pages (
+      id BIGINT NOT NULL PRIMARY KEY,
+      title VARCHAR(42)
+    );`)
+  }
+
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {},
+    usePrimaryKeySqlType: true
+  })
+
+  const pageEntity = mapper.entities.page
+  // A bigint cannot be represented as a JSON number without losing precision.
+  strictEqual(pageEntity.fields.id.stringifyOutput, true)
+
+  const [page] = await pageEntity.insert({ inputs: [{ id: 42, title: 'a page' }] })
+  strictEqual(typeof page.id, 'string')
+})
+
+test('primary keys are stringified by default', async () => {
+  async function onDatabaseLoad (db, sql) {
+    await clear(db, sql)
+    test.after(async () => {
+      await clear(db, sql)
+      db.dispose()
+    })
+
+    if (isSQLite) {
+      await db.query(sql`CREATE TABLE pages (
+        id INTEGER PRIMARY KEY,
+        title VARCHAR(42)
+      );`)
+    } else {
+      await db.query(sql`CREATE TABLE pages (
+        id SERIAL PRIMARY KEY,
+        title VARCHAR(42)
+      );`)
+    }
+  }
+
+  const mapper = await connect({
+    connectionString: connInfo.connectionString,
+    log: fakeLogger,
+    onDatabaseLoad,
+    ignore: {},
+    hooks: {}
+  })
+
+  const pageEntity = mapper.entities.page
+  strictEqual(pageEntity.fields.id.stringifyOutput, true)
+
+  const [page] = await pageEntity.insert({ inputs: [{ title: 'a page' }] })
+  strictEqual(typeof page.id, 'string')
+})

--- a/packages/sql-openapi/test/foreign-key-types.test.js
+++ b/packages/sql-openapi/test/foreign-key-types.test.js
@@ -91,3 +91,96 @@ test('numeric primary and referencing foreign keys are strings in REST output', 
   strictEqual(getResponse.statusCode, 200, getResponse.body)
   deepStrictEqual(getResponse.json(), { id: '1', contactId: '1', contactCode: 42 })
 })
+
+test('usePrimaryKeySqlType exposes numeric keys as numbers in REST output', async t => {
+  const app = fastify()
+  app.register(sqlMapper, {
+    ...connInfo,
+    usePrimaryKeySqlType: true,
+    async onDatabaseLoad (db, sql) {
+      await clear(db, sql)
+
+      if (isMysql) {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id INTEGER PRIMARY KEY AUTO_INCREMENT,
+            contact_id INTEGER NOT NULL,
+            FOREIGN KEY (contact_id) REFERENCES contacts(id)
+          );
+        `)
+      } else if (isSQLite) {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id INTEGER PRIMARY KEY,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id INTEGER PRIMARY KEY,
+            contact_id INTEGER NOT NULL REFERENCES contacts(id)
+          );
+        `)
+      } else {
+        await db.query(sql`
+          CREATE TABLE contacts (
+            id SERIAL PRIMARY KEY,
+            external_code INTEGER NOT NULL UNIQUE
+          );
+          CREATE TABLE registrations (
+            id SERIAL PRIMARY KEY,
+            contact_id INTEGER NOT NULL REFERENCES contacts(id)
+          );
+        `)
+      }
+    }
+  })
+  app.register(sqlOpenAPI)
+  t.after(() => app.close())
+
+  await app.ready()
+
+  // The request and the response schemas agree, unlike with the default
+  const openapi = app.swagger()
+  strictEqual(openapi.components.schemas.Contact.properties.id.type, 'integer')
+  strictEqual(openapi.components.schemas.ContactInput.properties.id.type, 'integer')
+  strictEqual(openapi.components.schemas.Registration.properties.id.type, 'integer')
+  strictEqual(openapi.components.schemas.Registration.properties.contactId.type, 'integer')
+  strictEqual(openapi.components.schemas.RegistrationInput.properties.contactId.type, 'integer')
+
+  const contactResponse = await app.inject({
+    method: 'POST',
+    url: '/contacts',
+    body: { externalCode: 42 }
+  })
+  strictEqual(contactResponse.statusCode, 200, contactResponse.body)
+  deepStrictEqual(contactResponse.json(), { id: 1, externalCode: 42 })
+
+  const contact = contactResponse.json()
+  const registrationResponse = await app.inject({
+    method: 'POST',
+    url: '/registrations',
+    // the primary key read from a response is accepted as a foreign key
+    body: { contactId: contact.id }
+  })
+  strictEqual(registrationResponse.statusCode, 200, registrationResponse.body)
+  deepStrictEqual(registrationResponse.json(), { id: 1, contactId: 1 })
+
+  const registration = registrationResponse.json()
+  strictEqual(registration.contactId, contact.id, 'the foreign key compares equal to the primary key')
+
+  const getResponse = await app.inject({ method: 'GET', url: '/registrations/1' })
+  strictEqual(getResponse.statusCode, 200, getResponse.body)
+  deepStrictEqual(getResponse.json(), { id: 1, contactId: 1 })
+
+  // a response can be sent straight back as a request body
+  const putResponse = await app.inject({
+    method: 'PUT',
+    url: '/registrations/1',
+    body: getResponse.json()
+  })
+  strictEqual(putResponse.statusCode, 200, putResponse.body)
+  deepStrictEqual(putResponse.json(), { id: 1, contactId: 1 })
+})


### PR DESCRIPTION
## Problem

An `int4` primary key is exposed with two different types by the same route:

```jsonc
// PUT /pages/1 accepts
{ "id": 1, "categoryId": 1 }
// GET /pages/1 returns
{ "id": "1", "categoryId": "1" }
```

A response cannot be sent back as a request body without coercion. The same split shows up between a table and a view over it, because a view carries no primary key or constraint to special-case:

```jsonc
// GET /pages/1        -> { "id": "1", "categoryId": "1" }
// GET /pagesViews/1   -> { "id": 1,   "categoryId": 1 }
```

The cause is in `sql-mapper`'s `fixOutput`, which stringifies every primary key regardless of SQL type, and since #4982 the foreign keys referencing one follow. The SQL-type mapping already handles the types that genuinely need it — `bigint`, `int8`, `numeric` and `decimal` map to `string` on their own — so the cast only ever changes types that are perfectly representable as JSON numbers. #4972's reporter noted this themselves: *"not bigint — bigint PKs were already `string` via the SQL-type mapping"*.

## What this does

Adds a `usePrimaryKeySqlType` option to the `db` configuration, **defaulting to `false`** so nothing changes unless it is turned on.

| | default | `usePrimaryKeySqlType: true` |
|---|---|---|
| table row | `{id: '1', bigId: '9007199254740993', categoryId: '1'}` | `{id: 1, bigId: '9007199254740993', categoryId: 1}` |
| view row | `{id: 1, categoryId: 1}` | `{id: 1, categoryId: 1}` |
| request vs response | `integer` vs `string` | agree |

With the option on, the exposed type of every column comes from its own SQL type and keys get no special treatment. Request and response schemas agree, tables and views agree, and `bigint`/`int8`/`numeric`/`decimal` still stay strings so no precision is lost.

Internally, `stringifyOutput` becomes the single source of truth for "this field is exposed as a string", computed in one place, instead of being implied by `primaryKey` independently in the mapper output, the JSON schemas and the generated types.

### Why the foreign key inheritance was dropped rather than kept

#4982 derives an FK's type from the referenced PK. That breaks as soon as the two columns have different widths: an `int8` FK referencing an `int4` PK would inherit *not-stringified* and be typed `integer`, while the pg driver hands back a string — the schema and the value disagree. The inverse pairing reinstates the input/output asymmetry this PR is removing.

Gating each column on its own SQL type avoids this. PK and FK still agree in the normal case, because an FK is nearly always declared with the same type as the PK it references — #4972's own schema (`contacts.id` ← `registrations.contact_id`, both `int4`) is exactly that shape. Where the types genuinely differ, they now serialize differently, which is correct.

## Included: a standalone GraphQL fix (ba202f6)

While verifying the above I found a bug that exists on `main` today, independent of this option: **a foreign key referencing a UNIQUE column that is not a primary key silently resolves to `null` in GraphQL.**

```jsonc
// main, contact_code REFERENCES contacts(external_code)
{ "contact": { "id": "1" }, "contactCode": null }
```

The relation DataLoader always stringified the key it looks up with, but `loadMany` matches rows by strict equality against the referenced column as the mapper exposes it. A non-primary-key column is not stringified, so `42 === '42'` never matched.

It is the first commit and is cherry-pickable on its own — I verified it green in isolation before stacking the option on top. **This may deserve its own issue**, since it affects users on `main` right now.

## A note on the original rationale

#4906 justifies the cast as: *"they are casted for GraphQL ID compatibility"*. That premise does not hold. `sql-graphql` maps keys to `GraphQLID`, and graphql-js coerces at the serialization boundary itself, so GraphQL emits `"1"` whether the mapper hands it `1` or `"1"`. Verified end-to-end — identical output in both modes:

```
usePrimaryKeySqlType: false -> {"id":"1","contact":{"id":"1","externalCode":42}}
usePrimaryKeySqlType: true  -> {"id":"1","contact":{"id":"1","externalCode":42}}
```

The cast never bought GraphQL compatibility; it only ever affected REST, which is where it caused the trouble. Worth knowing if this behaviour is ever considered for the default in v4 — nothing on the GraphQL side blocks it.

## Test plan

All across PostgreSQL, MySQL, MariaDB, MySQL 8 and SQLite:

- `sql-mapper`: `int4` keys stay numbers with the option on; `bigint` keys stay strings; primary keys are stringified by default
- `sql-openapi`: full REST round-trip, a `GET` response fed straight back into a `PUT`; the existing #4982 test still pins the default behaviour unchanged
- `sql-graphql`: relations to a non-primary-key column resolve; relations resolve with the option on. Both fail without commit 1 and pass with it
- `db`: the option travelling through a real `platformatic.db.json`

Suites run green: `sql-mapper` (114 tests × 5 dialects), `sql-openapi`, `sql-graphql`, `sql-json-schema-mapper`, `db` (140 tests). Lint clean.

One pre-existing test changed: `db/test/capability/get-config.test.js` now expects `usePrimaryKeySqlType: false` in the resolved config, because the schema default materializes it. Happy to drop `default` from the schema instead if you would rather leave resolved configs untouched — the runtime default in `connect()` is independent.

Refs #4972, #3862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7tEFJbVcrukDVrsNzrn4j
