### PR TITLE
fix(runtime): do not leave a failed stop after an unhandled error unobserved

### DIFF
--- a/packages/runtime/fixtures/unhandled-mode/platformatic.starting.json
+++ b/packages/runtime/fixtures/unhandled-mode/platformatic.starting.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/2.66.0.json",
+  "entrypoint": "starting",
+  "services": [
+    {
+      "id": "starting",
+      "path": "./starting"
+    }
+  ],
+  "logger": {
+    "level": "debug"
+  },
+  "startTimeout": 5000,
+  "restartOnError": 0
+}

--- a/packages/runtime/fixtures/unhandled-mode/service/index.js
+++ b/packages/runtime/fixtures/unhandled-mode/service/index.js
@@ -16,4 +16,15 @@ export default async function (fastify) {
 
     return { ok: true }
   })
+
+  fastify.get('/trigger-rejections', async () => {
+    setTimeout(() => {
+      // The first rejection stops the application successfully, which leaves its controller no
+      // longer started. The stop attempted for the second one therefore rejects.
+      Promise.reject(new Error('UNHANDLED'))
+      setTimeout(() => Promise.reject(new Error('UNHANDLED')), 50)
+    }, 500)
+
+    return { ok: true }
+  })
 }

--- a/packages/runtime/fixtures/unhandled-mode/starting/index.js
+++ b/packages/runtime/fixtures/unhandled-mode/starting/index.js
@@ -1,0 +1,17 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+
+export default async function () {
+  // Raise a rejection nobody observes while the controller is still in the "starting" state.
+  Promise.reject(new Error('UNHANDLED'))
+
+  // Never finish starting, so that the controller cannot reach the "started" state before the
+  // unhandled rejection above is delivered. The worker is expected to exit within a few hundred
+  // milliseconds, long before this resolves, and the runtime gives up on its startTimeout long
+  // before it too.
+  //
+  // This sleep is longer than fastify's default pluginTimeout, which nothing overrides here. That
+  // is harmless because startTimeout expires first, but it is one more reason not to raise
+  // startTimeout: past the plugin timeout the boot would fail on the plugin rather than on the
+  // defect under test.
+  await sleep(30000)
+}

--- a/packages/runtime/fixtures/unhandled-mode/starting/platformatic.json
+++ b/packages/runtime/fixtures/unhandled-mode/starting/platformatic.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.66.0.json",
+  "plugins": {
+    "paths": ["./index.js"]
+  }
+}

--- a/packages/runtime/lib/worker/controller.js
+++ b/packages/runtime/lib/worker/controller.js
@@ -69,7 +69,11 @@ function handleUnhandled (app, event, listeners, timeout, err, ...args) {
     }
   }
 
-  app.stop().catch()
+  // stop() rejects while the controller is not started. Left unobserved, that rejection re-enters
+  // this handler forever and starves the event loop, so the exit scheduled above never runs.
+  app.stop().catch(stopError => {
+    logger.debug({ err: ensureLoggableError(stopError) }, `Stopping the ${label} after the ${event} event failed.`)
+  })
 }
 
 export class Controller extends EventEmitter {

--- a/packages/runtime/test/unhandled-mode.test.js
+++ b/packages/runtime/test/unhandled-mode.test.js
@@ -144,3 +144,80 @@ test('should exit with the PROCESS_UNHANDLED_ERROR code on uncaught exceptions r
   strictEqual(payload.application, 'service')
   strictEqual(payload.code, exitCodes.PROCESS_UNHANDLED_ERROR)
 })
