### PR TITLE
fix(runtime): flush the module compile cache once the boot is complete

### DIFF
--- a/packages/basic/lib/worker/child-process.js
+++ b/packages/basic/lib/worker/child-process.js
@@ -3,7 +3,8 @@ import {
   buildPinoTimestamp,
   disablePinoDirectWrite,
   ensureLoggableError,
-  mirrorGlobalDispatcherForBuiltinFetch
+  mirrorGlobalDispatcherForBuiltinFetch,
+  scheduleCompileCacheFlush
 } from '@platformatic/foundation'
 import {
   getAdditionalServerOptions,
@@ -216,6 +217,18 @@ export class ChildProcess extends ITC {
 
     // Initialize health signals API for child processes
     this.#initHealthSignalsApi()
+  }
+
+  // The URL notification is sent when the application server is listening, either detected via the
+  // tracing channel or reported by the application itself (urlFromScript). Make the compile cache
+  // accumulated while booting durable, as Node.js would otherwise only write it when the process
+  // terminates.
+  notify (name, message, options) {
+    if (name === 'url' && compileCacheEnabled) {
+      scheduleCompileCacheFlush()
+    }
+
+    return super.notify(name, message, options)
   }
 
   registerGlobals (globals) {
@@ -801,6 +814,9 @@ function stripBasePath (basePath) {
   }
 }
 
+// Whether the module compile cache has been enabled in this process.
+let compileCacheEnabled = false
+
 // Enable compile cache if configured (Node.js 22.1.0+)
 async function setupCompileCache (contextData) {
   const config = contextData?.compileCache
@@ -841,6 +857,7 @@ async function setupCompileCache (contextData) {
 
   try {
     moduleApi.enableCompileCache(cacheDir)
+    compileCacheEnabled = true
   } catch {
     // Silently ignore - cache is optional optimization
   }

--- a/packages/foundation/index.d.ts
+++ b/packages/foundation/index.d.ts
@@ -325,6 +325,7 @@ export declare function loadModule (require: NodeRequire, path: string): Promise
 // Node types
 export declare function checkNodeVersionForApplications (): void
 export declare function mirrorGlobalDispatcherForBuiltinFetch (dispatcher: unknown): void
+export declare function scheduleCompileCacheFlush (logger?: Logger): void
 export declare const features: {
   node: {
     reusePort: boolean

--- a/packages/foundation/lib/node.js
+++ b/packages/foundation/lib/node.js
@@ -86,3 +86,35 @@ export const features = {
     }
   }
 }
+
+/*
+  Node.js only writes the module compile cache to disk when the process, or the worker thread that
+  populated it, terminates. Processes are often killed abruptly (SIGKILL, OOM killer, container
+  eviction), which discards the cache accumulated while booting and makes the next start pay the
+  full compilation cost again.
+
+  Flushing explicitly once the boot is complete, when most modules have been loaded, makes the cache
+  durable. Repeated flushes are cheap as Node.js skips the entries which have already been persisted.
+*/
+export function scheduleCompileCacheFlush (logger) {
+  // Defer the flush so that it never delays the caller.
+  setImmediate(async () => {
+    try {
+      const { flushCompileCache } = await import('node:module')
+
+      // flushCompileCache is available on Node.js 22.10.0+ and it is a no-op when the compile cache
+      // has not been enabled.
+      if (typeof flushCompileCache !== 'function') {
+        return
+      }
+
+      const start = process.hrtime.bigint()
+      flushCompileCache()
+      const duration = Number(process.hrtime.bigint() - start) / 1e6
+
+      logger?.debug({ duration }, 'Module compile cache flushed')
+    } catch (err) {
+      logger?.warn({ err }, 'Error flushing module compile cache')
+    }
+  })
+}

--- a/packages/runtime/fixtures/compile-cache-command/platformatic.json
+++ b/packages/runtime/fixtures/compile-cache-command/platformatic.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.0.0.json",
+  "entrypoint": "main",
+  "watch": false,
+  "compileCache": {
+    "enabled": true
+  },
+  "autoload": {
+    "path": "./services"
+  },
+  "server": {
+    "hostname": "127.0.0.1",
+    "port": 0
+  },
+  "logger": {
+    "level": "silent"
+  }
+}

--- a/packages/runtime/fixtures/compile-cache-command/services/main/index.mjs
+++ b/packages/runtime/fixtures/compile-cache-command/services/main/index.mjs
@@ -1,0 +1,10 @@
+import { createServer } from 'node:http'
+
+// This service runs as a command (`node index.mjs`), so it is executed in a child
+// process through the childManager, which enables the module compile cache.
+const server = createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify({ hello: 'world' }))
+})
+
+server.listen({ host: '127.0.0.1', port: 0 })

