### PR TITLE
chore: remove unnecessary test listener configuration

### DIFF
--- a/packages/astro/test/compatibility.test.js
+++ b/packages/astro/test/compatibility.test.js
@@ -13,7 +13,6 @@ import {
   verifyFrontendOnRoot
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const htmlContents = ['<body data-astro-source-file', /Hello from v\d+/]

--- a/packages/astro/test/development.test.js
+++ b/packages/astro/test/development.test.js
@@ -8,7 +8,6 @@ import {
   verifyDevelopmentMode
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const htmlContents = ['<body data-astro-source-file', /Hello from v\d+/]

--- a/packages/astro/test/production.test.js
+++ b/packages/astro/test/production.test.js
@@ -12,7 +12,6 @@ import {
   verifyPlatformaticService
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const files = ['services/frontend/dist/index.html']

--- a/packages/nest/test/development.test.js
+++ b/packages/nest/test/development.test.js
@@ -12,7 +12,6 @@ import {
   verifyJSONViaInject
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 function isTime (body) {

--- a/packages/nest/test/production.test.js
+++ b/packages/nest/test/production.test.js
@@ -9,7 +9,6 @@ import {
   verifyPlatformaticService
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const files = ['services/frontend/dist/main.js']

--- a/packages/next/test/adapter.test.js
+++ b/packages/next/test/adapter.test.js
@@ -13,9 +13,6 @@ import {
   valkeyPrefix,
   verifyValkeySequence
 } from './caching/helper.js'
-
-process.setMaxListeners(100)
-
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 const configuration = 'caching-adapter'
 

--- a/packages/next/test/caching/valkey-components.test.js
+++ b/packages/next/test/caching/valkey-components.test.js
@@ -17,9 +17,6 @@ import {
   valkeyUser,
   verifyValkeySequence
 } from './helper.js'
-
-process.setMaxListeners(100)
-
 setFixturesDir(resolve(import.meta.dirname, '../fixtures'))
 const configuration = 'caching-components'
 

--- a/packages/next/test/caching/valkey-isr.test.js
+++ b/packages/next/test/caching/valkey-isr.test.js
@@ -20,9 +20,6 @@ import {
   valkeyUser,
   verifyValkeySequence
 } from './helper.js'
-
-process.setMaxListeners(100)
-
 setFixturesDir(resolve(import.meta.dirname, '../fixtures'))
 const configuration = 'caching-valkey'
 

--- a/packages/next/test/compatibility/compatibility.test.js
+++ b/packages/next/test/compatibility/compatibility.test.js
@@ -16,7 +16,6 @@ import {
   ensureDependencies
 } from '../../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, '../fixtures'))
 
 async function verifyMiddlewareContext (t, url) {

--- a/packages/next/test/integration/development.test.js
+++ b/packages/next/test/integration/development.test.js
@@ -14,7 +14,6 @@ import {
   verifyJSONViaInject
 } from '../../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, '../fixtures'))
 
 const hmrTriggerFile = 'services/frontend/src/app/page.js'

--- a/packages/next/test/integration/production.test.js
+++ b/packages/next/test/integration/production.test.js
@@ -15,7 +15,6 @@ import {
   verifyPlatformaticServiceWithProxy
 } from '../../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, '../fixtures'))
 
 const files = ['services/frontend/.next/server/app/index.html']

--- a/packages/next/test/metrics.test.js
+++ b/packages/next/test/metrics.test.js
@@ -4,9 +4,6 @@ import { test } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { request } from 'undici'
 import { createRuntime, LOGS_TIMEOUT, setFixturesDir } from '../../basic/test/helper.js'
-
-process.setMaxListeners(100)
-
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 test('should configure metrics correctly with both node and http metrics', { skip: true }, async t => {

--- a/packages/nitro/test/development.test.js
+++ b/packages/nitro/test/development.test.js
@@ -13,7 +13,6 @@ import {
   verifyJSONViaInject
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(['nitro', 'nitropack', 'vite'])
 

--- a/packages/nitro/test/production.test.js
+++ b/packages/nitro/test/production.test.js
@@ -17,7 +17,6 @@ import {
   verifyPlatformaticService
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 // An application only starts its server when a port is configured.

--- a/packages/node/test/development.test.js
+++ b/packages/node/test/development.test.js
@@ -12,7 +12,6 @@ import {
   verifyJSONViaInject
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 function isTime (body) {

--- a/packages/node/test/meta.test.js
+++ b/packages/node/test/meta.test.js
@@ -4,9 +4,6 @@ import assert from 'node:assert'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { createRuntime, setFixturesDir } from '../../basic/test/helper.js'
-
-process.setMaxListeners(100)
-
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 test('should allow to setup connection string', async t => {

--- a/packages/node/test/metrics.test.js
+++ b/packages/node/test/metrics.test.js
@@ -3,9 +3,6 @@ import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { request } from 'undici'
 import { createRuntime, setFixturesDir } from '../../basic/test/helper.js'
-
-process.setMaxListeners(100)
-
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 test('should configure metrics correctly with both node and http metrics', async t => {

--- a/packages/node/test/production.test.js
+++ b/packages/node/test/production.test.js
@@ -9,7 +9,6 @@ import {
   verifyPlatformaticService
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const files = ['services/frontend/index.js']

--- a/packages/node/test/telemetry.test.js
+++ b/packages/node/test/telemetry.test.js
@@ -3,9 +3,6 @@ import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { Client } from 'undici'
 import { createRuntime, setFixturesDir } from '../../basic/test/helper.js'
-
-process.setMaxListeners(100)
-
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 test('should set telemetry in config on all the node applications', async t => {

--- a/packages/nuxt/test/development.test.js
+++ b/packages/nuxt/test/development.test.js
@@ -13,7 +13,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/nuxt/test/fetch.test.js
+++ b/packages/nuxt/test/fetch.test.js
@@ -14,7 +14,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/nuxt/test/production.test.js
+++ b/packages/nuxt/test/production.test.js
@@ -13,7 +13,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/react-router/test/development.test.js
+++ b/packages/react-router/test/development.test.js
@@ -10,7 +10,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/react-router/test/production.test.js
+++ b/packages/react-router/test/production.test.js
@@ -10,7 +10,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/remix/test/development.test.js
+++ b/packages/remix/test/development.test.js
@@ -10,7 +10,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/remix/test/production.test.js
+++ b/packages/remix/test/production.test.js
@@ -15,7 +15,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/tanstack/test/development.test.js
+++ b/packages/tanstack/test/development.test.js
@@ -11,7 +11,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/tanstack/test/fetch.test.js
+++ b/packages/tanstack/test/fetch.test.js
@@ -14,7 +14,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/tanstack/test/production.test.js
+++ b/packages/tanstack/test/production.test.js
@@ -13,7 +13,6 @@ import {
 } from '../../basic/test/helper.js'
 import { additionalDependencies } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 setAdditionalDependencies(additionalDependencies)
 

--- a/packages/tracing/test/pg.test.js
+++ b/packages/tracing/test/pg.test.js
@@ -5,7 +5,6 @@ import { request } from 'undici'
 import { createRuntime, setFixturesDir } from '../../basic/test/helper.js'
 import { createPGDataBase, parseNDJson } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 async function getSpans (spanPaths) {

--- a/packages/tracing/test/runtimes.integration.test.js
+++ b/packages/tracing/test/runtimes.integration.test.js
@@ -6,7 +6,6 @@ import { request } from 'undici'
 import { prepareRuntime, setFixturesDir, startRuntime } from '../../basic/test/helper.js'
 import { startOTEL } from './otelserver/index.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 let received = []

--- a/packages/tracing/test/runtimes.test.js
+++ b/packages/tracing/test/runtimes.test.js
@@ -7,7 +7,6 @@ import { request } from 'undici'
 import { createRuntime, prepareRuntime, setFixturesDir, startRuntime } from '../../basic/test/helper.js'
 import { findParentSpan, findSpanWithParentWithId, parseNDJson } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 async function getSpans (spanPaths) {

--- a/packages/vite/test/compatibility.test.js
+++ b/packages/vite/test/compatibility.test.js
@@ -17,7 +17,6 @@ import {
   verifyPlatformaticService
 } from '../../basic/test/helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const viteVersions = ['5.4.0', '6.3.5']

--- a/packages/vite/test/development.test.js
+++ b/packages/vite/test/development.test.js
@@ -9,7 +9,6 @@ import {
 } from '../../basic/test/helper.js'
 import { copyServerEntrypoint } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const htmlContentsSSR = ['<title>Vite App</title>', /Hello from v\d+ t\d+/]

--- a/packages/vite/test/production.test.js
+++ b/packages/vite/test/production.test.js
@@ -15,7 +15,6 @@ import {
 } from '../../basic/test/helper.js'
 import { copyServerEntrypoint } from './helper.js'
 
-process.setMaxListeners(100)
 setFixturesDir(resolve(import.meta.dirname, './fixtures'))
 
 const files = ['services/frontend/dist/index.html', 'services/frontend/dist/assets/index-*.js']


### PR DESCRIPTION
Remove the test-only process.setMaxListeners(100) workaround across affected packages.

# Changes

- Removed 35 process-wide listener-limit overrides from test files.
- Preserved intentional runtime emitter limits.
- Confirmed no listener-warning suppression remains in tests or fixtures.