+
+test('should exit with the PROCESS_UNHANDLED_ERROR code on unhandled rejections raised while starting', async t => {
+  const context = {}
+  const configFile = join(fixturesDir, 'unhandled-mode', 'platformatic.starting.json')
+  const server = await createRuntime(configFile, null, context)
+
+  t.after(() => {
+    return server.close()
+  })
+
+  // The application raises the rejection and then never finishes starting, so the worker handles it
+  // while its controller is still in the "starting" state. Stopping a controller in that state
+  // rejects, and an unobserved rejection there is delivered right back to the unhandled error
+  // handler: the worker would then spin instead of exiting, until the runtime gave up on the start
+  // timeout or the heap was exhausted.
+  //
+  // The fixture pins startTimeout and restartOnError on purpose. The timeout does not bound the
+  // boot, which is over before the runtime starts that clock; it bounds how long a regression here
+  // is allowed to spin, and raising it only lets the spin exhaust the heap instead. The restart
+  // count keeps the worker named in the message asserted below stable.
+  const startError = await server.start().then(
+    () => null,
+    error => error
+  )
+
+  // Assert that the fixture reached the defect before asserting how the worker died, so that a
+  // fixture which stops booting for an unrelated reason says so instead of looking like a
+  // regression of the fix. The default readLogs delay is deliberate: the record still has to travel
+  // through the file transport and there is no event left to wait on once the start has failed.
+  const logs = await readLogs(context.logsPath)
+  ok(
+    logs.some(entry => entry.msg?.endsWith('threw an unhandledRejection event.')),
+    'the worker should have reported the unhandled rejection'
+  )
+
+  ok(startError, 'starting the runtime should have failed')
+  strictEqual(startError.code, 'PLT_RUNTIME_APPLICATION_EXIT')
+  strictEqual(
+    startError.message,
+    `The application "starting:0" exited prematurely with error code ${exitCodes.PROCESS_UNHANDLED_ERROR}`
+  )
+
+  // The fixture runs at debug level so that this record exists. It is the only evidence that the
+  // stop was attempted at all and that its rejection was handled rather than never raised, so it
+  // pins the shape of the fix and not only the exit code above.
+  ok(
+    logs.some(entry => entry.msg?.endsWith('after the unhandledRejection event failed.')),
+    'the worker should have reported the failed stop'
+  )
+})
+
+test('should exit with the PROCESS_UNHANDLED_ERROR code when an unhandled rejection follows a stop', async t => {
+  const configFile = join(fixturesDir, 'unhandled-mode', 'platformatic.handled.json')
+  const server = await createRuntime(configFile)
+  const url = await server.start()
+
+  t.after(() => {
+    return server.close()
+  })
+
+  // The same defect outside the starting state: the first rejection stops the application, which
+  // leaves its controller no longer started, so the stop attempted for the second one rejects. A
+  // started application therefore hangs on a second unhandled error raised inside the exit grace
+  // period, rather than exiting. Listen before triggering, the worker exits about 100ms after the
+  // error is raised.
+  const errored = once(server, 'application:worker:error', { signal: AbortSignal.timeout(30000) }).catch(cause => {
+    throw new Error('The worker did not exit after the second unhandled rejection.', { cause })
+  })
+
+  const res = await request(url + '/service/trigger-rejections')
+  strictEqual(res.statusCode, 200)
+
+  const [payload] = await errored
+
+  strictEqual(payload.application, 'service')
+  strictEqual(payload.code, exitCodes.PROCESS_UNHANDLED_ERROR)
+})


### PR DESCRIPTION
## The bug

`handleUnhandled` in `packages/runtime/lib/worker/controller.js` discarded the result of `app.stop()` with a bare `.catch()`. A `.catch()` with no argument does not handle a rejection: it returns a derived promise that rejects with the same reason and has no handler of its own.

`Controller.stop()` rejects with `RuntimeNotStartedError` unless the controller is in the started state (`lib/worker/controller.js:270` on `main`). That is true in two situations, not one:

- while the application is still starting, and
- once an earlier `stop()` has completed and cleared `#started`, which is what a second unhandled error raised inside the 100 ms exit grace period runs into.

The rejection was therefore delivered straight back into `handleUnhandled`, which called `stop()` again, without bound. Each iteration creates a fresh rejected promise and the rejections are drained in the same tick-processing phase, so the event loop never reaches the timers phase and the `process.exit(PROCESS_UNHANDLED_ERROR)` deferred a few lines earlier never runs.

Measured on both paths:

| scenario | unpatched | patched |
| --- | --- | --- |
| rejection while starting, `startTimeout: 5000` | `PLT_RUNTIME_APPLICATION_START_TIMEOUT` at 5.26 s | exits in 0.37 s |
| rejection while starting, `startTimeout: 30000` (the runtime default) | `ERR_WORKER_OUT_OF_MEMORY`, "JS heap out of memory", at 24.1 s | exits in 0.37 s |
| second rejection 50 ms after the first, application already started | no `application:worker:error` at all within 15 s, twice | worker error event 0.6 s after the trigger request |

The third row is the one that matters in production: a long-running application that crashes twice inside the exit grace window hangs instead of exiting, and the supervisor keeps a live worker that will never serve again. The title is deliberately state-neutral for that reason.

