### PR TITLE
feat(runtime): support applications loaded from npm modules

### DIFF
--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -276,6 +276,7 @@ runtime. Each application object supports the following settings:
 - **`path`** (**required**, `string`) - The path to the directory containing
   the application. It can be omitted if `url` is provided.
 - **`url`** (**required**, `string`) - The URL of the application remote GIT repository, if it is a remote application. It can be omitted if `path` is provided. You can specify a branch using the URL fragment syntax: `https://github.com/user/repo.git#branch-name`.
+- **`module`** (`string`) - The installed npm package that implements the application. When specified, `path` is also required and is used as the writable application root. The package itself is resolved from the Watt project's dependencies and is not modified by the runtime.
 - **`gitBranch`** (`string`) - The branch of the application to resolve. Takes precedence over the branch specified in the URL fragment.
 - **`config`** (`string`) - The configuration file used to start
   the application.

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -108,8 +108,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -140,6 +153,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -108,16 +108,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -804,8 +804,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -836,6 +849,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -804,16 +804,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/create-wattpm/lib/utils.js
+++ b/packages/create-wattpm/lib/utils.js
@@ -1,8 +1,8 @@
 import { findConfigurationFile } from '@platformatic/foundation'
 import { execa } from 'execa'
 import { access, constants, readFile } from 'node:fs/promises'
-import { createRequire } from 'node:module'
-import { dirname, join, resolve } from 'node:path'
+import { findPackageJSON } from 'node:module'
+import { join, resolve } from 'node:path'
 
 export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 export const randomBetween = (min, max) => Math.floor(Math.random() * (max - min + 1) + min)