--- a/packages/runtime/fixtures/compile-cache-command/services/main/package.json
+++ b/packages/runtime/fixtures/compile-cache-command/services/main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "compile-cache-command-main",
+  "main": "index.mjs"
+}

--- a/packages/runtime/fixtures/compile-cache-command/services/main/platformatic.json
+++ b/packages/runtime/fixtures/compile-cache-command/services/main/platformatic.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/2.0.0.json",
+  "logger": {
+    "level": "silent"
+  },
+  "application": {
+    "commands": {
+      "development": "node index.mjs"
+    }
+  }
+}

--- a/packages/runtime/lib/runtime.js
+++ b/packages/runtime/lib/runtime.js
@@ -8,7 +8,8 @@ import {
   kEnvFileFallbackKeys,
   kMetadata,
   kTimeout,
-  parseMemorySize
+  parseMemorySize,
+  scheduleCompileCacheFlush
 } from '@platformatic/foundation'
 import { getExecutable } from '@platformatic/globals'
 import { ITC } from '@platformatic/itc'
@@ -448,6 +449,11 @@ export class Runtime extends EventEmitter {
     }
 
     this.#updateStatus('started')
+
+    // The CLI enables the module compile cache for this process. Node.js would only write it when
+    // the process terminates, so flush it now that the boot is complete to not lose it when the
+    // process is killed abruptly. This is a no-op when the compile cache is not enabled.
+    scheduleCompileCacheFlush()
 
     // Start the global health metrics timer for all workers if needed
     this.#startHealthMetricsCollectionIfNeeded()

--- a/packages/runtime/lib/worker/main.js
+++ b/packages/runtime/lib/worker/main.js
@@ -4,7 +4,8 @@ import {
   disablePinoDirectWrite,
   ensureLoggableError,
   getPrivateSymbol,
-  parseMemorySize
+  parseMemorySize,
+  scheduleCompileCacheFlush
 } from '@platformatic/foundation'
 import { getITC, getLogger, updateGlobals } from '@platformatic/globals'
 import { addPinoInstrumentation } from '@platformatic/telemetry'
@@ -149,6 +150,9 @@ function setupDefaultHighWaterMark (runtimeConfig, applicationConfig, logger) {
   }
 }
 
