### PR TITLE
refactor(gateway): decide the restart in the handler, not the subscription

### DIFF
--- a/packages/gateway/lib/capability.js
+++ b/packages/gateway/lib/capability.js
@@ -43,13 +43,8 @@ export class GatewayCapability extends ServiceCapability {
     // Only register the runtime event handler once. start() can be called
     // multiple times (first with listen:false, then listen:true) so guard
     // against duplicate registrations.
-    //
-    // Not registered at all when `restartOnApplicationChange` is false: a
-    // gateway that does not route from the application registry has nothing to
-    // recompose, and the restart is pure downtime for it. Skipping the
-    // subscription rather than the notify keeps it off the ITC entirely.
     const itc = getITC({ throwOnMissing: false })
-    if (this.config.gateway?.restartOnApplicationChange !== false && !this.#runtimeEventHandler && itc) {
+    if (!this.#runtimeEventHandler && itc) {
       this.#runtimeEventHandler = this.#handleRuntimeEvent.bind(this)
       itc.on('runtime:event', this.#runtimeEventHandler)
     }
@@ -113,13 +108,22 @@ export class GatewayCapability extends ServiceCapability {
     return replaceEnv(application.origin, this.config[kMetadata].env).endsWith('.plt.local')
   }
 
+  // The subscription is unconditional and the decision lives here, next to the
+  // behaviour it governs, so a future event handled from this method needs no
+  // change to start().
+  //
   // The runtime resolves `request:restart` by replacing this application's
   // workers one at a time. With two or more workers and SO_REUSEPORT that is
   // seamless; with ONE — the default, and forced wherever reusePort is
   // unavailable — the listening socket closes for the length of a worker boot.
-  // `restartOnApplicationChange: false` is how a gateway opts out of that.
+  // `restartOnApplicationChange: false` is how a gateway that does not route
+  // from the application registry opts out of paying that for nothing.
   #handleRuntimeEvent ({ event }) {
     if (event === 'application:added' || event === 'application:removed') {
+      if (this.config.gateway?.restartOnApplicationChange === false) {
+        return
+      }
+
       const itc = getITC()
       itc.notify('request:restart')
     }


### PR DESCRIPTION
Follow-up to #5099, applying @ShogunPanda's review note. It arrived after that PR was merged, so it needs its own.

> I would do something different: register the event handler anyway but do not restart in `#handleRuntimeEvent`. So if in the future we handle other events we don't have to make too many changes.

## The change

Subscribe unconditionally again, and let the handler decide:

```js
#handleRuntimeEvent ({ event }) {
  if (event === 'application:added' || event === 'application:removed') {
    if (this.config.gateway?.restartOnApplicationChange === false) {
      return
    }
    ...
  }
}
```

## He was right for a second reason too

The comment that shipped justified gating the subscription with this:

> *Skipping the subscription rather than the notify keeps it off the ITC entirely.*

**That is not true**, and it is removed here. `Runtime#emitAndNotify` notifies every worker whether or not anyone is listening:

```js
emitAndNotify (event, ...payload) {
  for (const worker of this.#workers.values()) {
    worker[kITC].notify('runtime:event', { event, payload })
  }
  ...
}
```

So not subscribing saved a local dispatch and nothing more. The only argument for the merged shape was mistaken; the future-proofing argument stands on its own.

## Verification

Behaviour is unchanged and **no test needed touching** — the three tests from #5099 pass as written, which is the point.

They also still have teeth against the new structure: removing the new guard fails both opt-out tests (`a gateway with restartOnApplicationChange disabled keeps serving…` and `opting out means the new application is NOT composed…`), so they exercise this path rather than passing by construction.

Gateway capability tests (7) and lint clean.

## Small bonus

The option is now read at event time rather than baked in at `start()`, so a config reload takes effect without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
