### PR TITLE
fix(wattpm): pin wattpm-utils delegation to wattpm's own version

### DIFF
--- a/packages/wattpm/lib/commands/create.js
+++ b/packages/wattpm/lib/commands/create.js
@@ -2,6 +2,7 @@ import { getPackageManager, parseArgs } from '@platformatic/foundation'
 import { bold } from 'colorette'
 import { spawn } from 'node:child_process'
 import { platform } from 'node:os'
+import { version } from '../schema.js'
 
 export async function runDelegatedCommand (context, logger, packageManager, args) {
   if (!packageManager) {
@@ -83,7 +84,7 @@ export async function createCommand (logger, args) {
     false
   )
 
-  const runArgs = ['wattpm-utils' + (latest ? '@latest' : ''), '--', 'create']
+  const runArgs = ['wattpm-utils' + (latest ? '@latest' : `@${version}`), '--', 'create']
 
   runArgs.push('-c', config)
 

--- a/packages/wattpm/test/create.test.js
+++ b/packages/wattpm/test/create.test.js
@@ -4,6 +4,7 @@ import { chmod, readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { test } from 'node:test'
 import { isWindows, temporaryFolder } from '../../basic/test/helper.js'
+import { version } from '../lib/schema.js'
 import { wattpm } from './helper.js'
 
 // This test cannot be run in Windows as it's pretty hard to mock the executable.
@@ -31,7 +32,7 @@ test('create should run wattpm-utils create with npx by default', { skip: isWind
   await wattpm('create', { cwd: root, env: { PATH: root } })
 
   const output = await readFile(resolve(root, 'cmdline'), 'utf-8')
-  deepStrictEqual(output.trim(), 'npx -y wattpm-utils -- create -c watt.json')
+  deepStrictEqual(output.trim(), `npx -y wattpm-utils@${version} -- create -c watt.json`)
 })
 
 test('create should autodetect the package manager', { skip: isWindows }, async t => {
@@ -48,7 +49,7 @@ test('create should allow to specify the package manager explictly', { skip: isW
   await wattpm('create', '-P', 'pnpm', { cwd: root, env: { PATH: root } })
 
   const output = await readFile(resolve(root, 'cmdline'), 'utf-8')
-  deepStrictEqual(output.trim(), 'pnpx wattpm-utils -- create -c watt.json -P pnpm')
+  deepStrictEqual(output.trim(), `pnpx wattpm-utils@${version} -- create -c watt.json -P pnpm`)
 })
 
 test('should propagate options', { skip: isWindows }, async t => {


### PR DESCRIPTION
When `wattpm` delegates the `create`/init/add commands to `wattpm-utils` via (p)npx, it previously requested the package without a version tag (unless `--latest`), so npx would resolve whatever version was installed or fetched.

This pins the non-latest delegation to the same version as the running `wattpm` itself, so the delegated utility always matches the wattpm release:

- `packages/wattpm/lib/commands/create.js`: import `version` from `../schema.js` and build the spec as `wattpm-utils@<version>` unless `--latest` is set.
- `packages/wattpm/test/create.test.js`: assert the two non-latest delegation strings against `@` from `lib/schema.js` instead of a hardcoded version, so tests stay in sync with the real package version.

### Verification

- `node --test test/create.test.js` passes (4 tests).
- ESLint passes on both changed files.