+// Whether the module compile cache has been enabled in this worker.
+let compileCacheEnabled = false
+
 // Enable compile cache if configured (Node.js 22.1.0+)
 async function setupCompileCache (runtimeConfig, applicationConfig, logger) {
   // Normalize boolean shorthand: true -> { enabled: true }
@@ -187,8 +191,10 @@ async function setupCompileCache (runtimeConfig, applicationConfig, logger) {
     const { compileCacheStatus } = moduleApi.constants ?? {}
 
     if (result.status === compileCacheStatus?.ENABLED) {
+      compileCacheEnabled = true
       logger.debug({ directory: result.directory }, 'Module compile cache enabled')
     } else if (result.status === compileCacheStatus?.ALREADY_ENABLED) {
+      compileCacheEnabled = true
       logger.debug({ directory: result.directory }, 'Module compile cache already enabled')
     } else if (result.status === compileCacheStatus?.FAILED) {
       logger.warn({ message: result.message }, 'Failed to enable module compile cache')
@@ -318,6 +324,14 @@ async function main () {
   )
 
   await controller.init(cleanup)
+
+  // Make the compile cache accumulated while booting durable, as Node.js would otherwise only write
+  // it when the worker terminates.
+  controller.on('started', () => {
+    if (compileCacheEnabled) {
+      scheduleCompileCacheFlush(logger)
+    }
+  })
 
   if (applicationConfig.entrypoint && runtimeConfig.basePath) {
     const meta = await controller.capability.getMeta()

--- a/packages/runtime/test/compile-cache-process.test.js
+++ b/packages/runtime/test/compile-cache-process.test.js
@@ -1,0 +1,67 @@
+import { safeRemove } from '@platformatic/foundation'
+import { ok, strictEqual } from 'node:assert'
+import { existsSync, readdirSync } from 'node:fs'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { enableCompileCache } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { pathToFileURL } from 'node:url'
+import { createRuntime } from './helpers.js'
+
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures')
+
+function countCacheEntries (cacheDir) {
+  if (!existsSync(cacheDir)) {
+    return 0
+  }
+
+  return readdirSync(cacheDir).flatMap(subdirectory => readdirSync(join(cacheDir, subdirectory))).length
+}
+
+async function waitForCacheEntries (cacheDir, timeout = 10000) {
+  const deadline = Date.now() + timeout
+
+  while (Date.now() < deadline) {
+    const entries = countCacheEntries(cacheDir)
+
+    if (entries > 0) {
+      return entries
+    }
+
+    await sleep(100)
+  }
+
+  return 0
+}
+
+// The CLI enables the compile cache for the runtime process, which Node.js would only write to disk
+// when the process exits. This test emulates the CLI by enabling the cache in the test process.
+test('compileCache - the compile cache of the runtime process is flushed when the runtime starts', async t => {
+  const root = await mkdtemp(join(tmpdir(), 'plt-compile-cache-'))
+  const cacheDir = join(root, 'compile-cache')
+
+  t.after(() => {
+    return safeRemove(root)
+  })
+
+  strictEqual(enableCompileCache(cacheDir).directory, cacheDir)
+
+  // Load a module which has never been loaded before, so that the cache has something to store.
+  const modulePath = join(root, 'module.mjs')
+  await writeFile(modulePath, 'export function sum (a, b) {\n  return a + b\n}\n', 'utf-8')
+  await import(pathToFileURL(modulePath))
+
+  strictEqual(countCacheEntries(cacheDir), 0, 'The compile cache has not been written to disk yet')
+
+  process.env.PORT = 0
+  const app = await createRuntime(join(fixturesDir, 'compile-cache', 'platformatic.runtime.json'))
+  await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  ok(await waitForCacheEntries(cacheDir), 'Compile cache has been flushed while the runtime is running')
+})

--- a/packages/runtime/test/compile-cache.test.js
+++ b/packages/runtime/test/compile-cache.test.js
@@ -1,7 +1,8 @@
 import { ok, strictEqual } from 'node:assert'
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { test } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { request } from 'undici'
 import { createRuntime } from './helpers.js'
 
@@ -15,6 +16,31 @@ async function isCompileCacheAvailable () {
   } catch {
     return false
   }
+}
+
+// The cache directory is nested per Node.js version and platform, so count the files it contains.
+function countCacheEntries (cacheDir) {
+  if (!existsSync(cacheDir)) {
+    return 0
+  }
+
+  return readdirSync(cacheDir).flatMap(subdirectory => readdirSync(join(cacheDir, subdirectory))).length
+}
+
+async function waitForCacheEntries (cacheDir, timeout = 10000) {
+  const deadline = Date.now() + timeout
+
+  while (Date.now() < deadline) {
+    const entries = countCacheEntries(cacheDir)
+
+    if (entries > 0) {
+      return entries
+    }
+
+    await sleep(100)
+  }
+
+  return 0
 }
 
 test('compileCache - runtime starts with compile cache enabled', async t => {
@@ -34,7 +60,7 @@ test('compileCache - runtime starts with compile cache enabled', async t => {
   strictEqual(body.hello, 'world')
 })
 
-test('compileCache - cache directory is created on Node.js 22.1.0+', async t => {
+test('compileCache - the cache is flushed to disk once the application has started', async t => {
   const compileCacheAvailable = await isCompileCacheAvailable()
 
   if (!compileCacheAvailable) {
@@ -44,8 +70,11 @@ test('compileCache - cache directory is created on Node.js 22.1.0+', async t => 
 
   process.env.PORT = 0
   const configFile = join(fixturesDir, 'compile-cache', 'platformatic.runtime.json')
-  const serviceDir = join(fixturesDir, 'compile-cache', 'services', 'a')
-  const cacheDir = join(serviceDir, '.plt', 'compile-cache')
+  const applicationDir = join(fixturesDir, 'compile-cache', 'services', 'a')
+  const cacheDir = join(applicationDir, '.plt', 'compile-cache')
+
+  // Start from a clean cache so that the entries can only come from this run.
+  rmSync(cacheDir, { recursive: true, force: true })
 
   const app = await createRuntime(configFile)
   const entryUrl = await app.start()
@@ -54,18 +83,39 @@ test('compileCache - cache directory is created on Node.js 22.1.0+', async t => 
     return app.close()
   })
 
-  // Make a request to ensure the app is running and modules have been loaded
   const res = await request(entryUrl + '/hello')
   strictEqual(res.statusCode, 200)
+  await res.body.dump()
 
-  // Note: The compile cache directory may not exist if:
-  // 1. No modules were cached yet (lazy creation)
-  // 2. The runtime decided not to cache (e.g., small modules)
-  // We check if it exists but don't fail if it doesn't, since cache is best-effort
-  if (existsSync(cacheDir)) {
-    ok(true, 'Compile cache directory exists')
-  } else {
-    // This is acceptable - the directory is created lazily by Node.js
-    ok(true, 'Compile cache directory not created yet (lazy creation)')
+  // Node.js only writes the compile cache when the worker exits, so without an explicit flush the
+  // cache would be lost whenever the process is killed abruptly.
+  ok(await waitForCacheEntries(cacheDir), 'Compile cache has been flushed while the application is running')
+})
+
+test('compileCache - the cache of an application running as a command is flushed to disk', async t => {
+  const compileCacheAvailable = await isCompileCacheAvailable()
+
+  if (!compileCacheAvailable) {
+    t.skip('Compile cache API not available on this Node.js version')
+    return
   }
+
+  const configFile = join(fixturesDir, 'compile-cache-command', 'platformatic.json')
+  const applicationDir = join(fixturesDir, 'compile-cache-command', 'services', 'main')
+  const cacheDir = join(applicationDir, '.plt', 'compile-cache')
+
+  rmSync(cacheDir, { recursive: true, force: true })
+
+  const app = await createRuntime(configFile)
+  const entryUrl = await app.start()
+
+  t.after(() => {
+    return app.close()
+  })
+
+  const res = await request(entryUrl + '/')
+  strictEqual(res.statusCode, 200)
+  await res.body.dump()
+
+  ok(await waitForCacheEntries(cacheDir), 'Compile cache has been flushed while the application is running')
 })


### PR DESCRIPTION
## Problem

We enable the module compile cache (`module.enableCompileCache()`) in three places — runtime thread workers, child processes running an application as a command, and the CLI bins — but we never flush it.

Node.js only writes the compile cache to disk when the process, or the worker thread that populated it, terminates. So the cache accumulated while booting is only durable on a graceful shutdown: a container that is OOM-killed, `docker kill`ed or hard-killed by Kubernetes past its termination grace period discards all of it, and the next start pays the full compilation cost again. That includes the very first boot of a fresh image, which is exactly the run that is supposed to populate the cache.

Measured on Node.js v24.18.0 with the `compile-cache` fixture, before this change:

```
cache entries while running : 0
cache entries after close   : 434
```

## Solution

Flush explicitly as soon as the boot is complete, when most modules have been loaded:

- **thread workers** (`packages/runtime/lib/worker/main.js`) flush when the application controller emits `started`
- **applications running as a command** (`packages/basic/lib/worker/child-process.js`) flush when the child process reports its URL, which is when their server is listening — this covers both the tracing channel detection and applications reporting their own URL (`urlFromScript`, e.g. Nuxt)
- **the runtime process** (`packages/runtime/lib/runtime.js`) flushes when the runtime is started, which makes the compile cache the CLI enables in `~/.cache/platformatic/compile-cache` durable as well

The shared helper lives in `@platformatic/foundation`. The flush is deferred with `setImmediate` so that it never delays the boot, and it is a no-op when the compile cache has not been enabled. Flushing more than once is cheap: Node.js skips the entries which have already been persisted (~9 ms for the first flush of 269 entries, ~0.002 ms for the next one).

## Verification

With the change, the same fixtures now have the cache on disk while the application is running:

```
thread worker    : 434 entries while running (was 0)
command / child  : 357 entries while running (was 0)
wattpm start     : 1035 files in ~/.cache/platformatic/compile-cache while running (was 0)
```

An isolated probe confirms the cache is otherwise lost: with a plain `enableCompileCache()`, a SIGKILLed process writes nothing, while a process which called `flushCompileCache()` keeps its entries.

Three tests were added (and the previous "the directory may or may not exist" assertion, which passed either way, was replaced), one per path. All of them fail on `main` and pass with this change. Running 4 workers of the same application, all flushing into the same directory concurrently, works without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dx9tLmiQyM5x9KCpc5W2b3