### PR TITLE
feat(foundation): declare the supported pino options in the logger schema

### DIFF
--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -290,6 +290,19 @@ Insights dashboards. To do this, the timestamp format needs to be changed.
 }
 ```
 
+Set `remove` to `true` to drop the keys entirely instead of replacing their values with the censor:
+
+```json
+{
+  "logger": {
+    "redact": {
+      "paths": ["password", "apiKey"],
+      "remove": true
+    }
+  }
+}
+```
+
 **Before redaction:**
 
 ```json
@@ -394,6 +407,34 @@ This provides:
   ```
 
   See the [Pino customLevels documentation](https://github.com/pinojs/pino/blob/main/docs/api.md#customlevels-object) for more details.
+
+  Once `customLevels` is set, `logger.level` can be set to one of them:
+
+  ```json
+  {
+    "logger": {
+      "customLevels": {
+        "verbose": 10
+      },
+      "level": "verbose"
+    }
+  }
+  ```
+
+- **Other Pino options**: `levelVal`, `useOnlyCustomLevels`, `levelComparison`, `msgPrefix`, `nestedKey`, `errorKey`,
+  `depthLimit`, `edgeLimit`, `crlf` and `enabled` are passed to Pino as they are. Like every other logger option, they
+  are inherited by all the applications.
+
+  ```json
+  {
+    "logger": {
+      "msgPrefix": "[my-app] ",
+      "nestedKey": "payload"
+    }
+  }
+  ```
+
+  See the [Pino options documentation](https://github.com/pinojs/pino/blob/main/docs/api.md#options) for more details.
 
 ---
 

--- a/docs/reference/runtime/_shared-configuration.md
+++ b/docs/reference/runtime/_shared-configuration.md
@@ -634,7 +634,7 @@ This configures the Platformatic Runtime `logger`, based on [pino](https://getpi
 
 An object with the following settings:
 
-- **`level`** — The log level. Default: `info`. Valid values are: `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`.
+- **`level`** — The log level. Default: `info`. Valid values are: `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`, or any level defined in `customLevels`.
 - **`transport`** — Configuration for logging transport, see [pino.transport](https://getpino.io/#/docs/transports) for more information. Can be configured in two ways:
   - As a single transport: An object with properties:
     - **`target`** — A string specifying the transport module.
@@ -651,6 +651,7 @@ An object with the following settings:
 - **`redact`** — Configuration for redacting sensitive information, see [pino.redact]https://getpino.io/#/docs/redaction) for more information. An object with properties:
   - **`paths`** (**required**) — An array of strings specifying paths to redact.
   - **`censor`** — A string to replace redacted values with. Default: `[redacted]`.
+  - **`remove`** — If `true`, the redacted keys are removed from the logs instead of having their values replaced with the censor. Default: `false`.
 - **`captureStdio`** — If `true`, the logger will capture the `stdout` and `stderr` streams of the main application. Default: `false`.
 - **`base`** — The base logger configuration; setting to `null` will remove `pid` and `hostname` from the logs, otherwise it can be an object to add custom properties to the logs.
 - **`messageKey`** — The key to use for the log message. Default: `msg`.
@@ -659,6 +660,16 @@ An object with the following settings:
   - **`time`** — The key that contains the log timestamp. Default: `time`.
   - **`message`** — The key that contains the log message. Default: `msg`.
 - **`customLevels`** — Configuration for custom levels, see [pino.customLevels](https://getpino.io/#/docs/api?id=customlevels-object) for more information.
+- **`levelVal`** — The numeric value of the level set in `level`, when it is not one of the standard pino levels, see [pino.levelVal](https://getpino.io/#/docs/api?id=levelval-number) for more information.
+- **`useOnlyCustomLevels`** — If `true`, only the levels defined in `customLevels` are available and the standard pino ones are omitted. Default: `false`.
+- **`levelComparison`** — How log levels are compared to the logger level. Valid values are `ASC` and `DESC`; use `DESC` when lower values are more severe. Default: `ASC`.
+- **`msgPrefix`** — A string prefixed to every message, including the ones of child loggers.
+- **`nestedKey`** — The key under which any logged object is placed, see [pino.nestedKey](https://getpino.io/#/docs/api?id=nestedkey-string) for more information.
+- **`errorKey`** — The key used for the serialized error in the log object. Default: `err`.
+- **`depthLimit`** — The stringification limit at a specific nesting depth when logging circular objects. Default: `5`.
+- **`edgeLimit`** — The stringification limit of properties or elements when logging a circular object or array. Default: `100`.
+- **`crlf`** — If `true`, each log line is terminated with `\r\n` instead of `\n`. Default: `false`.
+- **`enabled`** — If `false`, logging is disabled entirely. Default: `true`.
 - **`openTelemetryExporter`** — Configuration for exporting logs to OpenTelemetry collectors. When configured alongside the `telemetry` section, logs are automatically enriched with trace context (trace ID, span ID, trace flags) for correlation with distributed traces. An object with properties:
   - **`protocol`** (**required**) — The protocol to use for export. Valid values are: `http`, `grpc`.
   - **`url`** (**required**) — The OTLP collector endpoint URL.

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticAstroConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticAstroConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticAstroConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticAstroConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticAstroConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticAstroConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticAstroConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticAstroConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticAstroConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticAstroConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticAstroConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticAstroConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/astro/schema.json
+++ b/packages/astro/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -88,7 +88,7 @@ export interface PlatformaticBasicConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -108,7 +108,7 @@ export interface PlatformaticBasicConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -120,23 +120,23 @@ export interface PlatformaticBasicConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/basic/config.d.ts
+++ b/packages/basic/config.d.ts
@@ -51,13 +51,10 @@ export interface PlatformaticBasicConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -90,6 +87,10 @@ export interface PlatformaticBasicConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -98,6 +99,46 @@ export interface PlatformaticBasicConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -600,22 +600,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -716,6 +701,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -741,6 +731,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -760,6 +800,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/basic/schema.json
+++ b/packages/basic/schema.json
@@ -704,8 +704,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -745,8 +744,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -758,28 +756,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -32,13 +32,10 @@ export interface PlatformaticComposerConfig {
     logger?:
       | boolean
       | {
-          level?: (
-            | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-            | {
-                [k: string]: unknown;
-              }
-          ) &
-            string;
+          /**
+           * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+           */
+          level?: string;
           transport?:
             | {
                 target?: string;
@@ -71,6 +68,10 @@ export interface PlatformaticComposerConfig {
           redact?: {
             paths: string[];
             censor?: string;
+            /**
+             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             */
+            remove?: boolean;
           };
           base?: {
             [k: string]: unknown;
@@ -79,6 +80,46 @@ export interface PlatformaticComposerConfig {
           customLevels?: {
             [k: string]: unknown;
           };
+          /**
+           * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+           */
+          levelVal?: number;
+          /**
+           * Only use the levels defined in customLevels and omit the standard pino ones.
+           */
+          useOnlyCustomLevels?: boolean;
+          /**
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           */
+          levelComparison?: "ASC" | "DESC";
+          /**
+           * A string prefixed to every message, including the ones of child loggers.
+           */
+          msgPrefix?: string;
+          /**
+           * The key under which any logged object is placed.
+           */
+          nestedKey?: string;
+          /**
+           * The key used for the serialized error in the log object.
+           */
+          errorKey?: string;
+          /**
+           * The stringification limit at a specific nesting depth when logging circular objects.
+           */
+          depthLimit?: number;
+          /**
+           * The stringification limit of properties or elements when logging a circular object or array.
+           */
+          edgeLimit?: number;
+          /**
+           * Terminate each log line with \r\n instead of \n.
+           */
+          crlf?: boolean;
+          /**
+           * Set to false to disable logging entirely.
+           */
+          enabled?: boolean;
           openTelemetryExporter?: {
             protocol: "grpc" | "http";
             url: string;
@@ -231,13 +272,10 @@ export interface PlatformaticComposerConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -270,6 +308,10 @@ export interface PlatformaticComposerConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -278,6 +320,46 @@ export interface PlatformaticComposerConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/composer/config.d.ts
+++ b/packages/composer/config.d.ts
@@ -69,7 +69,7 @@ export interface PlatformaticComposerConfig {
             paths: string[];
             censor?: string;
             /**
-             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
              */
             remove?: boolean;
           };
@@ -89,7 +89,7 @@ export interface PlatformaticComposerConfig {
            */
           useOnlyCustomLevels?: boolean;
           /**
-           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
            */
           levelComparison?: "ASC" | "DESC";
           /**
@@ -101,23 +101,23 @@ export interface PlatformaticComposerConfig {
            */
           nestedKey?: string;
           /**
-           * The key used for the serialized error in the log object.
+           * The key used for the serialized error in the log object. Defaults to err.
            */
           errorKey?: string;
           /**
-           * The stringification limit at a specific nesting depth when logging circular objects.
+           * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
            */
           depthLimit?: number;
           /**
-           * The stringification limit of properties or elements when logging a circular object or array.
+           * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
            */
           edgeLimit?: number;
           /**
-           * Terminate each log line with \r\n instead of \n.
+           * Terminate each log line with \r\n instead of \n. Defaults to false.
            */
           crlf?: boolean;
           /**
-           * Set to false to disable logging entirely.
+           * Set to false to disable logging entirely. Defaults to true.
            */
           enabled?: boolean;
           openTelemetryExporter?: {
@@ -309,7 +309,7 @@ export interface PlatformaticComposerConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -329,7 +329,7 @@ export interface PlatformaticComposerConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -341,23 +341,23 @@ export interface PlatformaticComposerConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -97,22 +97,7 @@
               "properties": {
                 "level": {
                   "type": "string",
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "fatal",
-                        "error",
-                        "warn",
-                        "info",
-                        "debug",
-                        "trace",
-                        "silent"
-                      ]
-                    },
-                    {
-                      "pattern": "^\\{.+\\}$"
-                    }
-                  ]
+                  "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
                 },
                 "transport": {
                   "anyOf": [
@@ -213,6 +198,11 @@
                     "censor": {
                       "type": "string",
                       "default": "[redacted]"
+                    },
+                    "remove": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                     }
                   },
                   "required": [
@@ -238,6 +228,56 @@
                   "type": "object",
                   "additionalProperties": true
                 },
+                "levelVal": {
+                  "type": "integer",
+                  "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+                },
+                "useOnlyCustomLevels": {
+                  "type": "boolean",
+                  "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+                },
+                "levelComparison": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ],
+                  "default": "ASC",
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                },
+                "msgPrefix": {
+                  "type": "string",
+                  "description": "A string prefixed to every message, including the ones of child loggers."
+                },
+                "nestedKey": {
+                  "type": "string",
+                  "description": "The key under which any logged object is placed."
+                },
+                "errorKey": {
+                  "type": "string",
+                  "default": "err",
+                  "description": "The key used for the serialized error in the log object."
+                },
+                "depthLimit": {
+                  "type": "integer",
+                  "default": 5,
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                },
+                "edgeLimit": {
+                  "type": "integer",
+                  "default": 100,
+                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                },
+                "crlf": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Set to false to disable logging entirely."
+                },
                 "openTelemetryExporter": {
                   "type": "object",
                   "properties": {
@@ -257,6 +297,35 @@
                     "url"
                   ],
                   "additionalProperties": false
+                }
+              },
+              "if": {
+                "not": {
+                  "required": [
+                    "customLevels"
+                  ]
+                }
+              },
+              "then": {
+                "properties": {
+                  "level": {
+                    "oneOf": [
+                      {
+                        "enum": [
+                          "fatal",
+                          "error",
+                          "warn",
+                          "info",
+                          "debug",
+                          "trace",
+                          "silent"
+                        ]
+                      },
+                      {
+                        "pattern": "^\\{.+\\}$"
+                      }
+                    ]
+                  }
                 }
               },
               "default": {},
@@ -1297,22 +1366,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1413,6 +1467,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1438,6 +1497,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1457,6 +1566,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/composer/schema.json
+++ b/packages/composer/schema.json
@@ -201,8 +201,7 @@
                     },
                     "remove": {
                       "type": "boolean",
-                      "default": false,
-                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                     }
                   },
                   "required": [
@@ -242,8 +241,7 @@
                     "ASC",
                     "DESC"
                   ],
-                  "default": "ASC",
-                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
                 },
                 "msgPrefix": {
                   "type": "string",
@@ -255,28 +253,23 @@
                 },
                 "errorKey": {
                   "type": "string",
-                  "default": "err",
-                  "description": "The key used for the serialized error in the log object."
+                  "description": "The key used for the serialized error in the log object. Defaults to err."
                 },
                 "depthLimit": {
                   "type": "integer",
-                  "default": 5,
-                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
                 },
                 "edgeLimit": {
                   "type": "integer",
-                  "default": 100,
-                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                  "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
                 },
                 "crlf": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                  "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
                 },
                 "enabled": {
                   "type": "boolean",
-                  "default": true,
-                  "description": "Set to false to disable logging entirely."
+                  "description": "Set to false to disable logging entirely. Defaults to true."
                 },
                 "openTelemetryExporter": {
                   "type": "object",
@@ -1470,8 +1463,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1511,8 +1503,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1524,28 +1515,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -49,13 +49,10 @@ export interface PlatformaticDatabaseConfig {
     logger?:
       | boolean
       | {
-          level?: (
-            | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-            | {
-                [k: string]: unknown;
-              }
-          ) &
-            string;
+          /**
+           * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+           */
+          level?: string;
           transport?:
             | {
                 target?: string;
@@ -88,6 +85,10 @@ export interface PlatformaticDatabaseConfig {
           redact?: {
             paths: string[];
             censor?: string;
+            /**
+             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             */
+            remove?: boolean;
           };
           base?: {
             [k: string]: unknown;
@@ -96,6 +97,46 @@ export interface PlatformaticDatabaseConfig {
           customLevels?: {
             [k: string]: unknown;
           };
+          /**
+           * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+           */
+          levelVal?: number;
+          /**
+           * Only use the levels defined in customLevels and omit the standard pino ones.
+           */
+          useOnlyCustomLevels?: boolean;
+          /**
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           */
+          levelComparison?: "ASC" | "DESC";
+          /**
+           * A string prefixed to every message, including the ones of child loggers.
+           */
+          msgPrefix?: string;
+          /**
+           * The key under which any logged object is placed.
+           */
+          nestedKey?: string;
+          /**
+           * The key used for the serialized error in the log object.
+           */
+          errorKey?: string;
+          /**
+           * The stringification limit at a specific nesting depth when logging circular objects.
+           */
+          depthLimit?: number;
+          /**
+           * The stringification limit of properties or elements when logging a circular object or array.
+           */
+          edgeLimit?: number;
+          /**
+           * Terminate each log line with \r\n instead of \n.
+           */
+          crlf?: boolean;
+          /**
+           * Set to false to disable logging entirely.
+           */
+          enabled?: boolean;
           openTelemetryExporter?: {
             protocol: "grpc" | "http";
             url: string;
@@ -568,13 +609,10 @@ export interface PlatformaticDatabaseConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -607,6 +645,10 @@ export interface PlatformaticDatabaseConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -615,6 +657,46 @@ export interface PlatformaticDatabaseConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/db/config.d.ts
+++ b/packages/db/config.d.ts
@@ -86,7 +86,7 @@ export interface PlatformaticDatabaseConfig {
             paths: string[];
             censor?: string;
             /**
-             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
              */
             remove?: boolean;
           };
@@ -106,7 +106,7 @@ export interface PlatformaticDatabaseConfig {
            */
           useOnlyCustomLevels?: boolean;
           /**
-           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
            */
           levelComparison?: "ASC" | "DESC";
           /**
@@ -118,23 +118,23 @@ export interface PlatformaticDatabaseConfig {
            */
           nestedKey?: string;
           /**
-           * The key used for the serialized error in the log object.
+           * The key used for the serialized error in the log object. Defaults to err.
            */
           errorKey?: string;
           /**
-           * The stringification limit at a specific nesting depth when logging circular objects.
+           * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
            */
           depthLimit?: number;
           /**
-           * The stringification limit of properties or elements when logging a circular object or array.
+           * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
            */
           edgeLimit?: number;
           /**
-           * Terminate each log line with \r\n instead of \n.
+           * Terminate each log line with \r\n instead of \n. Defaults to false.
            */
           crlf?: boolean;
           /**
-           * Set to false to disable logging entirely.
+           * Set to false to disable logging entirely. Defaults to true.
            */
           enabled?: boolean;
           openTelemetryExporter?: {
@@ -646,7 +646,7 @@ export interface PlatformaticDatabaseConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -666,7 +666,7 @@ export interface PlatformaticDatabaseConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -678,23 +678,23 @@ export interface PlatformaticDatabaseConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -98,22 +98,7 @@
               "properties": {
                 "level": {
                   "type": "string",
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "fatal",
-                        "error",
-                        "warn",
-                        "info",
-                        "debug",
-                        "trace",
-                        "silent"
-                      ]
-                    },
-                    {
-                      "pattern": "^\\{.+\\}$"
-                    }
-                  ]
+                  "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
                 },
                 "transport": {
                   "anyOf": [
@@ -214,6 +199,11 @@
                     "censor": {
                       "type": "string",
                       "default": "[redacted]"
+                    },
+                    "remove": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                     }
                   },
                   "required": [
@@ -239,6 +229,56 @@
                   "type": "object",
                   "additionalProperties": true
                 },
+                "levelVal": {
+                  "type": "integer",
+                  "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+                },
+                "useOnlyCustomLevels": {
+                  "type": "boolean",
+                  "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+                },
+                "levelComparison": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ],
+                  "default": "ASC",
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                },
+                "msgPrefix": {
+                  "type": "string",
+                  "description": "A string prefixed to every message, including the ones of child loggers."
+                },
+                "nestedKey": {
+                  "type": "string",
+                  "description": "The key under which any logged object is placed."
+                },
+                "errorKey": {
+                  "type": "string",
+                  "default": "err",
+                  "description": "The key used for the serialized error in the log object."
+                },
+                "depthLimit": {
+                  "type": "integer",
+                  "default": 5,
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                },
+                "edgeLimit": {
+                  "type": "integer",
+                  "default": 100,
+                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                },
+                "crlf": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Set to false to disable logging entirely."
+                },
                 "openTelemetryExporter": {
                   "type": "object",
                   "properties": {
@@ -258,6 +298,35 @@
                     "url"
                   ],
                   "additionalProperties": false
+                }
+              },
+              "if": {
+                "not": {
+                  "required": [
+                    "customLevels"
+                  ]
+                }
+              },
+              "then": {
+                "properties": {
+                  "level": {
+                    "oneOf": [
+                      {
+                        "enum": [
+                          "fatal",
+                          "error",
+                          "warn",
+                          "info",
+                          "debug",
+                          "trace",
+                          "silent"
+                        ]
+                      },
+                      {
+                        "pattern": "^\\{.+\\}$"
+                      }
+                    ]
+                  }
                 }
               },
               "default": {},
@@ -2000,22 +2069,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -2116,6 +2170,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -2141,6 +2200,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -2160,6 +2269,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/db/schema.json
+++ b/packages/db/schema.json
@@ -202,8 +202,7 @@
                     },
                     "remove": {
                       "type": "boolean",
-                      "default": false,
-                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                     }
                   },
                   "required": [
@@ -243,8 +242,7 @@
                     "ASC",
                     "DESC"
                   ],
-                  "default": "ASC",
-                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
                 },
                 "msgPrefix": {
                   "type": "string",
@@ -256,28 +254,23 @@
                 },
                 "errorKey": {
                   "type": "string",
-                  "default": "err",
-                  "description": "The key used for the serialized error in the log object."
+                  "description": "The key used for the serialized error in the log object. Defaults to err."
                 },
                 "depthLimit": {
                   "type": "integer",
-                  "default": 5,
-                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
                 },
                 "edgeLimit": {
                   "type": "integer",
-                  "default": 100,
-                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                  "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
                 },
                 "crlf": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                  "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
                 },
                 "enabled": {
                   "type": "boolean",
-                  "default": true,
-                  "description": "Set to false to disable logging entirely."
+                  "description": "Set to false to disable logging entirely. Defaults to true."
                 },
                 "openTelemetryExporter": {
                   "type": "object",
@@ -2173,8 +2166,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -2214,8 +2206,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -2227,28 +2218,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/foundation/lib/logger.js
+++ b/packages/foundation/lib/logger.js
@@ -55,6 +55,20 @@ export function buildPinoTimestamp (timestamp) {
   return stdTimeFunctions[timestamp]
 }
 
+// Pino options which have no Platformatic specific handling and are therefore passed to pino verbatim
+export const forwardedPinoOptions = [
+  'levelVal',
+  'useOnlyCustomLevels',
+  'levelComparison',
+  'msgPrefix',
+  'nestedKey',
+  'errorKey',
+  'depthLimit',
+  'edgeLimit',
+  'crlf',
+  'enabled'
+]
+
 export function buildPinoOptions (loggerConfig, serverConfig, applicationId, workerId, context, root) {
   const pinoOptions = {
     level: loggerConfig?.level ?? serverConfig?.level ?? 'trace'
@@ -112,10 +126,21 @@ export function buildPinoOptions (loggerConfig, serverConfig, applicationId, wor
       paths: loggerConfig.redact.paths,
       censor: loggerConfig.redact.censor
     }
+
+    if (loggerConfig.redact.remove !== undefined) {
+      pinoOptions.redact.remove = loggerConfig.redact.remove
+    }
   }
 
   if (loggerConfig?.messageKey) {
     pinoOptions.messageKey = loggerConfig.messageKey
+  }
+
+  // Options which are forwarded to pino as they are
+  for (const option of forwardedPinoOptions) {
+    if (loggerConfig?.[option] !== undefined) {
+      pinoOptions[option] = loggerConfig[option]
+    }
   }
 
   if (loggerConfig?.customLevels) {

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -263,12 +263,8 @@ export const logger = {
   properties: {
     level: {
       type: 'string',
-      oneOf: [
-        {
-          enum: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']
-        },
-        { pattern: '^\\{.+\\}$' }
-      ]
+      description:
+        'The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.'
     },
     transport: {
       anyOf: [
@@ -354,6 +350,11 @@ export const logger = {
         censor: {
           type: 'string',
           default: '[redacted]'
+        },
+        remove: {
+          type: 'boolean',
+          default: false,
+          description: 'Remove the redacted keys entirely instead of replacing their values with the censor.'
         }
       },
       required: ['paths'],
@@ -369,6 +370,53 @@ export const logger = {
       type: 'object',
       additionalProperties: true
     },
+    levelVal: {
+      type: 'integer',
+      description: 'The numeric value of the level defined in level, when it is not one of the standard pino levels.'
+    },
+    useOnlyCustomLevels: {
+      type: 'boolean',
+      description: 'Only use the levels defined in customLevels and omit the standard pino ones.'
+    },
+    levelComparison: {
+      type: 'string',
+      enum: ['ASC', 'DESC'],
+      default: 'ASC',
+      description: 'How log levels are compared to the logger level. Use DESC when lower values are more severe.'
+    },
+    msgPrefix: {
+      type: 'string',
+      description: 'A string prefixed to every message, including the ones of child loggers.'
+    },
+    nestedKey: {
+      type: 'string',
+      description: 'The key under which any logged object is placed.'
+    },
+    errorKey: {
+      type: 'string',
+      default: 'err',
+      description: 'The key used for the serialized error in the log object.'
+    },
+    depthLimit: {
+      type: 'integer',
+      default: 5,
+      description: 'The stringification limit at a specific nesting depth when logging circular objects.'
+    },
+    edgeLimit: {
+      type: 'integer',
+      default: 100,
+      description: 'The stringification limit of properties or elements when logging a circular object or array.'
+    },
+    crlf: {
+      type: 'boolean',
+      default: false,
+      description: 'Terminate each log line with \\r\\n instead of \\n.'
+    },
+    enabled: {
+      type: 'boolean',
+      default: true,
+      description: 'Set to false to disable logging entirely.'
+    },
     openTelemetryExporter: {
       type: 'object',
       properties: {
@@ -382,6 +430,15 @@ export const logger = {
       },
       required: ['protocol', 'url'],
       additionalProperties: false
+    }
+  },
+  // Custom levels can only be validated when customLevels is not set.
+  if: { not: { required: ['customLevels'] } },
+  then: {
+    properties: {
+      level: {
+        oneOf: [{ enum: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'] }, { pattern: '^\\{.+\\}$' }]
+      }
     }
   },
   default: {},

--- a/packages/foundation/lib/schema.js
+++ b/packages/foundation/lib/schema.js
@@ -353,8 +353,8 @@ export const logger = {
         },
         remove: {
           type: 'boolean',
-          default: false,
-          description: 'Remove the redacted keys entirely instead of replacing their values with the censor.'
+          description:
+            'Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.'
         }
       },
       required: ['paths'],
@@ -381,8 +381,8 @@ export const logger = {
     levelComparison: {
       type: 'string',
       enum: ['ASC', 'DESC'],
-      default: 'ASC',
-      description: 'How log levels are compared to the logger level. Use DESC when lower values are more severe.'
+      description:
+        'How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.'
     },
     msgPrefix: {
       type: 'string',
@@ -394,28 +394,25 @@ export const logger = {
     },
     errorKey: {
       type: 'string',
-      default: 'err',
-      description: 'The key used for the serialized error in the log object.'
+      description: 'The key used for the serialized error in the log object. Defaults to err.'
     },
     depthLimit: {
       type: 'integer',
-      default: 5,
-      description: 'The stringification limit at a specific nesting depth when logging circular objects.'
+      description:
+        'The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.'
     },
     edgeLimit: {
       type: 'integer',
-      default: 100,
-      description: 'The stringification limit of properties or elements when logging a circular object or array.'
+      description:
+        'The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.'
     },
     crlf: {
       type: 'boolean',
-      default: false,
-      description: 'Terminate each log line with \\r\\n instead of \\n.'
+      description: 'Terminate each log line with \\r\\n instead of \\n. Defaults to false.'
     },
     enabled: {
       type: 'boolean',
-      default: true,
-      description: 'Set to false to disable logging entirely.'
+      description: 'Set to false to disable logging entirely. Defaults to true.'
     },
     openTelemetryExporter: {
       type: 'object',

--- a/packages/foundation/test/logger.test.js
+++ b/packages/foundation/test/logger.test.js
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual, throws } from 'node:assert'
+import { deepStrictEqual, ok, strictEqual, throws } from 'node:assert'
 import { once } from 'node:events'
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { hostname as currentHostname } from 'node:os'
@@ -11,6 +11,7 @@ import {
   buildPinoOptions,
   buildPinoTimestamp,
   disablePinoDirectWrite,
+  forwardedPinoOptions,
   loadFormatters,
   setPinoFormatters,
   setPinoTimestamp
@@ -509,6 +510,41 @@ test('buildPinoOptions - with valid customLevels', t => {
     myLevel: 35,
     anotherLevel: 45
   })
+})
+
+test('buildPinoOptions - forwards additional pino options', t => {
+  const loggerConfig = {
+    levelVal: 35,
+    useOnlyCustomLevels: true,
+    levelComparison: 'DESC',
+    msgPrefix: '[PLT] ',
+    nestedKey: 'payload',
+    errorKey: 'error',
+    depthLimit: 3,
+    edgeLimit: 10,
+    crlf: true,
+    enabled: false
+  }
+  const pinoOptions = buildPinoOptions(loggerConfig, {}, 'test-application', 'worker-1', {}, import.meta.dirname)
+
+  for (const [key, value] of Object.entries(loggerConfig)) {
+    deepStrictEqual(pinoOptions[key], value)
+  }
+})
+
+test('buildPinoOptions - does not set additional pino options which are not configured', t => {
+  const pinoOptions = buildPinoOptions({}, {}, 'test-application', 'worker-1', {}, import.meta.dirname)
+
+  for (const option of forwardedPinoOptions) {
+    ok(!(option in pinoOptions))
+  }
+})
+
+test('buildPinoOptions - with redact remove', t => {
+  const loggerConfig = { redact: { paths: ['secret'], remove: true } }
+  const pinoOptions = buildPinoOptions(loggerConfig, {}, 'test-application', 'worker-1', {}, import.meta.dirname)
+
+  deepStrictEqual(pinoOptions.redact, { paths: ['secret'], censor: undefined, remove: true })
 })
 
 test('buildPinoOptions - with pretty option', t => {

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -69,7 +69,7 @@ export interface PlatformaticGatewayConfig {
             paths: string[];
             censor?: string;
             /**
-             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
              */
             remove?: boolean;
           };
@@ -89,7 +89,7 @@ export interface PlatformaticGatewayConfig {
            */
           useOnlyCustomLevels?: boolean;
           /**
-           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
            */
           levelComparison?: "ASC" | "DESC";
           /**
@@ -101,23 +101,23 @@ export interface PlatformaticGatewayConfig {
            */
           nestedKey?: string;
           /**
-           * The key used for the serialized error in the log object.
+           * The key used for the serialized error in the log object. Defaults to err.
            */
           errorKey?: string;
           /**
-           * The stringification limit at a specific nesting depth when logging circular objects.
+           * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
            */
           depthLimit?: number;
           /**
-           * The stringification limit of properties or elements when logging a circular object or array.
+           * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
            */
           edgeLimit?: number;
           /**
-           * Terminate each log line with \r\n instead of \n.
+           * Terminate each log line with \r\n instead of \n. Defaults to false.
            */
           crlf?: boolean;
           /**
-           * Set to false to disable logging entirely.
+           * Set to false to disable logging entirely. Defaults to true.
            */
           enabled?: boolean;
           openTelemetryExporter?: {
@@ -584,7 +584,7 @@ export interface PlatformaticGatewayConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -604,7 +604,7 @@ export interface PlatformaticGatewayConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -616,23 +616,23 @@ export interface PlatformaticGatewayConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/gateway/config.d.ts
+++ b/packages/gateway/config.d.ts
@@ -32,13 +32,10 @@ export interface PlatformaticGatewayConfig {
     logger?:
       | boolean
       | {
-          level?: (
-            | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-            | {
-                [k: string]: unknown;
-              }
-          ) &
-            string;
+          /**
+           * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+           */
+          level?: string;
           transport?:
             | {
                 target?: string;
@@ -71,6 +68,10 @@ export interface PlatformaticGatewayConfig {
           redact?: {
             paths: string[];
             censor?: string;
+            /**
+             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             */
+            remove?: boolean;
           };
           base?: {
             [k: string]: unknown;
@@ -79,6 +80,46 @@ export interface PlatformaticGatewayConfig {
           customLevels?: {
             [k: string]: unknown;
           };
+          /**
+           * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+           */
+          levelVal?: number;
+          /**
+           * Only use the levels defined in customLevels and omit the standard pino ones.
+           */
+          useOnlyCustomLevels?: boolean;
+          /**
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           */
+          levelComparison?: "ASC" | "DESC";
+          /**
+           * A string prefixed to every message, including the ones of child loggers.
+           */
+          msgPrefix?: string;
+          /**
+           * The key under which any logged object is placed.
+           */
+          nestedKey?: string;
+          /**
+           * The key used for the serialized error in the log object.
+           */
+          errorKey?: string;
+          /**
+           * The stringification limit at a specific nesting depth when logging circular objects.
+           */
+          depthLimit?: number;
+          /**
+           * The stringification limit of properties or elements when logging a circular object or array.
+           */
+          edgeLimit?: number;
+          /**
+           * Terminate each log line with \r\n instead of \n.
+           */
+          crlf?: boolean;
+          /**
+           * Set to false to disable logging entirely.
+           */
+          enabled?: boolean;
           openTelemetryExporter?: {
             protocol: "grpc" | "http";
             url: string;
@@ -506,13 +547,10 @@ export interface PlatformaticGatewayConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -545,6 +583,10 @@ export interface PlatformaticGatewayConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -553,6 +595,46 @@ export interface PlatformaticGatewayConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -97,22 +97,7 @@
               "properties": {
                 "level": {
                   "type": "string",
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "fatal",
-                        "error",
-                        "warn",
-                        "info",
-                        "debug",
-                        "trace",
-                        "silent"
-                      ]
-                    },
-                    {
-                      "pattern": "^\\{.+\\}$"
-                    }
-                  ]
+                  "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
                 },
                 "transport": {
                   "anyOf": [
@@ -213,6 +198,11 @@
                     "censor": {
                       "type": "string",
                       "default": "[redacted]"
+                    },
+                    "remove": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                     }
                   },
                   "required": [
@@ -238,6 +228,56 @@
                   "type": "object",
                   "additionalProperties": true
                 },
+                "levelVal": {
+                  "type": "integer",
+                  "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+                },
+                "useOnlyCustomLevels": {
+                  "type": "boolean",
+                  "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+                },
+                "levelComparison": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ],
+                  "default": "ASC",
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                },
+                "msgPrefix": {
+                  "type": "string",
+                  "description": "A string prefixed to every message, including the ones of child loggers."
+                },
+                "nestedKey": {
+                  "type": "string",
+                  "description": "The key under which any logged object is placed."
+                },
+                "errorKey": {
+                  "type": "string",
+                  "default": "err",
+                  "description": "The key used for the serialized error in the log object."
+                },
+                "depthLimit": {
+                  "type": "integer",
+                  "default": 5,
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                },
+                "edgeLimit": {
+                  "type": "integer",
+                  "default": 100,
+                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                },
+                "crlf": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Set to false to disable logging entirely."
+                },
                 "openTelemetryExporter": {
                   "type": "object",
                   "properties": {
@@ -257,6 +297,35 @@
                     "url"
                   ],
                   "additionalProperties": false
+                }
+              },
+              "if": {
+                "not": {
+                  "required": [
+                    "customLevels"
+                  ]
+                }
+              },
+              "then": {
+                "properties": {
+                  "level": {
+                    "oneOf": [
+                      {
+                        "enum": [
+                          "fatal",
+                          "error",
+                          "warn",
+                          "info",
+                          "debug",
+                          "trace",
+                          "silent"
+                        ]
+                      },
+                      {
+                        "pattern": "^\\{.+\\}$"
+                      }
+                    ]
+                  }
                 }
               },
               "default": {},
@@ -2290,22 +2359,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -2406,6 +2460,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -2431,6 +2490,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -2450,6 +2559,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/gateway/schema.json
+++ b/packages/gateway/schema.json
@@ -201,8 +201,7 @@
                     },
                     "remove": {
                       "type": "boolean",
-                      "default": false,
-                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                     }
                   },
                   "required": [
@@ -242,8 +241,7 @@
                     "ASC",
                     "DESC"
                   ],
-                  "default": "ASC",
-                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
                 },
                 "msgPrefix": {
                   "type": "string",
@@ -255,28 +253,23 @@
                 },
                 "errorKey": {
                   "type": "string",
-                  "default": "err",
-                  "description": "The key used for the serialized error in the log object."
+                  "description": "The key used for the serialized error in the log object. Defaults to err."
                 },
                 "depthLimit": {
                   "type": "integer",
-                  "default": 5,
-                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
                 },
                 "edgeLimit": {
                   "type": "integer",
-                  "default": 100,
-                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                  "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
                 },
                 "crlf": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                  "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
                 },
                 "enabled": {
                   "type": "boolean",
-                  "default": true,
-                  "description": "Set to false to disable logging entirely."
+                  "description": "Set to false to disable logging entirely. Defaults to true."
                 },
                 "openTelemetryExporter": {
                   "type": "object",
@@ -2463,8 +2456,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -2504,8 +2496,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -2517,28 +2508,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticNestJSConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticNestJSConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticNestJSConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticNestJSConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticNestJSConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticNestJSConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/nest/config.d.ts
+++ b/packages/nest/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticNestJSConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticNestJSConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticNestJSConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticNestJSConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticNestJSConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticNestJSConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/nest/schema.json
+++ b/packages/nest/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticNextJsConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticNextJsConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticNextJsConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticNextJsConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticNextJsConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticNextJsConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticNextJsConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticNextJsConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticNextJsConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticNextJsConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticNextJsConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticNextJsConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/next/schema.json
+++ b/packages/next/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/nitro/config.d.ts
+++ b/packages/nitro/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticNitroConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticNitroConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticNitroConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -170,13 +211,10 @@ export interface PlatformaticNitroConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -209,6 +247,10 @@ export interface PlatformaticNitroConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -217,6 +259,46 @@ export interface PlatformaticNitroConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/nitro/config.d.ts
+++ b/packages/nitro/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticNitroConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticNitroConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticNitroConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -248,7 +248,7 @@ export interface PlatformaticNitroConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -268,7 +268,7 @@ export interface PlatformaticNitroConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -280,23 +280,23 @@ export interface PlatformaticNitroConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -993,22 +1062,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1109,6 +1163,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1134,6 +1193,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1153,6 +1262,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/nitro/schema.json
+++ b/packages/nitro/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1166,8 +1159,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1207,8 +1199,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1220,28 +1211,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticNodeJsConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticNodeJsConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticNodeJsConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticNodeJsConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticNodeJsConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticNodeJsConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/node/config.d.ts
+++ b/packages/node/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticNodeJsConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticNodeJsConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticNodeJsConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticNodeJsConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticNodeJsConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticNodeJsConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/node/schema.json
+++ b/packages/node/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticNuxtConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticNuxtConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticNuxtConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticNuxtConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticNuxtConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticNuxtConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticNuxtConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticNuxtConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticNuxtConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticNuxtConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticNuxtConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticNuxtConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/nuxt/schema.json
+++ b/packages/nuxt/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticReactRouterConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticReactRouterConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticReactRouterConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticReactRouterConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticReactRouterConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticReactRouterConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/react-router/config.d.ts
+++ b/packages/react-router/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticReactRouterConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticReactRouterConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticReactRouterConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticReactRouterConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticReactRouterConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticReactRouterConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/react-router/schema.json
+++ b/packages/react-router/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticRemixConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticRemixConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticRemixConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticRemixConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticRemixConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticRemixConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/remix/config.d.ts
+++ b/packages/remix/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticRemixConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticRemixConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticRemixConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticRemixConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticRemixConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticRemixConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/remix/schema.json
+++ b/packages/remix/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -160,13 +160,10 @@ export type PlatformaticRuntimeConfig = {
       };
   workersRestartDelay?: number | string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -199,6 +196,10 @@ export type PlatformaticRuntimeConfig = {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -207,6 +208,46 @@ export type PlatformaticRuntimeConfig = {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;

--- a/packages/runtime/config.d.ts
+++ b/packages/runtime/config.d.ts
@@ -197,7 +197,7 @@ export type PlatformaticRuntimeConfig = {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -217,7 +217,7 @@ export type PlatformaticRuntimeConfig = {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -229,23 +229,23 @@ export type PlatformaticRuntimeConfig = {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {

--- a/packages/runtime/fixtures/logger-pino-options/package.json
+++ b/packages/runtime/fixtures/logger-pino-options/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "logger-pino-options",
+  "version": "1.0.0",
+  "private": true
+}

--- a/packages/runtime/fixtures/logger-pino-options/platformatic.json
+++ b/packages/runtime/fixtures/logger-pino-options/platformatic.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.65.1.json",
+  "entrypoint": "node-app",
+  "autoload": {
+    "path": "services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": "0"
+  },
+  "watch": false,
+  "managementApi": false,
+  "logger": {
+    "level": "custom",
+    "customLevels": {
+      "custom": 25
+    },
+    "msgPrefix": "[PLT] ",
+    "nestedKey": "payload",
+    "errorKey": "error",
+    "redact": {
+      "paths": [
+        "secret"
+      ],
+      "remove": true
+    }
+  }
+}

--- a/packages/runtime/fixtures/logger-pino-options/services/node-app/index.js
+++ b/packages/runtime/fixtures/logger-pino-options/services/node-app/index.js
@@ -1,0 +1,12 @@
+import { getLogger } from '@platformatic/globals'
+import fastify from 'fastify'
+
+const logger = getLogger()
+const app = fastify({ loggerInstance: logger.child({}) })
+
+app.get('/logs', async () => {
+  logger.custom({ secret: 'hidden', hello: 'world' }, 'call route /logs')
+  return 'ok'
+})
+
+await app.listen({ port: 0 })

--- a/packages/runtime/fixtures/logger-pino-options/services/node-app/package.json
+++ b/packages/runtime/fixtures/logger-pino-options/services/node-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@platformatic/globals": ">=3.0.0"
+  }
+}

--- a/packages/runtime/fixtures/logger-pino-options/services/node-app/platformatic.json
+++ b/packages/runtime/fixtures/logger-pino-options/services/node-app/platformatic.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.65.1.json"
+}

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -1998,8 +1998,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -2039,8 +2038,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -2052,28 +2050,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",

--- a/packages/runtime/schema.json
+++ b/packages/runtime/schema.json
@@ -1894,22 +1894,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -2010,6 +1995,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -2034,6 +2024,56 @@
         "customLevels": {
           "type": "object",
           "additionalProperties": true
+        },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -2077,6 +2117,35 @@
             }
           },
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},

--- a/packages/runtime/test/logger.test.js
+++ b/packages/runtime/test/logger.test.js
@@ -667,6 +667,33 @@ test('should inherit logger level from runtime when node app does not specify lo
   )
 })
 
+test('should support additional pino options and inherit them in the applications', async t => {
+  const configPath = join(import.meta.dirname, '..', 'fixtures', 'logger-pino-options', 'platformatic.json')
+
+  let requested = false
+  const { stdout } = await execRuntime({
+    configPath,
+    onReady: async ({ url }) => {
+      await requestAndDump(url, { path: '/logs' })
+      requested = true
+    },
+    done: message => {
+      return requested && message.includes('call route /logs')
+    }
+  })
+  const logs = stdioOutputToLogs(stdout)
+
+  // The runtime logger uses msgPrefix
+  ok(logs.find(log => log.msg?.startsWith('[PLT] Platformatic is now listening at http://127.0.0.1:')))
+
+  // The application logger inherits msgPrefix, nestedKey, customLevels and redact.remove
+  const applicationLog = logs.find(log => log.msg === '[PLT] call route /logs')
+  ok(applicationLog)
+  deepStrictEqual(applicationLog.level, 25)
+  deepStrictEqual(applicationLog.name, 'node-app')
+  deepStrictEqual(applicationLog.payload, { hello: 'world' })
+})
+
 // Same test but for @platformatic/node applications
 test('should export logs to OpenTelemetry', async t => {
   function findAttribute (log, name) {

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -69,7 +69,7 @@ export interface PlatformaticServiceConfig {
             paths: string[];
             censor?: string;
             /**
-             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
              */
             remove?: boolean;
           };
@@ -89,7 +89,7 @@ export interface PlatformaticServiceConfig {
            */
           useOnlyCustomLevels?: boolean;
           /**
-           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
            */
           levelComparison?: "ASC" | "DESC";
           /**
@@ -101,23 +101,23 @@ export interface PlatformaticServiceConfig {
            */
           nestedKey?: string;
           /**
-           * The key used for the serialized error in the log object.
+           * The key used for the serialized error in the log object. Defaults to err.
            */
           errorKey?: string;
           /**
-           * The stringification limit at a specific nesting depth when logging circular objects.
+           * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
            */
           depthLimit?: number;
           /**
-           * The stringification limit of properties or elements when logging a circular object or array.
+           * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
            */
           edgeLimit?: number;
           /**
-           * Terminate each log line with \r\n instead of \n.
+           * Terminate each log line with \r\n instead of \n. Defaults to false.
            */
           crlf?: boolean;
           /**
-           * Set to false to disable logging entirely.
+           * Set to false to disable logging entirely. Defaults to true.
            */
           enabled?: boolean;
           openTelemetryExporter?: {
@@ -468,7 +468,7 @@ export interface PlatformaticServiceConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -488,7 +488,7 @@ export interface PlatformaticServiceConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -500,23 +500,23 @@ export interface PlatformaticServiceConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/service/config.d.ts
+++ b/packages/service/config.d.ts
@@ -32,13 +32,10 @@ export interface PlatformaticServiceConfig {
     logger?:
       | boolean
       | {
-          level?: (
-            | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-            | {
-                [k: string]: unknown;
-              }
-          ) &
-            string;
+          /**
+           * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+           */
+          level?: string;
           transport?:
             | {
                 target?: string;
@@ -71,6 +68,10 @@ export interface PlatformaticServiceConfig {
           redact?: {
             paths: string[];
             censor?: string;
+            /**
+             * Remove the redacted keys entirely instead of replacing their values with the censor.
+             */
+            remove?: boolean;
           };
           base?: {
             [k: string]: unknown;
@@ -79,6 +80,46 @@ export interface PlatformaticServiceConfig {
           customLevels?: {
             [k: string]: unknown;
           };
+          /**
+           * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+           */
+          levelVal?: number;
+          /**
+           * Only use the levels defined in customLevels and omit the standard pino ones.
+           */
+          useOnlyCustomLevels?: boolean;
+          /**
+           * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+           */
+          levelComparison?: "ASC" | "DESC";
+          /**
+           * A string prefixed to every message, including the ones of child loggers.
+           */
+          msgPrefix?: string;
+          /**
+           * The key under which any logged object is placed.
+           */
+          nestedKey?: string;
+          /**
+           * The key used for the serialized error in the log object.
+           */
+          errorKey?: string;
+          /**
+           * The stringification limit at a specific nesting depth when logging circular objects.
+           */
+          depthLimit?: number;
+          /**
+           * The stringification limit of properties or elements when logging a circular object or array.
+           */
+          edgeLimit?: number;
+          /**
+           * Terminate each log line with \r\n instead of \n.
+           */
+          crlf?: boolean;
+          /**
+           * Set to false to disable logging entirely.
+           */
+          enabled?: boolean;
           openTelemetryExporter?: {
             protocol: "grpc" | "http";
             url: string;
@@ -390,13 +431,10 @@ export interface PlatformaticServiceConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -429,6 +467,10 @@ export interface PlatformaticServiceConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -437,6 +479,46 @@ export interface PlatformaticServiceConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -201,8 +201,7 @@
                     },
                     "remove": {
                       "type": "boolean",
-                      "default": false,
-                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                     }
                   },
                   "required": [
@@ -242,8 +241,7 @@
                     "ASC",
                     "DESC"
                   ],
-                  "default": "ASC",
-                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
                 },
                 "msgPrefix": {
                   "type": "string",
@@ -255,28 +253,23 @@
                 },
                 "errorKey": {
                   "type": "string",
-                  "default": "err",
-                  "description": "The key used for the serialized error in the log object."
+                  "description": "The key used for the serialized error in the log object. Defaults to err."
                 },
                 "depthLimit": {
                   "type": "integer",
-                  "default": 5,
-                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
                 },
                 "edgeLimit": {
                   "type": "integer",
-                  "default": 100,
-                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                  "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
                 },
                 "crlf": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                  "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
                 },
                 "enabled": {
                   "type": "boolean",
-                  "default": true,
-                  "description": "Set to false to disable logging entirely."
+                  "description": "Set to false to disable logging entirely. Defaults to true."
                 },
                 "openTelemetryExporter": {
                   "type": "object",
@@ -1844,8 +1837,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1885,8 +1877,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1898,28 +1889,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/service/schema.json
+++ b/packages/service/schema.json
@@ -97,22 +97,7 @@
               "properties": {
                 "level": {
                   "type": "string",
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "fatal",
-                        "error",
-                        "warn",
-                        "info",
-                        "debug",
-                        "trace",
-                        "silent"
-                      ]
-                    },
-                    {
-                      "pattern": "^\\{.+\\}$"
-                    }
-                  ]
+                  "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
                 },
                 "transport": {
                   "anyOf": [
@@ -213,6 +198,11 @@
                     "censor": {
                       "type": "string",
                       "default": "[redacted]"
+                    },
+                    "remove": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                     }
                   },
                   "required": [
@@ -238,6 +228,56 @@
                   "type": "object",
                   "additionalProperties": true
                 },
+                "levelVal": {
+                  "type": "integer",
+                  "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+                },
+                "useOnlyCustomLevels": {
+                  "type": "boolean",
+                  "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+                },
+                "levelComparison": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ],
+                  "default": "ASC",
+                  "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+                },
+                "msgPrefix": {
+                  "type": "string",
+                  "description": "A string prefixed to every message, including the ones of child loggers."
+                },
+                "nestedKey": {
+                  "type": "string",
+                  "description": "The key under which any logged object is placed."
+                },
+                "errorKey": {
+                  "type": "string",
+                  "default": "err",
+                  "description": "The key used for the serialized error in the log object."
+                },
+                "depthLimit": {
+                  "type": "integer",
+                  "default": 5,
+                  "description": "The stringification limit at a specific nesting depth when logging circular objects."
+                },
+                "edgeLimit": {
+                  "type": "integer",
+                  "default": 100,
+                  "description": "The stringification limit of properties or elements when logging a circular object or array."
+                },
+                "crlf": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Terminate each log line with \\r\\n instead of \\n."
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Set to false to disable logging entirely."
+                },
                 "openTelemetryExporter": {
                   "type": "object",
                   "properties": {
@@ -257,6 +297,35 @@
                     "url"
                   ],
                   "additionalProperties": false
+                }
+              },
+              "if": {
+                "not": {
+                  "required": [
+                    "customLevels"
+                  ]
+                }
+              },
+              "then": {
+                "properties": {
+                  "level": {
+                    "oneOf": [
+                      {
+                        "enum": [
+                          "fatal",
+                          "error",
+                          "warn",
+                          "info",
+                          "debug",
+                          "trace",
+                          "silent"
+                        ]
+                      },
+                      {
+                        "pattern": "^\\{.+\\}$"
+                      }
+                    ]
+                  }
                 }
               },
               "default": {},
@@ -1671,22 +1740,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1787,6 +1841,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1812,6 +1871,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1831,6 +1940,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticTanStackConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticTanStackConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticTanStackConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticTanStackConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticTanStackConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticTanStackConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/tanstack/config.d.ts
+++ b/packages/tanstack/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticTanStackConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticTanStackConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticTanStackConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticTanStackConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticTanStackConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticTanStackConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/tanstack/schema.json
+++ b/packages/tanstack/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -46,7 +46,7 @@ export interface PlatformaticViteConfig {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -66,7 +66,7 @@ export interface PlatformaticViteConfig {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -78,23 +78,23 @@ export interface PlatformaticViteConfig {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {
@@ -249,7 +249,7 @@ export interface PlatformaticViteConfig {
         paths: string[];
         censor?: string;
         /**
-         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
          */
         remove?: boolean;
       };
@@ -269,7 +269,7 @@ export interface PlatformaticViteConfig {
        */
       useOnlyCustomLevels?: boolean;
       /**
-       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
        */
       levelComparison?: "ASC" | "DESC";
       /**
@@ -281,23 +281,23 @@ export interface PlatformaticViteConfig {
        */
       nestedKey?: string;
       /**
-       * The key used for the serialized error in the log object.
+       * The key used for the serialized error in the log object. Defaults to err.
        */
       errorKey?: string;
       /**
-       * The stringification limit at a specific nesting depth when logging circular objects.
+       * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
        */
       depthLimit?: number;
       /**
-       * The stringification limit of properties or elements when logging a circular object or array.
+       * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
        */
       edgeLimit?: number;
       /**
-       * Terminate each log line with \r\n instead of \n.
+       * Terminate each log line with \r\n instead of \n. Defaults to false.
        */
       crlf?: boolean;
       /**
-       * Set to false to disable logging entirely.
+       * Set to false to disable logging entirely. Defaults to true.
        */
       enabled?: boolean;
       openTelemetryExporter?: {

--- a/packages/vite/config.d.ts
+++ b/packages/vite/config.d.ts
@@ -9,13 +9,10 @@ export interface PlatformaticViteConfig {
   $schema?: string;
   module?: string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -48,6 +45,10 @@ export interface PlatformaticViteConfig {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -56,6 +57,46 @@ export interface PlatformaticViteConfig {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;
@@ -171,13 +212,10 @@ export interface PlatformaticViteConfig {
         };
     workersRestartDelay?: number | string;
     logger?: {
-      level?: (
-        | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-        | {
-            [k: string]: unknown;
-          }
-      ) &
-        string;
+      /**
+       * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+       */
+      level?: string;
       transport?:
         | {
             target?: string;
@@ -210,6 +248,10 @@ export interface PlatformaticViteConfig {
       redact?: {
         paths: string[];
         censor?: string;
+        /**
+         * Remove the redacted keys entirely instead of replacing their values with the censor.
+         */
+        remove?: boolean;
       };
       base?: {
         [k: string]: unknown;
@@ -218,6 +260,46 @@ export interface PlatformaticViteConfig {
       customLevels?: {
         [k: string]: unknown;
       };
+      /**
+       * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+       */
+      levelVal?: number;
+      /**
+       * Only use the levels defined in customLevels and omit the standard pino ones.
+       */
+      useOnlyCustomLevels?: boolean;
+      /**
+       * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+       */
+      levelComparison?: "ASC" | "DESC";
+      /**
+       * A string prefixed to every message, including the ones of child loggers.
+       */
+      msgPrefix?: string;
+      /**
+       * The key under which any logged object is placed.
+       */
+      nestedKey?: string;
+      /**
+       * The key used for the serialized error in the log object.
+       */
+      errorKey?: string;
+      /**
+       * The stringification limit at a specific nesting depth when logging circular objects.
+       */
+      depthLimit?: number;
+      /**
+       * The stringification limit of properties or elements when logging a circular object or array.
+       */
+      edgeLimit?: number;
+      /**
+       * Terminate each log line with \r\n instead of \n.
+       */
+      crlf?: boolean;
+      /**
+       * Set to false to disable logging entirely.
+       */
+      enabled?: boolean;
       openTelemetryExporter?: {
         protocol: "grpc" | "http";
         url: string;

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -119,8 +119,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -160,8 +159,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -173,28 +171,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -1172,8 +1165,7 @@
                 },
                 "remove": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
                 }
               },
               "required": [
@@ -1213,8 +1205,7 @@
                 "ASC",
                 "DESC"
               ],
-              "default": "ASC",
-              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
             },
             "msgPrefix": {
               "type": "string",
@@ -1226,28 +1217,23 @@
             },
             "errorKey": {
               "type": "string",
-              "default": "err",
-              "description": "The key used for the serialized error in the log object."
+              "description": "The key used for the serialized error in the log object. Defaults to err."
             },
             "depthLimit": {
               "type": "integer",
-              "default": 5,
-              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+              "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
             },
             "edgeLimit": {
               "type": "integer",
-              "default": 100,
-              "description": "The stringification limit of properties or elements when logging a circular object or array."
+              "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
             },
             "crlf": {
               "type": "boolean",
-              "default": false,
-              "description": "Terminate each log line with \\r\\n instead of \\n."
+              "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
             },
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Set to false to disable logging entirely."
+              "description": "Set to false to disable logging entirely. Defaults to true."
             },
             "openTelemetryExporter": {
               "type": "object",

--- a/packages/vite/schema.json
+++ b/packages/vite/schema.json
@@ -15,22 +15,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -131,6 +116,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -156,6 +146,56 @@
           "type": "object",
           "additionalProperties": true
         },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
+        },
         "openTelemetryExporter": {
           "type": "object",
           "properties": {
@@ -175,6 +215,35 @@
             "url"
           ],
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},
@@ -999,22 +1068,7 @@
           "properties": {
             "level": {
               "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "fatal",
-                    "error",
-                    "warn",
-                    "info",
-                    "debug",
-                    "trace",
-                    "silent"
-                  ]
-                },
-                {
-                  "pattern": "^\\{.+\\}$"
-                }
-              ]
+              "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
             },
             "transport": {
               "anyOf": [
@@ -1115,6 +1169,11 @@
                 "censor": {
                   "type": "string",
                   "default": "[redacted]"
+                },
+                "remove": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
                 }
               },
               "required": [
@@ -1140,6 +1199,56 @@
               "type": "object",
               "additionalProperties": true
             },
+            "levelVal": {
+              "type": "integer",
+              "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+            },
+            "useOnlyCustomLevels": {
+              "type": "boolean",
+              "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+            },
+            "levelComparison": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ],
+              "default": "ASC",
+              "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+            },
+            "msgPrefix": {
+              "type": "string",
+              "description": "A string prefixed to every message, including the ones of child loggers."
+            },
+            "nestedKey": {
+              "type": "string",
+              "description": "The key under which any logged object is placed."
+            },
+            "errorKey": {
+              "type": "string",
+              "default": "err",
+              "description": "The key used for the serialized error in the log object."
+            },
+            "depthLimit": {
+              "type": "integer",
+              "default": 5,
+              "description": "The stringification limit at a specific nesting depth when logging circular objects."
+            },
+            "edgeLimit": {
+              "type": "integer",
+              "default": 100,
+              "description": "The stringification limit of properties or elements when logging a circular object or array."
+            },
+            "crlf": {
+              "type": "boolean",
+              "default": false,
+              "description": "Terminate each log line with \\r\\n instead of \\n."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Set to false to disable logging entirely."
+            },
             "openTelemetryExporter": {
               "type": "object",
               "properties": {
@@ -1159,6 +1268,35 @@
                 "url"
               ],
               "additionalProperties": false
+            }
+          },
+          "if": {
+            "not": {
+              "required": [
+                "customLevels"
+              ]
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "fatal",
+                      "error",
+                      "warn",
+                      "info",
+                      "debug",
+                      "trace",
+                      "silent"
+                    ]
+                  },
+                  {
+                    "pattern": "^\\{.+\\}$"
+                  }
+                ]
+              }
             }
           },
           "default": {},

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -160,13 +160,10 @@ export type PlatformaticRuntimeConfig = {
       };
   workersRestartDelay?: number | string;
   logger?: {
-    level?: (
-      | ("fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent")
-      | {
-          [k: string]: unknown;
-        }
-    ) &
-      string;
+    /**
+     * The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels.
+     */
+    level?: string;
     transport?:
       | {
           target?: string;
@@ -199,6 +196,10 @@ export type PlatformaticRuntimeConfig = {
     redact?: {
       paths: string[];
       censor?: string;
+      /**
+       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       */
+      remove?: boolean;
     };
     base?: {
       [k: string]: unknown;
@@ -207,6 +208,46 @@ export type PlatformaticRuntimeConfig = {
     customLevels?: {
       [k: string]: unknown;
     };
+    /**
+     * The numeric value of the level defined in level, when it is not one of the standard pino levels.
+     */
+    levelVal?: number;
+    /**
+     * Only use the levels defined in customLevels and omit the standard pino ones.
+     */
+    useOnlyCustomLevels?: boolean;
+    /**
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     */
+    levelComparison?: "ASC" | "DESC";
+    /**
+     * A string prefixed to every message, including the ones of child loggers.
+     */
+    msgPrefix?: string;
+    /**
+     * The key under which any logged object is placed.
+     */
+    nestedKey?: string;
+    /**
+     * The key used for the serialized error in the log object.
+     */
+    errorKey?: string;
+    /**
+     * The stringification limit at a specific nesting depth when logging circular objects.
+     */
+    depthLimit?: number;
+    /**
+     * The stringification limit of properties or elements when logging a circular object or array.
+     */
+    edgeLimit?: number;
+    /**
+     * Terminate each log line with \r\n instead of \n.
+     */
+    crlf?: boolean;
+    /**
+     * Set to false to disable logging entirely.
+     */
+    enabled?: boolean;
     openTelemetryExporter?: {
       protocol: "grpc" | "http";
       url: string;

--- a/packages/wattpm/config.d.ts
+++ b/packages/wattpm/config.d.ts
@@ -197,7 +197,7 @@ export type PlatformaticRuntimeConfig = {
       paths: string[];
       censor?: string;
       /**
-       * Remove the redacted keys entirely instead of replacing their values with the censor.
+       * Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false.
        */
       remove?: boolean;
     };
@@ -217,7 +217,7 @@ export type PlatformaticRuntimeConfig = {
      */
     useOnlyCustomLevels?: boolean;
     /**
-     * How log levels are compared to the logger level. Use DESC when lower values are more severe.
+     * How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC.
      */
     levelComparison?: "ASC" | "DESC";
     /**
@@ -229,23 +229,23 @@ export type PlatformaticRuntimeConfig = {
      */
     nestedKey?: string;
     /**
-     * The key used for the serialized error in the log object.
+     * The key used for the serialized error in the log object. Defaults to err.
      */
     errorKey?: string;
     /**
-     * The stringification limit at a specific nesting depth when logging circular objects.
+     * The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5.
      */
     depthLimit?: number;
     /**
-     * The stringification limit of properties or elements when logging a circular object or array.
+     * The stringification limit of properties or elements when logging a circular object or array. Defaults to 100.
      */
     edgeLimit?: number;
     /**
-     * Terminate each log line with \r\n instead of \n.
+     * Terminate each log line with \r\n instead of \n. Defaults to false.
      */
     crlf?: boolean;
     /**
-     * Set to false to disable logging entirely.
+     * Set to false to disable logging entirely. Defaults to true.
      */
     enabled?: boolean;
     openTelemetryExporter?: {

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -1998,8 +1998,7 @@
             },
             "remove": {
               "type": "boolean",
-              "default": false,
-              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor. Defaults to false."
             }
           },
           "required": [
@@ -2039,8 +2038,7 @@
             "ASC",
             "DESC"
           ],
-          "default": "ASC",
-          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe. Defaults to ASC."
         },
         "msgPrefix": {
           "type": "string",
@@ -2052,28 +2050,23 @@
         },
         "errorKey": {
           "type": "string",
-          "default": "err",
-          "description": "The key used for the serialized error in the log object."
+          "description": "The key used for the serialized error in the log object. Defaults to err."
         },
         "depthLimit": {
           "type": "integer",
-          "default": 5,
-          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+          "description": "The stringification limit at a specific nesting depth when logging circular objects. Defaults to 5."
         },
         "edgeLimit": {
           "type": "integer",
-          "default": 100,
-          "description": "The stringification limit of properties or elements when logging a circular object or array."
+          "description": "The stringification limit of properties or elements when logging a circular object or array. Defaults to 100."
         },
         "crlf": {
           "type": "boolean",
-          "default": false,
-          "description": "Terminate each log line with \\r\\n instead of \\n."
+          "description": "Terminate each log line with \\r\\n instead of \\n. Defaults to false."
         },
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Set to false to disable logging entirely."
+          "description": "Set to false to disable logging entirely. Defaults to true."
         },
         "openTelemetryExporter": {
           "type": "object",

--- a/packages/wattpm/schema.json
+++ b/packages/wattpm/schema.json
@@ -1894,22 +1894,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "fatal",
-                "error",
-                "warn",
-                "info",
-                "debug",
-                "trace",
-                "silent"
-              ]
-            },
-            {
-              "pattern": "^\\{.+\\}$"
-            }
-          ]
+          "description": "The log level. It must be one of the standard pino levels (fatal, error, warn, info, debug, trace, silent) or, when customLevels is set, one of the custom levels."
         },
         "transport": {
           "anyOf": [
@@ -2010,6 +1995,11 @@
             "censor": {
               "type": "string",
               "default": "[redacted]"
+            },
+            "remove": {
+              "type": "boolean",
+              "default": false,
+              "description": "Remove the redacted keys entirely instead of replacing their values with the censor."
             }
           },
           "required": [
@@ -2034,6 +2024,56 @@
         "customLevels": {
           "type": "object",
           "additionalProperties": true
+        },
+        "levelVal": {
+          "type": "integer",
+          "description": "The numeric value of the level defined in level, when it is not one of the standard pino levels."
+        },
+        "useOnlyCustomLevels": {
+          "type": "boolean",
+          "description": "Only use the levels defined in customLevels and omit the standard pino ones."
+        },
+        "levelComparison": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ],
+          "default": "ASC",
+          "description": "How log levels are compared to the logger level. Use DESC when lower values are more severe."
+        },
+        "msgPrefix": {
+          "type": "string",
+          "description": "A string prefixed to every message, including the ones of child loggers."
+        },
+        "nestedKey": {
+          "type": "string",
+          "description": "The key under which any logged object is placed."
+        },
+        "errorKey": {
+          "type": "string",
+          "default": "err",
+          "description": "The key used for the serialized error in the log object."
+        },
+        "depthLimit": {
+          "type": "integer",
+          "default": 5,
+          "description": "The stringification limit at a specific nesting depth when logging circular objects."
+        },
+        "edgeLimit": {
+          "type": "integer",
+          "default": 100,
+          "description": "The stringification limit of properties or elements when logging a circular object or array."
+        },
+        "crlf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Terminate each log line with \\r\\n instead of \\n."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable logging entirely."
         },
         "openTelemetryExporter": {
           "type": "object",
@@ -2077,6 +2117,35 @@
             }
           },
           "additionalProperties": false
+        }
+      },
+      "if": {
+        "not": {
+          "required": [
+            "customLevels"
+          ]
+        }
+      },
+      "then": {
+        "properties": {
+          "level": {
+            "oneOf": [
+              {
+                "enum": [
+                  "fatal",
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "trace",
+                  "silent"
+                ]
+              },
+              {
+                "pattern": "^\\{.+\\}$"
+              }
+            ]
+          }
         }
       },
       "default": {},


### PR DESCRIPTION
The runtime logger, the worker logger and the service capability all spread the whole `logger` configuration into `pino()`, so any pino option already worked there. Only ten of them were declared in the schema, though: the rest validated purely because the logger schema sets `additionalProperties: true`, which means no editor completion, no generated types and no documentation.

Verifying that turned up two concrete gaps.

### `logger.level` could not name a custom level

`customLevels` was in the schema, but `level` was restricted to the seven standard names or an env placeholder, so this was rejected at startup:

```json
{
  "logger": {
    "customLevels": { "custom": 25 },
    "level": "custom"
  }
}
```

```
The configuration does not validate against the configuration schema:
  - /logger/level: must be equal to one of the allowed values
  - /logger/level: must match pattern "^\{.+\}$"
  - /logger/level: must match exactly one schema in oneOf