@@ -101,18 +101,7 @@ export async function getDependencyVersion (dependencyName) {
   }
 
   async function resolveWorkspaceDependency (dependencyName) {
-    const require = createRequire(import.meta.url)
-    let dependencyPath = dirname(require.resolve(dependencyName))
-    // some deps are resolved not at their root level
-    // for instance 'typescript' will be risolved in its own ./lib directory
-    // next loop is to find the nearest parent directory that contains a package.json file
-    while (!(await isFileAccessible(join(dependencyPath, 'package.json')))) {
-      dependencyPath = join(dependencyPath, '..')
-      if (dependencyPath === '/') {
-        throw new Error(`Cannot find package.json for ${dependencyName}`)
-      }
-    }
-    const pathToPackageJson = join(dependencyPath, 'package.json')
+    const pathToPackageJson = findPackageJSON(dependencyName, import.meta.url)
     const packageJsonFile = await readFile(pathToPackageJson, 'utf-8')
     const packageJson = JSON.parse(packageJsonFile)
     return packageJson.version

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1502,16 +1502,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -1502,8 +1502,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -1534,6 +1547,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -866,7 +866,14 @@ export const compileCache = {
 
 export const application = {
   type: 'object',
-  anyOf: [{ required: ['id', 'path'] }, { required: ['id', 'url'] }],
+  anyOf: [
+    { required: ['id', 'path'] },
+    { required: ['id', 'url'] },
+    { required: ['id', 'path', 'module'] }
+  ],
+  not: {
+    required: ['module', 'url']
+  },
   properties: {
     id: {
       type: 'string'
@@ -892,6 +899,9 @@ export const application = {
       type: 'string'
     },
     url: {
+      type: 'string'
+    },
+    module: {
       type: 'string'
     },
     gitBranch: {
@@ -1084,7 +1094,7 @@ export const runtimeProperties = {
           type: 'object',
           additionalProperties: false,
           required: ['id'],
-          properties: omitProperties(applications.items.properties, ['path', 'url', 'gitBranch'])
+          properties: omitProperties(applications.items.properties, ['path', 'url', 'gitBranch', 'module'])
         }
       }
     }
@@ -1630,6 +1640,7 @@ export const applicationsUnwrappablePropertiesList = [
   'path',
   'config',
   'url',
+  'module',
   'gitBranch',
   'dependencies',
   'management'

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -868,10 +868,10 @@ export const application = {
   type: 'object',
   anyOf: [
     { required: ['id', 'path'] },
-    { required: ['id', 'url'] },
-    { required: ['id', 'path', 'module'] }
+    { required: ['id', 'url'] }
   ],
   not: {
+    type: 'object',
     required: ['module', 'url']
   },
   properties: {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1787,8 +1787,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -1819,6 +1832,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -1787,16 +1787,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/next/lib/pack.js
+++ b/packages/next/lib/pack.js
@@ -15,7 +15,7 @@ import {
   symlink,
   writeFile
 } from 'node:fs/promises'
-import { createRequire } from 'node:module'
+import { findPackageJSON } from 'node:module'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, relative, resolve as resolvePath } from 'node:path'
 import { version as platformaticVersion } from './schema.js'
@@ -169,60 +169,15 @@ async function loadPackageFromRoot (root, fallbackName) {
 }
 
 async function resolvePackageRoot (name, from) {
-  const require = createRequire(from)
-
   try {
-    const packageJsonPath = require.resolve(`${name}/package.json`)
-    return dirname(packageJsonPath)
+    return dirname(findPackageJSON(name, from))
   } catch (error) {
-    const packageJsonPath = resolvePackageJsonFromSearchPaths(require, name)
-    if (packageJsonPath) {
-      return dirname(packageJsonPath)
+    const workspacePackage = resolveWorkspacePackageRoot(name)
+    if (workspacePackage) {
+      return workspacePackage
     }
 
-    try {
-      const resolvedEntry = require.resolve(name)
-      return await findPackageRoot(dirname(resolvedEntry))
-    } catch (resolveError) {
-      const workspacePackage = resolveWorkspacePackageRoot(name)
-      if (workspacePackage) {
-        return workspacePackage
-      }
-
-      throw resolveError
-    }
-  }
-}
-
-function resolvePackageJsonFromSearchPaths (require, name) {
-  const searchPaths = require.resolve.paths(name) ?? []
-  const packageSegments = name.split('/')
-
-  for (const searchPath of searchPaths) {
-    const candidate = resolvePath(searchPath, ...packageSegments, 'package.json')
-    if (existsSync(candidate)) {
-      return candidate
-    }
-  }
-
-  return null
-}
-
-async function findPackageRoot (directory) {
-  let current = directory
-
-  while (true) {
-    const candidate = resolvePath(current, 'package.json')
-    if (existsSync(candidate)) {
-      return current
-    }
-
-    const parent = resolvePath(current, '..')
-    if (parent === current) {
-      throw new Error(`Cannot determine package root for ${directory}.`)
-    }
-
-    current = parent
+    throw error
   }
 }
 

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -501,8 +501,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -533,6 +546,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -501,16 +501,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/runtime/fixtures/module-application/mock-application/index.js
+++ b/packages/runtime/fixtures/module-application/mock-application/index.js
@@ -1,0 +1,18 @@
+import { ServiceCapability } from '@platformatic/service'
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export async function create (root, config, context) {
+  await writeFile(
+    resolve(root, 'module-created.json'),
+    JSON.stringify({ root, sourcePath: context.sourcePath }),
+    'utf8'
+  )
+
+  return new ServiceCapability(root, config, {
+    ...context,
+    applicationFactory: async app => {
+      app.get('/module', async () => ({ running: true }))
+    }
+  })
+}

--- a/packages/runtime/fixtures/module-application/mock-application/package.json
+++ b/packages/runtime/fixtures/module-application/mock-application/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mock-application",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@platformatic/service": "workspace:*"
+  }
+}

--- a/packages/runtime/fixtures/module-application/package.json
+++ b/packages/runtime/fixtures/module-application/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "module-application-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -123,8 +123,12 @@ export async function loadApplicationsCommands (executableName = '', configurati
 
   for (const application of config.applications) {
     try {
-      const applicationConfig = await utilsLoadConfiguration(application.config)
-      const pkg = await loadConfigurationModule(application.path, applicationConfig)
+      const applicationConfig = application.config ? await utilsLoadConfiguration(application.config) : {}
+      const pkg = await loadConfigurationModule(
+        application.moduleRoot ?? application.sourcePath ?? application.path,
+        applicationConfig,
+        application.module
+      )
 
       if (pkg.createCommands) {
         const definition = await pkg.createCommands(application.id)

--- a/packages/runtime/lib/config.js
+++ b/packages/runtime/lib/config.js
@@ -1,5 +1,6 @@
 import { importCapabilityAndConfig, validationOptions } from '@platformatic/basic'
 import {
+  createDirectory,
   extractModuleFromSchemaUrl,
   findConfigurationFile,
   kMetadata,
@@ -10,14 +11,15 @@ import {
   runtimeUnwrappablePropertiesList
 } from '@platformatic/foundation'
 import { readdir, readFile } from 'node:fs/promises'
-import { createRequire } from 'node:module'
-import { isAbsolute, join, resolve as resolvePath } from 'node:path'
+import { createRequire, findPackageJSON } from 'node:module'
+import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path'
 
 import {
   InspectAndInspectBrkError,
   InspectorHostError,
   InspectorPortError,
-  InvalidArgumentError
+  InvalidArgumentError,
+  MissingDependencyError
 } from './errors.js'
 import { schema } from './schema.js'
 import { upgrade } from './upgrade.js'
@@ -219,6 +221,20 @@ export async function prepareApplication (config, application, defaultWorkers) {
     application.path = resolvePath(config[kMetadata].root, application.path)
   }
 
+  if (application.module) {
+    if (!application.path) {
+      throw new InvalidArgumentError(`Application "${application.id}" must define path when module is set`)
+    }
+
+    try {
+      application.sourcePath = dirname(findPackageJSON(application.module, resolvePath(config[kMetadata].root, 'noop.js')))
+    } catch (error) {
+      throw new MissingDependencyError(application.module, { cause: error })
+    }
+    application.moduleRoot = config[kMetadata].root
+    await createDirectory(application.path)
+  }
+
   if (application.path && application.config) {
     application.config = resolvePath(application.path, application.config)
   }
@@ -226,7 +242,9 @@ export async function prepareApplication (config, application, defaultWorkers) {
   // Skip capability detection for external services (url without path)
   // These services will have their path resolved later in runtime.js #setupApplication
   // Attempting to detect capability here would cause slow glob operations on the cwd
-  if (application.url && !application.path) {
+  if (application.module) {
+    application.type = application.module
+  } else if (application.url && !application.path) {
     application.type = 'unknown'
   } else {
     try {
@@ -250,7 +268,7 @@ export async function prepareApplication (config, application, defaultWorkers) {
       // This is needed to work around Rust bug on dylibs:
       // https://github.com/rust-lang/rust/issues/91979
       // https://github.com/rollup/rollup/issues/5761
-      const _require = createRequire(application.path)
+      const _require = createRequire(application.sourcePath ?? application.path)
       for (const m of pkg.modulesToLoad ?? []) {
         const toLoad = _require.resolve(m)
         loadModule(_require, toLoad).catch(() => {})

--- a/packages/runtime/lib/errors.js
+++ b/packages/runtime/lib/errors.js
@@ -103,6 +103,10 @@ export const NoConfigFileFoundError = createError(
   "No config file found for application '%s'"
 )
 export const MissingDependencyError = createError(`${ERROR_PREFIX}_MISSING_DEPENDENCY`, 'Missing dependency: "%s"')
+export const InvalidApplicationModuleError = createError(
+  `${ERROR_PREFIX}_INVALID_APPLICATION_MODULE`,
+  'Application module "%s" must export a create function'
+)
 export const InspectAndInspectBrkError = createError(
   `${ERROR_PREFIX}_INSPECT_AND_INSPECT_BRK`,
   '--inspect and --inspect-brk cannot be used together'

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -4343,6 +4343,10 @@ export class Runtime extends EventEmitter {
       }
     }
 
+    if (applicationConfig.sourcePath) {
+      allows.add(`--allow-fs-read=${join(applicationConfig.sourcePath, '*')}`)
+    }
+
     if (write?.length) {
       for (const p of write) {
         allows.add(`--allow-fs-write=${isAbsolute(p) ? p : join(applicationConfig.path, p)}`)

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -23,7 +23,12 @@ import { resolve } from 'node:path'
 import { getActiveResourcesInfo } from 'node:process'
 import { workerData } from 'node:worker_threads'
 import { getGlobalDispatcher } from 'undici'
-import { ApplicationAlreadyStartedError, exitCodes, RuntimeNotStartedError } from '../errors.js'
+import {
+  ApplicationAlreadyStartedError,
+  exitCodes,
+  InvalidApplicationModuleError,
+  RuntimeNotStartedError
+} from '../errors.js'
 import { getApplicationUrl } from '../utils.js'
 import { installGlobalDispatcher, refreshGlobalDispatcher } from './interceptors.js'
 
@@ -82,6 +87,7 @@ export class Controller extends EventEmitter {
       applicationId: this.applicationId,
       workerId: this.workerId,
       directory: this.applicationConfig.path,
+      sourcePath: this.applicationConfig.sourcePath,
       dependencies: this.applicationConfig.dependencies,
       isProduction: this.applicationConfig.isProduction,
       telemetryConfig: this.applicationConfig.telemetry,
@@ -126,7 +132,7 @@ export class Controller extends EventEmitter {
 
       // Before returning the base application, check if there is any file we recognize
       // and the user just forgot to specify in the configuration.
-      if (!appConfig.config) {
+      if (!appConfig.module && !appConfig.config) {
         const candidate = listRecognizedConfigurationFiles().find(f => existsSync(resolve(appConfig.path, f)))
 
         if (candidate) {
@@ -134,7 +140,13 @@ export class Controller extends EventEmitter {
         }
       }
 
-      if (appConfig.config) {
+      if (appConfig.module) {
+        const pkg = await loadConfigurationModule(workerData.dirname, {}, appConfig.module)
+        if (typeof pkg.create !== 'function') {
+          throw new InvalidApplicationModuleError(appConfig.module)
+        }
+        this.capability = await pkg.create(appConfig.path, appConfig.config ?? {}, this.#context)
+      } else if (appConfig.config) {
         // Parse the configuration file the first time to obtain the schema
         const unvalidatedConfig = await loadConfiguration(appConfig.config, null, {
           onMissingEnv: this.#context.fetchApplicationUrl,

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -527,8 +527,21 @@
               "id",
               "url"
             ]
+          },
+          {
+            "required": [
+              "id",
+              "path",
+              "module"
+            ]
           }
         ],
+        "not": {
+          "required": [
+            "module",
+            "url"
+          ]
+        },
         "properties": {
           "id": {
             "type": "string"
@@ -559,6 +572,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "module": {
             "type": "string"
           },
           "gitBranch": {
@@ -954,8 +970,21 @@
               "id",
               "url"
             ]
+          },
+          {
+            "required": [
+              "id",
+              "path",
+              "module"
+            ]
           }
         ],
+        "not": {
+          "required": [
+            "module",
+            "url"
+          ]
+        },
         "properties": {
           "id": {
             "type": "string"
@@ -986,6 +1015,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "module": {
             "type": "string"
           },
           "gitBranch": {
@@ -1381,8 +1413,21 @@
               "id",
               "url"
             ]
+          },
+          {
+            "required": [
+              "id",
+              "path",
+              "module"
+            ]
           }
         ],
+        "not": {
+          "required": [
+            "module",
+            "url"
+          ]
+        },
         "properties": {
           "id": {
             "type": "string"
@@ -1413,6 +1458,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "module": {
             "type": "string"
           },
           "gitBranch": {

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -527,16 +527,10 @@
               "id",
               "url"
             ]
-          },
-          {
-            "required": [
-              "id",
-              "path",
-              "module"
-            ]
           }
         ],
         "not": {
+          "type": "object",
           "required": [
             "module",
             "url"
@@ -970,16 +964,10 @@
               "id",
               "url"
             ]
-          },
-          {
-            "required": [
-              "id",
-              "path",
-              "module"
-            ]
           }
         ],
         "not": {
+          "type": "object",
           "required": [
             "module",
             "url"
@@ -1413,16 +1401,10 @@
               "id",
               "url"
             ]
-          },
-          {
-            "required": [
-              "id",
-              "path",
-              "module"
-            ]
           }
         ],
         "not": {
+          "type": "object",
           "required": [
             "module",
             "url"

--- a/packages/runtime/test/config.test.js
+++ b/packages/runtime/test/config.test.js
@@ -1,10 +1,12 @@
+import { kMetadata } from '@platformatic/foundation'
 import { loadConfiguration as databaseLoadConfiguration } from '@platformatic/db'
 import { deepStrictEqual, ok, rejects, strictEqual, throws } from 'node:assert'
-import { writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, symlink, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { test } from 'node:test'
 import { loadConfiguration, wrapInRuntimeConfig } from '../index.js'
-import { parseInspectorOptions } from '../lib/config.js'
+import { parseInspectorOptions, prepareApplication } from '../lib/config.js'
 import { createRuntime, createTemporaryDirectory } from './helpers.js'
 
 const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
@@ -13,6 +15,85 @@ test('parseInspectorOptions - throws if --inspect and --inspect-brk are both use
   throws(() => {
     parseInspectorOptions({}, 'true', 'true')
   }, /--inspect and --inspect-brk cannot be used together/)
+})
+
+test('prepareApplication - resolves module source separately from writable application root', async t => {
+  const root = await createTemporaryDirectory(t, 'module')
+  const applicationPath = join(root, 'applications', 'module-app')
+  const config = {
+    [kMetadata]: {
+      root: resolve(import.meta.dirname, '..')
+    },
+    watch: false
+  }
+
+  const application = await prepareApplication(
+    config,
+    {
+      id: 'module-app',
+      path: applicationPath,
+      module: '@platformatic/basic'
+    },
+    { static: 1, dynamic: false }
+  )
+
+  strictEqual(application.path, applicationPath)
+  ok(application.sourcePath !== application.path)
+  strictEqual(JSON.parse(await readFile(join(application.sourcePath, 'package.json'), 'utf8')).name, '@platformatic/basic')
+  ok(existsSync(application.path))
+})
+
+test('prepareApplication - reports missing application modules with a coded error', async () => {
+  await rejects(
+    prepareApplication(
+      {
+        [kMetadata]: { root: resolve(fixturesDir, 'missing') },
+        watch: false
+      },
+      {
+        id: 'missing-module',
+        path: resolve(fixturesDir, 'missing', 'application'),
+        module: '@platformatic/does-not-exist'
+      },
+      { static: 1, dynamic: false }
+    ),
+    error => error.code === 'PLT_RUNTIME_MISSING_DEPENDENCY'
+  )
+})
+
+test('module applications invoke create with a separate writable root', async t => {
+  const root = await createTemporaryDirectory(t, 'module-runtime')
+  const nodeModules = join(root, 'node_modules')
+  const packageScope = join(nodeModules, '@platformatic')
+  const applicationPath = join(root, 'applications', 'module-app')
+  const fixtureRoot = join(fixturesDir, 'module-application')
+  const configFile = join(root, 'watt.json')
+
+  await mkdir(packageScope, { recursive: true })
+  await symlink(join(fixtureRoot, 'mock-application'), join(nodeModules, 'mock-application'), 'dir')
+  await symlink(resolve(import.meta.dirname, '../node_modules/@platformatic/basic'), join(packageScope, 'basic'), 'dir')
+  await symlink(resolve(import.meta.dirname, '../node_modules/@platformatic/service'), join(packageScope, 'service'), 'dir')
+  await writeFile(
+    configFile,
+    JSON.stringify({
+      $schema: 'https://schemas.platformatic.dev/@platformatic/runtime/3.67.0.json',
+      applications: [{ id: 'module-app', path: applicationPath, module: 'mock-application' }]
+    })
+  )
+
+  const runtime = await createRuntime(configFile)
+  t.after(() => runtime.close(true))
+
+  await runtime.init()
+  await runtime.start()
+
+  const created = JSON.parse(await readFile(join(applicationPath, 'module-created.json'), 'utf8'))
+  strictEqual(created.root, applicationPath)
+  strictEqual(created.sourcePath, join(nodeModules, 'mock-application'))
+
+  const response = await runtime.inject('module-app', { method: 'GET', url: '/module' })
+  strictEqual(response.statusCode, 200)
+  strictEqual(response.payload, JSON.stringify({ running: true }))
 })
 
 test('parseInspectorOptions - --inspect default settings', () => {

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1173,8 +1173,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -1205,6 +1218,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -1173,16 +1173,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -507,16 +507,10 @@
                   "id",
                   "url"
                 ]
-              },
-              {
-                "required": [
-                  "id",
-                  "path",
-                  "module"
-                ]
               }
             ],
             "not": {
+              "type": "object",
               "required": [
                 "module",
                 "url"

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -507,8 +507,21 @@
                   "id",
                   "url"
                 ]
+              },
+              {
+                "required": [
+                  "id",
+                  "path",
+                  "module"
+                ]
               }
             ],
+            "not": {
+              "required": [
+                "module",
+                "url"
+              ]
+            },
             "properties": {
               "id": {
                 "type": "string"
@@ -539,6 +552,9 @@
                 "type": "string"
               },
               "url": {
+                "type": "string"
+              },
+              "module": {
                 "type": "string"
               },
               "gitBranch": {

--- a/packages/wattpm-pprof-capture/lib/node-modules-sourcemaps.js
+++ b/packages/wattpm-pprof-capture/lib/node-modules-sourcemaps.js
@@ -1,7 +1,7 @@
 import { getLogger } from '@platformatic/globals'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import { createRequire } from 'node:module'
+import { createRequire, findPackageJSON } from 'node:module'
 import * as sourceMap from 'source-map'
 
 const MAP_EXT = '.map'
@@ -130,10 +130,15 @@ function resolveModulePath (appPath, moduleName) {
   // Try using require.resolve from the app's context
   try {
     const require = createRequire(path.join(appPath, 'package.json'))
+    const packageJsonPath = findPackageJSON(moduleName, path.join(appPath, 'package.json'))
     const modulePath = require.resolve(moduleName)
     // Get the module's root directory
     // For regular packages: node_modules/next/dist/file.js -> node_modules/next
     // For scoped packages: node_modules/@next/next-server/dist/file.js -> node_modules/@next/next-server
+    if (packageJsonPath) {
+      return path.dirname(packageJsonPath)
+    }
+
     const nodeModulesIndex = modulePath.lastIndexOf('node_modules')
     if (nodeModulesIndex === -1) {
       return null

--- a/packages/wattpm-utils/lib/commands/dependencies.js
+++ b/packages/wattpm-utils/lib/commands/dependencies.js
@@ -113,7 +113,12 @@ export async function installDependencies (logger, root, applications, productio
     )
   }
 
-  for (let { id, path, packageManager: applicationPackageManager } of applications) {
+  for (let { id, path, module, packageManager: applicationPackageManager } of applications) {
+    // Module applications use dependencies installed in the Watt root and their package is not writable.
+    if (module) {
+      continue
+    }
+
     const hasConfiguredPackageManager = !!applicationPackageManager
     applicationPackageManager ??= await getPackageManager(path, packageManager)
     const applicationPackageArgs = getInstallationCommand(applicationPackageManager, production)
@@ -349,6 +354,10 @@ export async function updateCommand (logger, args) {
 
   // Now, for all the applications in the configuration file, update the dependencies
   for (const application of applications) {
+    if (application.module) {
+      continue
+    }
+
     await updateDependencies(
       logger,
       latest,

--- a/packages/wattpm-utils/lib/commands/external.js
+++ b/packages/wattpm-utils/lib/commands/external.js
@@ -138,7 +138,11 @@ async function fixConfiguration (context, logger, root, configOption, skipDepend
   }
 
   // For each application, if there is no watt.json, create one and fix package dependencies
-  for (const { path } of applications) {
+  for (const { path, module } of applications) {
+    if (module) {
+      continue
+    }
+
     const wattConfiguration = await findConfigurationFile(path, 'application')
 
     const appType = await parseLocalFolder(resolve(root, path))

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -527,8 +527,21 @@
               "id",
               "url"
             ]
+          },
+          {
+            "required": [
+              "id",
+              "path",
+              "module"
+            ]
           }
         ],
+        "not": {
+          "required": [
+            "module",
+            "url"
+          ]
+        },
         "properties": {
           "id": {
             "type": "string"
@@ -559,6 +572,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "module": {
             "type": "string"
           },
           "gitBranch": {
@@ -954,8 +970,21 @@
               "id",
               "url"
             ]
+          },
+          {
+            "required": [
+              "id",
+              "path",
+              "module"
+            ]
           }
         ],
+        "not": {
+          "required": [
+            "module",
+            "url"
+          ]
+        },
         "properties": {
           "id": {
             "type": "string"
@@ -986,6 +1015,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "module": {
             "type": "string"
           },
           "gitBranch": {
@@ -1381,8 +1413,21 @@
               "id",
               "url"
             ]
+          },
+          {
+            "required": [
+              "id",
+              "path",
+              "module"
+            ]
           }
         ],
+        "not": {
+          "required": [
+            "module",
+            "url"
+          ]
+        },
         "properties": {
           "id": {
             "type": "string"
@@ -1413,6 +1458,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "module": {
             "type": "string"
           },
           "gitBranch": {

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -527,16 +527,10 @@
               "id",
               "url"
             ]
-          },
-          {
-            "required": [
-              "id",
-              "path",
-              "module"
-            ]
           }
         ],
         "not": {
+          "type": "object",
           "required": [
             "module",
             "url"
@@ -970,16 +964,10 @@
               "id",
               "url"
             ]
-          },
-          {
-            "required": [
-              "id",
-              "path",
-              "module"
-            ]
           }
         ],
         "not": {
+          "type": "object",
           "required": [
             "module",
             "url"
@@ -1413,16 +1401,10 @@
               "id",
               "url"
             ]
-          },
-          {
-            "required": [
-              "id",
-              "path",
-              "module"
-            ]
           }
         ],
         "not": {
+          "type": "object",
           "required": [
             "module",
             "url"


### PR DESCRIPTION
## Summary

Allow Watt applications to be loaded from installed npm modules while retaining a separate writable application root for local state, generated files, and configuration.
Module packages expose the existing capability-style create() contract and receive both the writable root and resolved package source path.

## Changes

- Added module support to application configuration and regenerated dependent schemas.
- Resolved module packages from the Watt project using `findPackageJSON()`, while creating and preserving the configured writable application path.
- Added module-aware worker and custom-command loading with coded errors for missing dependencies and invalid module exports.
- Granted module source read permissions without allowing dependency tooling to modify installed packages.
- Added an end-to-end fixture that loads a mock npm application, invokes create(), writes local state, starts the service, and serves a request.
- Documented the npm module application configuration.

## Notes
Module applications require an explicit path, must be installed in the Watt project, and must export a create() function. The module and url source options are mutually exclusive.

Assisted-By: OpenAI:GPT-5.6-Sol <openai/gpt-5.6-sol>