Reachable since 3.58.0 (#4842). Before that commit the site read `executeWithTimeout(app?.stop(), 1000).catch().finally(() => { process.exit(1) })`. The bare `.catch()` was already there, but the exit was chained onto the stop promise with `.finally()`, so it ran as soon as `stop()` settled and the re-entry could not outlive the first turn. #4842 moved the exit to a `setTimeout`, which is what the spin now starves. (`93ef65026` is an ancestor of the v3.58.0 bump and not of v3.57.0.)

Attaching a real handler breaks the re-entry, the event loop runs, and the deferred exit fires.

This is a direct follow-up to #5027, which changed that deferred exit from `process.exit(1)` to `process.exit(exitCodes.PROCESS_UNHANDLED_ERROR)` and left the `stop()` call on the line below untouched. The spin is what starves that exit, so this change is what makes the code from #5027 reachable when the controller is not started. The two new tests sit in the file that PR added.

## What the tests prove

Two tests in `test/unhandled-mode.test.js`, one per state.

**While starting.** The new `fixtures/unhandled-mode/starting` application raises a rejection nobody observes and then never finishes starting, so the worker handles it while its controller is still in the `starting` state. The test asserts, in this order: that the worker reported an `unhandledRejection` event at all, so that a fixture which stops booting for an unrelated reason says so rather than reading as a regression of this fix; then that the runtime surfaces `PLT_RUNTIME_APPLICATION_EXIT` naming exit code 20; then that the failed stop was logged.

**After a stop.** The existing `service` fixture gains a route that raises two rejections 50 ms apart, and the test asserts the worker reaches `application:worker:error` with the same exit code. Without the fix the worker spins until the heap limit kills it, so the event either never arrives or arrives carrying exit code 1 from the out-of-memory kill instead of 20; on this machine the kill comes first, at about 26 s. The test carries its own 30 s deadline so that the first case fails with a sentence instead of a suite timeout.

Mutation-checked against the production line: deleting `app.stop()` outright, and replacing the handler with a silent `.catch(() => {})`, both fail the first test now. Reverting to `app.stop().catch()` fails both tests.

Both fixture knobs were measured rather than assumed:

- `startTimeout: 5000` does not bound the boot. `lib/runtime.js:3307` starts that clock only at `executeWithTimeout(sendViaITC(worker, 'start'), config.startTimeout)`, after the worker thread is already up. With the timeout raised to 60 s the patched path still rejects in 361-373 ms across three runs, so 5 s is roughly 14x headroom and never participates in a passing run. It should not be raised: at the stock 30 s the unpatched path reaches `ERR_WORKER_OUT_OF_MEMORY` instead of failing an assertion, which kills the runner rather than reporting it. Raising it also eventually walks into fastify's default `pluginTimeout`, which nothing overrides here and which the fixture's 30 s sleep already exceeds, at which point the boot fails on the plugin rather than on the defect.
- `restartOnError: 0` is load-bearing, not decoration. Without it the runtime restarts the worker and the asserted message names `starting:5` instead of `starting:0`.

## Alternatives not taken

`app.stop(true)` bypasses the guard instead of handling the rejection, and `lib/worker/itc.js:192` already does exactly that, `await controller.stop(true)` when `controller.start()` rejects, with the ITC `stop` handler at `itc.js:225-238` deliberately admitting the `starting` state. There is precedent for forcing at this site and this PR does not claim otherwise.

The difference is timing. In `itc.js` the start promise has already settled, so forcing acts on a boot that is over. `handleUnhandled` fires with the boot still in flight, and `stop(true)` would run `capability.stop()` concurrently with a `capability.start()` that has not returned. Handling the rejection is the smaller change and leaves the stop path itself untouched.

Measured, `app.stop(true).catch()` satisfies both exit-code assertions but fails the log assertion in the first test, because a forced stop succeeds and there is then no failure to record. So the tests do encode this fix rather than the outcome alone: choosing `stop(true)` instead means dropping that one assertion, which is the honest price of pinning the stop attempt at all. Swapping to `stop(true)` and dropping that assertion is straightforward if the symmetry with `itc.js` is preferred.

A re-entry guard inside `handleUnhandled` would additionally cover a replayed application listener that rejects asynchronously. It is left out to keep this to a single statement and can follow separately.

## Observability

The handled error goes to `logger.debug`, so it is visible when the runtime runs at `debug` or `trace` and not at the default level. `RuntimeNotStartedError` is the expected case here and does not warrant a louder one. Branching on `stopError.code` so that anything else is logged at `warn` is a two-line change if that is preferred.

The second test assertion pins that debug record, which pins the shape of the fix and not only its observable effect. That is deliberate, since it is the only thing that distinguishes this fix from a silent discard, but it does mean a reworded log line has to be reflected in the test.

## Verification

- `node --test test/unhandled-mode.test.js`: 7/7 twice with the fix. With only the production line reverted: 5/7 twice, failing on both new tests: `actual 'PLT_RUNTIME_APPLICATION_START_TIMEOUT'` against `expected 'PLT_RUNTIME_APPLICATION_EXIT'` for the first, and exit code 1 from the out-of-memory kill at about 26 s against the expected 20 for the second (with a shorter deadline the same run fails on the deadline instead).
- `pnpm run lint` in `packages/runtime`: exit 0.
- The whole `packages/runtime` suite (all 161 files of `test:main`, `test:api`, `test:cli`, `test:start` and `test:multiple-workers`, run one file per process with a 200 s cap each rather than CI's five batched invocations): 108 files clean, 53 not. Every one of those 53 was then re-run on unpatched main, and all 53 behave identically, down to the exact number of failing tests per file. They are environmental on this machine: an unrelated local runtime holds `0.0.0.0:9090`, so anything that starts the Prometheus server fails with `EADDRINUSE`, and the management-API files hang on the socket. `test/unhandled-mode.test.js` itself is 7/7 inside that run.
- Run on macOS with Node 24 only. Your CI covers ubuntu-24.04 and windows-2025 on Node 22, 24 and 26; the Windows leg is the one I could not exercise, and it is the slowest at worker-thread teardown, which is what the 30 s deadline in the second test bounds.