```

`level` is now a plain string, and the standard-name check moved into an `if`/`then` that applies only when `customLevels` is absent, so typos are still caught in the common case.

### `buildPinoOptions()` dropped options for half the capabilities

It cherry-picked a subset of the configuration, so capabilities built on `@platformatic/basic` (node, next, vite, astro, remix, …) silently ignored `msgPrefix`, `nestedKey`, `errorKey` and `redact.remove`, while `service`, `db` and `gateway` honored them. Running a node application with `msgPrefix` and `nestedKey` set on the runtime, the runtime's own lines carried them and the application's did not.

## Changes

- `packages/foundation/lib/schema.js` — declare `levelVal`, `useOnlyCustomLevels`, `levelComparison`, `msgPrefix`, `nestedKey`, `errorKey`, `depthLimit`, `edgeLimit`, `crlf`, `enabled` and `redact.remove`, each with a description; relax `level` as described above.
- `packages/foundation/lib/logger.js` — `buildPinoOptions()` forwards the new options (via the exported `forwardedPinoOptions` list) and `redact.remove`, so every capability behaves like the runtime.
- Regenerated every `schema.json` and `config.d.ts`.
- Documented the options in `docs/reference/runtime/_shared-configuration.md` and `docs/guides/logging.md`.

`name` is left out on purpose: the worker sets it to the application id, and overriding it would break log prefixing and routing.

## Tests

- Three unit tests in `packages/foundation/test/logger.test.js` for the forwarding and for `redact.remove`.
- An end-to-end runtime test with a new `packages/runtime/fixtures/logger-pino-options` fixture, asserting a custom level, `msgPrefix`, `nestedKey` and `redact.remove` are inherited by a `@platformatic/node` application.

Locally green: `foundation` (370), `basic` (57), `runtime/logger` (19), `runtime/config` (31), `service/config`, `service/logger`, `node/logger`; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLokFSn5w3QRPZUBYegC1A
